### PR TITLE
fix(core): use IntegratedUAS::accept_invite so BYE finds the dialog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -114,7 +114,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -524,7 +524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1558,7 +1558,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2068,7 +2068,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2291,7 +2291,7 @@ dependencies = [
 [[package]]
 name = "sip-auth"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=fix%2Fintegrated-uas-accept-invite-tracks-dialog#7790537cbd3adf3562f6495a24eceaf5ced78497"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#b3063067b593bab136bb21543ff753dec3315f0d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2314,7 +2314,7 @@ dependencies = [
 [[package]]
 name = "sip-core"
 version = "0.7.6"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=fix%2Fintegrated-uas-accept-invite-tracks-dialog#7790537cbd3adf3562f6495a24eceaf5ced78497"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#b3063067b593bab136bb21543ff753dec3315f0d"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2327,7 +2327,7 @@ dependencies = [
 [[package]]
 name = "sip-dialog"
 version = "0.3.3"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=fix%2Fintegrated-uas-accept-invite-tracks-dialog#7790537cbd3adf3562f6495a24eceaf5ced78497"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#b3063067b593bab136bb21543ff753dec3315f0d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2345,7 +2345,7 @@ dependencies = [
 [[package]]
 name = "sip-dns"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=fix%2Fintegrated-uas-accept-invite-tracks-dialog#7790537cbd3adf3562f6495a24eceaf5ced78497"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#b3063067b593bab136bb21543ff753dec3315f0d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2359,7 +2359,7 @@ dependencies = [
 [[package]]
 name = "sip-observe"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=fix%2Fintegrated-uas-accept-invite-tracks-dialog#7790537cbd3adf3562f6495a24eceaf5ced78497"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#b3063067b593bab136bb21543ff753dec3315f0d"
 dependencies = [
  "once_cell",
  "tracing",
@@ -2368,7 +2368,7 @@ dependencies = [
 [[package]]
 name = "sip-parse"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=fix%2Fintegrated-uas-accept-invite-tracks-dialog#7790537cbd3adf3562f6495a24eceaf5ced78497"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#b3063067b593bab136bb21543ff753dec3315f0d"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2382,21 +2382,12 @@ dependencies = [
 [[package]]
 name = "sip-ratelimit"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=fix%2Fintegrated-uas-accept-invite-tracks-dialog#7790537cbd3adf3562f6495a24eceaf5ced78497"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#b3063067b593bab136bb21543ff753dec3315f0d"
 dependencies = [
  "dashmap",
  "parking_lot",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "sip-sdp"
-version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=fix%2Fintegrated-uas-accept-invite-tracks-dialog#7790537cbd3adf3562f6495a24eceaf5ced78497"
-dependencies = [
- "nom",
- "smol_str",
 ]
 
 [[package]]
@@ -2409,9 +2400,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sip-sdp"
+version = "0.3.0"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#b3063067b593bab136bb21543ff753dec3315f0d"
+dependencies = [
+ "nom",
+ "smol_str",
+]
+
+[[package]]
 name = "sip-transaction"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=fix%2Fintegrated-uas-accept-invite-tracks-dialog#7790537cbd3adf3562f6495a24eceaf5ced78497"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#b3063067b593bab136bb21543ff753dec3315f0d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2430,7 +2430,7 @@ dependencies = [
 [[package]]
 name = "sip-transport"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=fix%2Fintegrated-uas-accept-invite-tracks-dialog#7790537cbd3adf3562f6495a24eceaf5ced78497"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#b3063067b593bab136bb21543ff753dec3315f0d"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2448,7 +2448,7 @@ dependencies = [
 [[package]]
 name = "sip-uac"
 version = "0.4.2"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=fix%2Fintegrated-uas-accept-invite-tracks-dialog#7790537cbd3adf3562f6495a24eceaf5ced78497"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#b3063067b593bab136bb21543ff753dec3315f0d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2461,7 +2461,7 @@ dependencies = [
  "sip-dialog",
  "sip-dns",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?branch=fix%2Fintegrated-uas-accept-invite-tracks-dialog)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?branch=main)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -2473,7 +2473,7 @@ dependencies = [
 [[package]]
 name = "sip-uas"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=fix%2Fintegrated-uas-accept-invite-tracks-dialog#7790537cbd3adf3562f6495a24eceaf5ced78497"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#b3063067b593bab136bb21543ff753dec3315f0d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2483,7 +2483,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?branch=fix%2Fintegrated-uas-accept-invite-tracks-dialog)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?branch=main)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -2750,7 +2750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3019,7 +3019,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2291,7 +2291,7 @@ dependencies = [
 [[package]]
 name = "sip-auth"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#61dee7f60e92704bda5ea2ba5b1f9dc3ec1dcdb7"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=fix%2Fintegrated-uas-accept-invite-tracks-dialog#7790537cbd3adf3562f6495a24eceaf5ced78497"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2314,7 +2314,7 @@ dependencies = [
 [[package]]
 name = "sip-core"
 version = "0.7.6"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#61dee7f60e92704bda5ea2ba5b1f9dc3ec1dcdb7"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=fix%2Fintegrated-uas-accept-invite-tracks-dialog#7790537cbd3adf3562f6495a24eceaf5ced78497"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2327,7 +2327,7 @@ dependencies = [
 [[package]]
 name = "sip-dialog"
 version = "0.3.3"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#61dee7f60e92704bda5ea2ba5b1f9dc3ec1dcdb7"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=fix%2Fintegrated-uas-accept-invite-tracks-dialog#7790537cbd3adf3562f6495a24eceaf5ced78497"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2345,7 +2345,7 @@ dependencies = [
 [[package]]
 name = "sip-dns"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#61dee7f60e92704bda5ea2ba5b1f9dc3ec1dcdb7"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=fix%2Fintegrated-uas-accept-invite-tracks-dialog#7790537cbd3adf3562f6495a24eceaf5ced78497"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2359,7 +2359,7 @@ dependencies = [
 [[package]]
 name = "sip-observe"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#61dee7f60e92704bda5ea2ba5b1f9dc3ec1dcdb7"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=fix%2Fintegrated-uas-accept-invite-tracks-dialog#7790537cbd3adf3562f6495a24eceaf5ced78497"
 dependencies = [
  "once_cell",
  "tracing",
@@ -2368,7 +2368,7 @@ dependencies = [
 [[package]]
 name = "sip-parse"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#61dee7f60e92704bda5ea2ba5b1f9dc3ec1dcdb7"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=fix%2Fintegrated-uas-accept-invite-tracks-dialog#7790537cbd3adf3562f6495a24eceaf5ced78497"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2382,12 +2382,21 @@ dependencies = [
 [[package]]
 name = "sip-ratelimit"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#61dee7f60e92704bda5ea2ba5b1f9dc3ec1dcdb7"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=fix%2Fintegrated-uas-accept-invite-tracks-dialog#7790537cbd3adf3562f6495a24eceaf5ced78497"
 dependencies = [
  "dashmap",
  "parking_lot",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "sip-sdp"
+version = "0.3.0"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=fix%2Fintegrated-uas-accept-invite-tracks-dialog#7790537cbd3adf3562f6495a24eceaf5ced78497"
+dependencies = [
+ "nom",
+ "smol_str",
 ]
 
 [[package]]
@@ -2400,18 +2409,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "sip-sdp"
-version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#61dee7f60e92704bda5ea2ba5b1f9dc3ec1dcdb7"
-dependencies = [
- "nom",
- "smol_str",
-]
-
-[[package]]
 name = "sip-transaction"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#61dee7f60e92704bda5ea2ba5b1f9dc3ec1dcdb7"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=fix%2Fintegrated-uas-accept-invite-tracks-dialog#7790537cbd3adf3562f6495a24eceaf5ced78497"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2430,7 +2430,7 @@ dependencies = [
 [[package]]
 name = "sip-transport"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#61dee7f60e92704bda5ea2ba5b1f9dc3ec1dcdb7"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=fix%2Fintegrated-uas-accept-invite-tracks-dialog#7790537cbd3adf3562f6495a24eceaf5ced78497"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2448,7 +2448,7 @@ dependencies = [
 [[package]]
 name = "sip-uac"
 version = "0.4.2"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#61dee7f60e92704bda5ea2ba5b1f9dc3ec1dcdb7"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=fix%2Fintegrated-uas-accept-invite-tracks-dialog#7790537cbd3adf3562f6495a24eceaf5ced78497"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2461,7 +2461,7 @@ dependencies = [
  "sip-dialog",
  "sip-dns",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?branch=main)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?branch=fix%2Fintegrated-uas-accept-invite-tracks-dialog)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -2473,7 +2473,7 @@ dependencies = [
 [[package]]
 name = "sip-uas"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#61dee7f60e92704bda5ea2ba5b1f9dc3ec1dcdb7"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=fix%2Fintegrated-uas-accept-invite-tracks-dialog#7790537cbd3adf3562f6495a24eceaf5ced78497"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2483,7 +2483,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?branch=main)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?branch=fix%2Fintegrated-uas-accept-invite-tracks-dialog)",
  "sip-transaction",
  "sip-transport",
  "smol_str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,15 +97,21 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 # releases. For reproducibility, pin to a specific rev before v0.1.0 ships
 # (see CLAUDE.md §7.5 "Bumping Upstream Dep").
 
-# siphon-rs — RFC 3261 SIP stack
-sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "main" }
-sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "main" }
-sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "main", features = ["tls"] }
-sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "main" }
-sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "main" }
-sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "main" }
-sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "main" }
-sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "main" }
+# siphon-rs — RFC 3261 SIP stack.
+#
+# Temporary pin to the fix branch for siphon-rs PR #35
+# (https://github.com/thevoiceguy/siphon-rs/pull/35), which adds
+# `IntegratedUAS::accept_invite` and unblocks the unknown-dialog 481
+# response paths from a tokio::Mutex re-entrancy deadlock. When that
+# PR lands on main, flip these back to `branch = "main"`.
+sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "fix/integrated-uas-accept-invite-tracks-dialog" }
+sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "fix/integrated-uas-accept-invite-tracks-dialog" }
+sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "fix/integrated-uas-accept-invite-tracks-dialog", features = ["tls"] }
+sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "fix/integrated-uas-accept-invite-tracks-dialog" }
+sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "fix/integrated-uas-accept-invite-tracks-dialog" }
+sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "fix/integrated-uas-accept-invite-tracks-dialog" }
+sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "fix/integrated-uas-accept-invite-tracks-dialog" }
+sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "fix/integrated-uas-accept-invite-tracks-dialog" }
 
 # forge-media — RTP / codecs / SDP / DTMF / engine.
 #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,21 +97,15 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 # releases. For reproducibility, pin to a specific rev before v0.1.0 ships
 # (see CLAUDE.md §7.5 "Bumping Upstream Dep").
 
-# siphon-rs — RFC 3261 SIP stack.
-#
-# Temporary pin to the fix branch for siphon-rs PR #35
-# (https://github.com/thevoiceguy/siphon-rs/pull/35), which adds
-# `IntegratedUAS::accept_invite` and unblocks the unknown-dialog 481
-# response paths from a tokio::Mutex re-entrancy deadlock. When that
-# PR lands on main, flip these back to `branch = "main"`.
-sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "fix/integrated-uas-accept-invite-tracks-dialog" }
-sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "fix/integrated-uas-accept-invite-tracks-dialog" }
-sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "fix/integrated-uas-accept-invite-tracks-dialog", features = ["tls"] }
-sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "fix/integrated-uas-accept-invite-tracks-dialog" }
-sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "fix/integrated-uas-accept-invite-tracks-dialog" }
-sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "fix/integrated-uas-accept-invite-tracks-dialog" }
-sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "fix/integrated-uas-accept-invite-tracks-dialog" }
-sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "fix/integrated-uas-accept-invite-tracks-dialog" }
+# siphon-rs — RFC 3261 SIP stack
+sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "main" }
+sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "main" }
+sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "main", features = ["tls"] }
+sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "main" }
+sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "main" }
+sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "main" }
+sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "main" }
+sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "main" }
 
 # forge-media — RTP / codecs / SDP / DTMF / engine.
 #

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -55,7 +55,6 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use forge_engine::{MediaBridgeManager, SessionManager, SessionManagerConfig};
 use forge_rtp::PortPoolConfig;
-use sip_core::SipUri;
 use sip_parse::parse_request;
 use sip_transaction::{
     TransactionManager, TransportContext, TransportDispatcher, TransportKind as TxTransportKind,
@@ -65,7 +64,6 @@ use sip_transport::{
     TransportKind as TpTransportKind,
 };
 use sip_uas::integrated::{IntegratedUAS, UasRequestHandler};
-use sip_uas::UserAgentServer;
 use siphon_ai_cdr::{CdrSinkHandle, FileSink, MultiSink, NullSink, WebhookSink, WebhookSinkConfig};
 use siphon_ai_config::{
     CdrConfig, CdrFileConfig, CdrWebhookConfig, Config, MediaConfig, NodeConfig,
@@ -154,17 +152,15 @@ impl Runtime {
         ));
 
         // ─── Bridging acceptor + dialog registry ───────────────────
+        // Built without the IntegratedUAS here because the routing
+        // handler (which the UAS needs as its request handler) holds
+        // an Arc to this acceptor. We close the cycle below via
+        // `acceptor.install_uas(...)` once the UAS exists.
         let registry = CallRegistry::new();
-        let uas_helper = build_uas_helper(&node, &sip)?;
         let acceptor = Arc::new(
-            BridgingAcceptor::new(
-                media_setup,
-                bridge_defaults,
-                Arc::clone(&uas_helper),
-                registry.clone(),
-            )
-            .with_cdr_sink(cdr_sink)
-            .with_webhook_sink(webhook_sink),
+            BridgingAcceptor::new(media_setup, bridge_defaults, registry.clone())
+                .with_cdr_sink(cdr_sink)
+                .with_webhook_sink(webhook_sink),
         );
 
         // ─── Registration manager ──────────────────────────────────
@@ -192,7 +188,7 @@ impl Runtime {
         // ─── SIP routing handler ───────────────────────────────────
         let dialog_terminator: DialogTerminatorHandle = Arc::new(registry);
         let routing_handler = Arc::new(
-            RoutingHandler::new(Arc::new(routes), acceptor)
+            RoutingHandler::new(Arc::new(routes), Arc::clone(&acceptor))
                 .with_dialog_terminator(dialog_terminator)
                 .with_register_source_resolver(register_source_resolver(&registration_mgr)),
         );
@@ -241,6 +237,14 @@ impl Runtime {
                 .map_err(|e| anyhow!("public_addr: {e}"))?;
         }
         let uas = Arc::new(uas_builder.build()?);
+
+        // Close the BridgingAcceptor ↔ IntegratedUAS cycle now that
+        // both exist. The acceptor uses this handle in `on_matched`
+        // to send the 200 OK via `IntegratedUAS::accept_invite`,
+        // which registers the confirmed dialog with the SAME
+        // dialog_manager that `IntegratedUAS::dispatch` consults on
+        // the follow-up BYE.
+        acceptor.install_uas(Arc::clone(&uas));
 
         // ─── Spawn the inbound UDP/TCP/TLS readers + pump ─────────
         let udp_bound_addr = udp_socket
@@ -516,18 +520,6 @@ fn rtp_port_pool(media: &MediaConfig) -> Result<PortPoolConfig> {
             .map_err(|e| anyhow!("[media].rtp_port_range invalid: {e}")),
         None => Ok(PortPoolConfig::default()),
     }
-}
-
-fn build_uas_helper(node: &NodeConfig, sip: &SipConfig) -> Result<Arc<UserAgentServer>> {
-    let local_uri = SipUri::parse(&sip_local_uri(node, sip))
-        .map_err(|e| anyhow!("synthesised SIP local URI is invalid: {e}"))?;
-    let contact_str = sip
-        .contact
-        .clone()
-        .unwrap_or_else(|| sip_local_uri(node, sip));
-    let contact_uri = SipUri::parse(&contact_str)
-        .map_err(|e| anyhow!("[sip].contact {contact_str:?} is not a valid SIP URI: {e}"))?;
-    Ok(Arc::new(UserAgentServer::new(local_uri, contact_uri)))
 }
 
 /// `sip:siphon@<host>` derived from `[sip].listen` (or

--- a/configs/local-dev.toml
+++ b/configs/local-dev.toml
@@ -1,0 +1,26 @@
+[node]
+id = "siphon-ai-local"
+
+[sip]
+listen = "127.0.0.1:5070"
+transports = ["udp"]
+user_agent = "SiphonAI/local-dev"
+
+[media]
+codecs = ["pcmu", "pcma"]
+dtmf = "rfc2833"
+rtp_port_range = [40000, 40100]
+
+[bridge]
+ws_url = "ws://127.0.0.1:8765/"
+ws_connect_timeout_ms = 3000
+audio_sample_rate = 8000
+
+[observability]
+enabled = true
+http_listen = "127.0.0.1:9091"
+
+[[route]]
+name = "default"
+[route.match]
+any = true

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -49,12 +49,13 @@
 //!   caller passes a list, but the daemon doesn't read it from
 //!   config yet.
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use sip_core::Request;
+use sip_uas::integrated::IntegratedUAS;
 use sip_uas::UserAgentServer;
 use siphon_ai_bridge::{
     AudioEncoding, AudioFormat, BridgeConfig, CallId as BridgeCallId, Direction, DisconnectReason,
@@ -420,11 +421,14 @@ fn default_call_id_factory() -> CallIdFactory {
 /// to "running [`CallController`]". Constructed once at daemon
 /// startup; cheap to clone (everything inside is `Arc` or `Clone`).
 ///
-/// `uas` is the upstream [`UserAgentServer`] the daemon already
-/// configures with its local URI / contact URI. We borrow its
-/// `create_ok` to stamp Contact + To-tag onto the 200 OK; sharing
-/// one instance per daemon (rather than rebuilding per call) keeps
-/// the deterministic-tag seed wiring upstream owns intact.
+/// `uas` is the [`IntegratedUAS`] the daemon already builds for the
+/// dispatcher. The acceptor uses [`IntegratedUAS::accept_invite`] to
+/// send the 200 OK so the confirmed dialog lands in the SAME dialog
+/// manager that dispatch consults on the follow-up BYE/REFER/INFO.
+/// Holding a parallel `UserAgentServer` here would silently produce
+/// an independent `dialog_manager`, making BYE come back as
+/// "Received BYE for unknown dialog" — see siphon-rs PR #35 for the
+/// upstream fix that exposes the canonical `accept_invite` helper.
 ///
 /// `registry` is the shared [`CallRegistry`] the SIP-side BYE /
 /// CANCEL handlers consult. The acceptor inserts a [`CallHandle`]
@@ -434,7 +438,12 @@ fn default_call_id_factory() -> CallIdFactory {
 pub struct BridgingAcceptor {
     media: Arc<MediaSetup>,
     defaults: BridgeDefaults,
-    uas: Arc<UserAgentServer>,
+    /// Late-bound: the daemon builds `BridgingAcceptor` first (so the
+    /// routing handler can hold an `Arc` to it), then builds the
+    /// `IntegratedUAS` that owns the routing handler, then calls
+    /// [`Self::install_uas`] to close the cycle. Tests that don't
+    /// drive `on_matched` (the only consumer) can leave it unset.
+    uas: OnceLock<Arc<IntegratedUAS>>,
     registry: CallRegistry,
     cdr_sink: CdrSinkHandle,
     webhook_sink: WebhookSinkHandle,
@@ -445,18 +454,28 @@ impl BridgingAcceptor {
     pub fn new(
         media: Arc<MediaSetup>,
         defaults: BridgeDefaults,
-        uas: Arc<UserAgentServer>,
         registry: CallRegistry,
     ) -> Self {
         Self {
             media,
             defaults,
-            uas,
+            uas: OnceLock::new(),
             registry,
             cdr_sink: Arc::new(NullSink),
             webhook_sink: Arc::new(WebhookNullSink),
             call_id_factory: default_call_id_factory(),
         }
+    }
+
+    /// Install the [`IntegratedUAS`] handle the acceptor uses to send
+    /// the 2xx via [`IntegratedUAS::accept_invite`]. Must be called
+    /// once after both this acceptor and its enclosing `IntegratedUAS`
+    /// are built; calling twice panics.
+    pub fn install_uas(&self, uas: Arc<IntegratedUAS>) {
+        self.uas
+            .set(uas)
+            .map_err(|_| ())
+            .expect("install_uas called twice on BridgingAcceptor");
     }
 
     /// Override the bridge call-id factory. Useful in tests where
@@ -623,13 +642,27 @@ impl CallAcceptor for BridgingAcceptor {
             .await
         {
             Ok(prepared) => {
-                // 200 OK with the negotiated SDP. Use the upstream
-                // helper so we get Contact + To-tag for free.
-                let response = self
+                // 200 OK with the negotiated SDP via the canonical
+                // upstream helper (siphon-rs PR #35). This builds the
+                // response, auto-fills Via/Contact/User-Agent, sends
+                // it through the transaction handle, AND registers
+                // the confirmed dialog with the dialog manager that
+                // `dispatch` consults — so the follow-up BYE finds
+                // it instead of falling through to "unknown dialog".
+                let uas = self
                     .uas
-                    .create_ok(call.request, Some(&prepared.answer.answer_text))
-                    .map_err(|e| anyhow::anyhow!("failed to build 200 OK: {e}"))?;
-                call.handle.send_final(response).await;
+                    .get()
+                    .ok_or_else(|| anyhow::anyhow!(
+                        "BridgingAcceptor::install_uas was not called; on_matched cannot accept INVITE without the IntegratedUAS handle"
+                    ))?;
+                uas.accept_invite(
+                    call.request,
+                    &call.handle,
+                    call.transport,
+                    Some(&prepared.answer.answer_text),
+                )
+                .await
+                .map_err(|e| anyhow::anyhow!("failed to accept INVITE: {e}"))?;
 
                 metrics::counter!(INVITES_TOTAL, "result" => "accepted").increment(1);
                 self.run_call(prepared, call.route.name.as_str());

--- a/crates/core/tests/acceptor_cdr.rs
+++ b/crates/core/tests/acceptor_cdr.rs
@@ -15,7 +15,6 @@ use futures::{SinkExt, StreamExt};
 use parking_lot::Mutex;
 use serde_json::Value;
 use sip_core::{Headers as SipHeaders, Method, Request, RequestLine, SipUri};
-use sip_uas::UserAgentServer;
 use siphon_ai_bridge::CallId as BridgeCallId;
 use siphon_ai_cdr::{CdrRecord, CdrSink, Direction as CdrDirection, TerminationCause};
 use siphon_ai_core::{BridgeDefaults, BridgingAcceptor, CallRegistry};
@@ -144,13 +143,10 @@ async fn run_call_emits_cdr_when_controller_exits() {
         bridge_mgr,
         "192.168.1.10",
     ));
-    let local = SipUri::parse("sip:siphon@192.168.1.10").unwrap();
-    let contact = SipUri::parse("sip:siphon@192.168.1.10").unwrap();
-    let uas = Arc::new(UserAgentServer::new(local, contact));
     let registry = CallRegistry::new();
     let recorder = Arc::new(Recorder::default());
 
-    let acceptor = BridgingAcceptor::new(media, BridgeDefaults::default(), uas, registry.clone())
+    let acceptor = BridgingAcceptor::new(media, BridgeDefaults::default(), registry.clone())
         .with_call_id_factory(Arc::new(|| BridgeCallId::new("siphon-cdr-test")))
         .with_cdr_sink(Arc::clone(&recorder) as Arc<dyn CdrSink>);
 
@@ -231,11 +227,8 @@ async fn null_sink_is_the_default_when_no_sink_configured() {
         bridge_mgr,
         "192.168.1.10",
     ));
-    let local = SipUri::parse("sip:siphon@192.168.1.10").unwrap();
-    let contact = SipUri::parse("sip:siphon@192.168.1.10").unwrap();
-    let uas = Arc::new(UserAgentServer::new(local, contact));
     let registry = CallRegistry::new();
-    let acceptor = BridgingAcceptor::new(media, BridgeDefaults::default(), uas, registry.clone())
+    let acceptor = BridgingAcceptor::new(media, BridgeDefaults::default(), registry.clone())
         .with_call_id_factory(Arc::new(|| BridgeCallId::new("siphon-null-cdr")));
 
     let routes = one_route(ws_url);

--- a/crates/core/tests/acceptor_metrics.rs
+++ b/crates/core/tests/acceptor_metrics.rs
@@ -15,7 +15,6 @@ use forge_rtp::PortPoolConfig;
 use futures::{SinkExt, StreamExt};
 use serde_json::Value;
 use sip_core::{Headers as SipHeaders, Method, Request, RequestLine, SipUri};
-use sip_uas::UserAgentServer;
 use siphon_ai_bridge::CallId as BridgeCallId;
 use siphon_ai_core::{BridgeDefaults, BridgingAcceptor, CallRegistry};
 use siphon_ai_media_glue::MediaSetup;
@@ -131,11 +130,8 @@ fn build_acceptor() -> (BridgingAcceptor, Arc<MediaBridgeManager>, CallRegistry)
         Arc::clone(&bridge_mgr),
         "192.168.1.10",
     ));
-    let local = SipUri::parse("sip:siphon@192.168.1.10").unwrap();
-    let contact = SipUri::parse("sip:siphon@192.168.1.10").unwrap();
-    let uas = Arc::new(UserAgentServer::new(local, contact));
     let registry = CallRegistry::new();
-    let acceptor = BridgingAcceptor::new(media, BridgeDefaults::default(), uas, registry.clone())
+    let acceptor = BridgingAcceptor::new(media, BridgeDefaults::default(), registry.clone())
         .with_call_id_factory(Arc::new(|| BridgeCallId::new("siphon-metrics-test")));
     (acceptor, bridge_mgr, registry)
 }

--- a/crates/core/tests/acceptor_prepare.rs
+++ b/crates/core/tests/acceptor_prepare.rs
@@ -14,7 +14,6 @@ use forge_engine::{MediaBridgeManager, SessionManager, SessionManagerConfig};
 use forge_rtp::PortPoolConfig;
 use forge_sdp::{MediaType, SessionDescription, SessionDescriptionExt};
 use sip_core::{Headers as SipHeaders, Method, Request, RequestLine, SipUri};
-use sip_uas::UserAgentServer;
 use siphon_ai_bridge::{AudioEncoding, CallId as BridgeCallId, Direction, PROTOCOL_VERSION};
 use siphon_ai_core::{AcceptError, BridgeDefaults, BridgingAcceptor, CallRegistry};
 use siphon_ai_media_glue::MediaSetup;
@@ -101,12 +100,9 @@ fn build_acceptor(
         forward_headers: vec!["User-Agent".into()],
         ..BridgeDefaults::default()
     };
-    let local = SipUri::parse("sip:siphon@192.168.1.10").unwrap();
-    let contact = SipUri::parse("sip:siphon@192.168.1.10").unwrap();
-    let uas = Arc::new(UserAgentServer::new(local, contact));
     let registry = CallRegistry::new();
     (
-        BridgingAcceptor::new(media, defaults, uas, registry.clone())
+        BridgingAcceptor::new(media, defaults, registry.clone())
             .with_call_id_factory(Arc::new(|| BridgeCallId::new("siphon-test-fixed"))),
         bridge_mgr,
         session_mgr,
@@ -235,11 +231,8 @@ async fn route_without_ws_url_when_no_default_yields_503() {
         Arc::clone(&bridge_mgr),
         "192.168.1.10",
     ));
-    let local = SipUri::parse("sip:siphon@192.168.1.10").unwrap();
-    let contact = SipUri::parse("sip:siphon@192.168.1.10").unwrap();
-    let uas = Arc::new(UserAgentServer::new(local, contact));
     let acceptor =
-        BridgingAcceptor::new(media, BridgeDefaults::default(), uas, CallRegistry::new());
+        BridgingAcceptor::new(media, BridgeDefaults::default(), CallRegistry::new());
 
     let routes = load_from_toml(
         r#"
@@ -315,11 +308,8 @@ async fn second_call_gets_a_fresh_forge_session() {
         Arc::clone(&bridge_mgr),
         "192.168.1.10",
     ));
-    let local = SipUri::parse("sip:siphon@192.168.1.10").unwrap();
-    let contact = SipUri::parse("sip:siphon@192.168.1.10").unwrap();
-    let uas = Arc::new(UserAgentServer::new(local, contact));
     let acceptor =
-        BridgingAcceptor::new(media, BridgeDefaults::default(), uas, CallRegistry::new());
+        BridgingAcceptor::new(media, BridgeDefaults::default(), CallRegistry::new());
 
     // We need a default ws_url so prepare_call accepts the offer.
     let routes = load_from_toml(

--- a/crates/core/tests/acceptor_webhooks.rs
+++ b/crates/core/tests/acceptor_webhooks.rs
@@ -15,7 +15,6 @@ use futures::{SinkExt, StreamExt};
 use parking_lot::Mutex;
 use serde_json::Value;
 use sip_core::{Headers as SipHeaders, Method, Request, RequestLine, SipUri};
-use sip_uas::UserAgentServer;
 use siphon_ai_bridge::CallId as BridgeCallId;
 use siphon_ai_core::{BridgeDefaults, BridgingAcceptor, CallRegistry};
 use siphon_ai_media_glue::MediaSetup;
@@ -134,13 +133,10 @@ async fn run_call_emits_call_start_then_call_end() {
         bridge_mgr,
         "192.168.1.10",
     ));
-    let local = SipUri::parse("sip:siphon@192.168.1.10").unwrap();
-    let contact = SipUri::parse("sip:siphon@192.168.1.10").unwrap();
-    let uas = Arc::new(UserAgentServer::new(local, contact));
     let registry = CallRegistry::new();
     let recorder = Arc::new(Recorder::default());
 
-    let acceptor = BridgingAcceptor::new(media, BridgeDefaults::default(), uas, registry.clone())
+    let acceptor = BridgingAcceptor::new(media, BridgeDefaults::default(), registry.clone())
         .with_call_id_factory(Arc::new(|| BridgeCallId::new("siphon-webhook-test")))
         .with_webhook_sink(Arc::clone(&recorder) as Arc<dyn WebhookSink>);
 
@@ -221,11 +217,8 @@ async fn null_webhook_sink_is_the_default() {
         bridge_mgr,
         "192.168.1.10",
     ));
-    let local = SipUri::parse("sip:siphon@192.168.1.10").unwrap();
-    let contact = SipUri::parse("sip:siphon@192.168.1.10").unwrap();
-    let uas = Arc::new(UserAgentServer::new(local, contact));
     let registry = CallRegistry::new();
-    let acceptor = BridgingAcceptor::new(media, BridgeDefaults::default(), uas, registry.clone())
+    let acceptor = BridgingAcceptor::new(media, BridgeDefaults::default(), registry.clone())
         .with_call_id_factory(Arc::new(|| BridgeCallId::new("siphon-null-webhook")));
 
     let routes = one_route(&ws_url);


### PR DESCRIPTION
## Summary

Inbound calls were leaking on the server side: `BridgingAcceptor` built
its 200 OK with `UserAgentServer::create_ok` and sent it via
`handle.send_final` directly, which **bypassed dialog tracking**. The
resulting confirmed dialog never landed in the dispatcher's dialog
manager, so the next BYE on the call dispatched as
\"Received BYE for unknown dialog\" → 481, the controller never tore
down, and `siphon_ai_calls_active` climbed monotonically with every
test call. Worse, `BridgingAcceptor` held its OWN `Arc<UserAgentServer>`
instance separate from the one `IntegratedUAS` builds internally, so
the two dialog managers were independent — calling `accept_invite` on
the wrong one wouldn't have helped either.

Switches the accept path to the canonical upstream helper from
[siphon-rs#35](https://github.com/thevoiceguy/siphon-rs/pull/35):
`IntegratedUAS::accept_invite(request, &handle, ctx, sdp_body)` —
builds the 2xx, auto-fills Via/Contact/User-Agent, sends through the
handle, AND registers the confirmed dialog with the dialog_manager
that the dispatcher's BYE/REFER/INFO arms consult.

## Changes

- `BridgingAcceptor` late-binds an `Arc<IntegratedUAS>` via a new
  `install_uas` setter (closes the BridgingAcceptor ↔ RoutingHandler
  ↔ IntegratedUAS cycle in the daemon runtime).
- `BridgingAcceptor::new` no longer takes a `uas` arg — tests that
  never drove `on_matched` lose their no-op `let uas = ...` setup.
- Daemon `runtime.rs` drops `build_uas_helper` and the parallel
  `Arc<UserAgentServer>`. One `IntegratedUAS`-owned helper now owns
  the shared dialog_manager.
- `Cargo.toml` pins the siphon-rs deps to the fix branch
  (`fix/integrated-uas-accept-invite-tracks-dialog`); flip back to
  `branch = \"main\"` once siphon-rs#35 merges.
- Adds `configs/local-dev.toml` as the minimal-viable single-route
  config used to reproduce the bug and validate the fix.

## Test plan

- [x] `cargo test --workspace --no-fail-fast` — all crates green
- [x] SIPp UAC scenario INVITE → 200 OK → ACK → pause → BYE → 200 OK:
  - SIPp screen: `Successful call: 1`, `Failed call: 0`, `BYE 200 <---- 1`
  - daemon log: `BYE → controller shutdown → Terminating → Done`
  - `curl /metrics` shows `siphon_ai_calls_active 0` post-call
    (previously: stayed at 1+ because BYE was rejected as unknown
    dialog and the controller never received the shutdown signal)

## Depends on

[thevoiceguy/siphon-rs#35](https://github.com/thevoiceguy/siphon-rs/pull/35).
This PR can land first behind that pin; once siphon-rs#35 merges, a
follow-up flips the Cargo.toml branch back to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)