### PR TITLE
feat(week3): wire RFC-2833 DTMF detect → BridgeOut::Dtmf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2616,6 +2616,7 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "bytes",
+ "chrono",
  "forge-codecs",
  "forge-core",
  "forge-dtmf",

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -53,6 +53,7 @@ use std::time::Duration;
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
+use forge_core::EventBus as ForgeEventBus;
 use forge_engine::{MediaBridgeManager, SessionManager, SessionManagerConfig};
 use forge_rtp::PortPoolConfig;
 use sip_parse::{parse_request, parse_response};
@@ -138,11 +139,18 @@ impl Runtime {
         let webhook_sink_for_registrations = Arc::clone(&webhook_sink);
 
         // ─── Forge media stack ──────────────────────────────────────
+        // One process-wide EventBus. Forge's session manager publishes
+        // ForgeEvents (DTMF detect, session-state, quality reports) on
+        // it; per-call MediaTaps subscribe and forward the ones the
+        // bridge protocol covers (currently DTMF) over the WS as
+        // BridgeOut events.
+        let event_bus = Arc::new(ForgeEventBus::new());
+
         let session_mgr_config = SessionManagerConfig {
             port_pool_config: rtp_port_pool(&media)?,
             ..Default::default()
         };
-        let session_mgr = SessionManager::new(session_mgr_config, None);
+        let session_mgr = SessionManager::new(session_mgr_config, Some(Arc::clone(&event_bus)));
         // Background task that reaps idle sessions per
         // SessionManagerConfig::cleanup_interval. Must run for forge
         // to enforce its session_timeout.
@@ -152,6 +160,7 @@ impl Runtime {
         let media_setup = Arc::new(MediaSetup::new(
             Arc::clone(&session_mgr),
             Arc::clone(&bridge_mgr),
+            Arc::clone(&event_bus),
             node.public_address.clone(),
         ));
 

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -664,6 +664,28 @@ impl CallAcceptor for BridgingAcceptor {
                 .await
                 .map_err(|e| anyhow::anyhow!("failed to accept INVITE: {e}"))?;
 
+                // Start forge's RTP forwarding loop — this is what
+                // decodes inbound audio, runs the RFC-2833 detector,
+                // and publishes ForgeEvent::DtmfDigitDetected to the
+                // EventBus our taps subscribe to. Skipping it would
+                // leave the call silent and DTMF unheard, even though
+                // the SDP/200-OK round-trip looks healthy. forge's
+                // internal state requires Initializing → Active here;
+                // calling twice errors loudly, so do it exactly once
+                // per accepted INVITE.
+                if let Err(e) = self
+                    .media
+                    .session_manager()
+                    .start_session(&prepared.forge_call_id)
+                    .await
+                {
+                    warn!(
+                        call_id = %prepared.bridge_call_id,
+                        error = %e,
+                        "forge start_session failed; call will be silent",
+                    );
+                }
+
                 metrics::counter!(INVITES_TOTAL, "result" => "accepted").increment(1);
                 self.run_call(prepared, call.route.name.as_str());
                 Ok(())

--- a/crates/core/src/call.rs
+++ b/crates/core/src/call.rs
@@ -250,8 +250,14 @@ impl CallController {
 
         let mut bridge_task: JoinHandle<Result<DisconnectReason, BridgeError>> =
             tokio::spawn(connect_and_run(bridge, start, channels));
-        let mut tap_task: JoinHandle<Result<TapDisconnect, MediaTapError>> =
-            tokio::spawn(media_tap.run(caller_audio_tx, playout_audio_rx));
+        // The tap forwards out-of-band events (currently DTMF) onto
+        // the same control stream the bridge reads. Cloning the
+        // sender means tap and controller are independent producers
+        // — bridge teardown closes the receiver, both producers see
+        // the same EOF.
+        let mut tap_task: JoinHandle<Result<TapDisconnect, MediaTapError>> = tokio::spawn(
+            media_tap.run(caller_audio_tx, playout_audio_rx, control_out_tx.clone()),
+        );
 
         // We don't wait for the bridge handshake to declare
         // Active; the moment both tasks are spawned, audio plumbing

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -145,7 +145,7 @@ mod tests {
     fn fresh_handle(bridge_call_id: &str) -> CallHandle {
         let manager = Arc::new(MediaBridgeManager::new());
         let tap =
-            MediaTap::attach(&manager, ForgeCallId::new(bridge_call_id), 8000).expect("attach tap");
+            MediaTap::attach(&manager, &::std::sync::Arc::new(forge_core::EventBus::new()), ForgeCallId::new(bridge_call_id), 8000).expect("attach tap");
         let cfg = CallControllerConfig {
             call_id: BridgeCallId::new(bridge_call_id),
             bridge: BridgeConfig {

--- a/crates/core/tests/acceptor_cdr.rs
+++ b/crates/core/tests/acceptor_cdr.rs
@@ -141,6 +141,7 @@ async fn run_call_emits_cdr_when_controller_exits() {
     let media = Arc::new(MediaSetup::new(
         Arc::clone(&session_mgr),
         bridge_mgr,
+            Arc::new(forge_core::EventBus::new()),
         "192.168.1.10",
     ));
     let registry = CallRegistry::new();
@@ -225,6 +226,7 @@ async fn null_sink_is_the_default_when_no_sink_configured() {
     let media = Arc::new(MediaSetup::new(
         Arc::clone(&session_mgr),
         bridge_mgr,
+            Arc::new(forge_core::EventBus::new()),
         "192.168.1.10",
     ));
     let registry = CallRegistry::new();

--- a/crates/core/tests/acceptor_metrics.rs
+++ b/crates/core/tests/acceptor_metrics.rs
@@ -128,6 +128,7 @@ fn build_acceptor() -> (BridgingAcceptor, Arc<MediaBridgeManager>, CallRegistry)
     let media = Arc::new(MediaSetup::new(
         Arc::clone(&session_mgr),
         Arc::clone(&bridge_mgr),
+            Arc::new(forge_core::EventBus::new()),
         "192.168.1.10",
     ));
     let registry = CallRegistry::new();

--- a/crates/core/tests/acceptor_prepare.rs
+++ b/crates/core/tests/acceptor_prepare.rs
@@ -94,6 +94,7 @@ fn build_acceptor(
     let media = Arc::new(MediaSetup::new(
         Arc::clone(&session_mgr),
         Arc::clone(&bridge_mgr),
+            Arc::new(forge_core::EventBus::new()),
         "192.168.1.10",
     ));
     let defaults = BridgeDefaults {
@@ -229,6 +230,7 @@ async fn route_without_ws_url_when_no_default_yields_503() {
     let media = Arc::new(MediaSetup::new(
         Arc::clone(&session_mgr),
         Arc::clone(&bridge_mgr),
+            Arc::new(forge_core::EventBus::new()),
         "192.168.1.10",
     ));
     let acceptor =
@@ -306,6 +308,7 @@ async fn second_call_gets_a_fresh_forge_session() {
     let media = Arc::new(MediaSetup::new(
         Arc::clone(&session_mgr),
         Arc::clone(&bridge_mgr),
+            Arc::new(forge_core::EventBus::new()),
         "192.168.1.10",
     ));
     let acceptor =

--- a/crates/core/tests/acceptor_webhooks.rs
+++ b/crates/core/tests/acceptor_webhooks.rs
@@ -131,6 +131,7 @@ async fn run_call_emits_call_start_then_call_end() {
     let media = Arc::new(MediaSetup::new(
         Arc::clone(&session_mgr),
         bridge_mgr,
+            Arc::new(forge_core::EventBus::new()),
         "192.168.1.10",
     ));
     let registry = CallRegistry::new();
@@ -215,6 +216,7 @@ async fn null_webhook_sink_is_the_default() {
     let media = Arc::new(MediaSetup::new(
         Arc::clone(&session_mgr),
         bridge_mgr,
+            Arc::new(forge_core::EventBus::new()),
         "192.168.1.10",
     ));
     let registry = CallRegistry::new();

--- a/crates/core/tests/controller_lifecycle.rs
+++ b/crates/core/tests/controller_lifecycle.rs
@@ -91,7 +91,7 @@ fn echo_subprotocol(
 
 fn make_controller(port: u16, call_id: &str) -> (CallController, siphon_ai_core::CallHandle) {
     let manager = Arc::new(MediaBridgeManager::new());
-    let tap = MediaTap::attach(&manager, ForgeCallId::new(call_id), 8000).expect("attach tap");
+    let tap = MediaTap::attach(&manager, &::std::sync::Arc::new(forge_core::EventBus::new()), ForgeCallId::new(call_id), 8000).expect("attach tap");
     // Keep the manager alive for the duration of the call by
     // leaking it intentionally — in production the daemon owns the
     // manager. Tests deliberately don't tear it down between calls.

--- a/crates/core/tests/registry_bye.rs
+++ b/crates/core/tests/registry_bye.rs
@@ -96,7 +96,7 @@ async fn dispatch_bye_wakes_running_controller_via_registry() {
     // 2. Build a controller around a real MediaTap + WS bridge.
     let manager = Arc::new(MediaBridgeManager::new());
     let forge_call_id = ForgeCallId::new("siphon-bye-test");
-    let tap = MediaTap::attach(&manager, forge_call_id, 8000).expect("attach");
+    let tap = MediaTap::attach(&manager, &::std::sync::Arc::new(forge_core::EventBus::new()), forge_call_id, 8000).expect("attach");
     let cfg = CallControllerConfig {
         call_id: BridgeCallId::new("siphon-bye-test"),
         bridge: BridgeConfig {

--- a/crates/media-glue/Cargo.toml
+++ b/crates/media-glue/Cargo.toml
@@ -26,3 +26,8 @@ forge-engine.workspace = true
 forge-codecs.workspace = true
 forge-sdp.workspace    = true
 forge-dtmf.workspace   = true
+
+[dev-dependencies]
+# `chrono` is in our forge_core::ForgeEvent::DtmfDigitDetected
+# `timestamp` field, used in tests that publish synthesised events.
+chrono.workspace = true

--- a/crates/media-glue/src/setup.rs
+++ b/crates/media-glue/src/setup.rs
@@ -41,7 +41,7 @@
 
 use std::sync::Arc;
 
-use forge_core::{CallId, ForgeError, ParticipantId};
+use forge_core::{CallId, EventBus, ForgeError, ParticipantId};
 use forge_engine::{
     MediaBridgeManager, MediaSession, ParticipantCodecConfig, ParticipantLabel,
     ParticipantMediaUpdate, SessionManager,
@@ -55,10 +55,15 @@ use crate::sdp::{
 use crate::tap::{MediaTap, MediaTapError};
 
 /// Daemon-wide handles `MediaSetup` needs once at startup. Cheap to
-/// clone — both managers are already `Arc`-ed.
+/// clone — every field is already `Arc`-ed.
 pub struct MediaSetup {
     session_manager: Arc<SessionManager>,
     bridge_manager: Arc<MediaBridgeManager>,
+    /// Same `EventBus` the [`SessionManager`] publishes to. Each tap
+    /// `subscribe()`s here so per-call DTMF / VAD / quality events
+    /// reach the bridge layer without going through forge's
+    /// session-internal channels.
+    event_bus: Arc<EventBus>,
     /// IP that goes into the answer's `c=` and `o=` lines. Same
     /// address forge's RTP socket is bound to (or the public-facing
     /// address when behind 1:1 NAT — left to deployment config).
@@ -140,11 +145,13 @@ impl MediaSetup {
     pub fn new(
         session_manager: Arc<SessionManager>,
         bridge_manager: Arc<MediaBridgeManager>,
+        event_bus: Arc<EventBus>,
         local_ip: impl Into<String>,
     ) -> Self {
         Self {
             session_manager,
             bridge_manager,
+            event_bus,
             local_ip: local_ip.into(),
         }
     }
@@ -155,6 +162,10 @@ impl MediaSetup {
 
     pub fn bridge_manager(&self) -> &Arc<MediaBridgeManager> {
         &self.bridge_manager
+    }
+
+    pub fn event_bus(&self) -> &Arc<EventBus> {
+        &self.event_bus
     }
 
     pub fn local_ip(&self) -> &str {
@@ -233,6 +244,7 @@ impl MediaSetup {
 
         let tap = MediaTap::attach(
             &self.bridge_manager,
+            &self.event_bus,
             call.call_id.clone(),
             answer.negotiated_audio_sample_rate,
         )?;
@@ -340,6 +352,7 @@ mod tests {
         let setup = MediaSetup::new(
             Arc::clone(&session_mgr),
             Arc::clone(&bridge_mgr),
+            Arc::new(forge_core::EventBus::new()),
             "127.0.0.1",
         );
 

--- a/crates/media-glue/src/tap.rs
+++ b/crates/media-glue/src/tap.rs
@@ -41,21 +41,32 @@
 //!   committed to in `start.audio.sample_rate`. A mid-call codec
 //!   switch that changes the rate yields a fatal `SampleRateMismatch`.
 //!
+//! ## DTMF events
+//!
+//! The tap subscribes to the daemon-wide [`EventBus`] forge publishes
+//! to. When a [`ForgeEvent::DtmfDigitDetected`] for *this* call's
+//! `call_id` arrives — and only on the `End` of the press, so each
+//! press maps to one WS event with a final `duration_ms` — we forward
+//! it through the supplied [`OutgoingEvent`] sender as
+//! `OutgoingEvent::Dtmf`. The bridge crate stamps `call_id` and `seq`
+//! and writes the JSON `dtmf` text frame on the WS.
+//!
 //! ## Not yet wired
 //!
-//! - DTMF / VAD events (forge `ForgeEvent` broadcast bus → channel to
-//!   the controller). Tracked as a follow-up; the audio path here is
-//!   independent.
+//! - VAD `speech_started` / `speech_stopped`. Forge has the detector
+//!   surface; we just don't have a `ForgeEvent` variant for it yet.
 
 use std::sync::Arc;
 
-use forge_core::{CallId, ForgeError};
+use forge_core::{CallId, DtmfDetectionMethod, DtmfEventKind, EventBus, ForgeError, ForgeEvent};
 use forge_engine::{
     MediaBridgeHandle, MediaBridgeManager, MediaTarget, OutboundMediaFrame, PlayoutMode,
 };
-use siphon_ai_bridge::{pack_pcm16_le, unpack_pcm16_le, AudioError, Reframer};
+use siphon_ai_bridge::{
+    pack_pcm16_le, unpack_pcm16_le, AudioError, DtmfMethod, OutgoingEvent, Reframer,
+};
 use thiserror::Error;
-use tokio::sync::mpsc;
+use tokio::sync::{broadcast, mpsc};
 use tracing::{debug, instrument, warn};
 
 #[derive(Debug, Error)]
@@ -99,6 +110,13 @@ pub struct MediaTap {
     handle: MediaBridgeHandle,
     sample_rate: u32,
     call_id: CallId,
+    /// Subscription to the daemon-wide forge [`EventBus`]. The tap
+    /// filters for events matching its own `call_id`. Subscribing at
+    /// `attach` time (rather than inside `run`) means events emitted
+    /// between attach and run are still buffered for us — the
+    /// broadcast channel's per-receiver queue holds up to the bus's
+    /// configured capacity.
+    events_rx: broadcast::Receiver<ForgeEvent>,
 }
 
 impl std::fmt::Debug for MediaTap {
@@ -113,7 +131,8 @@ impl std::fmt::Debug for MediaTap {
 
 impl MediaTap {
     /// Attach a new tap for `call_id` against the process-wide
-    /// `MediaBridgeManager`.
+    /// `MediaBridgeManager` and subscribe to the supplied `EventBus`
+    /// (the same bus forge's session manager publishes on).
     ///
     /// Fails with [`MediaTapError::AttachFailed`] if a tap is already
     /// attached for the same call (forge enforces 1 handle per call).
@@ -121,6 +140,7 @@ impl MediaTap {
     /// audio module's rules (8 kHz or 16 kHz only in v1).
     pub fn attach(
         manager: &Arc<MediaBridgeManager>,
+        event_bus: &Arc<EventBus>,
         call_id: CallId,
         sample_rate: u32,
     ) -> Result<Self, MediaTapError> {
@@ -130,10 +150,12 @@ impl MediaTap {
         let handle = manager
             .attach_call(call_id.clone())
             .map_err(forge_attach_err)?;
+        let events_rx = event_bus.subscribe();
         Ok(Self {
             handle,
             sample_rate,
             call_id,
+            events_rx,
         })
     }
 
@@ -155,11 +177,16 @@ impl MediaTap {
     /// - `playout_audio_rx`: bytes the bridge crate received from the
     ///   WS server arrive here; the tap unpacks and hands them to
     ///   forge for playout into the SIP leg.
+    /// - `events_tx`: out-of-band [`OutgoingEvent`]s the tap derives
+    ///   from forge's event bus (currently only DTMF). The bridge
+    ///   crate stamps `call_id` + `seq` and writes the JSON text
+    ///   frame on the WS.
     #[instrument(skip_all, fields(call_id = %self.call_id, sample_rate = self.sample_rate))]
     pub async fn run(
         mut self,
         caller_audio_tx: mpsc::Sender<Vec<u8>>,
         mut playout_audio_rx: mpsc::Receiver<Vec<u8>>,
+        events_tx: mpsc::Sender<OutgoingEvent>,
     ) -> Result<TapDisconnect, MediaTapError> {
         let mut reframer = Reframer::new(self.sample_rate)?;
 
@@ -221,8 +248,81 @@ impl MediaTap {
                         }
                     }
                 }
+
+                // Forge events (currently only DTMF). Filter to this
+                // call_id; map End-of-press to a single OutgoingEvent.
+                event = self.events_rx.recv() => {
+                    match event {
+                        Ok(ev) => {
+                            if let Some(out) = derive_outgoing_event(&self.call_id, ev) {
+                                if events_tx.send(out).await.is_err() {
+                                    debug!("events_tx closed; ending tap");
+                                    return Ok(TapDisconnect::ControllerHungUp);
+                                }
+                            }
+                        }
+                        Err(broadcast::error::RecvError::Lagged(n)) => {
+                            // The broadcast queue overflowed for this
+                            // subscriber. Per CLAUDE.md §4.5 we never
+                            // panic on the audio path; just log and
+                            // resume — events from the lag window are
+                            // best-effort by definition.
+                            warn!(skipped = n, "tap event subscriber lagged");
+                        }
+                        Err(broadcast::error::RecvError::Closed) => {
+                            debug!("forge event bus closed; tap continues without events");
+                            // Falling through to the next iteration
+                            // would spin on an immediately-ready Closed
+                            // arm. Replace the receiver with one that
+                            // blocks forever instead.
+                            let (_dummy_tx, dummy_rx) = broadcast::channel(1);
+                            self.events_rx = dummy_rx;
+                        }
+                    }
+                }
             }
         }
+    }
+}
+
+/// Map a forge `ForgeEvent` to an `OutgoingEvent` the bridge can ship.
+///
+/// Returns `None` for events that aren't this call's, that aren't part
+/// of the v1 WS protocol surface, or that don't carry the final
+/// duration we need (DTMF `Start`/`Continue`).
+fn derive_outgoing_event(call_id: &CallId, event: ForgeEvent) -> Option<OutgoingEvent> {
+    match event {
+        ForgeEvent::DtmfDigitDetected {
+            call_id: ev_call,
+            digit,
+            duration_ms,
+            method,
+            event_type: DtmfEventKind::End,
+            ..
+        } if &ev_call == call_id => Some(OutgoingEvent::Dtmf {
+            digit,
+            // RFC 2833 detection always reports duration, but the
+            // ForgeEvent type is Option to model SIP INFO. Fall back
+            // to 0 — the bridge protocol's `duration_ms` is u32 and
+            // a missing duration on End is forge giving up; we still
+            // emit the press so the WS server isn't left guessing.
+            duration_ms: duration_ms.unwrap_or(0),
+            method: map_dtmf_method(method),
+        }),
+        _ => None,
+    }
+}
+
+fn map_dtmf_method(method: DtmfDetectionMethod) -> DtmfMethod {
+    match method {
+        DtmfDetectionMethod::Rfc2833 => DtmfMethod::Rfc2833,
+        DtmfDetectionMethod::Inband => DtmfMethod::Inband,
+        // SIP INFO DTMF rides on the SIP layer (not RTP), so the
+        // bridge's RTP-derived `method` enum has no slot for it. v1's
+        // SIP layer doesn't surface INFO DTMF anyway; map it to
+        // Inband so a future change here doesn't break wire shape if
+        // forge ever publishes one.
+        DtmfDetectionMethod::SipInfo => DtmfMethod::Inband,
     }
 }
 
@@ -239,7 +339,7 @@ mod tests {
         // We don't need a manager for the failure path: validation
         // happens before attach_call is invoked.
         let manager = Arc::new(MediaBridgeManager::new());
-        let err = MediaTap::attach(&manager, CallId::new("c"), 48000).unwrap_err();
+        let err = MediaTap::attach(&manager, &::std::sync::Arc::new(forge_core::EventBus::new()), CallId::new("c"), 48000).unwrap_err();
         assert!(matches!(err, MediaTapError::Audio(_)));
     }
 
@@ -248,7 +348,7 @@ mod tests {
         let manager = Arc::new(MediaBridgeManager::new());
         let call = CallId::new("c");
         {
-            let tap = MediaTap::attach(&manager, call.clone(), 8000).expect("attach");
+            let tap = MediaTap::attach(&manager, &::std::sync::Arc::new(forge_core::EventBus::new()), call.clone(), 8000).expect("attach");
             assert_eq!(tap.sample_rate(), 8000);
             assert_eq!(tap.call_id(), &call);
             assert!(manager.has_bridge(&call));
@@ -261,8 +361,8 @@ mod tests {
     fn attach_twice_for_same_call_fails() {
         let manager = Arc::new(MediaBridgeManager::new());
         let call = CallId::new("c");
-        let _t1 = MediaTap::attach(&manager, call.clone(), 8000).expect("first attach");
-        let err = MediaTap::attach(&manager, call, 8000).unwrap_err();
+        let _t1 = MediaTap::attach(&manager, &::std::sync::Arc::new(forge_core::EventBus::new()), call.clone(), 8000).expect("first attach");
+        let err = MediaTap::attach(&manager, &::std::sync::Arc::new(forge_core::EventBus::new()), call, 8000).unwrap_err();
         assert!(matches!(err, MediaTapError::AttachFailed(_)));
     }
 }

--- a/crates/media-glue/tests/setup.rs
+++ b/crates/media-glue/tests/setup.rs
@@ -54,6 +54,7 @@ fn fresh_setup(
     let setup = MediaSetup::new(
         Arc::clone(&session_mgr),
         Arc::clone(&bridge_mgr),
+            Arc::new(forge_core::EventBus::new()),
         "192.168.1.10",
     );
     (setup, session_mgr, bridge_mgr)
@@ -152,7 +153,7 @@ async fn pre_attached_tap_pumps_real_audio() {
 
     let (caller_tx, mut caller_rx) = mpsc::channel::<Vec<u8>>(10);
     let (playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
-    let pump = tokio::spawn(accepted.tap.run(caller_tx, playout_rx));
+    let pump = tokio::spawn(accepted.tap.run(caller_tx, playout_rx, ::tokio::sync::mpsc::channel::<::siphon_ai_bridge::OutgoingEvent>(1).0));
 
     // Push 20 ms of inbound at 8 kHz (160 samples).
     let pattern: Vec<i16> = (0..160).map(|i| (i as i16) * 3).collect();

--- a/crates/media-glue/tests/tap.rs
+++ b/crates/media-glue/tests/tap.rs
@@ -36,12 +36,12 @@ fn synth_inbound(seq: u16, sample_rate: u32, samples: Vec<i16>) -> InboundMediaF
 async fn inbound_audio_reframed_and_packed_to_caller_channel() {
     let manager = Arc::new(MediaBridgeManager::with_capacities(10, 10));
     let call = CallId::new("c");
-    let tap = MediaTap::attach(&manager, call.clone(), 8000).expect("attach");
+    let tap = MediaTap::attach(&manager, &::std::sync::Arc::new(forge_core::EventBus::new()), call.clone(), 8000).expect("attach");
 
     let (caller_tx, mut caller_rx) = mpsc::channel::<Vec<u8>>(10);
     let (_playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
 
-    let pump = tokio::spawn(tap.run(caller_tx, playout_rx));
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, ::tokio::sync::mpsc::channel::<::siphon_ai_bridge::OutgoingEvent>(1).0));
 
     // Push a 20 ms frame of pattern data; the tap should emit one
     // packed wire frame.
@@ -74,11 +74,11 @@ async fn small_inbound_frames_are_buffered_until_a_full_20ms_is_available() {
     // collect two 10 ms frames into one 20 ms wire frame.
     let manager = Arc::new(MediaBridgeManager::with_capacities(10, 10));
     let call = CallId::new("c");
-    let tap = MediaTap::attach(&manager, call.clone(), 8000).expect("attach");
+    let tap = MediaTap::attach(&manager, &::std::sync::Arc::new(forge_core::EventBus::new()), call.clone(), 8000).expect("attach");
 
     let (caller_tx, mut caller_rx) = mpsc::channel::<Vec<u8>>(10);
     let (_playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
-    let pump = tokio::spawn(tap.run(caller_tx, playout_rx));
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, ::tokio::sync::mpsc::channel::<::siphon_ai_bridge::OutgoingEvent>(1).0));
 
     // Two 10 ms half-frames at 8 kHz = 80 samples each.
     manager
@@ -105,11 +105,11 @@ async fn small_inbound_frames_are_buffered_until_a_full_20ms_is_available() {
 async fn outbound_audio_unpacked_and_handed_to_forge() {
     let manager = Arc::new(MediaBridgeManager::with_capacities(10, 10));
     let call = CallId::new("c");
-    let tap = MediaTap::attach(&manager, call.clone(), 8000).expect("attach");
+    let tap = MediaTap::attach(&manager, &::std::sync::Arc::new(forge_core::EventBus::new()), call.clone(), 8000).expect("attach");
 
     let (caller_tx, _caller_rx) = mpsc::channel::<Vec<u8>>(10);
     let (playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
-    let pump = tokio::spawn(tap.run(caller_tx, playout_rx));
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, ::tokio::sync::mpsc::channel::<::siphon_ai_bridge::OutgoingEvent>(1).0));
 
     // Send a 20 ms frame's worth of wire bytes.
     let samples: Vec<i16> = (10..170).collect();
@@ -146,11 +146,11 @@ async fn outbound_audio_unpacked_and_handed_to_forge() {
 async fn sample_rate_mismatch_yields_error() {
     let manager = Arc::new(MediaBridgeManager::with_capacities(10, 10));
     let call = CallId::new("c");
-    let tap = MediaTap::attach(&manager, call.clone(), 8000).expect("attach");
+    let tap = MediaTap::attach(&manager, &::std::sync::Arc::new(forge_core::EventBus::new()), call.clone(), 8000).expect("attach");
 
     let (caller_tx, _caller_rx) = mpsc::channel::<Vec<u8>>(10);
     let (_playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
-    let pump = tokio::spawn(tap.run(caller_tx, playout_rx));
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, ::tokio::sync::mpsc::channel::<::siphon_ai_bridge::OutgoingEvent>(1).0));
 
     // Push a frame at the WRONG rate.
     manager
@@ -174,11 +174,11 @@ async fn sample_rate_mismatch_yields_error() {
 async fn malformed_outbound_bytes_yield_audio_error() {
     let manager = Arc::new(MediaBridgeManager::with_capacities(10, 10));
     let call = CallId::new("c");
-    let tap = MediaTap::attach(&manager, call.clone(), 8000).expect("attach");
+    let tap = MediaTap::attach(&manager, &::std::sync::Arc::new(forge_core::EventBus::new()), call.clone(), 8000).expect("attach");
 
     let (caller_tx, _caller_rx) = mpsc::channel::<Vec<u8>>(10);
     let (playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
-    let pump = tokio::spawn(tap.run(caller_tx, playout_rx));
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, ::tokio::sync::mpsc::channel::<::siphon_ai_bridge::OutgoingEvent>(1).0));
 
     // Odd-length payload — PCM16 needs an even byte count.
     playout_tx.send(vec![0u8; 5]).await.expect("send");
@@ -197,11 +197,11 @@ async fn malformed_outbound_bytes_yield_audio_error() {
 async fn forge_call_ended_returns_call_ended() {
     let manager = Arc::new(MediaBridgeManager::with_capacities(10, 10));
     let call = CallId::new("c");
-    let tap = MediaTap::attach(&manager, call.clone(), 8000).expect("attach");
+    let tap = MediaTap::attach(&manager, &::std::sync::Arc::new(forge_core::EventBus::new()), call.clone(), 8000).expect("attach");
 
     let (caller_tx, _caller_rx) = mpsc::channel::<Vec<u8>>(10);
     let (_playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
-    let pump = tokio::spawn(tap.run(caller_tx, playout_rx));
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, ::tokio::sync::mpsc::channel::<::siphon_ai_bridge::OutgoingEvent>(1).0));
 
     // Emulate forge ending the inbound stream by detaching the
     // call-id slot from the manager.
@@ -226,11 +226,11 @@ async fn dropping_playout_sender_does_not_end_tap_alone() {
     // tolerated.)
     let manager = Arc::new(MediaBridgeManager::with_capacities(10, 10));
     let call = CallId::new("c");
-    let tap = MediaTap::attach(&manager, call.clone(), 8000).expect("attach");
+    let tap = MediaTap::attach(&manager, &::std::sync::Arc::new(forge_core::EventBus::new()), call.clone(), 8000).expect("attach");
 
     let (caller_tx, caller_rx) = mpsc::channel::<Vec<u8>>(10);
     let (playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
-    let pump = tokio::spawn(tap.run(caller_tx, playout_rx));
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, ::tokio::sync::mpsc::channel::<::siphon_ai_bridge::OutgoingEvent>(1).0));
 
     drop(playout_tx);
     // Pump observes playout_rx closed and exits with ControllerHungUp.
@@ -249,11 +249,11 @@ async fn round_trip_audio_via_tap_then_back_through_forge() {
     // back into playout_tx → forge outbound side → assert match.
     let manager = Arc::new(MediaBridgeManager::with_capacities(10, 10));
     let call = CallId::new("c");
-    let tap = MediaTap::attach(&manager, call.clone(), 8000).expect("attach");
+    let tap = MediaTap::attach(&manager, &::std::sync::Arc::new(forge_core::EventBus::new()), call.clone(), 8000).expect("attach");
 
     let (caller_tx, mut caller_rx) = mpsc::channel::<Vec<u8>>(10);
     let (playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
-    let pump = tokio::spawn(tap.run(caller_tx, playout_rx));
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, ::tokio::sync::mpsc::channel::<::siphon_ai_bridge::OutgoingEvent>(1).0));
 
     let pattern: Vec<i16> = (0..SAMPLES_PER_FRAME_8K).map(|i| (i as i16) * 7).collect();
     manager
@@ -287,5 +287,137 @@ async fn round_trip_audio_via_tap_then_back_through_forge() {
 
     drop(caller_rx);
     drop(playout_tx);
+    let _ = tokio::time::timeout(Duration::from_secs(1), pump).await;
+}
+
+// ─── DTMF subscription path ────────────────────────────────────────
+
+/// Publish a `DtmfDigitDetected{End}` for the tap's call_id and assert
+/// the tap forwards exactly one `OutgoingEvent::Dtmf` with the right
+/// digit / duration / method.
+///
+/// Pins the wire-shape requirement that the WS server gets ONE event
+/// per press (on `End`), not one per `Start`/`Continue`/`End` triple.
+#[tokio::test]
+async fn dtmf_end_event_emits_outgoing_event() {
+    use chrono::Utc;
+    use forge_core::{
+        DtmfDetectionMethod, DtmfEventKind, EventBus as ForgeEventBus, ForgeEvent,
+    };
+    use siphon_ai_bridge::{DtmfMethod, OutgoingEvent};
+
+    let manager = Arc::new(MediaBridgeManager::with_capacities(10, 10));
+    let bus = Arc::new(ForgeEventBus::new());
+    let call = CallId::new("dtmf-test");
+    let tap = MediaTap::attach(&manager, &bus, call.clone(), 8000).expect("attach");
+
+    let (caller_tx, _caller_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (_playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (events_tx, mut events_rx) =
+        mpsc::channel::<OutgoingEvent>(8);
+
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, events_tx));
+
+    // Tap subscribes inside `attach`; `events_rx` (the broadcast
+    // receiver inside the tap) is live by the time we publish below.
+
+    // A Start should NOT produce an event — we only emit on End so
+    // the WS receives a single complete press with `duration_ms`.
+    bus.publish(ForgeEvent::DtmfDigitDetected {
+        call_id: call.clone(),
+        digit: '5',
+        duration_ms: None,
+        method: DtmfDetectionMethod::Rfc2833,
+        event_type: DtmfEventKind::Start,
+        timestamp: Utc::now(),
+    })
+    .expect("publish start");
+
+    // The End event with the duration is what should fire.
+    bus.publish(ForgeEvent::DtmfDigitDetected {
+        call_id: call.clone(),
+        digit: '5',
+        duration_ms: Some(120),
+        method: DtmfDetectionMethod::Rfc2833,
+        event_type: DtmfEventKind::End,
+        timestamp: Utc::now(),
+    })
+    .expect("publish end");
+
+    let event = tokio::time::timeout(Duration::from_millis(500), events_rx.recv())
+        .await
+        .expect("event arrives within 500 ms")
+        .expect("events_tx still open");
+
+    match event {
+        OutgoingEvent::Dtmf {
+            digit,
+            duration_ms,
+            method,
+        } => {
+            assert_eq!(digit, '5');
+            assert_eq!(duration_ms, 120);
+            assert_eq!(method, DtmfMethod::Rfc2833);
+        }
+        other => panic!("expected Dtmf variant, got {other:?}"),
+    }
+
+    // No second event should follow the single End publish.
+    let no_more = tokio::time::timeout(Duration::from_millis(50), events_rx.recv()).await;
+    assert!(
+        no_more.is_err(),
+        "exactly one OutgoingEvent::Dtmf per End — got an extra: {no_more:?}",
+    );
+
+    drop(events_rx);
+    drop(_caller_rx);
+    drop(_playout_tx);
+    let _ = tokio::time::timeout(Duration::from_secs(1), pump).await;
+}
+
+/// A DTMF event for a *different* call must not leak through to
+/// our tap. Multiple concurrent calls subscribe to the same bus, so
+/// per-call filtering is the property that keeps cross-call audio
+/// from cross-talking.
+#[tokio::test]
+async fn dtmf_event_for_other_call_is_ignored() {
+    use chrono::Utc;
+    use forge_core::{
+        DtmfDetectionMethod, DtmfEventKind, EventBus as ForgeEventBus, ForgeEvent,
+    };
+    use siphon_ai_bridge::OutgoingEvent;
+
+    let manager = Arc::new(MediaBridgeManager::with_capacities(10, 10));
+    let bus = Arc::new(ForgeEventBus::new());
+    let call = CallId::new("dtmf-mine");
+    let tap = MediaTap::attach(&manager, &bus, call.clone(), 8000).expect("attach");
+
+    let (caller_tx, _caller_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (_playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (events_tx, mut events_rx) =
+        mpsc::channel::<OutgoingEvent>(8);
+
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, events_tx));
+
+    // Publish for an unrelated call_id.
+    bus.publish(ForgeEvent::DtmfDigitDetected {
+        call_id: CallId::new("dtmf-someone-else"),
+        digit: '9',
+        duration_ms: Some(80),
+        method: DtmfDetectionMethod::Rfc2833,
+        event_type: DtmfEventKind::End,
+        timestamp: Utc::now(),
+    })
+    .expect("publish foreign");
+
+    let nothing = tokio::time::timeout(Duration::from_millis(50), events_rx.recv()).await;
+    assert!(
+        nothing.is_err(),
+        "tap must filter by call_id; got an event meant for another call: {nothing:?}",
+    );
+
+    drop(events_rx);
+    drop(_caller_rx);
+    drop(_playout_tx);
     let _ = tokio::time::timeout(Duration::from_secs(1), pump).await;
 }


### PR DESCRIPTION
## Summary

Closes the first Week-3 control-plane gap. RTP DTMF presses inbound
from the SIP caller are now decoded by forge's RFC-2833 detector, fan
out through the daemon-wide forge `EventBus`, and reach the WS server
as a single `dtmf` text frame per press (one event on `End`, with the
final `duration_ms`).

## Plumbing

- Daemon builds a process-wide `forge_core::EventBus` and passes it
  to `SessionManager::new(...)` (forge publishes there) and into
  `MediaSetup` (each per-call tap subscribes from there).
- `MediaTap::attach` takes the bus and stores a
  `broadcast::Receiver<ForgeEvent>` per tap. The `run()` loop grows
  a fourth `select!` arm that filters `DtmfDigitDetected` for the
  tap's own `call_id`, maps `DtmfEventKind::End` to
  `OutgoingEvent::Dtmf`, and forwards it through a new `events_tx`
  mpsc the controller wires to the same channel the bridge already
  reads. `Lagged` increments a log line; `Closed` swaps in a
  forever-pending receiver so the `select!` arm doesn't spin.
- `forge_core::DtmfDetectionMethod::SipInfo` maps defensively to
  bridge `DtmfMethod::Inband`. v1's SIP layer doesn't surface INFO
  DTMF, but the wire shape is fixed against future drift.

## Activation gap fixed in the same commit

`BridgingAcceptor::on_matched` now calls
`session_manager.start_session(forge_call_id)` immediately after
`accept_invite` returns. This was always required for forge's RTP
forwarding loop to run (and therefore for the DTMF detector + audio
decoder to fire); the daemon shipped without it because the v1 cut
never exercised audio end-to-end past the 200 OK. Without this, the
call looks healthy at the SIP layer but produces zero RTP frames and
zero events.

## Tests

- `tap.rs::dtmf_end_event_emits_outgoing_event` — publish a
  synthesised `DtmfDigitDetected{End}`, assert exactly one
  `OutgoingEvent::Dtmf` arrives with digit / duration / method
  preserved, and no extra event follows.
- `tap.rs::dtmf_event_for_other_call_is_ignored` — publish for a
  different `call_id`, assert nothing reaches this tap. Pins the
  per-call filter that keeps multi-call deployments from cross-
  talking.
- All call-site tests (acceptor, controller, registry,
  media-glue/tests) updated to the new `MediaTap::attach` and
  `tap.run` signatures via fresh-bus / drop-receiver helpers.

## Validation

End-to-end SIPp INVITE → daemon → RTP injection of an RFC-2833 `'7'`
press → echo WS server logs:

```
echo-ws: dtmf: {'call_id': 'siphon-786c1bb9...', 'seq': 1, 'digit': '7', 'duration_ms': 80, 'method': 'rfc2833'}
```

`cargo test --workspace` passes.

## Out of scope (next Week-3 chunks)

- DTMF out (`BridgeIn::SendDtmf` → forge generates RFC2833).
- VAD `speech_started` / `speech_stopped`.
- Barge-in `auto_clear` / `Clear` handler.
- `Mark` round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)