### PR TITLE
feat(week3): wire BridgeIn::SendDtmf → forge RFC 2833 outbound

### DIFF
--- a/crates/core/src/call.rs
+++ b/crates/core/src/call.rs
@@ -61,7 +61,7 @@ use siphon_ai_bridge::{
     connect_and_run, BridgeChannels, BridgeConfig, BridgeError, BridgeIn, CallId, DisconnectReason,
     OutgoingEvent, StartMsg, StopReason,
 };
-use siphon_ai_media_glue::{MediaTap, MediaTapError, TapDisconnect};
+use siphon_ai_media_glue::{MediaTap, MediaTapError, TapCommand, TapDisconnect};
 use thiserror::Error;
 use tokio::sync::{mpsc, Notify};
 use tokio::task::JoinHandle;
@@ -237,6 +237,9 @@ impl CallController {
         // bridge → controller: BridgeIn from server
         let (control_in_tx, mut control_in_rx) =
             mpsc::channel::<BridgeIn>(CONTROL_CHANNEL_CAPACITY);
+        // controller → tap: out-of-band commands the controller routes
+        // from BridgeIn (currently SendDtmf; future Clear / Mark).
+        let (tap_cmd_tx, tap_cmd_rx) = mpsc::channel::<TapCommand>(CONTROL_CHANNEL_CAPACITY);
 
         let channels = BridgeChannels {
             audio_out_rx: caller_audio_rx,
@@ -255,9 +258,13 @@ impl CallController {
         // sender means tap and controller are independent producers
         // — bridge teardown closes the receiver, both producers see
         // the same EOF.
-        let mut tap_task: JoinHandle<Result<TapDisconnect, MediaTapError>> = tokio::spawn(
-            media_tap.run(caller_audio_tx, playout_audio_rx, control_out_tx.clone()),
-        );
+        let mut tap_task: JoinHandle<Result<TapDisconnect, MediaTapError>> =
+            tokio::spawn(media_tap.run(
+                caller_audio_tx,
+                playout_audio_rx,
+                control_out_tx.clone(),
+                tap_cmd_rx,
+            ));
 
         // We don't wait for the bridge handshake to declare
         // Active; the moment both tasks are spawned, audio plumbing
@@ -305,10 +312,31 @@ impl CallController {
                                 .await;
                             break;
                         }
+                        Some(BridgeIn::SendDtmf {
+                            call_id: cid,
+                            digit,
+                            duration_ms,
+                        }) => {
+                            debug!(
+                                ws_call_id = %cid,
+                                digit = %digit,
+                                duration_ms,
+                                "forwarding SendDtmf to tap",
+                            );
+                            // tap_cmd_tx capacity is small (8); a
+                            // backed-up tap means forge or the WS
+                            // side is misbehaving. Drop with a warn
+                            // rather than blocking the control loop.
+                            if let Err(e) = tap_cmd_tx
+                                .try_send(TapCommand::SendDtmf { digit, duration_ms })
+                            {
+                                warn!(error = %e, "tap command channel full or closed; dropping SendDtmf");
+                            }
+                        }
                         Some(other) => {
-                            // Clear / Mark / Transfer / SendDtmf:
-                            // log for now; full handling lands with
-                            // their respective glue layers.
+                            // Clear / Mark / Transfer: log for now;
+                            // full handling lands with their
+                            // respective glue layers.
                             debug!(?other, "control message not yet handled");
                         }
                         None => {

--- a/crates/media-glue/src/lib.rs
+++ b/crates/media-glue/src/lib.rs
@@ -15,4 +15,4 @@ pub use sdp::{
     build_answer, negotiate_answer, parse_offer, AnswerOutcome, Codec, LocalCapabilities, SdpError,
 };
 pub use setup::{InboundAccepted, InboundCall, MediaSetup, SetupError};
-pub use tap::{MediaTap, MediaTapError, TapDisconnect};
+pub use tap::{MediaTap, MediaTapError, TapCommand, TapDisconnect};

--- a/crates/media-glue/src/tap.rs
+++ b/crates/media-glue/src/tap.rs
@@ -59,8 +59,10 @@
 use std::sync::Arc;
 
 use forge_core::{CallId, DtmfDetectionMethod, DtmfEventKind, EventBus, ForgeError, ForgeEvent};
+use forge_dtmf::DtmfDigit;
 use forge_engine::{
-    MediaBridgeHandle, MediaBridgeManager, MediaTarget, OutboundMediaFrame, PlayoutMode,
+    MediaBridgeHandle, MediaBridgeManager, MediaTarget, OutboundDtmfRequest, OutboundMediaFrame,
+    PlayoutMode,
 };
 use siphon_ai_bridge::{
     pack_pcm16_le, unpack_pcm16_le, AudioError, DtmfMethod, OutgoingEvent, Reframer,
@@ -91,6 +93,30 @@ pub enum MediaTapError {
     Audio(#[from] AudioError),
 }
 
+/// Out-of-band commands the controller can drive the tap with —
+/// distinct from the audio path because they're rare control-plane
+/// events, not per-frame data.
+///
+/// Each variant maps to a forge `MediaBridgeHandle` action. The tap
+/// translates the WS server's intent (`BridgeIn::SendDtmf`, future
+/// `Clear`, future `Mark`) into the right forge call.
+///
+/// New variants are additive — older controllers / tests building
+/// only `SendDtmf` keep working without any match-arm churn here.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum TapCommand {
+    /// Server-driven outbound DTMF press. The tap turns it into an
+    /// [`OutboundDtmfRequest`] targeting [`MediaTarget::A`] (the SIP
+    /// caller); forge's encoder writes the RFC 2833 packets onto the
+    /// session's RTP socket.
+    ///
+    /// Invalid `digit` chars (anything outside `0-9 * # A-D`) are
+    /// dropped with a warning rather than tearing the call down — a
+    /// misbehaving WS server shouldn't kill a call.
+    SendDtmf { digit: char, duration_ms: u32 },
+}
+
 /// Why the tap pump exited cleanly.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TapDisconnect {
@@ -117,6 +143,15 @@ pub struct MediaTap {
     /// broadcast channel's per-receiver queue holds up to the bus's
     /// configured capacity.
     events_rx: broadcast::Receiver<ForgeEvent>,
+    /// Held alive across calls to [`Self::run`] so that, if the
+    /// daemon-wide bus's `Sender` is dropped (test fixtures that don't
+    /// keep the `Arc<EventBus>` alive, or a future shutdown sequence),
+    /// the swapped-in fallback receiver doesn't immediately re-close.
+    /// Without this anchor the `events_rx` `select!` arm would fire
+    /// `Closed` every poll under `biased;`, starving the other arms.
+    /// `None` while the original bus is still feeding us; `Some`
+    /// after we've swapped in a fallback channel.
+    events_keepalive: Option<broadcast::Sender<ForgeEvent>>,
 }
 
 impl std::fmt::Debug for MediaTap {
@@ -156,6 +191,7 @@ impl MediaTap {
             sample_rate,
             call_id,
             events_rx,
+            events_keepalive: None,
         })
     }
 
@@ -181,12 +217,16 @@ impl MediaTap {
     ///   from forge's event bus (currently only DTMF). The bridge
     ///   crate stamps `call_id` + `seq` and writes the JSON text
     ///   frame on the WS.
+    /// - `commands_rx`: control-plane requests from the controller
+    ///   (currently [`TapCommand::SendDtmf`]). The tap translates
+    ///   each into the right forge `MediaBridgeHandle` call.
     #[instrument(skip_all, fields(call_id = %self.call_id, sample_rate = self.sample_rate))]
     pub async fn run(
         mut self,
         caller_audio_tx: mpsc::Sender<Vec<u8>>,
         mut playout_audio_rx: mpsc::Receiver<Vec<u8>>,
         events_tx: mpsc::Sender<OutgoingEvent>,
+        mut commands_rx: mpsc::Receiver<TapCommand>,
     ) -> Result<TapDisconnect, MediaTapError> {
         let mut reframer = Reframer::new(self.sample_rate)?;
 
@@ -271,15 +311,64 @@ impl MediaTap {
                         }
                         Err(broadcast::error::RecvError::Closed) => {
                             debug!("forge event bus closed; tap continues without events");
-                            // Falling through to the next iteration
-                            // would spin on an immediately-ready Closed
-                            // arm. Replace the receiver with one that
-                            // blocks forever instead.
-                            let (_dummy_tx, dummy_rx) = broadcast::channel(1);
+                            // Without holding a keepalive sender, the
+                            // fresh receiver would also be Closed, the
+                            // arm would fire on every poll, and under
+                            // `biased;` the cmd / audio arms would be
+                            // starved. Stash the sender on `self` so
+                            // it lives as long as the tap.
+                            let (dummy_tx, dummy_rx) = broadcast::channel(1);
+                            self.events_keepalive = Some(dummy_tx);
                             self.events_rx = dummy_rx;
                         }
                     }
                 }
+
+                // Controller-driven commands (currently only SendDtmf).
+                cmd = commands_rx.recv() => {
+                    let Some(cmd) = cmd else {
+                        // Controller dropped its sender. The audio
+                        // arms still drive the call; treat command
+                        // closure as a non-fatal "no more commands"
+                        // and stop polling this arm by recreating the
+                        // receiver against a dropped sender.
+                        debug!("commands_rx closed; tap continues without commands");
+                        let (_drop_tx, replacement) = mpsc::channel::<TapCommand>(1);
+                        commands_rx = replacement;
+                        continue;
+                    };
+                    handle_tap_command(&self.call_id, &self.handle, cmd).await;
+                }
+            }
+        }
+    }
+}
+
+async fn handle_tap_command(call_id: &CallId, handle: &MediaBridgeHandle, cmd: TapCommand) {
+    match cmd {
+        TapCommand::SendDtmf { digit, duration_ms } => {
+            let parsed = match DtmfDigit::from_char(digit) {
+                Ok(d) => d,
+                Err(e) => {
+                    warn!(
+                        call_id = %call_id,
+                        digit = %digit, error = %e,
+                        "ignoring SendDtmf with unsupported digit char",
+                    );
+                    return;
+                }
+            };
+            let req = OutboundDtmfRequest {
+                target: MediaTarget::A,
+                digit: parsed,
+                duration_ms,
+                playback_id: None,
+                mode: PlayoutMode::Append,
+            };
+            if let Err(e) = handle.send_dtmf(req).await {
+                warn!(call_id = %call_id, error = %e, "forge send_dtmf failed");
+            } else {
+                debug!(call_id = %call_id, digit = %digit, duration_ms, "queued outbound DTMF");
             }
         }
     }

--- a/crates/media-glue/tests/setup.rs
+++ b/crates/media-glue/tests/setup.rs
@@ -153,7 +153,7 @@ async fn pre_attached_tap_pumps_real_audio() {
 
     let (caller_tx, mut caller_rx) = mpsc::channel::<Vec<u8>>(10);
     let (playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
-    let pump = tokio::spawn(accepted.tap.run(caller_tx, playout_rx, ::tokio::sync::mpsc::channel::<::siphon_ai_bridge::OutgoingEvent>(1).0));
+    let pump = tokio::spawn(accepted.tap.run(caller_tx, playout_rx, ::tokio::sync::mpsc::channel::<::siphon_ai_bridge::OutgoingEvent>(1).0, ::tokio::sync::mpsc::channel::<::siphon_ai_media_glue::TapCommand>(1).1));
 
     // Push 20 ms of inbound at 8 kHz (160 samples).
     let pattern: Vec<i16> = (0..160).map(|i| (i as i16) * 3).collect();

--- a/crates/media-glue/tests/tap.rs
+++ b/crates/media-glue/tests/tap.rs
@@ -41,7 +41,7 @@ async fn inbound_audio_reframed_and_packed_to_caller_channel() {
     let (caller_tx, mut caller_rx) = mpsc::channel::<Vec<u8>>(10);
     let (_playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
 
-    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, ::tokio::sync::mpsc::channel::<::siphon_ai_bridge::OutgoingEvent>(1).0));
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, ::tokio::sync::mpsc::channel::<::siphon_ai_bridge::OutgoingEvent>(1).0, ::tokio::sync::mpsc::channel::<::siphon_ai_media_glue::TapCommand>(1).1));
 
     // Push a 20 ms frame of pattern data; the tap should emit one
     // packed wire frame.
@@ -78,7 +78,7 @@ async fn small_inbound_frames_are_buffered_until_a_full_20ms_is_available() {
 
     let (caller_tx, mut caller_rx) = mpsc::channel::<Vec<u8>>(10);
     let (_playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
-    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, ::tokio::sync::mpsc::channel::<::siphon_ai_bridge::OutgoingEvent>(1).0));
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, ::tokio::sync::mpsc::channel::<::siphon_ai_bridge::OutgoingEvent>(1).0, ::tokio::sync::mpsc::channel::<::siphon_ai_media_glue::TapCommand>(1).1));
 
     // Two 10 ms half-frames at 8 kHz = 80 samples each.
     manager
@@ -109,7 +109,7 @@ async fn outbound_audio_unpacked_and_handed_to_forge() {
 
     let (caller_tx, _caller_rx) = mpsc::channel::<Vec<u8>>(10);
     let (playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
-    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, ::tokio::sync::mpsc::channel::<::siphon_ai_bridge::OutgoingEvent>(1).0));
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, ::tokio::sync::mpsc::channel::<::siphon_ai_bridge::OutgoingEvent>(1).0, ::tokio::sync::mpsc::channel::<::siphon_ai_media_glue::TapCommand>(1).1));
 
     // Send a 20 ms frame's worth of wire bytes.
     let samples: Vec<i16> = (10..170).collect();
@@ -150,7 +150,7 @@ async fn sample_rate_mismatch_yields_error() {
 
     let (caller_tx, _caller_rx) = mpsc::channel::<Vec<u8>>(10);
     let (_playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
-    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, ::tokio::sync::mpsc::channel::<::siphon_ai_bridge::OutgoingEvent>(1).0));
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, ::tokio::sync::mpsc::channel::<::siphon_ai_bridge::OutgoingEvent>(1).0, ::tokio::sync::mpsc::channel::<::siphon_ai_media_glue::TapCommand>(1).1));
 
     // Push a frame at the WRONG rate.
     manager
@@ -178,7 +178,7 @@ async fn malformed_outbound_bytes_yield_audio_error() {
 
     let (caller_tx, _caller_rx) = mpsc::channel::<Vec<u8>>(10);
     let (playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
-    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, ::tokio::sync::mpsc::channel::<::siphon_ai_bridge::OutgoingEvent>(1).0));
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, ::tokio::sync::mpsc::channel::<::siphon_ai_bridge::OutgoingEvent>(1).0, ::tokio::sync::mpsc::channel::<::siphon_ai_media_glue::TapCommand>(1).1));
 
     // Odd-length payload — PCM16 needs an even byte count.
     playout_tx.send(vec![0u8; 5]).await.expect("send");
@@ -201,7 +201,7 @@ async fn forge_call_ended_returns_call_ended() {
 
     let (caller_tx, _caller_rx) = mpsc::channel::<Vec<u8>>(10);
     let (_playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
-    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, ::tokio::sync::mpsc::channel::<::siphon_ai_bridge::OutgoingEvent>(1).0));
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, ::tokio::sync::mpsc::channel::<::siphon_ai_bridge::OutgoingEvent>(1).0, ::tokio::sync::mpsc::channel::<::siphon_ai_media_glue::TapCommand>(1).1));
 
     // Emulate forge ending the inbound stream by detaching the
     // call-id slot from the manager.
@@ -230,7 +230,7 @@ async fn dropping_playout_sender_does_not_end_tap_alone() {
 
     let (caller_tx, caller_rx) = mpsc::channel::<Vec<u8>>(10);
     let (playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
-    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, ::tokio::sync::mpsc::channel::<::siphon_ai_bridge::OutgoingEvent>(1).0));
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, ::tokio::sync::mpsc::channel::<::siphon_ai_bridge::OutgoingEvent>(1).0, ::tokio::sync::mpsc::channel::<::siphon_ai_media_glue::TapCommand>(1).1));
 
     drop(playout_tx);
     // Pump observes playout_rx closed and exits with ControllerHungUp.
@@ -253,7 +253,7 @@ async fn round_trip_audio_via_tap_then_back_through_forge() {
 
     let (caller_tx, mut caller_rx) = mpsc::channel::<Vec<u8>>(10);
     let (playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
-    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, ::tokio::sync::mpsc::channel::<::siphon_ai_bridge::OutgoingEvent>(1).0));
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, ::tokio::sync::mpsc::channel::<::siphon_ai_bridge::OutgoingEvent>(1).0, ::tokio::sync::mpsc::channel::<::siphon_ai_media_glue::TapCommand>(1).1));
 
     let pattern: Vec<i16> = (0..SAMPLES_PER_FRAME_8K).map(|i| (i as i16) * 7).collect();
     manager
@@ -316,7 +316,7 @@ async fn dtmf_end_event_emits_outgoing_event() {
     let (events_tx, mut events_rx) =
         mpsc::channel::<OutgoingEvent>(8);
 
-    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, events_tx));
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, events_tx, ::tokio::sync::mpsc::channel::<::siphon_ai_media_glue::TapCommand>(1).1));
 
     // Tap subscribes inside `attach`; `events_rx` (the broadcast
     // receiver inside the tap) is live by the time we publish below.
@@ -397,7 +397,7 @@ async fn dtmf_event_for_other_call_is_ignored() {
     let (events_tx, mut events_rx) =
         mpsc::channel::<OutgoingEvent>(8);
 
-    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, events_tx));
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, events_tx, ::tokio::sync::mpsc::channel::<::siphon_ai_media_glue::TapCommand>(1).1));
 
     // Publish for an unrelated call_id.
     bus.publish(ForgeEvent::DtmfDigitDetected {
@@ -417,6 +417,148 @@ async fn dtmf_event_for_other_call_is_ignored() {
     );
 
     drop(events_rx);
+    drop(_caller_rx);
+    drop(_playout_tx);
+    let _ = tokio::time::timeout(Duration::from_secs(1), pump).await;
+}
+
+// ─── Outbound DTMF (TapCommand::SendDtmf) ──────────────────────────
+
+/// Send a `TapCommand::SendDtmf` into the tap and assert forge's
+/// outbound queue gets a matching `OutboundMediaRequest::Dtmf` with
+/// the right digit + duration + target leg.
+///
+/// Pins the WS-server-driven outbound DTMF path: the bridge sends
+/// `BridgeIn::SendDtmf` → controller routes to `TapCommand::SendDtmf`
+/// → tap turns into a forge handle call. This test bypasses the
+/// controller and drives the tap directly.
+#[tokio::test]
+async fn send_dtmf_command_queues_outbound_dtmf_to_forge() {
+    use siphon_ai_media_glue::TapCommand;
+
+    let manager = Arc::new(MediaBridgeManager::with_capacities(10, 10));
+    let call = CallId::new("dtmf-out-test");
+    let tap = MediaTap::attach(
+        &manager,
+        &::std::sync::Arc::new(forge_core::EventBus::new()),
+        call.clone(),
+        8000,
+    )
+    .expect("attach");
+
+    let (caller_tx, _caller_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (_playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (events_tx, _events_rx) = mpsc::channel::<siphon_ai_bridge::OutgoingEvent>(8);
+    let (cmd_tx, cmd_rx) = mpsc::channel::<TapCommand>(8);
+
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, events_tx, cmd_rx));
+
+    cmd_tx
+        .send(TapCommand::SendDtmf {
+            digit: '5',
+            duration_ms: 160,
+        })
+        .await
+        .expect("send command");
+
+    let drained = tokio::time::timeout(Duration::from_millis(500), async {
+        loop {
+            if let Some(req) = manager.try_recv_outbound_request(&call).await {
+                return req;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("forge sees outbound DTMF");
+
+    match drained {
+        OutboundMediaRequest::Dtmf(req) => {
+            assert_eq!(req.target, MediaTarget::A, "single-leg → leg A");
+            assert_eq!(req.duration_ms, 160);
+            assert_eq!(req.digit, forge_engine::DtmfDigit::Five);
+        }
+        other => panic!("expected Dtmf variant, got {other:?}"),
+    }
+
+    drop(cmd_tx);
+    drop(_events_rx);
+    drop(_caller_rx);
+    drop(_playout_tx);
+    let _ = tokio::time::timeout(Duration::from_secs(1), pump).await;
+}
+
+/// An invalid digit char must be silently dropped — a misbehaving WS
+/// server sending `digit: 'Z'` shouldn't tear down the call. The tap
+/// keeps running and accepts subsequent valid presses.
+#[tokio::test]
+async fn send_dtmf_command_with_invalid_digit_does_not_kill_tap() {
+    use siphon_ai_media_glue::TapCommand;
+
+    let manager = Arc::new(MediaBridgeManager::with_capacities(10, 10));
+    let call = CallId::new("dtmf-bad-digit");
+    let tap = MediaTap::attach(
+        &manager,
+        &::std::sync::Arc::new(forge_core::EventBus::new()),
+        call.clone(),
+        8000,
+    )
+    .expect("attach");
+
+    let (caller_tx, _caller_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (_playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (events_tx, _events_rx) = mpsc::channel::<siphon_ai_bridge::OutgoingEvent>(8);
+    let (cmd_tx, cmd_rx) = mpsc::channel::<TapCommand>(8);
+
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, events_tx, cmd_rx));
+
+    cmd_tx
+        .send(TapCommand::SendDtmf {
+            digit: 'Z',
+            duration_ms: 160,
+        })
+        .await
+        .expect("send bad cmd");
+
+    // Forge must NOT see anything from the bad digit.
+    let nothing = tokio::time::timeout(Duration::from_millis(50), async {
+        manager.try_recv_outbound_request(&call).await
+    })
+    .await;
+    assert!(
+        matches!(nothing, Ok(None)) || nothing.is_err(),
+        "invalid digit must produce no outbound forge request: {nothing:?}",
+    );
+
+    // A subsequent valid press should still work — pinning the
+    // "drop one bad command, keep going" property.
+    cmd_tx
+        .send(TapCommand::SendDtmf {
+            digit: '7',
+            duration_ms: 100,
+        })
+        .await
+        .expect("send good cmd");
+
+    let drained = tokio::time::timeout(Duration::from_millis(500), async {
+        loop {
+            if let Some(req) = manager.try_recv_outbound_request(&call).await {
+                return req;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("good digit reaches forge");
+    match drained {
+        OutboundMediaRequest::Dtmf(req) => {
+            assert_eq!(req.digit, forge_engine::DtmfDigit::Seven);
+        }
+        other => panic!("expected Dtmf variant, got {other:?}"),
+    }
+
+    drop(cmd_tx);
+    drop(_events_rx);
     drop(_caller_rx);
     drop(_playout_tx);
     let _ = tokio::time::timeout(Duration::from_secs(1), pump).await;


### PR DESCRIPTION
## Summary

Closes the second Week-3 control-plane gap. WS-server-driven outbound
DTMF (e.g. for IVR-prompt-to-DTMF dial-out scenarios) now traverses:

```
WS server → bridge BridgeIn::SendDtmf
          → CallController control_in_rx
          → mpsc<TapCommand>          (NEW)
          → MediaTap select! arm
          → forge MediaBridgeHandle::send_dtmf(OutboundDtmfRequest)
          → forge encoder → RFC 2833 packets on the SIP RTP socket
```

## Plumbing

- New `siphon_ai_media_glue::TapCommand` enum (currently
  `SendDtmf { digit, duration_ms }`, marked `#[non_exhaustive]` so
  future `Clear` / `Mark` variants land additively).
- `MediaTap::run` grows a fifth `select!` arm consuming a
  `mpsc::Receiver<TapCommand>`. Per-command handler maps the WS
  protocol's `digit: char` via `forge_dtmf::DtmfDigit::from_char` and
  dispatches to forge with `target = MediaTarget::A` (single-leg
  model, same as outbound audio).
- Invalid digit chars are dropped with a `warn!` rather than tearing
  the call down — a misbehaving WS server can't kill a call.
- `CallController` builds the command channel, hands the receiver to
  the tap, and routes `BridgeIn::SendDtmf` from `control_in_rx` via
  `tap_cmd_tx.try_send`. A backed-up command channel logs and drops
  rather than blocking the controller's main loop.

## Bug fix discovered in the process

`MediaTap`'s previous handling of an `events_rx` `Closed` outcome
swapped in a fresh `broadcast::Receiver` whose `Sender` immediately
dropped (the `_dummy_tx` binding only lived for the match arm). That
made the new receiver also `Closed`, so the `events_rx` arm fired
`Closed` on every poll. Under `biased;` this starved every later arm
— including the new `commands_rx` arm, which is why the first
DTMF-out unit test timed out without `handle_tap_command` running.

Fixed by stashing the keepalive sender on `MediaTap.events_keepalive`.

## Tests

- `send_dtmf_command_queues_outbound_dtmf_to_forge` — push
  `TapCommand::SendDtmf` into a tap, assert forge's outbound MPSC gets
  the matching `OutboundMediaRequest::Dtmf`.
- `send_dtmf_command_with_invalid_digit_does_not_kill_tap` — send a
  `digit: 'Z'` first, assert nothing reaches forge, then send a valid
  press and assert the tap is still alive and forwards it.
- All existing `tap.run(...)` callers updated to the new 4-arg
  signature.

## End-to-end validation

SIPp INVITE → daemon → small WS server that sends
`{"type":"send_dtmf","digit":"9","duration_ms":200}` on `start`. A
Python loopback (sends PCMA silence to bootstrap forge's symmetric-RTP
peer learning, listens on its bind port) saw the full RFC 2833
sequence:

```
pt=101 seq=...  digit=9 end=False dur=320
pt=101 seq=...  digit=9 end=False dur=480
...
pt=101 seq=...  digit=9 end=True  dur=1600
```

`cargo test --workspace --no-fail-fast` passes; 10 media-glue tap
integration tests (2 new) plus 2 in-process DTMF-in tests from PR #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)