### PR TITLE
feat(week3): wire BridgeIn::Clear → forge flush + drain in-flight playout

### DIFF
--- a/crates/core/src/call.rs
+++ b/crates/core/src/call.rs
@@ -333,10 +333,21 @@ impl CallController {
                                 warn!(error = %e, "tap command channel full or closed; dropping SendDtmf");
                             }
                         }
+                        Some(BridgeIn::Clear { call_id: cid }) => {
+                            debug!(ws_call_id = %cid, "forwarding Clear to tap");
+                            // Same drop-rather-than-block policy as
+                            // SendDtmf — Clear is barge-in-driven and
+                            // the WS server typically follows up
+                            // with a fresh playback, so a missed
+                            // command is recoverable.
+                            if let Err(e) = tap_cmd_tx.try_send(TapCommand::Clear) {
+                                warn!(error = %e, "tap command channel full or closed; dropping Clear");
+                            }
+                        }
                         Some(other) => {
-                            // Clear / Mark / Transfer: log for now;
-                            // full handling lands with their
-                            // respective glue layers.
+                            // Mark / Transfer: log for now; full
+                            // handling lands with their respective
+                            // glue layers.
                             debug!(?other, "control message not yet handled");
                         }
                         None => {

--- a/crates/media-glue/src/tap.rs
+++ b/crates/media-glue/src/tap.rs
@@ -115,6 +115,15 @@ pub enum TapCommand {
     /// dropped with a warning rather than tearing the call down — a
     /// misbehaving WS server shouldn't kill a call.
     SendDtmf { digit: char, duration_ms: u32 },
+
+    /// Drop every byte of pending outbound playout — both the bytes
+    /// queued in the controller→tap audio channel that haven't yet
+    /// reached forge, and forge's own encoder queue. Drives the WS
+    /// protocol's `Clear` message: the server's typical use is
+    /// "stop talking immediately" in response to caller barge-in,
+    /// so any tail audio left in the pipe must not reach the
+    /// caller.
+    Clear,
 }
 
 /// Why the tap pump exited cleanly.
@@ -337,40 +346,74 @@ impl MediaTap {
                         commands_rx = replacement;
                         continue;
                     };
-                    handle_tap_command(&self.call_id, &self.handle, cmd).await;
+                    match cmd {
+                        TapCommand::Clear => {
+                            // Drain any bytes queued in the
+                            // controller→tap audio channel before
+                            // they can reach forge. The mpsc bound
+                            // is small (10 frames = 200 ms) but
+                            // letting that tail slip through a
+                            // barge-in event would be perceptible.
+                            let mut drained = 0usize;
+                            while let Ok(_bytes) = playout_audio_rx.try_recv() {
+                                drained += 1;
+                            }
+                            if let Err(e) = self
+                                .handle
+                                .flush(Some(MediaTarget::A), None)
+                                .await
+                            {
+                                warn!(
+                                    call_id = %self.call_id,
+                                    error = %e,
+                                    "forge flush failed during Clear",
+                                );
+                            } else {
+                                debug!(
+                                    call_id = %self.call_id,
+                                    drained,
+                                    "cleared pending outbound playout",
+                                );
+                            }
+                        }
+                        TapCommand::SendDtmf { digit, duration_ms } => {
+                            handle_send_dtmf(&self.call_id, &self.handle, digit, duration_ms).await;
+                        }
+                    }
                 }
             }
         }
     }
 }
 
-async fn handle_tap_command(call_id: &CallId, handle: &MediaBridgeHandle, cmd: TapCommand) {
-    match cmd {
-        TapCommand::SendDtmf { digit, duration_ms } => {
-            let parsed = match DtmfDigit::from_char(digit) {
-                Ok(d) => d,
-                Err(e) => {
-                    warn!(
-                        call_id = %call_id,
-                        digit = %digit, error = %e,
-                        "ignoring SendDtmf with unsupported digit char",
-                    );
-                    return;
-                }
-            };
-            let req = OutboundDtmfRequest {
-                target: MediaTarget::A,
-                digit: parsed,
-                duration_ms,
-                playback_id: None,
-                mode: PlayoutMode::Append,
-            };
-            if let Err(e) = handle.send_dtmf(req).await {
-                warn!(call_id = %call_id, error = %e, "forge send_dtmf failed");
-            } else {
-                debug!(call_id = %call_id, digit = %digit, duration_ms, "queued outbound DTMF");
-            }
+async fn handle_send_dtmf(
+    call_id: &CallId,
+    handle: &MediaBridgeHandle,
+    digit: char,
+    duration_ms: u32,
+) {
+    let parsed = match DtmfDigit::from_char(digit) {
+        Ok(d) => d,
+        Err(e) => {
+            warn!(
+                call_id = %call_id,
+                digit = %digit, error = %e,
+                "ignoring SendDtmf with unsupported digit char",
+            );
+            return;
         }
+    };
+    let req = OutboundDtmfRequest {
+        target: MediaTarget::A,
+        digit: parsed,
+        duration_ms,
+        playback_id: None,
+        mode: PlayoutMode::Append,
+    };
+    if let Err(e) = handle.send_dtmf(req).await {
+        warn!(call_id = %call_id, error = %e, "forge send_dtmf failed");
+    } else {
+        debug!(call_id = %call_id, digit = %digit, duration_ms, "queued outbound DTMF");
     }
 }
 

--- a/crates/media-glue/tests/tap.rs
+++ b/crates/media-glue/tests/tap.rs
@@ -563,3 +563,145 @@ async fn send_dtmf_command_with_invalid_digit_does_not_kill_tap() {
     drop(_playout_tx);
     let _ = tokio::time::timeout(Duration::from_secs(1), pump).await;
 }
+
+// ─── Clear (barge-in / interrupt outbound playout) ─────────────────
+
+/// Send `TapCommand::Clear` with no audio in flight, assert forge
+/// sees a `Flush` request targeting leg A.
+///
+/// `MediaTap::run` polls audio arms before the command arm (`biased;`),
+/// so pre-staged playout frames already in the controller→tap
+/// channel will reach forge as `Audio` requests *before* Clear is
+/// processed — that's expected, and forge's `Flush` is what
+/// actually drops them from the encoder's pending-out queue. So
+/// this test focuses on the contract the tap owns: when Clear
+/// fires, exactly one `Flush` lands on forge for leg A.
+#[tokio::test]
+async fn clear_command_emits_flush_on_forge() {
+    use siphon_ai_media_glue::TapCommand;
+
+    let manager = Arc::new(MediaBridgeManager::with_capacities(10, 10));
+    let call = CallId::new("clear-test");
+    let tap = MediaTap::attach(
+        &manager,
+        &::std::sync::Arc::new(forge_core::EventBus::new()),
+        call.clone(),
+        8000,
+    )
+    .expect("attach");
+
+    let (caller_tx, _caller_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (_playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (events_tx, _events_rx) = mpsc::channel::<siphon_ai_bridge::OutgoingEvent>(8);
+    let (cmd_tx, cmd_rx) = mpsc::channel::<TapCommand>(8);
+
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, events_tx, cmd_rx));
+
+    cmd_tx.send(TapCommand::Clear).await.expect("send clear");
+
+    let drained = tokio::time::timeout(Duration::from_millis(500), async {
+        loop {
+            if let Some(req) = manager.try_recv_outbound_request(&call).await {
+                return req;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("forge sees Flush");
+
+    match drained {
+        OutboundMediaRequest::Flush { target, playback_id } => {
+            assert_eq!(
+                target,
+                Some(MediaTarget::A),
+                "single-leg model → flush leg A",
+            );
+            assert!(
+                playback_id.is_none(),
+                "v1 doesn't use playback_id; got {playback_id:?}",
+            );
+        }
+        other => panic!("expected Flush, got {other:?}"),
+    }
+
+    drop(cmd_tx);
+    drop(_events_rx);
+    drop(_caller_rx);
+    drop(_playout_tx);
+    let _ = tokio::time::timeout(Duration::from_secs(1), pump).await;
+}
+
+/// Clear drains the controller→tap audio buffer of bytes that haven't
+/// yet been polled by the playout arm. Pre-stage two frames, send
+/// Clear, then push one more frame — the post-Clear frame must
+/// reach forge while the tap stays alive.
+///
+/// We don't pin "zero pre-Clear frames reach forge" because the
+/// `biased` select polls audio first; in production, Clear's
+/// usefulness rests on forge's `Flush` (which this test pins in
+/// `clear_command_emits_flush_on_forge`).
+#[tokio::test]
+async fn clear_command_does_not_kill_tap() {
+    use siphon_ai_bridge::pack_pcm16_le;
+    use siphon_ai_media_glue::TapCommand;
+
+    let manager = Arc::new(MediaBridgeManager::with_capacities(10, 10));
+    let call = CallId::new("clear-resume-test");
+    let tap = MediaTap::attach(
+        &manager,
+        &::std::sync::Arc::new(forge_core::EventBus::new()),
+        call.clone(),
+        8000,
+    )
+    .expect("attach");
+
+    let (caller_tx, _caller_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (events_tx, _events_rx) = mpsc::channel::<siphon_ai_bridge::OutgoingEvent>(8);
+    let (cmd_tx, cmd_rx) = mpsc::channel::<TapCommand>(8);
+
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, events_tx, cmd_rx));
+
+    cmd_tx.send(TapCommand::Clear).await.expect("send clear");
+
+    // Drain whatever the Clear pushed (Flush).
+    let _ = tokio::time::timeout(Duration::from_millis(300), async {
+        loop {
+            if let Some(req) = manager.try_recv_outbound_request(&call).await {
+                if matches!(req, OutboundMediaRequest::Flush { .. }) {
+                    return;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("Flush observed");
+
+    // Tap should still be alive: a follow-up audio frame reaches forge.
+    let frame = pack_pcm16_le(&vec![3i16; 160]);
+    playout_tx.send(frame).await.expect("send post-Clear audio");
+    let drained = tokio::time::timeout(Duration::from_millis(500), async {
+        loop {
+            if let Some(req) = manager.try_recv_outbound_request(&call).await {
+                return req;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("post-Clear audio reaches forge");
+    match drained {
+        OutboundMediaRequest::Audio(f) => {
+            assert_eq!(f.samples, vec![3i16; 160]);
+        }
+        other => panic!("expected Audio post-Clear, got {other:?}"),
+    }
+
+    drop(cmd_tx);
+    drop(_events_rx);
+    drop(_caller_rx);
+    drop(playout_tx);
+    let _ = tokio::time::timeout(Duration::from_secs(1), pump).await;
+}


### PR DESCRIPTION
## Summary

Server-driven barge-in interrupt. When the WS server sends a
`{\"type\": \"clear\", ...}` text frame, the daemon drops every byte
of pending outbound playout — both the bytes queued in the
controller→tap audio channel that haven't yet reached forge, AND
forge's own encoder queue.

## Plumbing

- New `TapCommand::Clear` variant.
- `MediaTap::run`'s `commands_rx` arm matches on the variant: the
  Clear branch drains `playout_audio_rx` via `try_recv` and calls
  `handle.flush(Some(MediaTarget::A), None)`. Drain catches the
  audio channel's bounded buffer (10 frames = 200ms); forge's flush
  catches anything already on the encoder side.
- `CallController` routes `BridgeIn::Clear` via the same
  `try_send`-with-warn-on-full pattern SendDtmf uses.
- Helper `handle_tap_command` renamed to `handle_send_dtmf` and
  takes unpacked digit/duration so the dispatch site can match
  TapCommand variants directly. Adding new commands no longer
  requires updating an enum-matching helper.

## Tests

- `clear_command_emits_flush_on_forge` — Clear with no audio in
  flight, assert exactly one `OutboundMediaRequest::Flush` with
  `target = Some(MediaTarget::A)`, `playback_id = None`.
- `clear_command_does_not_kill_tap` — Clear, then push a follow-up
  audio frame; the frame must reach forge intact.

A unit test pinning \"zero pre-Clear frames reach forge\" would be
incorrect under `biased;` polling — the playout arm wins the race
against cmd, so what Clear actually buys you is forge's flush
dropping them from the encoder pipeline. The two tests above pin
the part the tap owns.

## End-to-end validation

WS server pumps 10 PCM16 frames, then a `{\"type\":\"clear\"}` text
frame. With `RUST_LOG=siphon_ai_core=debug,siphon_ai_media_glue=debug`,
the daemon logs:

```
DEBUG ... siphon_ai_core::call: forwarding Clear to tap
DEBUG ... siphon_ai_media_glue::tap: cleared pending outbound playout
```

`cargo test --workspace --no-fail-fast` passes (14 media-glue tap
integration tests, including the 2 new Clear cases).

## Out of scope

- VAD-driven `auto_clear` mode (depends on a forge `ForgeEvent::SpeechStarted`
  variant that doesn't exist yet — likely needs a forge upstream PR).
- `Mark` round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)