### PR TITLE
feat(week3): wire [bridge.barge_in] config + auto_clear behavior

### DIFF
--- a/crates/config/src/compile.rs
+++ b/crates/config/src/compile.rs
@@ -199,6 +199,9 @@ pub enum CompileError {
     #[error("[media].dtmf is {0:?}; expected \"rfc2833\" or \"off\"")]
     UnknownDtmfMode(String),
 
+    #[error("[bridge.barge_in].mode is {0:?}; expected \"auto_clear\" or \"notify_only\"")]
+    UnknownBargeInMode(String),
+
     #[error("[media].rtp_port_range {min}-{max} is invalid (min must be < max and even)")]
     BadRtpPortRange { min: u16, max: u16 },
 
@@ -393,6 +396,8 @@ fn compile_bridge(raw: RawBridge, media: &RawMedia) -> Result<BridgeDefaults, Co
         .map(strip_bearer_prefix)
         .filter(|s| !s.is_empty());
 
+    let barge_in = compile_barge_in_default(&raw.barge_in)?;
+
     Ok(BridgeDefaults {
         ws_url: raw.ws_url.filter(|s| !s.is_empty()),
         auth_bearer,
@@ -400,7 +405,33 @@ fn compile_bridge(raw: RawBridge, media: &RawMedia) -> Result<BridgeDefaults, Co
         codecs,
         dtmf_payload_type,
         forward_headers: raw.forward_headers.unwrap_or_default(),
+        barge_in,
     })
+}
+
+/// Translate `[bridge.barge_in]` into a resolved
+/// [`siphon_ai_core::BargeInConfig`]. Defaults follow `BargeInConfig`'s
+/// own `Default` (`enabled = true`, `mode = AutoClear`); only fields
+/// the operator set in TOML override.
+fn compile_barge_in_default(
+    raw: &crate::raw::RawBargeIn,
+) -> Result<siphon_ai_core::BargeInConfig, CompileError> {
+    let mut cfg = siphon_ai_core::BargeInConfig::default();
+    if let Some(enabled) = raw.enabled {
+        cfg.enabled = enabled;
+    }
+    if let Some(mode) = raw.mode.as_deref() {
+        cfg.mode = parse_barge_in_mode(mode)?;
+    }
+    Ok(cfg)
+}
+
+fn parse_barge_in_mode(s: &str) -> Result<siphon_ai_core::BargeInMode, CompileError> {
+    match s {
+        "auto_clear" => Ok(siphon_ai_core::BargeInMode::AutoClear),
+        "notify_only" => Ok(siphon_ai_core::BargeInMode::NotifyOnly),
+        other => Err(CompileError::UnknownBargeInMode(other.to_string())),
+    }
 }
 
 fn parse_codecs(names: &[String]) -> Result<Vec<Codec>, CompileError> {

--- a/crates/config/src/raw.rs
+++ b/crates/config/src/raw.rs
@@ -290,4 +290,28 @@ pub struct RawBridge {
     /// Names are case-insensitive at lookup time.
     #[serde(default)]
     pub forward_headers: Option<Vec<String>>,
+    /// `[bridge.barge_in]` block. Empty = inherit defaults
+    /// (`enabled = true`, `mode = "auto_clear"`).
+    #[serde(default)]
+    pub barge_in: RawBargeIn,
+}
+
+/// `[bridge.barge_in]` — global default barge-in policy.
+/// Mirrors the `[route.bridge.barge_in]` override grammar so the
+/// merge in the compile step is purely "if route field is `Some`,
+/// take it; else inherit the default."
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawBargeIn {
+    /// Master switch. Defaults to `true` on the global side.
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    /// `"auto_clear"` (default) or `"notify_only"`.
+    #[serde(default)]
+    pub mode: Option<String>,
+    /// Reserved for future use (event debouncing). Accepted today
+    /// so configs that set it don't fail validation; not yet read
+    /// by the runtime.
+    #[serde(default)]
+    pub debounce_ms: Option<u64>,
 }

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -107,6 +107,46 @@ pub struct BridgeDefaults {
     /// `start.sip.headers` map. Names are matched case-insensitively
     /// against the INVITE.
     pub forward_headers: Vec<String>,
+    /// Barge-in policy. [`BargeInMode::AutoClear`] (the default)
+    /// drops pending outbound playout the moment forge-vad reports
+    /// the caller started speaking — caller interruption acks
+    /// without a server round-trip. [`BargeInMode::NotifyOnly`]
+    /// just forwards `speech_started` and leaves the decision to
+    /// the WS server.
+    pub barge_in: BargeInConfig,
+}
+
+/// What the daemon does when forge-vad reports speech-started.
+///
+/// Public so the acceptor / media-glue / config layers can refer to
+/// the type by symbol rather than threading a `String`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BargeInMode {
+    /// Just forward `speech_started` / `speech_stopped` to the WS.
+    /// The server decides whether to send `clear`.
+    NotifyOnly,
+    /// Forward the event AND drop pending outbound playout the
+    /// moment speech-started fires.
+    AutoClear,
+}
+
+/// Resolved barge-in plan after merging globals + route overrides.
+#[derive(Debug, Clone)]
+pub struct BargeInConfig {
+    /// Master enable. When `false`, VAD events still flow to the WS
+    /// (the tap subscribes regardless), but `mode` is treated as if
+    /// it were `NotifyOnly` and never drives a server-side flush.
+    pub enabled: bool,
+    pub mode: BargeInMode,
+}
+
+impl Default for BargeInConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            mode: BargeInMode::AutoClear,
+        }
+    }
 }
 
 impl Default for BridgeDefaults {
@@ -118,6 +158,7 @@ impl Default for BridgeDefaults {
             codecs: vec![Codec::Pcmu, Codec::Pcma],
             dtmf_payload_type: Some(101),
             forward_headers: Vec::new(),
+            barge_in: BargeInConfig::default(),
         }
     }
 }
@@ -346,6 +387,49 @@ pub fn resolve_dtmf_pt(defaults: &BridgeDefaults, route: &CompiledRoute) -> Opti
         // doesn't need a PT but advertising one costs nothing and
         // lets a peer that prefers RFC-2833 pick it.
         _ => defaults.dtmf_payload_type,
+    }
+}
+
+/// Resolve the barge-in plan for one call by merging
+/// `[bridge.barge_in]` (global) with `[route.bridge.barge_in]`. Same
+/// shape as the other `resolve_*` helpers — unset route fields
+/// inherit the default. An unrecognised `mode` string on a route
+/// silently falls back to the global mode rather than failing the
+/// call, matching the config crate's existing tolerance for partial
+/// overrides.
+pub fn resolve_barge_in(defaults: &BridgeDefaults, route: &CompiledRoute) -> BargeInConfig {
+    let mut out = defaults.barge_in.clone();
+    if let Some(enabled) = route.bridge.barge_in.enabled {
+        out.enabled = enabled;
+    }
+    if let Some(mode) = route.bridge.barge_in.mode.as_deref() {
+        if let Some(parsed) = parse_barge_in_mode_route(mode) {
+            out.mode = parsed;
+        }
+    }
+    out
+}
+
+fn parse_barge_in_mode_route(s: &str) -> Option<BargeInMode> {
+    match s {
+        "auto_clear" => Some(BargeInMode::AutoClear),
+        "notify_only" => Some(BargeInMode::NotifyOnly),
+        _ => None,
+    }
+}
+
+/// Translate the public [`BargeInConfig`] into the media-glue tap's
+/// own enum. Kept as a single chokepoint so a future
+/// `BargeInConfig.enabled = false` flip — which today degrades
+/// `AutoClear` to `Notify` — can grow knobs without leaking into
+/// every call site.
+fn barge_in_to_tap_action(cfg: &BargeInConfig) -> siphon_ai_media_glue::BargeInAction {
+    if !cfg.enabled {
+        return siphon_ai_media_glue::BargeInAction::Notify;
+    }
+    match cfg.mode {
+        BargeInMode::AutoClear => siphon_ai_media_glue::BargeInAction::AutoClear,
+        BargeInMode::NotifyOnly => siphon_ai_media_glue::BargeInAction::Notify,
     }
 }
 
@@ -908,6 +992,10 @@ impl BridgingAcceptor {
                 participant_b: forge_core::ParticipantId::new(format!("ws-{}", forge_call_id.0)),
                 from_tag: None,
                 to_tag: None,
+                barge_in_action: barge_in_to_tap_action(&resolve_barge_in(
+                    &self.defaults,
+                    route,
+                )),
             })
             .await?;
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -10,9 +10,9 @@ pub mod call;
 pub mod registry;
 
 pub use acceptor::{
-    build_bridge_config, build_start_msg, extract_offer_sdp, extract_sip_call_id, resolve_codecs,
-    resolve_dtmf_pt, AcceptError, BridgeBuildError, BridgeDefaults, BridgingAcceptor,
-    CallIdFactory, OfferError, PreparedCall,
+    build_bridge_config, build_start_msg, extract_offer_sdp, extract_sip_call_id, resolve_barge_in,
+    resolve_codecs, resolve_dtmf_pt, AcceptError, BargeInConfig, BargeInMode, BridgeBuildError,
+    BridgeDefaults, BridgingAcceptor, CallIdFactory, OfferError, PreparedCall,
 };
 pub use call::{
     CallController, CallControllerConfig, CallError, CallHandle, CallOutcome, CallState,

--- a/crates/media-glue/src/lib.rs
+++ b/crates/media-glue/src/lib.rs
@@ -15,4 +15,4 @@ pub use sdp::{
     build_answer, negotiate_answer, parse_offer, AnswerOutcome, Codec, LocalCapabilities, SdpError,
 };
 pub use setup::{InboundAccepted, InboundCall, MediaSetup, SetupError};
-pub use tap::{MediaTap, MediaTapError, TapCommand, TapDisconnect};
+pub use tap::{BargeInAction, MediaTap, MediaTapError, TapCommand, TapDisconnect};

--- a/crates/media-glue/src/setup.rs
+++ b/crates/media-glue/src/setup.rs
@@ -52,7 +52,7 @@ use tracing::{debug, info, instrument, warn};
 use crate::sdp::{
     negotiate_answer, parse_offer, AnswerOutcome, Codec, LocalCapabilities, SdpError,
 };
-use crate::tap::{MediaTap, MediaTapError};
+use crate::tap::{BargeInAction, MediaTap, MediaTapError};
 
 /// Daemon-wide handles `MediaSetup` needs once at startup. Cheap to
 /// clone — every field is already `Arc`-ed.
@@ -91,6 +91,11 @@ pub struct InboundCall<'a> {
     pub participant_b: ParticipantId,
     pub from_tag: Option<String>,
     pub to_tag: Option<String>,
+    /// What the tap does when forge-vad reports speech-started.
+    /// `[BargeInAction::Notify]` (just forward the WS event) or
+    /// `[BargeInAction::AutoClear]` (drop pending outbound playout
+    /// before forwarding). Set from `[bridge].barge_in.mode`.
+    pub barge_in_action: BargeInAction,
 }
 
 /// What [`MediaSetup::accept_inbound`] hands back on success.
@@ -242,11 +247,12 @@ impl MediaSetup {
             .set_media_bridge_manager(Arc::clone(&self.bridge_manager))
             .await;
 
-        let tap = MediaTap::attach(
+        let tap = MediaTap::attach_with_barge_in(
             &self.bridge_manager,
             &self.event_bus,
             call.call_id.clone(),
             answer.negotiated_audio_sample_rate,
+            call.barge_in_action,
         )?;
 
         guard.disarm();
@@ -367,6 +373,7 @@ mod tests {
                 participant_b: ParticipantId::generate(),
                 from_tag: None,
                 to_tag: None,
+                barge_in_action: BargeInAction::Notify,
             })
             .await;
 

--- a/crates/media-glue/src/tap.rs
+++ b/crates/media-glue/src/tap.rs
@@ -154,6 +154,21 @@ pub enum TapCommand {
     Mark { name: String },
 }
 
+/// How the tap reacts to forge-vad `SpeechStarted` events. Mirrors
+/// `siphon-ai-core`'s public `BargeInMode` shape but lives in this
+/// crate so media-glue doesn't have to take a backwards dep on
+/// core. The acceptor translates `BargeInConfig` (`enabled` +
+/// `mode`) into one of these at call-setup time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BargeInAction {
+    /// Just forward the WS event. The server decides whether to
+    /// send `clear`.
+    Notify,
+    /// Drop pending outbound playout (drain the tap-side audio
+    /// channel + ask forge to flush leg A) AND forward the event.
+    AutoClear,
+}
+
 /// Why the tap pump exited cleanly.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TapDisconnect {
@@ -189,6 +204,13 @@ pub struct MediaTap {
     /// `None` while the original bus is still feeding us; `Some`
     /// after we've swapped in a fallback channel.
     events_keepalive: Option<broadcast::Sender<ForgeEvent>>,
+    /// What this call does when forge-vad reports speech started.
+    /// Resolved from `[bridge].barge_in` + `[route.bridge].barge_in`
+    /// by the acceptor; passed in at `attach` time. Defaults to
+    /// `Notify` on the bare `attach()` entry point so test fixtures
+    /// that don't care about barge-in don't have to thread it
+    /// through.
+    barge_in_action: BargeInAction,
 }
 
 impl std::fmt::Debug for MediaTap {
@@ -216,6 +238,19 @@ impl MediaTap {
         call_id: CallId,
         sample_rate: u32,
     ) -> Result<Self, MediaTapError> {
+        Self::attach_with_barge_in(manager, event_bus, call_id, sample_rate, BargeInAction::Notify)
+    }
+
+    /// Same as [`Self::attach`] but with an explicit barge-in policy.
+    /// The 4-arg form is kept so test fixtures that don't care
+    /// about barge-in don't have to thread the policy through.
+    pub fn attach_with_barge_in(
+        manager: &Arc<MediaBridgeManager>,
+        event_bus: &Arc<EventBus>,
+        call_id: CallId,
+        sample_rate: u32,
+        barge_in_action: BargeInAction,
+    ) -> Result<Self, MediaTapError> {
         // Validate sample rate up front so we don't attach a handle
         // we'd immediately have to detach.
         let _ = siphon_ai_bridge::samples_per_frame(sample_rate)?;
@@ -229,6 +264,7 @@ impl MediaTap {
             call_id,
             events_rx,
             events_keepalive: None,
+            barge_in_action,
         })
     }
 
@@ -344,6 +380,43 @@ impl MediaTap {
                     match event {
                         Ok(ev) => {
                             if let Some(out) = derive_outgoing_event(&self.call_id, ev) {
+                                // Barge-in `auto_clear`: when forge-vad
+                                // reports speech-started AND this call's
+                                // policy is AutoClear, drop pending
+                                // outbound playout before forwarding the
+                                // WS event. The drain catches bytes in
+                                // the controller→tap audio channel that
+                                // haven't yet reached forge; the flush
+                                // dumps forge's encoder queue. Reset the
+                                // Mark bookkeeping so the next `Mark`
+                                // doesn't wait on now-dropped audio.
+                                if matches!(out, OutgoingEvent::SpeechStarted { .. })
+                                    && self.barge_in_action == BargeInAction::AutoClear
+                                {
+                                    let mut drained = 0usize;
+                                    while let Ok(_bytes) = playout_audio_rx.try_recv() {
+                                        drained += 1;
+                                    }
+                                    if let Err(e) = self
+                                        .handle
+                                        .flush(Some(MediaTarget::A), None)
+                                        .await
+                                    {
+                                        warn!(
+                                            call_id = %self.call_id,
+                                            error = %e,
+                                            "forge flush failed during auto_clear",
+                                        );
+                                    } else {
+                                        debug!(
+                                            call_id = %self.call_id,
+                                            drained,
+                                            "auto_clear: dropped pending playout on speech",
+                                        );
+                                    }
+                                    frames_sent_to_forge = 0;
+                                    first_audio_pushed_at = None;
+                                }
                                 if events_tx.send(out).await.is_err() {
                                     debug!("events_tx closed; ending tap");
                                     return Ok(TapDisconnect::ControllerHungUp);

--- a/crates/media-glue/tests/setup.rs
+++ b/crates/media-glue/tests/setup.rs
@@ -70,6 +70,7 @@ fn pcmu_call(call_id: &str, offer: &'static str) -> InboundCall<'static> {
         participant_b: ParticipantId::new("siphon-ws"),
         from_tag: Some("from-tag-1".to_string()),
         to_tag: Some("to-tag-1".to_string()),
+        barge_in_action: ::siphon_ai_media_glue::BargeInAction::Notify,
     }
 }
 
@@ -221,6 +222,7 @@ async fn no_common_codec_rolls_back_session() {
             participant_b: ParticipantId::generate(),
             from_tag: None,
             to_tag: None,
+            barge_in_action: ::siphon_ai_media_glue::BargeInAction::Notify,
         })
         .await;
     assert!(matches!(
@@ -255,6 +257,7 @@ async fn malformed_offer_does_not_allocate_ports() {
             participant_b: ParticipantId::generate(),
             from_tag: None,
             to_tag: None,
+            barge_in_action: ::siphon_ai_media_glue::BargeInAction::Notify,
         })
         .await
         .unwrap_err();

--- a/crates/media-glue/tests/tap.rs
+++ b/crates/media-glue/tests/tap.rs
@@ -984,3 +984,129 @@ async fn forge_speech_event_for_other_call_is_ignored() {
     drop(_playout_tx);
     let _ = tokio::time::timeout(Duration::from_secs(1), pump).await;
 }
+
+// ─── Barge-in auto_clear (SpeechStarted triggers forge.flush) ──────
+
+/// `BargeInAction::AutoClear` + `SpeechStarted` must:
+///   1. Drop any pending bytes in `playout_audio_rx`.
+///   2. Ask forge to flush leg A.
+///   3. Forward the WS event so the server sees `speech_started`.
+///
+/// Pins the `[bridge].barge_in.mode = "auto_clear"` semantics: a
+/// caller interruption is acked immediately with no server round-trip.
+#[tokio::test]
+async fn auto_clear_drops_playout_and_flushes_on_speech_started() {
+    use chrono::Utc;
+    use forge_core::{EventBus as ForgeEventBus, ForgeEvent};
+    use siphon_ai_bridge::OutgoingEvent;
+    use siphon_ai_media_glue::{BargeInAction, TapCommand};
+
+    let manager = Arc::new(MediaBridgeManager::with_capacities(10, 10));
+    let bus = Arc::new(ForgeEventBus::new());
+    let call = CallId::new("auto-clear");
+    let tap = MediaTap::attach_with_barge_in(
+        &manager,
+        &bus,
+        call.clone(),
+        8000,
+        BargeInAction::AutoClear,
+    )
+    .expect("attach");
+
+    let (caller_tx, _caller_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (_playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (events_tx, mut events_rx) = mpsc::channel::<OutgoingEvent>(8);
+    let (_cmd_tx, cmd_rx) = mpsc::channel::<TapCommand>(8);
+
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, events_tx, cmd_rx));
+
+    bus.publish(ForgeEvent::SpeechStarted {
+        call_id: call.clone(),
+        timestamp: Utc::now(),
+    })
+    .expect("publish");
+
+    let drained = tokio::time::timeout(Duration::from_millis(500), async {
+        loop {
+            if let Some(req) = manager.try_recv_outbound_request(&call).await {
+                return req;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("forge sees Flush");
+    assert!(
+        matches!(drained, OutboundMediaRequest::Flush { target: Some(MediaTarget::A), .. }),
+        "expected Flush for leg A, got {drained:?}",
+    );
+
+    let event = tokio::time::timeout(Duration::from_millis(500), events_rx.recv())
+        .await
+        .expect("speech_started arrives")
+        .expect("events_tx open");
+    assert!(
+        matches!(event, OutgoingEvent::SpeechStarted { .. }),
+        "expected SpeechStarted, got {event:?}",
+    );
+
+    drop(_cmd_tx);
+    drop(_caller_rx);
+    drop(_playout_tx);
+    let _ = tokio::time::timeout(Duration::from_secs(1), pump).await;
+}
+
+/// `BargeInAction::Notify` forwards the WS event but does NOT ask
+/// forge to flush. Pins the `mode = "notify_only"` branch.
+#[tokio::test]
+async fn notify_only_does_not_flush_on_speech_started() {
+    use chrono::Utc;
+    use forge_core::{EventBus as ForgeEventBus, ForgeEvent};
+    use siphon_ai_bridge::OutgoingEvent;
+    use siphon_ai_media_glue::{BargeInAction, TapCommand};
+
+    let manager = Arc::new(MediaBridgeManager::with_capacities(10, 10));
+    let bus = Arc::new(ForgeEventBus::new());
+    let call = CallId::new("notify-only");
+    let tap = MediaTap::attach_with_barge_in(
+        &manager,
+        &bus,
+        call.clone(),
+        8000,
+        BargeInAction::Notify,
+    )
+    .expect("attach");
+
+    let (caller_tx, _caller_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (_playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (events_tx, mut events_rx) = mpsc::channel::<OutgoingEvent>(8);
+    let (_cmd_tx, cmd_rx) = mpsc::channel::<TapCommand>(8);
+
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, events_tx, cmd_rx));
+
+    bus.publish(ForgeEvent::SpeechStarted {
+        call_id: call.clone(),
+        timestamp: Utc::now(),
+    })
+    .expect("publish");
+
+    let event = tokio::time::timeout(Duration::from_millis(500), events_rx.recv())
+        .await
+        .expect("speech_started arrives")
+        .expect("events_tx open");
+    assert!(matches!(event, OutgoingEvent::SpeechStarted { .. }));
+
+    let nothing = tokio::time::timeout(Duration::from_millis(80), async {
+        manager.try_recv_outbound_request(&call).await
+    })
+    .await;
+    assert!(
+        matches!(nothing, Ok(None)) || nothing.is_err(),
+        "notify_only must NOT emit forge requests; got {nothing:?}",
+    );
+
+    drop(_cmd_tx);
+    drop(_caller_rx);
+    drop(_playout_tx);
+    let _ = tokio::time::timeout(Duration::from_secs(1), pump).await;
+}


### PR DESCRIPTION
## Summary

Closes the final Week-3 control-plane gap. SiphonAI now reacts to
forge-vad's `SpeechStarted` events according to the
`[bridge].barge_in` policy:

- `mode = \"auto_clear\"` (default) drops pending outbound playout
  the moment the caller starts speaking — caller interruption acks
  immediately with no server round-trip.
- `mode = \"notify_only\"` just forwards the WS event and leaves
  the decision to the WS server.

## Plumbing (top-down through config → core → media-glue)

- **config**: new `RawBargeIn { enabled, mode, debounce_ms }` shape
  on `RawBridge.barge_in`. `compile_barge_in_default` translates
  the raw block into a typed `siphon_ai_core::BargeInConfig`.
  Unknown `mode` strings produce `CompileError::UnknownBargeInMode`
  at config-load time (per CLAUDE.md §4.6 — fail loud at startup).
- **core**: `BargeInMode { NotifyOnly, AutoClear }` +
  `BargeInConfig { enabled, mode }` exported alongside
  `BridgeDefaults`. Default is `enabled=true, mode=AutoClear` —
  barge-in is the obvious good default for real-time speech UIs.
  `resolve_barge_in()` merges per-route over global, mirroring the
  existing `resolve_codecs` / `resolve_dtmf_pt` helpers.
- **media-glue**: `BargeInAction { Notify, AutoClear }` enum kept
  here so media-glue doesn't need a back-dep on core.
  `MediaTap::attach_with_barge_in()` is the new constructor that
  stores the action; the old 4-arg `attach()` delegates with the
  `Notify` default. The events `select!` arm now matches on
  `OutgoingEvent::SpeechStarted` AND
  `self.barge_in_action == AutoClear`: drains `playout_audio_rx`,
  calls `handle.flush(Some(MediaTarget::A), None)`, resets the Mark
  playback-estimation bookkeeping, and forwards the WS event.
- **acceptor → setup → tap**: `InboundCall.barge_in_action` field
  threaded through. `BridgingAcceptor::on_matched` resolves the
  per-call action via `barge_in_to_tap_action(resolve_barge_in(
  defaults, route))`.

## Tests

- `auto_clear_drops_playout_and_flushes_on_speech_started` —
  publish `ForgeEvent::SpeechStarted` into a tap attached with
  `AutoClear`, assert exactly one `OutboundMediaRequest::Flush`
  hits forge for leg A AND the WS event still arrives.
- `notify_only_does_not_flush_on_speech_started` — same with
  `Notify`, assert no forge request.

## End-to-end validation

Default config (auto_clear) + SIPp INVITE + 1500 ms of injected
PCMA speech → WS server receives both `speech_started` /
`speech_stopped` AND the daemon log shows the auto_clear branch
firing:

```
DEBUG ... siphon_ai_media_glue::tap: auto_clear: dropped pending
      playout on speech drained=0
```

`cargo test --workspace --no-fail-fast` green; tap integration
suite is now 21 tests.

## Out of scope

`[bridge.barge_in].debounce_ms` is accepted by the raw parser (so
configs that set it don't fail validation) but not yet read by the
runtime — barge-in already debounces via forge-vad's
`min_speech_duration_ms` hysteresis, so the knob is duplicative
until we surface a separate \"ignore short bursts after a previous
auto_clear\" policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)