### PR TITLE
feat(week7): docker quickstart — siphon-ai + echo-ws compose stack

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,27 @@
+# Exclude artefacts that bloat the build context without
+# contributing to the image. Keeps `docker build` fast and avoids
+# accidentally shipping (e.g.) a local `.env`.
+
+# Rust build artefacts — the multi-stage Dockerfile builds inside
+# the container; the host's `target/` is irrelevant and can be
+# tens of GB on a workstation with multiple test runs.
+target/
+**/target/
+
+# Editor / OS scratch
+.git/
+.vscode/
+.idea/
+.DS_Store
+*.swp
+*.swo
+.claude/
+
+# Secrets — never want these baked into a layer
+.env
+.env.*
+*.pem
+*.key
+
+# Test detritus from the SIPp scenarios runner
+*_errors.log

--- a/README.md
+++ b/README.md
@@ -9,7 +9,37 @@ call. **It does not contain any AI code** — that is the WebSocket server's job
 
 ## Status
 
-Pre-alpha; scaffold only. See `docs/DEV_PLAN.md` for the 7-week sprint plan.
+Pre-alpha. See `docs/DEV_PLAN.md` for the 7-week sprint plan.
+
+## Quickstart (Docker)
+
+The fastest way to see SiphonAI work end-to-end is the local demo
+stack — a containerized daemon talking to the reference Python echo
+WebSocket server.
+
+```sh
+# Build + run the daemon + echo-ws in the background.
+docker compose -f docker/compose.yaml up -d
+
+# Drive a call from your host. Any softphone pointed at
+# 127.0.0.1:5070 works; this one uses SIPp.
+sipp -sf test-harness/sipp-scenarios/basic_call_then_bye.xml \
+     -m 1 -p 5080 -s 1000 127.0.0.1:5070
+
+# Watch the call land:
+docker compose -f docker/compose.yaml logs -f siphon-ai echo-ws
+```
+
+The echo server replays every audio frame back into the call, so if
+you use a softphone you'll hear yourself.
+
+The compose file mounts `docker/local-dev.toml` over the image's
+default config. Edit it (or supply your own with `-v
+./my.toml:/app/config.toml:ro`) and `docker compose restart
+siphon-ai` to apply.
+
+Prometheus metrics live on `http://127.0.0.1:9091/metrics`;
+`/health` and `/ready` are next to them.
 
 ## Layout
 
@@ -51,7 +81,7 @@ the same author:
 
 - [`siphon-rs`](https://github.com/thevoiceguy/siphon-rs) — RFC 3261 SIP stack
 - [`forge-media`](https://github.com/thevoiceguy/forge-media) — RTP/codecs/SDP/jitter/VAD
-- `hep-rs` — HEP3 codec, transport, `HepSink` trait (in progress; not yet a public repo)
+- [`hep-rs`](https://github.com/thevoiceguy/hep-rs) — HEP3 codec, transport, `HepSink` trait
 
 ## License
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,99 @@
+# Multi-stage Dockerfile for the SiphonAI daemon.
+#
+# Builds the `siphon-ai` binary against a pinned Rust toolchain, then
+# copies it into a minimal Debian-slim runtime. The runtime image
+# carries only what's needed to execute the binary — no compiler,
+# no source — and is the artifact operators deploy.
+#
+# Target size: ~50 MB compressed, ~120 MB extracted. The bulk is
+# debian-slim's base layer (~30 MB) and the static-ish daemon
+# binary (~80 MB unstripped). Strip in a follow-up if size pressure
+# materializes; for v0.1.0 we lean on `cargo build --release`'s
+# defaults to keep stack traces readable.
+#
+# Build:
+#     docker build -f docker/Dockerfile -t siphon-ai:dev .
+#
+# Run (assumes docker-compose.yaml handles network + config):
+#     docker run --rm -p 5070:5070/udp siphon-ai:dev
+
+# ─── Build stage ───────────────────────────────────────────────────
+# Pin the Rust toolchain to match `rust-version` in workspace
+# Cargo.toml. Bookworm matches the runtime stage so libc / glibc
+# ABIs line up.
+FROM rust:1.85-bookworm AS builder
+
+# Cache mount-friendly dep install. The bookworm rust image already
+# ships build tools; we add only what siphon-rs / forge-media
+# transitively need:
+#   * pkg-config + libssl-dev: occasional indirect crates (NOT for
+#     the daemon's TLS — that path uses rustls — but bcg729-sys and
+#     forge-codecs may invoke pkg-config during build).
+#   * cmake: forge-codecs uses cmake for some bundled native libs.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        pkg-config libssl-dev cmake \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Copy the workspace verbatim. We don't try to cache the dep build
+# separately (the usual Cargo.toml-only trick) because workspace
+# member discovery is recursive and brittle to fake out; cargo's
+# fetch cache + Docker's layer cache get us most of the speed win
+# without the maintenance cost.
+COPY . .
+
+# Build the daemon only. `--locked` keeps the build reproducible —
+# if Cargo.lock is missing or out-of-date the build fails loudly
+# instead of silently bumping deps. CI builds run this way too.
+RUN cargo build --release --locked -p siphon-ai \
+ && strip target/release/siphon-ai
+
+
+# ─── Runtime stage ─────────────────────────────────────────────────
+# Debian-slim because:
+#   * matches the builder's glibc — no surprise ABI breaks
+#   * `ca-certificates` for HTTPS lookups (webhook sink, future
+#     hep-rs TLS transport)
+#   * smaller than `debian:bookworm` (~30 MB vs ~115 MB) and far
+#     better-supported than `distroless` for occasional sh-into
+#     debugging
+FROM debian:bookworm-slim AS runtime
+
+# Pinned minimal runtime deps. Adding to this list is a one-PR
+# event — keep it tight.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# Non-root user. SIP and RTP both bind unprivileged ports by
+# default in our config (5070 for SIP, 40000-40100 for RTP), so we
+# don't need root at runtime.
+ARG UID=10001
+RUN groupadd --system --gid ${UID} siphon \
+ && useradd --system --uid ${UID} --gid siphon --no-create-home siphon
+USER siphon
+
+WORKDIR /app
+
+# The binary is the entire delivery. Configs are mounted from the
+# host or built into a sibling image (see docker/compose.yaml).
+COPY --from=builder /build/target/release/siphon-ai /usr/local/bin/siphon-ai
+
+# Default config path. Operators override via `-v ./my.toml:/app/config.toml`.
+ENV SIPHON_AI_CONFIG=/app/config.toml
+
+# Document the runtime surface. Compose / k8s overrides as needed.
+#   5070/udp   — SIP signaling
+#   5070/tcp   — SIP TCP (when transports = ["tcp"])
+#   5061/tcp   — SIPS (when transports = ["tls"])
+#   9091/tcp   — Prometheus metrics + /health + /ready
+#   40000-40100/udp — RTP port pool (matches local-dev.toml default)
+EXPOSE 5070/udp 5070/tcp 5061/tcp 9091/tcp 40000-40100/udp
+
+# `--config` is positional in main.rs — keep the entrypoint thin so
+# operators can append `--help` etc. without fighting the wrapper.
+ENTRYPOINT ["/usr/local/bin/siphon-ai"]
+CMD ["--config", "/app/config.toml"]

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -1,0 +1,87 @@
+# Local-demo docker-compose for SiphonAI.
+#
+# What you get with `docker compose up`:
+#
+#   * `echo-ws`     — the reference Python WebSocket server on
+#                     ws://echo-ws:8765 inside the compose network.
+#                     Echoes every audio frame back into the call;
+#                     logs control messages.
+#
+#   * `siphon-ai`   — the daemon, configured to dial the echo WS
+#                     above. Listens for SIP on host port 5070/udp.
+#
+# Drive a call from your host with SIPp:
+#
+#   sipp -sf test-harness/sipp-scenarios/basic_call_then_bye.xml \
+#        -m 1 -p 5080 -s 1000 127.0.0.1:5070
+#
+# (or a softphone; point it at 127.0.0.1:5070 with any user-part.)
+#
+# This file deliberately leaves Homer out — running Homer pulls in
+# Postgres + heplify-server + the homer-app UI, which is its own
+# stack. See examples/homer-stack/ for that integration (deferred to
+# the docs/HEP.md PR).
+
+services:
+  echo-ws:
+    build:
+      context: ../examples/echo-ws-server-python
+      dockerfile: Dockerfile
+    image: siphon-ai/echo-ws:dev
+    # The daemon connects to ws://echo-ws:8765 inside the bridge
+    # network; we don't expose the port to the host unless an
+    # operator explicitly forwards it (uncomment the `ports` line
+    # below for poking from a host browser/`websocat`).
+    # ports:
+    #   - "8765:8765"
+    command:
+      - --bind
+      - "0.0.0.0:8765"
+      - --log-level
+      - INFO
+    healthcheck:
+      # `/healthz` short-circuits the WebSocket upgrade in the
+      # echo server (see server.py::process_request), so the probe
+      # gets a clean 200 without "InvalidUpgrade" log noise every
+      # 5 seconds.
+      test:
+        - CMD-SHELL
+        - "python3 -c \"import urllib.request,sys; r=urllib.request.urlopen('http://127.0.0.1:8765/healthz',timeout=2); sys.exit(0 if r.status==200 else 1)\""
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 3s
+    restart: unless-stopped
+
+  siphon-ai:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    image: siphon-ai/siphon-ai:dev
+    depends_on:
+      echo-ws:
+        condition: service_healthy
+    # Mount the compose-tuned config in over the image's default
+    # path. Operators editing on the host see changes after a
+    # `docker compose restart siphon-ai`.
+    volumes:
+      - ./local-dev.toml:/app/config.toml:ro
+    ports:
+      # SIP UDP — SIPp / softphones / PBX trunks. Mapped to host
+      # 5070 to match the existing test-harness/sipp-scenarios
+      # commands and configs/local-dev.toml.
+      - "5070:5070/udp"
+      # SIP TCP — same port, different namespace.
+      - "5070:5070/tcp"
+      # Prometheus metrics + /health + /ready.
+      - "9091:9091/tcp"
+      # RTP port pool. forge's port allocator picks from this range
+      # for the answer SDP's `m=audio` line; without these forwarded
+      # the caller's media flows nowhere.
+      - "40000-40100:40000-40100/udp"
+    environment:
+      # Verbose enough to see call lifecycle without drowning in
+      # per-frame logs. Override with `--log` or RUST_LOG when
+      # debugging a specific layer.
+      RUST_LOG: "siphon_ai=info,siphon=info,forge=info"
+    restart: unless-stopped

--- a/docker/local-dev.toml
+++ b/docker/local-dev.toml
@@ -1,0 +1,53 @@
+# SiphonAI config for the docker-compose demo.
+#
+# Differences from `configs/local-dev.toml`:
+#
+#   * `[sip].listen = "0.0.0.0:5070"` so the container accepts
+#     traffic on every interface (compose's bridge network gives
+#     each service a private IP).
+#
+#   * `[node].public_address = "127.0.0.1"` — the SDP answer's
+#     `c=` line goes here. With host-port forwarding, callers
+#     running on the host send RTP to 127.0.0.1:<rtp-port>, which
+#     the kernel forwards into the container. Operators running
+#     this on a remote machine should set this to the machine's
+#     external IP.
+#
+#   * `[bridge].ws_url = "ws://echo-ws:8765/"` — compose service
+#     discovery resolves `echo-ws` to the sibling container's IP.
+#
+#   * `[observability].http_listen = "0.0.0.0:9091"` so the host
+#     port-mapping reaches it.
+#
+# The HEP block is left disabled in this file because the demo
+# compose doesn't include Homer. Stand up Homer separately (see
+# docs/HEP.md, follow-up) and flip `[hep].enabled = true` with the
+# right `collector` to wire it in.
+
+[node]
+id = "siphon-ai-compose"
+public_address = "127.0.0.1"
+
+[sip]
+listen = "0.0.0.0:5070"
+transports = ["udp"]
+user_agent = "SiphonAI/compose-demo"
+
+[media]
+codecs = ["pcmu", "pcma"]
+dtmf = "rfc2833"
+rtp_port_range = [40000, 40100]
+
+[bridge]
+ws_url = "ws://echo-ws:8765/"
+ws_connect_timeout_ms = 3000
+audio_sample_rate = 8000
+
+[observability]
+enabled = true
+http_listen = "0.0.0.0:9091"
+
+[[route]]
+name = "default"
+[route.match]
+any = true

--- a/examples/echo-ws-server-python/.dockerignore
+++ b/examples/echo-ws-server-python/.dockerignore
@@ -1,0 +1,7 @@
+# Skip the local venv from `python -m venv .venv` and other
+# scratch state.
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+.DS_Store

--- a/examples/echo-ws-server-python/Dockerfile
+++ b/examples/echo-ws-server-python/Dockerfile
@@ -1,0 +1,32 @@
+# Reference echo WS server image. Tiny: python:3.13-slim + one
+# Python dep (`websockets`). Used by `docker/compose.yaml` as the
+# canary WS endpoint SiphonAI dials into.
+#
+# Build:
+#     docker build -t siphon-ai/echo-ws:dev examples/echo-ws-server-python/
+#
+# Run:
+#     docker run --rm -p 8765:8765 siphon-ai/echo-ws:dev \
+#         --bind 0.0.0.0:8765
+
+FROM python:3.13-slim
+
+# requirements.txt is one line (`websockets>=13`) — install at
+# build time, not at container start, so cold starts are fast.
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY server.py ./
+
+# Non-root user. The server binds 8765 (unprivileged) so we don't
+# need any caps.
+ARG UID=10001
+RUN groupadd --system --gid ${UID} echo \
+ && useradd --system --uid ${UID} --gid echo --no-create-home echo
+USER echo
+
+EXPOSE 8765
+
+ENTRYPOINT ["python3", "/app/server.py"]
+CMD ["--bind", "0.0.0.0:8765"]

--- a/examples/echo-ws-server-python/server.py
+++ b/examples/echo-ws-server-python/server.py
@@ -72,6 +72,13 @@ def make_request_handler(opts: Options):
     """
 
     def process_request(connection: ServerConnection, request: Request) -> Response | None:
+        # Cheap healthcheck endpoint. We short-circuit before the
+        # websockets handshake validation runs, so periodic
+        # `curl http://.../healthz` from a Docker / k8s probe
+        # doesn't show up as an `InvalidUpgrade` error in the log.
+        if request.path == "/healthz":
+            return connection.respond(200, "ok\n")
+
         if opts.auth_token is None:
             return None
         header = request.headers.get("Authorization", "")


### PR DESCRIPTION
## Summary
First slice of Week 7 (Packaging, Docs, Launch) from `docs/DEV_PLAN.md`. With this PR, `docker compose -f docker/compose.yaml up` brings up the daemon plus the reference Python echo WS server on a shared bridge network. Drive a SIP call from your host with SIPp or a softphone pointed at `127.0.0.1:5070` and you get a working end-to-end demo.

## What's in the box
- **`docker/Dockerfile`** — multi-stage, `rust:1.85-bookworm` builder → `debian:bookworm-slim` runtime. `--locked` build for reproducibility; binary is stripped. Runs as a non-root user. Final image is ~143 MB (target was 50 MB from the dev plan; deferring static-musl shrinkage to keep stack traces readable for v0.1.0 debugging).
- **`docker/compose.yaml`** — `siphon-ai` + `echo-ws` services with the right ports forwarded (5070 SIP udp+tcp, 9091 Prometheus, 40000-40100 RTP). The echo server stays internal to the bridge network.
- **`docker/local-dev.toml`** — bridge-friendly config: `0.0.0.0` binds, `[node].public_address = "127.0.0.1"` for host-loopback SDP answers, `ws_url = "ws://echo-ws:8765/"` for compose service discovery, observability on `0.0.0.0:9091`.
- **`examples/echo-ws-server-python/Dockerfile`** + `.dockerignore` — `python:3.13-slim` image built directly from the existing reference server.
- **`examples/echo-ws-server-python/server.py`** — adds a `/healthz` short-circuit in `process_request` so Docker healthchecks don't log every probe as an `InvalidUpgrade`. Backward compatible.
- **Top-level `.dockerignore`** — keeps the local 30+ GB `target/`, secrets, and SIPp error logs out of the build context.
- **README quickstart** — copy-paste demo + pointers to where to edit config.

## End-to-end verified
```
docker compose -f docker/compose.yaml up -d
sipp -sf test-harness/sipp-scenarios/basic_call_then_bye.xml -m 1 -p 5080 -s 1000 127.0.0.1:5070
  → Successful call: 1
docker compose -f docker/compose.yaml logs siphon-ai echo-ws
  → "bridge connected", "start", "stop reason=server_hangup", "BYE → controller shutdown"
```

## Out of scope (Week 7 follow-ups)
- `examples/openai-realtime-bridge-py/` — substantial deliverable on its own; separate PR.
- Mermaid architecture diagram in the README.
- Troubleshooting guide.
- `examples/homer-stack/` — full Homer + heplify-server + Postgres stack for the HEP end-to-end demo.
- v0.1.0 tag + GitHub release with prebuilt binaries (do once the above lands and everything works end-to-end).
- Image-size optimization (musl-static, distroless) to hit the 50 MB target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)