### PR TITLE
docs(readme): mermaid architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,39 @@ phone on a PBX), streams the call's audio over a WebSocket to a developer-
 supplied server, and plays audio received back over that WebSocket into the
 call. **It does not contain any AI code** — that is the WebSocket server's job.
 
+## How it fits together
+
+```mermaid
+flowchart LR
+    Caller([SIP caller<br/>softphone / trunk / PBX])
+    WS["Your WS server<br/>(STT • LLM • TTS)"]
+    Homer[("Homer / HEPIC<br/>HEP3 collector")]
+
+    subgraph SiphonAI ["SiphonAI daemon"]
+        direction LR
+        sip["siphon-rs<br/>SIP UAS / UAC"]
+        forge["forge-media<br/>RTP • codecs • SDP"]
+        bridge["bridge crate<br/>WS protocol v1"]
+        sip -- "INVITE / BYE / REFER" --> ctrl
+        forge -- "PCM16 20 ms frames" --> ctrl
+        ctrl["core::CallController<br/>per-call state machine"]
+        ctrl --> bridge
+    end
+
+    Caller -- "SIP + RTP" --> sip
+    forge <-- "RTP" --> Caller
+    bridge <== "WebSocket<br/>JSON ctrl + binary audio" ==> WS
+
+    sip -. "HEP3 SIP (0x01)" .-> Homer
+    forge -. "HEP3 RTCP (0x05) + QoS (0x20)" .-> Homer
+    ctrl -. "HEP3 CDR (0x65)" .-> Homer
+```
+
+The WebSocket server runs the AI — STT, LLM, TTS, whatever fits the
+use case. SiphonAI is the bridge: SIP signaling, RTP media, codec
+handling, jitter, barge-in, DTMF, hold, transfer. See
+[`docs/PROTOCOL.md`](docs/PROTOCOL.md) for the contract.
+
 ## Status
 
 Pre-alpha. See `docs/DEV_PLAN.md` for the 7-week sprint plan.


### PR DESCRIPTION
## Summary
Adds a top-level mermaid flowchart so visitors landing on the repo can see at a glance how the moving parts relate:

- SIP caller → `siphon-rs` UAS → `CallController` → `bridge` crate → WebSocket server
- `forge-media` handles RTP in parallel
- HEP3 chunks (SIP / RTCP / RTP-QoS / CDR) fan out to Homer for cross-protocol correlation

GitHub renders mermaid blocks natively — no extra build step, the diagram shows up inline on the landing page.

## Why
- Concrete picture of what's in the box, vs the existing prose intro.
- Anchors the rest of the README ("ah, that's where the bridge crate sits").
- Closes item 5 of the Week 7 acceptance criteria in `docs/DEV_PLAN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)