### PR TITLE
build(docker): musl-static daemon image — 143 MB → 31 MB

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,15 +1,11 @@
 # Multi-stage Dockerfile for the SiphonAI daemon.
 #
-# Builds the `siphon-ai` binary against a pinned Rust toolchain, then
-# copies it into a minimal Debian-slim runtime. The runtime image
-# carries only what's needed to execute the binary — no compiler,
-# no source — and is the artifact operators deploy.
-#
-# Target size: ~50 MB compressed, ~120 MB extracted. The bulk is
-# debian-slim's base layer (~30 MB) and the static-ish daemon
-# binary (~80 MB unstripped). Strip in a follow-up if size pressure
-# materializes; for v0.1.0 we lean on `cargo build --release`'s
-# defaults to keep stack traces readable.
+# Builds a fully-static `x86_64-unknown-linux-musl` binary on
+# Alpine, then drops it into a fresh `alpine:3` runtime carrying
+# only ca-certificates. Target size: ~50 MB. The static linkage
+# means there are no glibc/musl ABI gotchas at deploy time — the
+# image can be replaced with `scratch` or `distroless/static` if
+# operators want to shave another 7 MB.
 #
 # Build:
 #     docker build -f docker/Dockerfile -t siphon-ai:dev .
@@ -18,69 +14,77 @@
 #     docker run --rm -p 5070:5070/udp siphon-ai:dev
 
 # ─── Build stage ───────────────────────────────────────────────────
-# Pin the Rust toolchain to match `rust-version` in workspace
-# Cargo.toml. Bookworm matches the runtime stage so libc / glibc
-# ABIs line up.
-FROM rust:1.85-bookworm AS builder
+# Alpine + the matching Rust toolchain.  The `-alpine` image already
+# carries an x86_64-unknown-linux-musl target via the musl libc on
+# the system, so `cargo build --target x86_64-unknown-linux-musl`
+# Just Works — no rustup target add dance required.
+FROM rust:1.85-alpine AS builder
 
-# Cache mount-friendly dep install. The bookworm rust image already
-# ships build tools; we add only what siphon-rs / forge-media
-# transitively need:
-#   * pkg-config + libssl-dev: occasional indirect crates (NOT for
-#     the daemon's TLS — that path uses rustls — but bcg729-sys and
-#     forge-codecs may invoke pkg-config during build).
-#   * cmake: forge-codecs uses cmake for some bundled native libs.
-RUN apt-get update \
- && apt-get install -y --no-install-recommends \
-        pkg-config libssl-dev cmake \
- && rm -rf /var/lib/apt/lists/*
+# Musl + the C build tools forge-codecs and friends invoke at
+# compile time. `linux-headers` is required by tokio's TCP/UDP code
+# paths under musl; `make` is dragged in by a couple of `-sys`
+# crates that ship vendored C. We deliberately list each package
+# rather than installing `build-base` so the build context shows
+# which deps each addition adds.
+RUN apk add --no-cache \
+        musl-dev \
+        linux-headers \
+        cmake \
+        make \
+        g++ \
+        pkgconfig \
+        perl
 
 WORKDIR /build
 
-# Copy the workspace verbatim. We don't try to cache the dep build
-# separately (the usual Cargo.toml-only trick) because workspace
-# member discovery is recursive and brittle to fake out; cargo's
-# fetch cache + Docker's layer cache get us most of the speed win
-# without the maintenance cost.
+# Copy the workspace verbatim. `.dockerignore` at the repo root
+# excludes `target/`, `.git/`, etc. so this is small.
 COPY . .
 
-# Build the daemon only. `--locked` keeps the build reproducible —
-# if Cargo.lock is missing or out-of-date the build fails loudly
-# instead of silently bumping deps. CI builds run this way too.
-RUN cargo build --release --locked -p siphon-ai \
- && strip target/release/siphon-ai
+# Build the daemon only. `--locked` keeps the build reproducible.
+#
+# The `RUSTFLAGS` enable static linking against musl explicitly —
+# the alpine rust image defaults to it for musl targets but pinning
+# the flag here prevents surprises on toolchain upgrades.
+#
+# `--target x86_64-unknown-linux-musl` produces a binary that runs
+# on any Linux kernel ≥ 3.2 without dynamic library deps. `strip`
+# drops debug info, halving the binary size.
+ENV RUSTFLAGS="-C target-feature=+crt-static"
+RUN cargo build \
+        --release \
+        --locked \
+        --target x86_64-unknown-linux-musl \
+        -p siphon-ai \
+ && strip target/x86_64-unknown-linux-musl/release/siphon-ai
 
 
 # ─── Runtime stage ─────────────────────────────────────────────────
-# Debian-slim because:
-#   * matches the builder's glibc — no surprise ABI breaks
-#   * `ca-certificates` for HTTPS lookups (webhook sink, future
-#     hep-rs TLS transport)
-#   * smaller than `debian:bookworm` (~30 MB vs ~115 MB) and far
-#     better-supported than `distroless` for occasional sh-into
-#     debugging
-FROM debian:bookworm-slim AS runtime
+# Alpine because:
+#   * matches the builder's musl — fully-static binary, no surprises
+#   * a working /bin/sh for `docker exec` debugging when calls go sideways
+#   * `apk add ca-certificates` is one line and ~1 MB
+#   * `distroless/static` is a valid drop-in if operators want to
+#     shave another ~7 MB at the cost of `docker exec` ergonomics.
+FROM alpine:3 AS runtime
 
-# Pinned minimal runtime deps. Adding to this list is a one-PR
-# event — keep it tight.
-RUN apt-get update \
- && apt-get install -y --no-install-recommends \
-        ca-certificates \
- && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache ca-certificates
 
 # Non-root user. SIP and RTP both bind unprivileged ports by
 # default in our config (5070 for SIP, 40000-40100 for RTP), so we
 # don't need root at runtime.
 ARG UID=10001
-RUN groupadd --system --gid ${UID} siphon \
- && useradd --system --uid ${UID} --gid siphon --no-create-home siphon
+RUN addgroup -S -g ${UID} siphon \
+ && adduser -S -D -H -u ${UID} -G siphon siphon
 USER siphon
 
 WORKDIR /app
 
 # The binary is the entire delivery. Configs are mounted from the
 # host or built into a sibling image (see docker/compose.yaml).
-COPY --from=builder /build/target/release/siphon-ai /usr/local/bin/siphon-ai
+COPY --from=builder \
+     /build/target/x86_64-unknown-linux-musl/release/siphon-ai \
+     /usr/local/bin/siphon-ai
 
 # Default config path. Operators override via `-v ./my.toml:/app/config.toml`.
 ENV SIPHON_AI_CONFIG=/app/config.toml
@@ -93,7 +97,5 @@ ENV SIPHON_AI_CONFIG=/app/config.toml
 #   40000-40100/udp — RTP port pool (matches local-dev.toml default)
 EXPOSE 5070/udp 5070/tcp 5061/tcp 9091/tcp 40000-40100/udp
 
-# `--config` is positional in main.rs — keep the entrypoint thin so
-# operators can append `--help` etc. without fighting the wrapper.
 ENTRYPOINT ["/usr/local/bin/siphon-ai"]
 CMD ["--config", "/app/config.toml"]


### PR DESCRIPTION
## Summary
Rewrites `docker/Dockerfile` to build a fully-static `x86_64-unknown-linux-musl` binary on Alpine, then drop it into a fresh `alpine:3` runtime. Image size drops from **143 MB → 30.8 MB** — comfortably under the 50 MB Week-7 target from `docs/DEV_PLAN.md`.

## Why it works
- The daemon's only native deps are `libgcc`, `libm`, `libc` — all satisfied by Alpine's musl runtime. `ldd` on the prior image confirmed no other shared libs.
- `default-features = false, features = ["g722"]` on `forge-engine` keeps `bcg729-sys` and other native-library codecs out of the link graph entirely.
- `RUSTFLAGS=-C target-feature=+crt-static` pins the static linkage even if a future toolchain upgrade flips the Alpine Rust image's default.
- ELF inspection on the new binary shows zero `NEEDED` dynamic library entries — it's a true static binary.

## Verified
| Check                                                          | Result   |
|----------------------------------------------------------------|----------|
| `docker build`                                                 | 30.8 MB  |
| `docker compose up` (echo-ws + siphon-ai)                      | healthy  |
| `sipp basic_call_then_bye.xml`                                 | 1 Successful call |
| `curl /health`                                                 | `ok`     |
| Binary `NEEDED` libs                                           | none     |

## Out of scope
- `distroless/static` swap — drops another ~7 MB at the cost of losing `docker exec sh` for in-container debugging. Documented in the Dockerfile header as a callable alternative; kept Alpine as the default for v0.1.0 because operator triage matters more than a few MB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)