### PR TITLE
feat(admin): /admin/* endpoints for runtime introspection + control

### DIFF
--- a/bins/siphon-ai/src/main.rs
+++ b/bins/siphon-ai/src/main.rs
@@ -14,8 +14,9 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use clap::Parser;
 use siphon_ai::Runtime;
+use siphon_ai_telemetry::LogFilterHandle;
 use tracing::info;
-use tracing_subscriber::EnvFilter;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
 #[derive(Parser, Debug)]
 #[command(name = "siphon-ai", version, about = "SIP-to-WebSocket media bridge")]
@@ -34,7 +35,7 @@ struct Cli {
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
-    init_tracing(cli.log.as_deref());
+    let log_filter = init_tracing(cli.log.as_deref());
 
     info!(config = %cli.config.display(), "loading configuration");
     let config = siphon_ai_config::load_from_path(&cli.config)
@@ -48,20 +49,27 @@ async fn main() -> Result<()> {
         "configuration compiled",
     );
 
-    let runtime = Runtime::build(config)
+    let runtime = Runtime::build(config, log_filter)
         .await
         .context("runtime build failed")?;
 
     runtime.run(shutdown_signal()).await
 }
 
-/// Initialise the global tracing subscriber.
+/// Initialise the global tracing subscriber and return a reload
+/// handle the admin endpoint uses to swap the filter at runtime.
 ///
 /// Order of precedence for the filter: `--log` flag > `RUST_LOG` env
 /// var > built-in default. The default filter pulls siphon-ai
 /// crates in at `info` and silences busy upstream logs that don't
 /// add operator value at default verbosity.
-fn init_tracing(cli_filter: Option<&str>) {
+///
+/// Implementation note: we build the subscriber as
+/// `Registry → reload(EnvFilter) → fmt-layer` rather than the
+/// shorthand `tracing_subscriber::fmt()` builder, because the
+/// shorthand doesn't expose a reload handle. The layered form is
+/// the canonical way to make `EnvFilter` mutable at runtime.
+fn init_tracing(cli_filter: Option<&str>) -> LogFilterHandle {
     const DEFAULT: &str = "siphon_ai=info,siphon_ai_core=info,siphon_ai_media_glue=info,\
          siphon_ai_sip_glue=info,siphon_ai_bridge=info,siphon_ai_routes=info,\
          siphon_ai_config=info,sip_uas=warn,sip_transaction=warn,\
@@ -72,10 +80,18 @@ fn init_tracing(cli_filter: Option<&str>) {
         None => EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(DEFAULT)),
     };
 
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(env_filter)
-        .with_target(true)
+    let (filter_layer, reload_handle) = tracing_subscriber::reload::Layer::new(env_filter);
+    let fmt_layer = tracing_subscriber::fmt::layer().with_target(true);
+    // `try_init` so tests that initialise the subscriber separately
+    // don't crash this process; the second init is a noop. The
+    // reload handle works either way because the layer is part of
+    // the subscriber, not a global cell.
+    let _ = tracing_subscriber::registry()
+        .with(filter_layer)
+        .with(fmt_layer)
         .try_init();
+
+    LogFilterHandle::new(reload_handle)
 }
 
 /// Resolve when SIGINT (Ctrl-C) or SIGTERM is received. On Windows

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -80,7 +80,9 @@ use siphon_ai_sip_glue::{
     RoutingHandler,
 };
 use siphon_ai_telemetry::{
-    install_recorder, HepTelemetry, HepTelemetryBuild, ObservabilityServer, ReadinessFlag,
+    admin::{AdminCallRegistry, AdminState, CallRegistryHandle, RegistrationRow},
+    install_recorder, HepTelemetry, HepTelemetryBuild, HepWorkerHandle, LogFilterHandle,
+    ObservabilityServer, ReadinessFlag,
 };
 use siphon_ai_webhooks::{
     FilteredSink as WebhookFilteredSink, HttpSink as WebhookHttpSink,
@@ -107,10 +109,16 @@ pub struct Runtime {
     /// `Some` when `[observability].enabled = true`. Dropped on
     /// shutdown to stop the HTTP listener.
     observability: Option<ObservabilityServer>,
-    /// `Some` when `[hep].enabled = true`. Owned here so the UDP
-    /// worker stays alive for the daemon's lifetime; dropped on
-    /// shutdown so the worker exits.
-    hep_telemetry: Option<HepTelemetry>,
+    /// `Some` when `[hep].enabled = true`. Share-by-Arc so the admin
+    /// state, CDR sink, and per-call code can borrow it; the UDP
+    /// worker lives separately on `hep_worker` for shutdown. The
+    /// field is held for its drop-on-shutdown side effect (releasing
+    /// the last Arc clone the worker observes via the shared sink).
+    #[allow(dead_code)]
+    hep_telemetry: Option<Arc<HepTelemetry>>,
+    /// The HEP UDP worker JoinHandle. Held for the daemon's
+    /// lifetime; aborted on shutdown.
+    hep_worker: Option<HepWorkerHandle>,
     /// Per-`[[register]]` background tasks. v1's tasks are no-ops
     /// (UAC drive lands in a follow-up); we still own the handles
     /// so shutdown awaits them cleanly.
@@ -123,7 +131,7 @@ impl Runtime {
     ///
     /// Binds the UDP socket eagerly so a "port already in use" error
     /// surfaces during startup, not after we've logged "ready".
-    pub async fn build(config: Config) -> Result<Self> {
+    pub async fn build(config: Config, log_filter: LogFilterHandle) -> Result<Self> {
         let Config {
             node,
             sip,
@@ -137,17 +145,26 @@ impl Runtime {
             hep,
         } = config;
 
-        // ─── Telemetry: install Prometheus recorder + spawn HTTP ───
+        // ─── Telemetry: install Prometheus recorder ─────────────────
+        // We defer the HTTP listener until after the call registry +
+        // registration manager exist so admin routes have dependencies
+        // wired in. Prometheus install can happen up-front; the
+        // recorder is a global static.
         let readiness = ReadinessFlag::new();
-        let observability_server = build_observability(observability, readiness.clone()).await?;
+        let prometheus_handle =
+            install_recorder().map_err(|e| anyhow!("install Prometheus recorder: {e}"))?;
 
         // ─── HEP3 / Homer wiring ──────────────────────────────────
         // Built before any SIP / forge traffic so the global emitters
         // are installed before the listeners can fire. When `[hep]
         // .enabled = false` returns `None` with zero cost.
-        let hep_telemetry = build_hep_telemetry(&node, hep).await?;
+        let hep_built = build_hep_telemetry(&node, hep).await?;
+        let (hep_telemetry, hep_worker) = match hep_built {
+            Some((t, w)) => (Some(t), Some(w)),
+            None => (None, None),
+        };
 
-        let cdr_sink = build_cdr_sink(cdr, hep_telemetry.as_ref()).await?;
+        let cdr_sink = build_cdr_sink(cdr, hep_telemetry.as_deref()).await?;
         // The same sink fans out call lifecycle events from the
         // acceptor AND registration_state_changed events from the
         // per-[[register]] tasks. Cheap to share — Arc<dyn …>.
@@ -330,6 +347,36 @@ impl Runtime {
             tls_server_config,
         );
 
+        // ─── Build admin state + observability HTTP listener ──────
+        // Deferred until now so admin endpoints have the call
+        // registry, registration manager, hep telemetry, and log-
+        // filter reload handle all wired in. Any of these being None
+        // makes the corresponding endpoint return 503 rather than
+        // crashing — see telemetry::admin docs.
+        let call_registry_for_admin = acceptor.registry().clone();
+        let registration_mgr_for_admin = registration_mgr.clone();
+        let admin_state = AdminState {
+            call_registry: Some(Arc::new(RuntimeCallRegistry {
+                inner: call_registry_for_admin,
+            }) as AdminCallRegistry),
+            registration_snapshot: Some(Arc::new(move || {
+                registration_mgr_for_admin
+                    .snapshot()
+                    .into_iter()
+                    .map(registration_state_to_row)
+                    .collect()
+            })),
+            log_filter: Some(log_filter),
+            hep: hep_telemetry.clone(),
+        };
+        let observability_server = build_observability(
+            observability,
+            readiness.clone(),
+            prometheus_handle,
+            admin_state,
+        )
+        .await?;
+
         // We're now serving SIP — let the readiness probe flip.
         readiness.mark_ready();
 
@@ -341,6 +388,7 @@ impl Runtime {
             listeners,
             observability: observability_server,
             hep_telemetry,
+            hep_worker,
             registration_mgr,
             registration_listeners,
         })
@@ -402,12 +450,12 @@ impl Runtime {
             server.shutdown().await;
         }
 
-        // Drain the HEP UDP worker — drops the sink reference, the
-        // worker sees its channel close, and exits. Bounded by the
-        // sink's queue depth (default 256 packets, ~milliseconds at
-        // typical call volumes).
-        if let Some(hep) = self.hep_telemetry {
-            hep.shutdown().await;
+        // Drain the HEP UDP worker — aborts the task, bounded wait.
+        // The telemetry handle itself is dropped here too (Arc
+        // refcount goes to zero once `self.hep_telemetry` is out of
+        // scope at function end).
+        if let Some(worker) = self.hep_worker {
+            worker.shutdown().await;
         }
 
         // Drop the UAS / TM Arcs so any per-call task that's still
@@ -424,16 +472,17 @@ impl Runtime {
 
 // ─── Helpers ─────────────────────────────────────────────────────────
 
-/// Install the Prometheus recorder + spawn the `/health` /
-/// `/ready` / `/metrics` HTTP server. When the operator hasn't
-/// enabled `[observability]` we still install the recorder (so
-/// metric calls in the call layers don't crash) but skip the HTTP
-/// listener — the recorder is just unconsumed in that case.
+/// Spawn the observability `/health` / `/ready` / `/metrics` HTTP
+/// server with admin routes installed. The Prometheus recorder is
+/// installed earlier in `Runtime::build` (so metric calls in call
+/// layers don't crash even when `[observability]` is disabled); the
+/// `prometheus` handle here is just the renderer for `/metrics`.
 async fn build_observability(
     cfg: ObservabilityConfig,
     readiness: ReadinessFlag,
+    prometheus: siphon_ai_telemetry::PrometheusHandle,
+    admin: AdminState,
 ) -> Result<Option<ObservabilityServer>> {
-    let handle = install_recorder().context("install Prometheus recorder")?;
     if !cfg.enabled {
         debug!("[observability].enabled = false; skipping HTTP listener");
         return Ok(None);
@@ -441,10 +490,45 @@ async fn build_observability(
     let listen = cfg
         .http_listen
         .ok_or_else(|| anyhow!("[observability].http_listen unexpectedly empty"))?;
-    let server = ObservabilityServer::start(listen, handle, readiness)
+    let server = ObservabilityServer::start(listen, prometheus, readiness, admin)
         .await
         .with_context(|| format!("bind observability HTTP {listen}"))?;
     Ok(Some(server))
+}
+
+/// Adapter that exposes `CallRegistry` through the `admin` trait
+/// surface without forcing telemetry to depend on `siphon-ai-core`.
+struct RuntimeCallRegistry {
+    inner: CallRegistry,
+}
+
+impl CallRegistryHandle for RuntimeCallRegistry {
+    fn snapshot_ids(&self) -> Vec<String> {
+        self.inner.snapshot_call_ids()
+    }
+    fn hangup(&self, sip_call_id: &str) -> bool {
+        match self.inner.lookup(sip_call_id) {
+            Some(handle) => {
+                handle.shutdown();
+                true
+            }
+            None => false,
+        }
+    }
+}
+
+/// Map `siphon-ai-sip-glue`'s `RegistrationState` onto the
+/// telemetry crate's `RegistrationRow`. Lives here (not in
+/// telemetry) so telemetry doesn't have to dep on sip-glue.
+fn registration_state_to_row(s: siphon_ai_sip_glue::RegistrationState) -> RegistrationRow {
+    RegistrationRow {
+        name: s.name,
+        server_addr: s.server_addr.to_string(),
+        status: s.status.as_str().to_string(),
+        last_attempt_at: s.last_attempt_at.map(|t| t.to_rfc3339()),
+        expires_at: s.expires_at.map(|t| t.to_rfc3339()),
+        last_error: s.last_error,
+    }
 }
 
 /// Build the daemon's HEP3 plumbing from compiled `[hep]` config.
@@ -452,7 +536,10 @@ async fn build_observability(
 /// installing both `sip-hep` and `forge-hep` global emitters as a
 /// side effect so siphon-rs and forge-media start shipping the
 /// moment the first packet flows.
-async fn build_hep_telemetry(node: &NodeConfig, cfg: HepConfig) -> Result<Option<HepTelemetry>> {
+async fn build_hep_telemetry(
+    node: &NodeConfig,
+    cfg: HepConfig,
+) -> Result<Option<(Arc<HepTelemetry>, HepWorkerHandle)>> {
     if !cfg.enabled {
         debug!("[hep].enabled = false; HEP shipping disabled");
         return Ok(None);
@@ -467,7 +554,7 @@ async fn build_hep_telemetry(node: &NodeConfig, cfg: HepConfig) -> Result<Option
         .capture_id
         .ok_or_else(|| anyhow!("[hep].capture_id unexpectedly empty when enabled"))?;
 
-    let telemetry = HepTelemetry::build(HepTelemetryBuild {
+    let (telemetry, worker) = HepTelemetry::build(HepTelemetryBuild {
         collector,
         capture_id,
         capture_password: cfg.capture_password,
@@ -482,7 +569,7 @@ async fn build_hep_telemetry(node: &NodeConfig, cfg: HepConfig) -> Result<Option
         capture_id,
         "HEP3 shipping active (SIP + RTCP + RTP-QoS + log + CDR chunks)"
     );
-    Ok(Some(telemetry))
+    Ok(Some((Arc::new(telemetry), worker)))
 }
 
 /// Build the `RegisterSourceResolver` closure that the routing

--- a/bins/siphon-ai/tests/startup.rs
+++ b/bins/siphon-ai/tests/startup.rs
@@ -50,7 +50,9 @@ async fn runtime_starts_and_shuts_down_cleanly() {
     ]);
     let cfg = load_from_str_with_env(FIXTURE, &env).expect("config compiles");
 
-    let runtime = Runtime::build(cfg).await.expect("runtime builds");
+    let runtime = Runtime::build(cfg, siphon_ai_telemetry::LogFilterHandle::noop())
+        .await
+        .expect("runtime builds");
 
     // The kernel should have picked a non-zero port.
     let bound = runtime.local_addr().expect("local_addr");
@@ -118,7 +120,9 @@ async fn runtime_with_udp_and_tcp_transports_binds_both() {
     ]);
     let cfg = load_from_str_with_env(TCP_FIXTURE, &env).expect("config compiles");
 
-    let runtime = Runtime::build(cfg).await.expect("runtime builds");
+    let runtime = Runtime::build(cfg, siphon_ai_telemetry::LogFilterHandle::noop())
+        .await
+        .expect("runtime builds");
     let bound = runtime.local_addr().expect("local_addr");
     assert!(bound.port() > 0);
 
@@ -200,7 +204,9 @@ async fn registrations_seed_into_manager_on_startup() {
     ]);
     let cfg = load_from_str_with_env(REGISTER_FIXTURE, &env).expect("config compiles");
 
-    let runtime = Runtime::build(cfg).await.expect("runtime builds");
+    let runtime = Runtime::build(cfg, siphon_ai_telemetry::LogFilterHandle::noop())
+        .await
+        .expect("runtime builds");
     let snapshot = runtime.registration_snapshot();
     assert_eq!(snapshot.len(), 2);
 
@@ -257,7 +263,7 @@ async fn build_fails_when_listen_port_is_busy() {
     ]);
     let cfg = load_from_str_with_env(FIXTURE, &env).expect("config compiles");
 
-    let result = Runtime::build(cfg).await;
+    let result = Runtime::build(cfg, siphon_ai_telemetry::LogFilterHandle::noop()).await;
     assert!(result.is_err(), "expected bind conflict, got Ok");
 
     drop(placeholder);
@@ -328,7 +334,9 @@ async fn runtime_with_hep_enabled_binds_and_drains_worker_on_shutdown() {
     ]);
     let cfg = load_from_str_with_env(HEP_FIXTURE, &env).expect("config compiles");
 
-    let runtime = Runtime::build(cfg).await.expect("runtime builds with HEP");
+    let runtime = Runtime::build(cfg, siphon_ai_telemetry::LogFilterHandle::noop())
+        .await
+        .expect("runtime builds with HEP");
     let bound = runtime.local_addr().expect("local_addr");
     assert!(bound.port() > 0, "kernel must pick a port");
 

--- a/crates/telemetry/src/admin.rs
+++ b/crates/telemetry/src/admin.rs
@@ -1,0 +1,424 @@
+//! Admin HTTP endpoints.
+//!
+//! Operator surface for poking the daemon at runtime without
+//! restarting it. All endpoints live under `/admin/*` on the same
+//! observability HTTP listener as `/health` / `/ready` / `/metrics`.
+//!
+//! ## Endpoints
+//!
+//! | Method | Path                          | Purpose                              |
+//! |--------|-------------------------------|--------------------------------------|
+//! | GET    | `/admin/calls`                | List active per-call SIP Call-IDs    |
+//! | POST   | `/admin/calls/:id/hangup`     | Force-shutdown a call by Call-ID     |
+//! | GET    | `/admin/registrations`        | Snapshot of every `[[register]]` row |
+//! | GET    | `/admin/log`                  | Current `tracing` filter directive   |
+//! | PUT    | `/admin/log`                  | Replace the filter (body = directive)|
+//! | POST   | `/admin/hep/test`             | Emit a probe HEP log packet          |
+//!
+//! ## Threat model
+//!
+//! These endpoints expose enough power to take calls down. They
+//! MUST bind on a trusted address (loopback, k8s pod-internal, etc.)
+//! per CLAUDE.md §12 / docs/DEV_PLAN.md §12.1. The daemon does NOT
+//! authenticate them — front with an authenticating reverse proxy
+//! if you expose them publicly.
+//!
+//! ## Dependency injection
+//!
+//! Each handler takes its dependencies (CallRegistry, RegistrationManager,
+//! LogFilterHandle, HepTelemetry) by `Option<Arc<…>>` on the
+//! [`AdminState`] — `None` makes the corresponding endpoint return
+//! 503 instead of 500. That way a daemon configured without HEP
+//! doesn't panic on `/admin/hep/test`; tests can plug in only the
+//! pieces they care about.
+
+use std::sync::Arc;
+
+use http_body_util::Full;
+use hyper::body::Bytes;
+use hyper::header::CONTENT_TYPE;
+use hyper::{Response, StatusCode};
+use serde::Serialize;
+use serde_json::json;
+
+use crate::log_filter::LogFilterHandle;
+use crate::HepTelemetry;
+
+/// Bundle of dependencies the admin handlers may need. Each is
+/// optional so partially-configured deployments don't crash on
+/// unrelated routes.
+#[derive(Clone, Default)]
+pub struct AdminState {
+    pub call_registry: Option<AdminCallRegistry>,
+    pub registration_snapshot: Option<RegistrationSnapshotFn>,
+    pub log_filter: Option<LogFilterHandle>,
+    pub hep: Option<Arc<HepTelemetry>>,
+}
+
+/// Minimal trait surface the admin endpoints need on the call
+/// registry. Avoids a hard dep on `siphon-ai-core` here — the
+/// runtime adapter passes a closure-wrapping object that delegates
+/// to `CallRegistry`.
+pub trait CallRegistryHandle: Send + Sync + 'static {
+    fn snapshot_ids(&self) -> Vec<String>;
+    /// Best-effort: returns `true` iff a call with that SIP Call-ID
+    /// existed and was signalled to shut down.
+    fn hangup(&self, sip_call_id: &str) -> bool;
+}
+
+/// Boxed clone-friendly handle the runtime constructs.
+pub type AdminCallRegistry = Arc<dyn CallRegistryHandle>;
+
+/// Closure type producing a fresh registration snapshot on each
+/// admin request. Same indirection rationale as `CallRegistryHandle`
+/// — keeps `siphon-ai-sip-glue` out of the telemetry crate's deps.
+pub type RegistrationSnapshotFn = Arc<dyn Fn() -> Vec<RegistrationRow> + Send + Sync>;
+
+/// One row of the `GET /admin/registrations` response. Mirrors
+/// `sip_glue::RegistrationState` but defined here so telemetry
+/// doesn't depend on the upstream crate.
+#[derive(Debug, Clone, Serialize)]
+pub struct RegistrationRow {
+    pub name: String,
+    pub server_addr: String,
+    pub status: String,
+    pub last_attempt_at: Option<String>,
+    pub expires_at: Option<String>,
+    pub last_error: Option<String>,
+}
+
+// ─── Dispatcher ────────────────────────────────────────────────────
+
+/// Returns `Some(response)` when `path` is an admin route, `None`
+/// otherwise. Lets the parent dispatcher fall through to its own
+/// 404 logic when this isn't ours.
+pub async fn dispatch(
+    method: &hyper::Method,
+    path: &str,
+    body: Bytes,
+    state: &AdminState,
+) -> Option<Response<Full<Bytes>>> {
+    if !path.starts_with("/admin") {
+        return None;
+    }
+
+    let resp = match (method, path) {
+        (&hyper::Method::GET, "/admin/calls") => list_calls(state),
+        (&hyper::Method::GET, "/admin/registrations") => list_registrations(state),
+        (&hyper::Method::GET, "/admin/log") => get_log_filter(state),
+        (&hyper::Method::PUT, "/admin/log") => set_log_filter(state, &body),
+        (&hyper::Method::POST, "/admin/hep/test") => hep_test(state),
+        (m, p)
+            if m == hyper::Method::POST
+                && p.starts_with("/admin/calls/")
+                && p.ends_with("/hangup") =>
+        {
+            // /admin/calls/:id/hangup — pull the id from the middle.
+            let id = p
+                .strip_prefix("/admin/calls/")
+                .and_then(|s| s.strip_suffix("/hangup"))
+                .unwrap_or("");
+            hangup_call(state, id)
+        }
+        _ => not_found(),
+    };
+    Some(resp)
+}
+
+// ─── Handlers ──────────────────────────────────────────────────────
+
+fn list_calls(state: &AdminState) -> Response<Full<Bytes>> {
+    let Some(reg) = state.call_registry.as_ref() else {
+        return service_unavailable("call registry not installed");
+    };
+    let ids = reg.snapshot_ids();
+    json_response(StatusCode::OK, &json!({ "count": ids.len(), "calls": ids }))
+}
+
+fn hangup_call(state: &AdminState, sip_call_id: &str) -> Response<Full<Bytes>> {
+    if sip_call_id.is_empty() {
+        return json_response(
+            StatusCode::BAD_REQUEST,
+            &json!({ "error": "empty sip call_id" }),
+        );
+    }
+    let Some(reg) = state.call_registry.as_ref() else {
+        return service_unavailable("call registry not installed");
+    };
+    let hit = reg.hangup(sip_call_id);
+    if hit {
+        json_response(
+            StatusCode::OK,
+            &json!({ "shutdown_signalled": true, "sip_call_id": sip_call_id }),
+        )
+    } else {
+        json_response(
+            StatusCode::NOT_FOUND,
+            &json!({ "shutdown_signalled": false, "sip_call_id": sip_call_id }),
+        )
+    }
+}
+
+fn list_registrations(state: &AdminState) -> Response<Full<Bytes>> {
+    let Some(snapshot_fn) = state.registration_snapshot.as_ref() else {
+        return service_unavailable("registration manager not installed");
+    };
+    let rows = snapshot_fn();
+    json_response(
+        StatusCode::OK,
+        &json!({ "count": rows.len(), "registrations": rows }),
+    )
+}
+
+fn get_log_filter(state: &AdminState) -> Response<Full<Bytes>> {
+    let Some(handle) = state.log_filter.as_ref() else {
+        return service_unavailable("log filter reload handle not installed");
+    };
+    json_response(StatusCode::OK, &json!({ "filter": handle.current() }))
+}
+
+fn set_log_filter(state: &AdminState, body: &Bytes) -> Response<Full<Bytes>> {
+    let Some(handle) = state.log_filter.as_ref() else {
+        return service_unavailable("log filter reload handle not installed");
+    };
+
+    // Accept either:
+    //   * plaintext body: `siphon_ai=debug`
+    //   * JSON body: `{"filter":"siphon_ai=debug"}`
+    // Convention here mirrors `kubectl set image` style: prefer
+    // simplicity over a strict content-type contract.
+    let directive = parse_filter_body(body);
+    let directive = match directive {
+        Ok(s) => s,
+        Err(e) => {
+            return json_response(StatusCode::BAD_REQUEST, &json!({ "error": e }));
+        }
+    };
+
+    match handle.set(&directive) {
+        Ok(prev) => json_response(
+            StatusCode::OK,
+            &json!({ "filter": directive, "previous": prev }),
+        ),
+        Err(e) => json_response(StatusCode::BAD_REQUEST, &json!({ "error": e.to_string() })),
+    }
+}
+
+fn parse_filter_body(body: &Bytes) -> Result<String, String> {
+    if body.is_empty() {
+        return Err("empty body; expected directive string or JSON {filter:...}".into());
+    }
+    // Try JSON first; fall through to plaintext.
+    if let Ok(v) = serde_json::from_slice::<serde_json::Value>(body) {
+        if let Some(s) = v.get("filter").and_then(|f| f.as_str()) {
+            return Ok(s.trim().to_string());
+        }
+        // JSON parsed but no `filter` field — fall through to
+        // raw-bytes interpretation in case the operator sent a
+        // bare string with curly braces by accident.
+    }
+    let text = std::str::from_utf8(body)
+        .map_err(|_| "body is not UTF-8".to_string())?
+        .trim()
+        .to_string();
+    if text.is_empty() {
+        return Err("body is whitespace-only".into());
+    }
+    Ok(text)
+}
+
+fn hep_test(state: &AdminState) -> Response<Full<Bytes>> {
+    let Some(hep) = state.hep.as_ref() else {
+        return service_unavailable("HEP shipping not enabled");
+    };
+    hep.emit_log(
+        &format!("siphon-ai admin probe from node={}", hep.node_id()),
+        Some("admin-probe"),
+        None,
+    );
+    json_response(
+        StatusCode::OK,
+        &json!({
+            "emitted": true,
+            "correlation_id": "admin-probe",
+            "hint": "look for a chunk-type 100 log packet at the collector",
+        }),
+    )
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────
+
+fn json_response<T: Serialize>(status: StatusCode, body: &T) -> Response<Full<Bytes>> {
+    let body = serde_json::to_vec(body).unwrap_or_else(|_| b"{}".to_vec());
+    Response::builder()
+        .status(status)
+        .header(CONTENT_TYPE, "application/json")
+        .body(Full::new(Bytes::from(body)))
+        .expect("response builder accepts the headers we set")
+}
+
+fn service_unavailable(reason: &str) -> Response<Full<Bytes>> {
+    json_response(StatusCode::SERVICE_UNAVAILABLE, &json!({ "error": reason }))
+}
+
+fn not_found() -> Response<Full<Bytes>> {
+    json_response(
+        StatusCode::NOT_FOUND,
+        &json!({ "error": "unknown admin route" }),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    struct StubRegistry {
+        ids: Mutex<Vec<String>>,
+        hung_up: Mutex<Vec<String>>,
+    }
+
+    impl CallRegistryHandle for StubRegistry {
+        fn snapshot_ids(&self) -> Vec<String> {
+            self.ids.lock().unwrap().clone()
+        }
+        fn hangup(&self, sip_call_id: &str) -> bool {
+            let mut ids = self.ids.lock().unwrap();
+            if let Some(idx) = ids.iter().position(|x| x == sip_call_id) {
+                ids.remove(idx);
+                self.hung_up.lock().unwrap().push(sip_call_id.to_string());
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    fn empty_state() -> AdminState {
+        AdminState::default()
+    }
+
+    #[tokio::test]
+    async fn unknown_admin_route_is_404() {
+        let resp = dispatch(
+            &hyper::Method::GET,
+            "/admin/nope",
+            Bytes::new(),
+            &empty_state(),
+        )
+        .await
+        .expect("admin dispatch");
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn non_admin_path_passes_through() {
+        let resp = dispatch(
+            &hyper::Method::GET,
+            "/metrics",
+            Bytes::new(),
+            &empty_state(),
+        )
+        .await;
+        assert!(resp.is_none(), "non-admin path must fall through");
+    }
+
+    #[tokio::test]
+    async fn list_calls_503s_when_registry_absent() {
+        let resp = dispatch(
+            &hyper::Method::GET,
+            "/admin/calls",
+            Bytes::new(),
+            &empty_state(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn list_calls_returns_snapshot() {
+        let stub = Arc::new(StubRegistry {
+            ids: Mutex::new(vec!["abc@host".into(), "def@host".into()]),
+            hung_up: Mutex::new(vec![]),
+        });
+        let state = AdminState {
+            call_registry: Some(stub.clone() as AdminCallRegistry),
+            ..AdminState::default()
+        };
+        let resp = dispatch(&hyper::Method::GET, "/admin/calls", Bytes::new(), &state)
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn hangup_signals_existing_call() {
+        let stub = Arc::new(StubRegistry {
+            ids: Mutex::new(vec!["abc@host".into()]),
+            hung_up: Mutex::new(vec![]),
+        });
+        let state = AdminState {
+            call_registry: Some(stub.clone() as AdminCallRegistry),
+            ..AdminState::default()
+        };
+
+        let resp = dispatch(
+            &hyper::Method::POST,
+            "/admin/calls/abc@host/hangup",
+            Bytes::new(),
+            &state,
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(stub.hung_up.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn hangup_unknown_call_is_404() {
+        let stub = Arc::new(StubRegistry {
+            ids: Mutex::new(vec![]),
+            hung_up: Mutex::new(vec![]),
+        });
+        let state = AdminState {
+            call_registry: Some(stub as AdminCallRegistry),
+            ..AdminState::default()
+        };
+        let resp = dispatch(
+            &hyper::Method::POST,
+            "/admin/calls/missing@host/hangup",
+            Bytes::new(),
+            &state,
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn parses_filter_body_plaintext() {
+        assert_eq!(
+            parse_filter_body(&Bytes::from_static(b"siphon_ai=debug")).unwrap(),
+            "siphon_ai=debug"
+        );
+    }
+
+    #[test]
+    fn parses_filter_body_json() {
+        assert_eq!(
+            parse_filter_body(&Bytes::from_static(b"{\"filter\":\"siphon_ai=info\"}")).unwrap(),
+            "siphon_ai=info"
+        );
+    }
+
+    #[test]
+    fn parse_filter_body_rejects_empty() {
+        assert!(parse_filter_body(&Bytes::new()).is_err());
+    }
+
+    #[test]
+    fn parse_filter_body_rejects_whitespace_only() {
+        assert!(parse_filter_body(&Bytes::from_static(b"   \n   ")).is_err());
+    }
+}

--- a/crates/telemetry/src/hep.rs
+++ b/crates/telemetry/src/hep.rs
@@ -32,18 +32,36 @@ use tokio::task::JoinHandle;
 /// for both the sip-hep / forge-hep emitters and SiphonAI's own
 /// log/CDR emit calls.
 ///
-/// The daemon constructs this once at startup. Drop it on shutdown —
-/// the underlying worker exits when the last clone of the sink
-/// closes its mpsc channel.
+/// Shape: `HepTelemetry` is the share-by-Arc handle that admin
+/// endpoints, the CDR sink builder, and the call lifecycle all
+/// borrow. The UDP worker `JoinHandle` is split out into
+/// [`HepWorkerHandle`] so wrapping `HepTelemetry` in `Arc` doesn't
+/// strand the worker on shutdown.
 pub struct HepTelemetry {
     sink: HepSinkHandle,
     capture_id: u32,
     capture_password: Option<String>,
     node_id: String,
-    /// JoinHandle on the UDP worker task. Kept so callers can await
-    /// shutdown deterministically; the worker exits automatically
-    /// once every clone of the sink is dropped.
+}
+
+/// Owner of the spawned UDP worker. The runtime stashes this on
+/// `Runtime` and aborts it on shutdown — see
+/// `bins/siphon-ai/src/runtime.rs::Runtime::run`. Keeping it
+/// separate from [`HepTelemetry`] is what makes the latter
+/// Arc-friendly.
+pub struct HepWorkerHandle {
     worker: Option<JoinHandle<()>>,
+}
+
+impl HepWorkerHandle {
+    /// Abort the worker. Bounded wait so a wedged collector socket
+    /// can't block daemon shutdown.
+    pub async fn shutdown(mut self) {
+        if let Some(worker) = self.worker.take() {
+            worker.abort();
+            let _ = tokio::time::timeout(std::time::Duration::from_millis(250), worker).await;
+        }
+    }
 }
 
 /// Inputs to [`HepTelemetry::build`]. Mirrors the fields of
@@ -60,10 +78,12 @@ pub struct HepTelemetryBuild {
 }
 
 impl HepTelemetry {
-    /// Build a [`HepTelemetry`] from explicit fields. The daemon's
-    /// runtime calls this with the [`siphon-ai-config::HepConfig`]
-    /// fields after compile-time validation.
-    pub async fn build(args: HepTelemetryBuild) -> Result<Self, HepBuildError> {
+    /// Build a [`HepTelemetry`] from explicit fields. Returns the
+    /// share-by-Arc handle plus the worker JoinHandle as a separate
+    /// [`HepWorkerHandle`] — the runtime keeps the worker on
+    /// `Runtime` and stashes the telemetry handle in `Arc` for
+    /// admin / CDR / call-site consumers.
+    pub async fn build(args: HepTelemetryBuild) -> Result<(Self, HepWorkerHandle), HepBuildError> {
         let HepTelemetryBuild {
             collector,
             capture_id,
@@ -97,13 +117,16 @@ impl HepTelemetry {
         };
         let _ = forge_hep::set_emitter(Arc::new(forge_emitter));
 
-        Ok(Self {
+        let telemetry = Self {
             sink: arc_sink,
             capture_id,
             capture_password,
             node_id,
+        };
+        let worker_handle = HepWorkerHandle {
             worker: Some(worker),
-        })
+        };
+        Ok((telemetry, worker_handle))
     }
 
     /// Emit an application log line as a HEP3 chunk-type 100 (`Log`).
@@ -177,24 +200,9 @@ impl HepTelemetry {
         self.capture_password.as_deref()
     }
 
-    /// Stop the worker on shutdown.
-    ///
-    /// We can't rely on dropping our local `Arc<dyn HepSink>` clone
-    /// to close the producer channel — the per-protocol global
-    /// emitters (`sip-hep` / `forge-hep`) hold their own clones in
-    /// `OnceCell`s that don't get drained on daemon shutdown. So we
-    /// abort the worker explicitly. Any packets queued at this
-    /// moment are dropped, which is the right call: HEP is
-    /// best-effort observability, and we'd rather finish shutting
-    /// down than risk hanging on a wedged collector socket.
-    pub async fn shutdown(mut self) {
-        if let Some(worker) = self.worker.take() {
-            worker.abort();
-            // Bound the wait so a stuck abort can't block shutdown.
-            // Abort yields a JoinError(Cancelled); we don't care.
-            let _ = tokio::time::timeout(std::time::Duration::from_millis(250), worker).await;
-        }
-    }
+    // Shutdown lives on [`HepWorkerHandle::shutdown`] now; the
+    // telemetry handle itself is share-by-Arc and doesn't need a
+    // teardown method.
 }
 
 /// Filled-in for callers that don't have a real `SocketAddr` handy.

--- a/crates/telemetry/src/http.rs
+++ b/crates/telemetry/src/http.rs
@@ -1,16 +1,21 @@
-//! Hyper-based HTTP server for `/health`, `/ready`, `/metrics`.
+//! Hyper-based HTTP server for `/health`, `/ready`, `/metrics`,
+//! and the `/admin/*` operator surface.
 //!
-//! Single bind, three routes. Spawns a per-connection task; the
-//! routes themselves are zero-allocation in the steady state
+//! Single bind, all routes. Spawns a per-connection task; the
+//! probe routes are zero-allocation in the steady state
 //! (`/health` and `/ready` produce literal byte slices,
 //! `/metrics` calls `PrometheusHandle::render` which owns the
 //! string allocation).
 //!
+//! ## Admin endpoints
+//!
+//! See [`crate::admin`]. They go through the same listener so
+//! operators have one HTTP surface to point a probe / dashboard
+//! at, not two. Routes that need dependencies the runtime hasn't
+//! wired up return 503 (e.g., `/admin/hep/test` with HEP disabled).
+//!
 //! ## What's NOT here
 //!
-//! - **No admin endpoints** — dynamic log-level adjustment, force-
-//!   hangup, etc. are listed in `docs/DEV_PLAN.md` §11.7 as part of
-//!   the admin surface; that's a follow-up.
 //! - **No auth** — these endpoints are intended to bind on a
 //!   loopback or trusted-network address (k8s pods, localhost). If
 //!   exposed publicly, sit them behind an authenticating reverse
@@ -22,7 +27,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use http_body_util::Full;
+use http_body_util::{BodyExt, Full};
 use hyper::body::{Bytes, Incoming};
 use hyper::header::CONTENT_TYPE;
 use hyper::service::service_fn;
@@ -33,7 +38,13 @@ use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info};
 
+use crate::admin::{self, AdminState};
 use crate::readiness::ReadinessFlag;
+
+/// Body byte cap on PUT/POST admin requests. 8 KiB is far more than
+/// any directive string or hangup body needs; protects against a
+/// noisy probe consuming the daemon's heap.
+const ADMIN_MAX_BODY: usize = 8 * 1024;
 
 /// Handle to a running observability HTTP server. Drop or call
 /// [`Self::shutdown`] to stop accepting new connections.
@@ -53,6 +64,7 @@ impl ObservabilityServer {
         addr: SocketAddr,
         prometheus: PrometheusHandle,
         readiness: ReadinessFlag,
+        admin: AdminState,
     ) -> Result<Self> {
         let listener = TcpListener::bind(addr)
             .await
@@ -63,6 +75,7 @@ impl ObservabilityServer {
         let state = Arc::new(SharedState {
             prometheus,
             readiness,
+            admin,
         });
 
         let listener = tokio::spawn(async move {
@@ -91,6 +104,7 @@ impl ObservabilityServer {
 struct SharedState {
     prometheus: PrometheusHandle,
     readiness: ReadinessFlag,
+    admin: AdminState,
 }
 
 async fn run_accept_loop(listener: TcpListener, state: Arc<SharedState>) {
@@ -124,28 +138,75 @@ async fn run_accept_loop(listener: TcpListener, state: Arc<SharedState>) {
 }
 
 async fn handle_request(req: Request<Incoming>, state: Arc<SharedState>) -> Response<Full<Bytes>> {
-    match (req.method(), req.uri().path()) {
-        (&hyper::Method::GET, "/health") => respond(StatusCode::OK, "text/plain", b"ok\n"),
+    let method = req.method().clone();
+    let path = req.uri().path().to_string();
+
+    // Probe routes first — they're hot, parameter-less, and the
+    // existing /metrics scraper polls /metrics every few seconds.
+    match (&method, path.as_str()) {
+        (&hyper::Method::GET, "/health") => {
+            return respond(StatusCode::OK, "text/plain", b"ok\n");
+        }
         (&hyper::Method::GET, "/ready") => {
             if state.readiness.is_ready() {
-                respond(StatusCode::OK, "text/plain", b"ready\n")
-            } else {
-                respond(
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    "text/plain",
-                    b"not ready\n",
-                )
+                return respond(StatusCode::OK, "text/plain", b"ready\n");
             }
+            return respond(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "text/plain",
+                b"not ready\n",
+            );
         }
         (&hyper::Method::GET, "/metrics") => {
             let body = state.prometheus.render();
-            respond(
+            return respond(
                 StatusCode::OK,
                 "text/plain; version=0.0.4; charset=utf-8",
                 body.as_bytes(),
-            )
+            );
         }
-        _ => respond(StatusCode::NOT_FOUND, "text/plain", b"not found\n"),
+        _ => {}
+    }
+
+    // Admin routes — read the body (bounded) once, then dispatch.
+    if path.starts_with("/admin") {
+        let body = match read_admin_body(req).await {
+            Ok(b) => b,
+            Err(resp) => return resp,
+        };
+        if let Some(resp) = admin::dispatch(&method, &path, body, &state.admin).await {
+            return resp;
+        }
+    }
+
+    respond(StatusCode::NOT_FOUND, "text/plain", b"not found\n")
+}
+
+/// Bounded body reader for `/admin/*` PUT / POST. Returns the bytes
+/// on success or a ready-to-send error response on failure.
+async fn read_admin_body(req: Request<Incoming>) -> Result<Bytes, Response<Full<Bytes>>> {
+    use hyper::body::Body;
+
+    // Reject `Content-Length` past the cap before reading a byte.
+    if let Some(hint) = req.body().size_hint().upper() {
+        if hint as usize > ADMIN_MAX_BODY {
+            return Err(respond(
+                StatusCode::PAYLOAD_TOO_LARGE,
+                "application/json",
+                br#"{"error":"admin request body exceeds 8 KiB"}"#,
+            ));
+        }
+    }
+    match req.into_body().collect().await {
+        Ok(collected) => Ok(collected.to_bytes()),
+        Err(e) => {
+            debug!(error = %e, "admin body read failed");
+            Err(respond(
+                StatusCode::BAD_REQUEST,
+                "application/json",
+                br#"{"error":"failed to read body"}"#,
+            ))
+        }
     }
 }
 
@@ -176,9 +237,14 @@ mod tests {
         // Tag a metric so /metrics has something interesting; we
         // can't install globally inside the test (other tests do
         // the same), so just reuse the handle without installing.
-        let server = ObservabilityServer::start("127.0.0.1:0".parse().unwrap(), handle, readiness)
-            .await
-            .expect("start");
+        let server = ObservabilityServer::start(
+            "127.0.0.1:0".parse().unwrap(),
+            handle,
+            readiness,
+            AdminState::default(),
+        )
+        .await
+        .expect("start");
         let url = format!("http://{}", server.bound_addr());
         (server, url)
     }
@@ -255,6 +321,7 @@ mod tests {
             "127.0.0.1:0".parse().unwrap(),
             handle,
             ReadinessFlag::new(),
+            AdminState::default(),
         )
         .await
         .expect("start");

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -19,17 +19,25 @@
 //! - Dynamic log-level admin endpoint.
 //! - Per-call HEP correlation chunks.
 
+pub mod admin;
 pub mod hep;
 pub mod http;
+pub mod log_filter;
 pub mod metrics;
 pub mod readiness;
 
-pub use hep::{HepBuildError, HepTelemetry, HepTelemetryBuild};
+pub use admin::{AdminCallRegistry, AdminState, CallRegistryHandle, RegistrationRow};
+pub use hep::{HepBuildError, HepTelemetry, HepTelemetryBuild, HepWorkerHandle};
 pub use http::ObservabilityServer;
+pub use log_filter::{LogFilterError, LogFilterHandle};
+
+// Re-exports for the daemon binary so it doesn't need a second
+// direct dep on `metrics-exporter-prometheus`.
 pub use metrics::{
     install_recorder, prometheus_builder, register_descriptions, InitError, CALLS_ACTIVE,
     CALLS_TOTAL, CALL_DURATION_BUCKETS, CALL_DURATION_SECONDS, INVITES_TOTAL,
     REGISTER_ATTEMPTS_TOTAL, REGISTER_STATE, ROUTE_MATCH_TOTAL, SDP_NEGOTIATE_BUCKETS,
     SDP_NEGOTIATE_SECONDS, WS_CONNECT_BUCKETS, WS_CONNECT_SECONDS,
 };
+pub use metrics_exporter_prometheus::PrometheusHandle;
 pub use readiness::ReadinessFlag;

--- a/crates/telemetry/src/log_filter.rs
+++ b/crates/telemetry/src/log_filter.rs
@@ -1,0 +1,91 @@
+//! Dynamic log-filter handle.
+//!
+//! `tracing` doesn't ship a built-in way to swap the filter at
+//! runtime — the supported pattern is `tracing_subscriber::reload`,
+//! which gives you a `Handle` you can call `.reload(new_layer)` on.
+//! We wrap that handle here so the admin HTTP endpoint can flip the
+//! filter without re-implementing the reload dance every time it's
+//! used.
+//!
+//! The daemon's `main` builds the subscriber + reload handle and
+//! hands the [`LogFilterHandle`] to the runtime; the admin endpoint
+//! borrows it for `PUT /admin/log`.
+
+use std::sync::Arc;
+
+use thiserror::Error;
+use tracing_subscriber::reload;
+use tracing_subscriber::EnvFilter;
+
+/// Reload handle wrapper. Clone-on-demand; the inner `reload::Handle`
+/// is itself cheap to clone (it's an `Arc` under the hood).
+#[derive(Clone)]
+pub struct LogFilterHandle {
+    inner: Arc<reload::Handle<EnvFilter, tracing_subscriber::Registry>>,
+}
+
+impl LogFilterHandle {
+    /// Construct from a `tracing_subscriber::reload::Handle`.
+    /// Usually called by `init_tracing` in the daemon binary.
+    pub fn new(inner: reload::Handle<EnvFilter, tracing_subscriber::Registry>) -> Self {
+        Self {
+            inner: Arc::new(inner),
+        }
+    }
+
+    /// Build a handle wired to a fresh, no-effect reload layer.
+    ///
+    /// Useful in tests where the daemon's `Runtime::build` requires
+    /// a `LogFilterHandle` but the test doesn't actually exercise
+    /// the admin endpoint. `current()` returns the default filter
+    /// string; `set()` succeeds but doesn't affect any real
+    /// subscriber.
+    pub fn noop() -> Self {
+        let filter = EnvFilter::new("off");
+        let (_layer, handle) =
+            reload::Layer::<EnvFilter, tracing_subscriber::Registry>::new(filter);
+        Self::new(handle)
+    }
+
+    /// Read back the current filter directive as a string.
+    ///
+    /// Used by the admin endpoint's GET so operators can see what's
+    /// active without guessing.
+    pub fn current(&self) -> String {
+        // EnvFilter's Display impl produces the canonical directive
+        // string. `with_current` borrows the layer immutably.
+        self.inner
+            .with_current(|f| f.to_string())
+            .unwrap_or_else(|_| String::from("<unavailable>"))
+    }
+
+    /// Swap the filter to a new directive string. Returns the
+    /// previous directive on success; `Err` if `directive` doesn't
+    /// parse.
+    pub fn set(&self, directive: &str) -> Result<String, LogFilterError> {
+        let prev = self.current();
+        let new = EnvFilter::try_new(directive).map_err(|e| LogFilterError::Parse {
+            directive: directive.to_string(),
+            err: e.to_string(),
+        })?;
+        self.inner
+            .reload(new)
+            .map_err(|e| LogFilterError::Reload(e.to_string()))?;
+        Ok(prev)
+    }
+}
+
+/// Errors surfaced by [`LogFilterHandle::set`]. Returned over the
+/// admin API as a 4xx (bad directive) or 5xx (reload internals).
+#[derive(Debug, Error)]
+pub enum LogFilterError {
+    /// `directive` didn't parse as a valid `EnvFilter` string —
+    /// caller error.
+    #[error("invalid log directive {directive:?}: {err}")]
+    Parse { directive: String, err: String },
+
+    /// Reload itself failed — almost always means the subscriber
+    /// was dropped, which is fatal-ish for the daemon.
+    #[error("filter reload failed: {0}")]
+    Reload(String),
+}


### PR DESCRIPTION
## Summary
Closes DoD #15 from \`docs/DEV_PLAN.md\` §11.7. Adds the operator surface for poking the daemon at runtime without restarting it.

| Method | Path | Purpose |
|--------|------|---------|
| GET | \`/admin/calls\` | active per-call SIP Call-IDs |
| POST | \`/admin/calls/:id/hangup\` | force-shutdown a call by Call-ID |
| GET | \`/admin/registrations\` | snapshot of every \`[[register]]\` row |
| GET | \`/admin/log\` | current tracing filter directive |
| PUT | \`/admin/log\` | replace the filter (plaintext or JSON body) |
| POST | \`/admin/hep/test\` | emit a probe HEP log packet so operators can verify Homer |

All routes share the existing observability HTTP listener — one HTTP surface to point a dashboard at.

## Plumbing
- New \`siphon-ai-telemetry::admin\` module with dispatcher + handlers. Dependencies come through an \`AdminState\` struct; each \`None\` field returns 503 rather than crashing, so partially-configured deployments work cleanly.
- New \`LogFilterHandle\` wraps \`tracing_subscriber::reload\` so the daemon's tracing init produces a reload-able subscriber. Daemon binary's \`init_tracing\` now uses the layered subscriber form to expose the handle.
- \`HepTelemetry\` split: the share-by-Arc handle stays as \`HepTelemetry\`, the UDP worker \`JoinHandle\` moves to a new \`HepWorkerHandle\`. Makes wrapping in \`Arc\` clean while still letting \`Runtime::run\` drain the worker on shutdown.
- \`Runtime::build\` now takes a \`LogFilterHandle\`. \`build_observability\` defers HTTP listen until the call registry + reg manager exist so admin endpoints have all their dependencies wired in.

## Threat model
Endpoints expose enough power to take calls down. They MUST bind on a trusted address (loopback / k8s pod-internal); the daemon does NOT authenticate them. Same posture as Kamailio's xhttp. Documented in \`admin.rs\`.

## Tests
- 9 new unit tests in \`admin.rs\` (dispatch, 503-when-missing, hangup flow, filter-body parsing edge cases)
- 4 existing http.rs tests retrofitted for the new \`ObservabilityServer::start\` signature
- End-to-end smoke verified manually against a running daemon: every endpoint returns the expected JSON; \`PUT /admin/log\` atomically swaps the filter and returns \`{filter, previous}\`
- Full workspace \`cargo test --no-fail-fast\` green; \`cargo clippy -p siphon-ai-telemetry --all-targets -- -D warnings\` clean

The pre-existing clippy \`too_many_arguments\` on \`bins/siphon-ai/src/registration.rs::drive\` is unrelated and lives on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)