### PR TITLE
feat(hold-resume): handle re-INVITE direction changes (sendonly/inactive)

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -39,6 +39,10 @@ sip-transaction.workspace = true
 # media-glue owns the session/bridge logic so we only need the type stubs.
 forge-core.workspace   = true
 forge-engine.workspace = true
+# Re-INVITE handling re-parses the inbound offer to read its
+# direction attribute. forge-sdp re-exports the sip-sdp types we
+# need (`SessionDescription`, `MediaType`, `Direction`).
+forge-sdp.workspace    = true
 
 [dev-dependencies]
 bytes.workspace                       = true
@@ -46,6 +50,5 @@ tokio-tungstenite.workspace           = true
 futures.workspace                     = true
 serde_json.workspace                  = true
 forge-rtp.workspace                   = true
-forge-sdp.workspace                   = true
 metrics-exporter-prometheus.workspace = true
 async-trait.workspace                 = true

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -743,8 +743,149 @@ fn tap_detail(res: Option<Result<TapDisconnect, MediaTapError>>) -> String {
     }
 }
 
+/// Read the audio media's `a=` direction from a parsed offer.
+/// Returns `None` for offers without an audio media or with no
+/// explicit direction attribute (the caller maps that to the RFC
+/// 4566 §6 default of sendrecv).
+fn sdp_audio_direction(
+    session: &forge_sdp::SessionDescription,
+) -> Option<siphon_ai_media_glue::MediaDirection> {
+    use forge_sdp::MediaType;
+    let audio = session.find_media(MediaType::Audio)?;
+    audio
+        .direction()
+        .as_ref()
+        .map(|d| d.as_token())
+        .and_then(siphon_ai_media_glue::MediaDirection::from_attr)
+}
+
+/// RFC 3264 §6.1 direction mirror. Hold/resume re-INVITE answering
+/// depends on this — see `BridgingAcceptor::on_reinvite`.
+fn mirror_direction(
+    offer: siphon_ai_media_glue::MediaDirection,
+) -> siphon_ai_media_glue::MediaDirection {
+    use siphon_ai_media_glue::MediaDirection::*;
+    match offer {
+        SendRecv => SendRecv,
+        SendOnly => RecvOnly,
+        RecvOnly => SendOnly,
+        Inactive => Inactive,
+    }
+}
+
+/// Replace the `a=sendrecv|sendonly|recvonly|inactive` line in an
+/// SDP body with the requested direction. Linear scan over lines.
+/// The first match wins and no other lines are touched — re-using
+/// the original port / codec / rtpmap / fmtp values verbatim.
+///
+/// If no direction line exists in the input, one is appended after
+/// the audio media's `m=` line. This is rare in practice (the
+/// initial answer we cache always emits `a=sendrecv`) but keeps
+/// the helper total.
+fn rewrite_sdp_direction(sdp: &str, new_dir: siphon_ai_media_glue::MediaDirection) -> String {
+    let mut out = String::with_capacity(sdp.len());
+    let mut replaced = false;
+    for line in sdp.split_inclusive('\n') {
+        let trimmed = line.trim_end();
+        let is_direction = matches!(
+            trimmed,
+            "a=sendrecv" | "a=sendonly" | "a=recvonly" | "a=inactive"
+        );
+        if is_direction && !replaced {
+            // Preserve CRLF vs LF: take the trailing newline bytes
+            // off the original line and re-attach them.
+            let nl = &line[trimmed.len()..];
+            out.push_str("a=");
+            out.push_str(new_dir.as_attr());
+            out.push_str(nl);
+            replaced = true;
+        } else {
+            out.push_str(line);
+        }
+    }
+    if !replaced {
+        // Append. Caller's responsibility to ensure the audio
+        // media section is the last thing — true for our cached
+        // answers (built by `build_answer`).
+        out.push_str("a=");
+        out.push_str(new_dir.as_attr());
+        out.push_str("\r\n");
+    }
+    out
+}
+
 #[async_trait]
 impl CallAcceptor for BridgingAcceptor {
+    #[instrument(skip(self, call), fields(sip_call_id = %call.sip_call_id))]
+    async fn on_reinvite(&self, call: siphon_ai_sip_glue::ReinviteCall<'_>) -> anyhow::Result<()> {
+        // Look up the call's cached answer SDP. Without it we have
+        // no record of the original codec / port / direction and
+        // can't safely build a re-INVITE answer; surface that as
+        // 481 (the dialog effectively isn't ours).
+        let Some(entry) = self.registry.entry(&call.sip_call_id) else {
+            let response = UserAgentServer::create_response(
+                call.request,
+                481,
+                "Call/Transaction Does Not Exist",
+            );
+            call.handle.send_final(response).await;
+            return Ok(());
+        };
+        let Some(prev_answer) = entry.answer_text else {
+            // Legacy path: call was registered without an answer
+            // cache (currently only happens in tests). Refuse
+            // cleanly with 501.
+            let response = UserAgentServer::create_response(call.request, 501, "Not Implemented");
+            call.handle.send_final(response).await;
+            return Ok(());
+        };
+
+        // Determine the offer's new direction. Anything malformed
+        // or missing the audio media falls back to sendrecv per
+        // RFC 4566 §6.
+        let offer_direction = extract_offer_sdp(call.request)
+            .ok()
+            .and_then(|t| siphon_ai_media_glue::parse_offer(t).ok())
+            .as_ref()
+            .and_then(sdp_audio_direction)
+            .unwrap_or_default();
+
+        // RFC 3264 §6.1 mirror: offer sendonly → answer recvonly,
+        // offer recvonly → answer sendonly, offer inactive →
+        // answer inactive, offer sendrecv → answer sendrecv.
+        let answer_direction = mirror_direction(offer_direction);
+
+        // Take the cached answer SDP and flip its direction
+        // attribute. Re-using everything else (port, codecs,
+        // payload types) keeps forge's session intact — hold/
+        // resume by design only changes the `a=` line.
+        let new_answer = rewrite_sdp_direction(&prev_answer, answer_direction);
+
+        // Send 200 OK via the canonical helper so the dialog
+        // manager gets the updated CSeq / route-set.
+        let uas = self.uas.get().ok_or_else(|| {
+            anyhow::anyhow!(
+                "BridgingAcceptor::install_uas was not called; on_reinvite cannot accept INVITE"
+            )
+        })?;
+        uas.accept_invite(
+            call.request,
+            &call.handle,
+            call.transport,
+            Some(&new_answer),
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to accept re-INVITE: {e}"))?;
+
+        debug!(
+            sip_call_id = %call.sip_call_id,
+            offer = ?offer_direction,
+            answer = ?answer_direction,
+            "re-INVITE answered"
+        );
+        Ok(())
+    }
+
     #[instrument(skip(self, call), fields(
         route = %call.route.name,
         from = %call.facts.from_user,
@@ -848,9 +989,16 @@ impl BridgingAcceptor {
         };
 
         // Register before spawning so a BYE arriving on the very
-        // next packet finds an entry to wake.
-        self.registry
-            .insert(prepared.sip_call_id.clone(), prepared.handle);
+        // next packet finds an entry to wake. Cache the answer SDP
+        // we sent so a future re-INVITE (hold/resume) can rebuild a
+        // matching answer with just the direction flipped.
+        self.registry.insert(
+            prepared.sip_call_id.clone(),
+            crate::registry::CallEntry {
+                handle: prepared.handle,
+                answer_text: Some(prepared.answer.answer_text.clone()),
+            },
+        );
 
         // Per-route counter is owned-by-route — bounded cardinality
         // by config (operators have tens of routes, not millions).
@@ -1583,5 +1731,71 @@ a=sendrecv\r\n";
         use std::sync::OnceLock;
         static EMPTY: OnceLock<siphon_ai_routes::Headers> = OnceLock::new();
         EMPTY.get_or_init(siphon_ai_routes::Headers::new)
+    }
+
+    // ─── Hold / resume helpers ──────────────────────────────────
+
+    use siphon_ai_media_glue::MediaDirection;
+
+    #[test]
+    fn mirror_direction_follows_rfc_3264_section_6_1() {
+        assert_eq!(
+            mirror_direction(MediaDirection::SendRecv),
+            MediaDirection::SendRecv
+        );
+        assert_eq!(
+            mirror_direction(MediaDirection::SendOnly),
+            MediaDirection::RecvOnly
+        );
+        assert_eq!(
+            mirror_direction(MediaDirection::RecvOnly),
+            MediaDirection::SendOnly
+        );
+        assert_eq!(
+            mirror_direction(MediaDirection::Inactive),
+            MediaDirection::Inactive
+        );
+    }
+
+    #[test]
+    fn rewrite_sdp_direction_swaps_sendrecv_to_recvonly() {
+        let sdp = "v=0\r\no=- 1 1 IN IP4 10.0.0.1\r\ns=-\r\nc=IN IP4 10.0.0.1\r\n\
+                   t=0 0\r\nm=audio 30000 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\n\
+                   a=sendrecv\r\n";
+        let out = rewrite_sdp_direction(sdp, MediaDirection::RecvOnly);
+        assert!(out.contains("a=recvonly\r\n"));
+        assert!(!out.contains("a=sendrecv"));
+        // Everything else preserved verbatim — port, codec, rtpmap.
+        assert!(out.contains("m=audio 30000 RTP/AVP 0"));
+        assert!(out.contains("a=rtpmap:0 PCMU/8000"));
+    }
+
+    #[test]
+    fn rewrite_sdp_direction_swaps_recvonly_back_to_sendrecv() {
+        // The resume case: previous answer was recvonly (we were
+        // held); new offer is sendrecv; we mirror to sendrecv.
+        let sdp = "v=0\r\nm=audio 30000 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\na=recvonly\r\n";
+        let out = rewrite_sdp_direction(sdp, MediaDirection::SendRecv);
+        assert!(out.contains("a=sendrecv\r\n"));
+        assert!(!out.contains("a=recvonly"));
+    }
+
+    #[test]
+    fn rewrite_sdp_direction_appends_when_missing() {
+        // RFC 4566 §6 lets the direction attribute be implicit. If
+        // it's absent we append the explicit attribute rather than
+        // silently leaving the direction unspecified.
+        let sdp = "v=0\r\nm=audio 30000 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\n";
+        let out = rewrite_sdp_direction(sdp, MediaDirection::Inactive);
+        assert!(out.ends_with("a=inactive\r\n"));
+    }
+
+    #[test]
+    fn rewrite_sdp_direction_preserves_lf_only_endings() {
+        let sdp = "v=0\nm=audio 30000 RTP/AVP 0\na=sendrecv\n";
+        let out = rewrite_sdp_direction(sdp, MediaDirection::SendOnly);
+        assert!(out.contains("a=sendonly\n"));
+        // No spurious CR added.
+        assert!(!out.contains("\r"));
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -19,5 +19,5 @@ pub use call::{
     CallController, CallControllerConfig, CallError, CallHandle, CallOutcome, CallState,
     CallTermination,
 };
-pub use registry::CallRegistry;
+pub use registry::{CallEntry, CallRegistry};
 pub use transfer::{TransferContext, TransferOutcome};

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -44,10 +44,24 @@ use tracing::{debug, warn};
 
 use crate::call::CallHandle;
 
+/// Per-call session state the registry tracks. Beyond the shutdown
+/// handle, we cache the answer SDP we sent for the initial INVITE so
+/// re-INVITEs (hold/resume) can produce a matching answer with a
+/// flipped direction without re-allocating ports or re-running
+/// codec negotiation.
+#[derive(Debug, Clone)]
+pub struct CallEntry {
+    pub handle: CallHandle,
+    /// The SDP body sent in the 200 OK to the initial INVITE.
+    /// `None` for legacy tests / callers that don't track it; the
+    /// re-INVITE handler returns 501 in that case.
+    pub answer_text: Option<String>,
+}
+
 /// Process-wide handle table. Cheap to clone (`Arc` inside).
 #[derive(Debug, Clone, Default)]
 pub struct CallRegistry {
-    inner: Arc<RwLock<HashMap<String, CallHandle>>>,
+    inner: Arc<RwLock<HashMap<String, CallEntry>>>,
 }
 
 impl CallRegistry {
@@ -65,17 +79,17 @@ impl CallRegistry {
         self.inner.read().is_empty()
     }
 
-    /// Insert `handle` under `sip_call_id`. If a handle for the
+    /// Insert a call entry under `sip_call_id`. If an entry for the
     /// same Call-ID already existed, the previous one is dropped
     /// and a warning is logged — that situation is a bug in the
     /// caller (two concurrent acceptances of the same Call-ID).
-    pub fn insert(&self, sip_call_id: impl Into<String>, handle: CallHandle) {
+    pub fn insert(&self, sip_call_id: impl Into<String>, entry: CallEntry) {
         let key = sip_call_id.into();
         let mut guard = self.inner.write();
-        if let Some(prev) = guard.insert(key.clone(), handle) {
+        if let Some(prev) = guard.insert(key.clone(), entry) {
             warn!(
                 sip_call_id = %key,
-                bridge_call_id = %prev.call_id(),
+                bridge_call_id = %prev.handle.call_id(),
                 "registry insert collided with existing entry; previous handle dropped"
             );
         } else {
@@ -83,10 +97,16 @@ impl CallRegistry {
         }
     }
 
-    /// Look up a handle by SIP Call-ID. Returns a clone — the
-    /// underlying `CallHandle` is itself an `Arc`-of-`Notify`, so
+    /// Look up a [`CallHandle`] by SIP Call-ID. Returns a clone —
+    /// the underlying handle is itself an `Arc`-of-`Notify`, so
     /// cloning is essentially free.
     pub fn lookup(&self, sip_call_id: &str) -> Option<CallHandle> {
+        self.inner.read().get(sip_call_id).map(|e| e.handle.clone())
+    }
+
+    /// Borrow the full [`CallEntry`] for a Call-ID. Used by the
+    /// re-INVITE handler to read back the cached answer SDP.
+    pub fn entry(&self, sip_call_id: &str) -> Option<CallEntry> {
         self.inner.read().get(sip_call_id).cloned()
     }
 
@@ -98,7 +118,7 @@ impl CallRegistry {
         if removed.is_some() {
             debug!(sip_call_id = %sip_call_id, "deregistered call");
         }
-        removed
+        removed.map(|e| e.handle)
     }
 
     /// Snapshot every currently-registered Call-ID. Order is
@@ -142,6 +162,13 @@ mod tests {
     /// Build a real `CallHandle` by constructing a (never-run)
     /// `CallController`. Cheaper than mocking and exercises the
     /// actual handle plumbing.
+    fn fresh_entry(bridge_call_id: &str) -> CallEntry {
+        CallEntry {
+            handle: fresh_handle(bridge_call_id),
+            answer_text: None,
+        }
+    }
+
     fn fresh_handle(bridge_call_id: &str) -> CallHandle {
         let manager = Arc::new(MediaBridgeManager::new());
         let tap = MediaTap::attach(
@@ -191,7 +218,13 @@ mod tests {
         assert_eq!(reg.len(), 0);
 
         let h = fresh_handle("siphon-1");
-        reg.insert("abc@pbx", h.clone());
+        reg.insert(
+            "abc@pbx",
+            CallEntry {
+                handle: h.clone(),
+                answer_text: None,
+            },
+        );
         assert_eq!(reg.len(), 1);
 
         let looked_up = reg.lookup("abc@pbx").expect("present");
@@ -208,7 +241,7 @@ mod tests {
     #[test]
     fn lookup_returns_none_for_unknown_call_id() {
         let reg = CallRegistry::new();
-        reg.insert("abc@pbx", fresh_handle("siphon-1"));
+        reg.insert("abc@pbx", fresh_entry("siphon-1"));
         assert!(reg.lookup("never-seen@pbx").is_none());
     }
 
@@ -219,8 +252,8 @@ mod tests {
         // the regression we care about is that lookup returns the
         // *new* handle.)
         let reg = CallRegistry::new();
-        reg.insert("dupe@pbx", fresh_handle("siphon-old"));
-        reg.insert("dupe@pbx", fresh_handle("siphon-new"));
+        reg.insert("dupe@pbx", fresh_entry("siphon-old"));
+        reg.insert("dupe@pbx", fresh_entry("siphon-new"));
         assert_eq!(
             reg.lookup("dupe@pbx").unwrap().call_id().as_str(),
             "siphon-new"
@@ -231,8 +264,8 @@ mod tests {
     #[test]
     fn snapshot_lists_all_known_call_ids() {
         let reg = CallRegistry::new();
-        reg.insert("a@pbx", fresh_handle("siphon-a"));
-        reg.insert("b@pbx", fresh_handle("siphon-b"));
+        reg.insert("a@pbx", fresh_entry("siphon-a"));
+        reg.insert("b@pbx", fresh_entry("siphon-b"));
         let mut ids = reg.snapshot_call_ids();
         ids.sort();
         assert_eq!(ids, vec!["a@pbx".to_string(), "b@pbx".to_string()]);
@@ -245,7 +278,7 @@ mod tests {
         // and the BYE handler share one registry.
         let a = CallRegistry::new();
         let b = a.clone();
-        a.insert("x@pbx", fresh_handle("siphon-1"));
+        a.insert("x@pbx", fresh_entry("siphon-1"));
         assert!(b.lookup("x@pbx").is_some());
         b.remove("x@pbx");
         assert!(a.is_empty());

--- a/crates/core/tests/acceptor_prepare.rs
+++ b/crates/core/tests/acceptor_prepare.rs
@@ -282,7 +282,13 @@ async fn prepare_exposes_handle_and_sip_call_id_for_registry_use() {
     assert_eq!(prepared.handle.call_id().as_str(), "siphon-test-fixed");
 
     // Mirror the on_matched register step.
-    registry.insert(prepared.sip_call_id.clone(), prepared.handle);
+    registry.insert(
+        prepared.sip_call_id.clone(),
+        siphon_ai_core::registry::CallEntry {
+            handle: prepared.handle,
+            answer_text: Some(prepared.answer.answer_text.clone()),
+        },
+    );
     let looked_up = registry.lookup("abc-123@pbx.example.com").expect("present");
     assert_eq!(looked_up.call_id().as_str(), "siphon-test-fixed");
     assert_eq!(registry.len(), 1);

--- a/crates/core/tests/registry_bye.rs
+++ b/crates/core/tests/registry_bye.rs
@@ -135,7 +135,13 @@ async fn dispatch_bye_wakes_running_controller_via_registry() {
 
     // 3. Register and start the controller.
     let registry = CallRegistry::new();
-    registry.insert("abc-123@pbx.example.com", handle);
+    registry.insert(
+        "abc-123@pbx.example.com",
+        siphon_ai_core::registry::CallEntry {
+            handle,
+            answer_text: None,
+        },
+    );
 
     let run = tokio::spawn(async move { controller.run().await });
 

--- a/crates/media-glue/src/lib.rs
+++ b/crates/media-glue/src/lib.rs
@@ -12,7 +12,8 @@ pub mod setup;
 pub mod tap;
 
 pub use sdp::{
-    build_answer, negotiate_answer, parse_offer, AnswerOutcome, Codec, LocalCapabilities, SdpError,
+    build_answer, negotiate_answer, parse_offer, AnswerOutcome, Codec, LocalCapabilities,
+    MediaDirection, SdpError,
 };
 pub use setup::{InboundAccepted, InboundCall, MediaSetup, SetupError};
 pub use tap::{BargeInAction, MediaTap, MediaTapError, TapCommand, TapDisconnect};

--- a/crates/media-glue/src/sdp.rs
+++ b/crates/media-glue/src/sdp.rs
@@ -245,6 +245,65 @@ pub struct AnswerOutcome {
     /// `start.audio.sample_rate` once we map up: G.722 advertises
     /// 8000 but produces 16 kHz audio).
     pub negotiated_audio_sample_rate: u32,
+    /// Direction the answerer (us) committed to. RFC 3264 §6.1
+    /// mirroring: offer `sendonly` → answer `recvonly`, etc. Used
+    /// by the call layer to surface hold/resume to the WS server
+    /// and (eventually) pause forge's outbound RTP.
+    pub negotiated_direction: MediaDirection,
+}
+
+/// Media direction per RFC 4566 / RFC 3264. The values mirror
+/// `sip-sdp::Direction` but live here so consumers of media-glue
+/// don't need a second upstream dep just to name the enum.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MediaDirection {
+    /// Bidirectional audio. The normal "talking" state. Default —
+    /// matches RFC 4566 §6 ("the default value is sendrecv").
+    #[default]
+    SendRecv,
+    /// Answerer sends, doesn't expect to receive. From a hold
+    /// scenario: the held endpoint goes `sendonly` (often with
+    /// music-on-hold), so we answer `recvonly`. Net: we keep
+    /// receiving but pause our send.
+    SendOnly,
+    /// Answerer receives, doesn't expect to send. Mirror of the
+    /// above — counter-party held us.
+    RecvOnly,
+    /// Both directions paused. RFC 3264 §6.1 — used during
+    /// transient teardown or attended-transfer.
+    Inactive,
+}
+
+impl MediaDirection {
+    /// Parse from an SDP `a=` attribute name. `None` if the value
+    /// isn't one of the four direction attributes.
+    pub fn from_attr(s: &str) -> Option<Self> {
+        Some(match s {
+            "sendrecv" => Self::SendRecv,
+            "sendonly" => Self::SendOnly,
+            "recvonly" => Self::RecvOnly,
+            "inactive" => Self::Inactive,
+            _ => return None,
+        })
+    }
+
+    /// The attribute string for serialization (`a=<this>`).
+    pub fn as_attr(self) -> &'static str {
+        match self {
+            Self::SendRecv => "sendrecv",
+            Self::SendOnly => "sendonly",
+            Self::RecvOnly => "recvonly",
+            Self::Inactive => "inactive",
+        }
+    }
+
+    /// True iff this direction means "audio is paused in at least
+    /// one direction" — the hold-style state set by `sendonly` /
+    /// `recvonly` / `inactive`. Used by the call layer to decide
+    /// whether to emit `hold` / `resume` to the WS server.
+    pub fn is_held(self) -> bool {
+        !matches!(self, Self::SendRecv)
+    }
 }
 
 /// Parse an offer SDP string. Surfaces parse errors as
@@ -286,6 +345,23 @@ pub fn negotiate_answer(
     let primary = helpers::extract_primary_codec(audio).ok_or(SdpError::AudioRejected)?;
     let codec = Codec::from_encoding_name(&primary.encoding_name).ok_or(SdpError::NoCommonCodec)?;
 
+    // The upstream negotiator already mirrors direction per RFC
+    // 3264 §6.1; we just read it back via the typed accessor.
+    // `direction()` returns None when the attribute is absent,
+    // which RFC 4566 §6 maps to sendrecv.
+    // The upstream `MediaDescription::direction()` returns the
+    // typed enum from sip-sdp's `attrs` module, which isn't on our
+    // dep graph directly — go through its canonical-token string
+    // form so we don't have to pull sip-sdp in as a separate dep
+    // just to name the enum. Skipping the token also future-
+    // proofs against an upstream rename.
+    let negotiated_direction = audio
+        .direction()
+        .as_ref()
+        .map(|d| d.as_token())
+        .and_then(MediaDirection::from_attr)
+        .unwrap_or_default();
+
     let answer_text = answer.serialize();
     Ok(AnswerOutcome {
         answer,
@@ -294,6 +370,7 @@ pub fn negotiate_answer(
         negotiated_payload_type: primary.payload_type,
         negotiated_clock_rate: primary.clock_rate,
         negotiated_audio_sample_rate: codec.audio_sample_rate(),
+        negotiated_direction,
     })
 }
 

--- a/crates/media-glue/tests/sdp_negotiation.rs
+++ b/crates/media-glue/tests/sdp_negotiation.rs
@@ -180,3 +180,95 @@ fn answer_port_can_differ_from_offer_port() {
     let answer = build_answer(LINPHONE_PCMU_OFFER, &caps_pcmu_only(31337)).unwrap();
     assert!(answer.answer_text.contains("m=audio 31337 RTP/AVP"));
 }
+
+// ─── Hold / resume direction mirroring ────────────────────────────────
+
+use siphon_ai_media_glue::MediaDirection;
+
+fn pcmu_offer_with_direction(dir: &str) -> String {
+    format!(
+        "v=0\r\n\
+o=alice 1234 5678 IN IP4 10.0.0.5\r\n\
+s=Talk\r\n\
+c=IN IP4 10.0.0.5\r\n\
+t=0 0\r\n\
+m=audio 7078 RTP/AVP 0\r\n\
+a=rtpmap:0 PCMU/8000\r\n\
+a={dir}\r\n"
+    )
+}
+
+#[test]
+fn sendrecv_offer_yields_sendrecv_answer() {
+    let answer = build_answer(
+        &pcmu_offer_with_direction("sendrecv"),
+        &caps_pcmu_only(20100),
+    )
+    .expect("negotiate");
+    assert_eq!(answer.negotiated_direction, MediaDirection::SendRecv);
+    assert!(answer.answer_text.contains("a=sendrecv"));
+    assert!(!answer.negotiated_direction.is_held());
+}
+
+#[test]
+fn sendonly_offer_yields_recvonly_answer() {
+    // Classic hold: caller plays music-on-hold (sendonly).
+    // RFC 3264 §6.1 — answerer mirrors to recvonly.
+    let answer = build_answer(
+        &pcmu_offer_with_direction("sendonly"),
+        &caps_pcmu_only(20100),
+    )
+    .expect("negotiate");
+    assert_eq!(answer.negotiated_direction, MediaDirection::RecvOnly);
+    assert!(answer.answer_text.contains("a=recvonly"));
+    assert!(answer.negotiated_direction.is_held());
+}
+
+#[test]
+fn recvonly_offer_yields_sendonly_answer() {
+    let answer = build_answer(
+        &pcmu_offer_with_direction("recvonly"),
+        &caps_pcmu_only(20100),
+    )
+    .expect("negotiate");
+    assert_eq!(answer.negotiated_direction, MediaDirection::SendOnly);
+    assert!(answer.answer_text.contains("a=sendonly"));
+    assert!(answer.negotiated_direction.is_held());
+}
+
+#[test]
+fn inactive_offer_currently_errors_at_negotiator() {
+    // RFC 3264 §6.1 says the answerer SHOULD mirror with `inactive`,
+    // but sip-sdp's negotiator treats `inactive` vs our advertised
+    // `sendrecv` caps as incompatible and returns an error rather
+    // than producing an inactive answer. This test pins the
+    // current behavior so we notice if the upstream fixes it.
+    //
+    // The pragmatic workaround for callers that need inactive
+    // answers (attended-transfer / call-park) is to build the
+    // answer manually with `MediaDirection::Inactive` rather than
+    // routing through `negotiate_answer`. Out of scope for v1.
+    let err = build_answer(
+        &pcmu_offer_with_direction("inactive"),
+        &caps_pcmu_only(20100),
+    )
+    .expect_err("upstream rejects inactive↔sendrecv");
+    assert!(
+        matches!(err, SdpError::Negotiate(_)),
+        "expected Negotiate error, got {err:?}"
+    );
+}
+
+#[test]
+fn missing_direction_attr_defaults_to_sendrecv() {
+    // RFC 4566 §6: absent direction means sendrecv.
+    let offer = "v=0\r\n\
+o=alice 1234 5678 IN IP4 10.0.0.5\r\n\
+s=Talk\r\n\
+c=IN IP4 10.0.0.5\r\n\
+t=0 0\r\n\
+m=audio 7078 RTP/AVP 0\r\n\
+a=rtpmap:0 PCMU/8000\r\n";
+    let answer = build_answer(offer, &caps_pcmu_only(20100)).expect("negotiate");
+    assert_eq!(answer.negotiated_direction, MediaDirection::SendRecv);
+}

--- a/crates/sip-glue/src/handler.rs
+++ b/crates/sip-glue/src/handler.rs
@@ -121,6 +121,21 @@ pub struct MatchedCall<'a> {
     pub route: &'a CompiledRoute,
 }
 
+/// Inputs to a re-INVITE handler. The routing handler dispatches
+/// in-dialog INVITEs (the SIP UAS resolves the dialog before us)
+/// here so the acceptor can answer with a new SDP — typically for
+/// hold/resume, where only the `a=` direction attribute changes.
+pub struct ReinviteCall<'a> {
+    pub request: &'a Request,
+    pub handle: ServerTransactionHandle,
+    pub transport: &'a TransportContext,
+    pub dialog: &'a Dialog,
+    /// The SIP `Call-ID` header value. Cached here so the acceptor
+    /// doesn't have to re-parse it to look up the cached answer
+    /// SDP in its registry.
+    pub sip_call_id: String,
+}
+
 /// Hook for the eventual `core::CallController`. SiphonAI's
 /// per-call setup logic — answer with SDP, attach MediaTap, open
 /// the WS bridge — implements this trait. Routing doesn't know
@@ -133,6 +148,16 @@ pub trait CallAcceptor: Send + Sync {
     /// arranging for a spawned task to do so); otherwise the call
     /// stays in 100 Trying until the transaction times out.
     async fn on_matched(&self, call: MatchedCall<'_>) -> anyhow::Result<()>;
+
+    /// A re-INVITE on an existing dialog arrived. The default impl
+    /// returns 501 Not Implemented; consumers that handle
+    /// hold/resume override this. Same contract as `on_matched`
+    /// re sending the final response.
+    async fn on_reinvite(&self, call: ReinviteCall<'_>) -> anyhow::Result<()> {
+        let response = UserAgentServer::create_response(call.request, 501, "Not Implemented");
+        call.handle.send_final(response).await;
+        Ok(())
+    }
 }
 
 /// `UasRequestHandler` that does INVITE routing and mid-dialog
@@ -197,19 +222,28 @@ impl<A: CallAcceptor + 'static> UasRequestHandler for RoutingHandler<A> {
         ctx: &TransportContext,
         dialog: Option<&Dialog>,
     ) -> anyhow::Result<()> {
-        if dialog.is_some() {
-            // Re-INVITE on an existing dialog. Routing has nothing
-            // to say here; the dialog's controller should handle
-            // it. Until core::CallController exists, refuse cleanly.
-            debug!("re-INVITE received; routing layer cannot handle it yet");
-            handle
-                .send_final(UserAgentServer::create_response(
+        if let Some(dialog) = dialog {
+            // Re-INVITE on an existing dialog — hold / resume /
+            // mid-call codec change. Routing doesn't dispatch on
+            // route again; the acceptor knows the call's negotiated
+            // state (RTP port, codec, last answer SDP) and answers
+            // with a matching mid-dialog 200 OK.
+            let sip_call_id = request
+                .headers()
+                .get_smol("Call-ID")
+                .map(|s| s.to_string())
+                .unwrap_or_default();
+            debug!(sip_call_id = %sip_call_id, "re-INVITE → acceptor");
+            return self
+                .acceptor
+                .on_reinvite(ReinviteCall {
                     request,
-                    501,
-                    "Not Implemented",
-                ))
+                    handle,
+                    transport: ctx,
+                    dialog,
+                    sip_call_id,
+                })
                 .await;
-            return Ok(());
         }
 
         let register_source = (self.resolver)(request, ctx);

--- a/crates/sip-glue/src/lib.rs
+++ b/crates/sip-glue/src/lib.rs
@@ -31,7 +31,8 @@ pub use dialog::{
     NullDialogTerminator,
 };
 pub use handler::{
-    dispatch_invite, CallAcceptor, MatchedCall, RegisterSourceResolver, RouteAction, RoutingHandler,
+    dispatch_invite, CallAcceptor, MatchedCall, RegisterSourceResolver, ReinviteCall, RouteAction,
+    RoutingHandler,
 };
 pub use invite::InviteFacts;
 pub use register::{


### PR DESCRIPTION
## Summary
Replaces the routing handler's \`501 Not Implemented\` stub for re-INVITE with a real RFC 3264 §6.1 direction-mirroring path. Closes the **Hold / resume — re-INVITE with sendonly/inactive not handled** item from the dev-plan audit.

## How it flows now
1. \`RoutingHandler::on_invite\` sees \`dialog.is_some()\` → dispatches to \`CallAcceptor::on_reinvite\` (new trait method, default impl still 501 so non-Bridging acceptors keep their existing behaviour).
2. \`BridgingAcceptor::on_reinvite\` looks up the call's cached answer SDP in \`CallRegistry\`. Missing → 481 Call/Transaction Does Not Exist.
3. Parse the new offer, read its \`a=\` direction attribute, compute the RFC 3264 mirror (sendrecv↔sendrecv, sendonly↔recvonly, recvonly↔sendonly, inactive↔inactive).
4. Take the cached answer text and rewrite just the direction line — everything else (port, codec, rtpmap, fmtp) stays put so forge's RTP session doesn't have to renegotiate.
5. Send 200 OK via \`IntegratedUAS::accept_invite\` so the dialog manager gets the new CSeq.

## Supporting plumbing
- \`media-glue::sdp\` — new \`MediaDirection\` enum + the negotiated direction surfaces on \`AnswerOutcome\`.
- \`CallRegistry\` — entries are now \`CallEntry { handle, answer_text }\` so re-INVITE handlers can rebuild a matching answer without rerunning codec negotiation.
- \`acceptor.rs\` — \`mirror_direction\`, \`rewrite_sdp_direction\`, \`sdp_audio_direction\` helpers with full unit-test coverage.

## Tests
- 4 new SDP direction-mirror tests in \`tests/sdp_negotiation.rs\` (sendrecv → sendrecv, sendonly → recvonly, recvonly → sendonly, missing → sendrecv default). Plus a pinned-behaviour test for the upstream's strict \`inactive↔sendrecv\` rejection (workaround documented inline).
- 5 new unit tests for the helpers (mirror, rewrite round-trips, append-when-missing, LF/CRLF preservation).
- Full workspace \`cargo test --no-fail-fast\` green (37 test groups, including the 33 \`siphon-ai-core\` lib tests).

## Out of scope
- WS protocol \`BridgeOut::Hold\` / \`Resume\` events — protocol version bump; defer until a real consumer asks for them.
- Forge-side "pause outbound RTP while held" — the SDP answer is the wire contract; most PBXs (Asterisk, FreeSWITCH) keep sending music-on-hold even on \`recvonly\`.
- Mid-call codec change — same handler path would need \`negotiate_answer\` instead of text-rewrite; out of scope for hold/resume specifically.

The pre-existing clippy \`let-unit-value\` warning in \`crates/media-glue/tests/tap.rs\` is unrelated and lives on main; \`cargo clippy -p siphon-ai-core -p siphon-ai-sip-glue --all-targets -- -D warnings\` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)