### PR TITLE
fix(call): server-driven hangup tears down SIP dialog + 3 related bugs

### DIFF
--- a/crates/config/src/compile.rs
+++ b/crates/config/src/compile.rs
@@ -257,6 +257,12 @@ pub enum CompileError {
     #[error("[hep].collector {0:?} resolved to no addresses")]
     HepCollectorResolveEmpty(String),
 
+    #[error(
+        "[node].public_address must be set when [sip].listen binds an unspecified address \
+         (got {0}); the SDP answer's c= line cannot use 0.0.0.0 / ::"
+    )]
+    PublicAddressRequiredForWildcardListen(std::net::IpAddr),
+
     #[error("[hep].capture_id is required when [hep].enabled = true")]
     HepCaptureIdRequired,
 
@@ -287,7 +293,7 @@ pub enum CompileError {
 /// Compile a raw config into the consumer-ready form.
 pub fn compile(raw: RawConfig) -> Result<Config, CompileError> {
     let sip = compile_sip(raw.sip)?;
-    let node = compile_node(raw.node, &sip);
+    let node = compile_node(raw.node, &sip)?;
     let media = compile_media(&raw.media)?;
     let bridge_defaults = compile_bridge(raw.bridge, &raw.media)?;
     let routes = compile_dialplan(raw.routes)?;
@@ -391,12 +397,27 @@ fn compile_sip_tls(
     }))
 }
 
-fn compile_node(raw: RawNode, sip: &SipConfig) -> NodeConfig {
+fn compile_node(raw: RawNode, sip: &SipConfig) -> Result<NodeConfig, CompileError> {
     let id = raw.id.unwrap_or_else(|| "siphon-ai".to_string());
-    let public_address = raw
-        .public_address
-        .unwrap_or_else(|| sip.listen_addr.ip().to_string());
-    NodeConfig { id, public_address }
+
+    // When the operator didn't supply `[node].public_address`, fall
+    // back to the SIP bind host — but ONLY if it's a real
+    // routable address. An unspecified bind (`0.0.0.0` / `::`)
+    // would otherwise leak into the SDP answer's `c=` line and
+    // RTP from the caller goes nowhere. Refuse loudly rather than
+    // silently misconfigure.
+    let public_address = match raw.public_address {
+        Some(addr) => addr,
+        None => {
+            let ip = sip.listen_addr.ip();
+            if ip.is_unspecified() {
+                return Err(CompileError::PublicAddressRequiredForWildcardListen(ip));
+            }
+            ip.to_string()
+        }
+    };
+
+    Ok(NodeConfig { id, public_address })
 }
 
 fn compile_media(raw: &RawMedia) -> Result<MediaConfig, CompileError> {

--- a/crates/config/tests/load.rs
+++ b/crates/config/tests/load.rs
@@ -36,7 +36,7 @@ id = "siphon-ai-test"
 public_address = "203.0.113.10"
 
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 transports = ["udp", "tcp"]
 user_agent = "SiphonAI/0.1.0-test"
 
@@ -128,7 +128,7 @@ fn env_default_used_when_var_absent() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:${SIP_PORT:-5070}"
+listen = "127.0.0.1:${SIP_PORT:-5070}"
 
 [bridge]
 ws_url = "wss://${HOST:-fallback.example.com}/ws"
@@ -165,7 +165,7 @@ fn unknown_codec_is_a_compile_error() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 
 [media]
 codecs = ["pcmu", "g729"]
@@ -206,7 +206,7 @@ fn unknown_transport_is_a_compile_error() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 transports = ["udp", "smoke"]
 
 [bridge]
@@ -221,7 +221,7 @@ fn audio_sample_rate_must_be_8k_or_16k() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 
 [bridge]
 ws_url = "wss://x/y"
@@ -236,7 +236,7 @@ fn dtmf_off_disables_payload_type() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 
 [media]
 dtmf = "off"
@@ -258,7 +258,7 @@ fn unknown_dtmf_mode_errors() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 
 [media]
 dtmf = "morse"
@@ -278,7 +278,7 @@ fn unknown_top_level_section_is_tolerated() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 
 [bridge]
 ws_url = "wss://x/y"
@@ -306,7 +306,7 @@ fn unknown_field_in_known_section_errors() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 
 [bridge]
 ws_url = "wss://x/y"
@@ -324,7 +324,7 @@ fn no_default_route_loads_but_warns() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 
 [bridge]
 ws_url = "wss://x/y"
@@ -346,7 +346,7 @@ fn duplicate_codecs_are_deduplicated() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 
 [media]
 codecs = ["pcmu", "pcma", "pcmu"]
@@ -368,7 +368,7 @@ fn cdr_disabled_by_default() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 
 [bridge]
 ws_url = "wss://x/y"
@@ -389,7 +389,7 @@ fn cdr_file_sink_compiles_with_path() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 
 [bridge]
 ws_url = "wss://x/y"
@@ -417,7 +417,7 @@ fn cdr_webhook_sink_compiles_with_url_and_auth() {
     let env = MapEnv::new([("CDR_TOKEN", "tok-123")]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 
 [bridge]
 ws_url = "wss://x/y"
@@ -449,7 +449,7 @@ fn cdr_file_enabled_without_path_errors() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 
 [bridge]
 ws_url = "wss://x/y"
@@ -473,7 +473,7 @@ fn cdr_webhook_enabled_without_url_errors() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 
 [bridge]
 ws_url = "wss://x/y"
@@ -501,7 +501,7 @@ fn cdr_disabled_overrides_sub_block_misconfig() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 
 [bridge]
 ws_url = "wss://x/y"
@@ -527,7 +527,7 @@ fn register_blocks_default_to_empty() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 
 [bridge]
 ws_url = "wss://x/y"
@@ -546,7 +546,7 @@ fn register_block_compiles_with_required_fields() {
     let env = MapEnv::new([("CUCM_PASS", "hunter2")]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 
 [bridge]
 ws_url = "wss://x/y"
@@ -580,7 +580,7 @@ fn register_block_picks_default_port_per_transport() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 
 [bridge]
 ws_url = "wss://x/y"
@@ -606,7 +606,7 @@ fn register_explicit_port_overrides_default() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 
 [bridge]
 ws_url = "wss://x/y"
@@ -632,7 +632,7 @@ fn register_duplicate_name_errors() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 
 [bridge]
 ws_url = "wss://x/y"
@@ -665,7 +665,7 @@ fn register_hostname_server_errors_in_v1() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 
 [bridge]
 ws_url = "wss://x/y"
@@ -690,7 +690,7 @@ fn register_unknown_transport_errors() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 
 [bridge]
 ws_url = "wss://x/y"
@@ -716,7 +716,7 @@ fn register_auth_username_defaults_to_username() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 
 [bridge]
 ws_url = "wss://x/y"
@@ -741,7 +741,7 @@ fn sip_tls_disabled_by_default() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 
 [bridge]
 ws_url = "wss://x/y"
@@ -790,7 +790,7 @@ fn sip_tls_explicit_listen_overrides_default() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 transports = ["tls"]
 
 [sip.tls]
@@ -816,7 +816,7 @@ fn sip_tls_missing_cert_errors() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 transports = ["tls"]
 
 [sip.tls]
@@ -839,7 +839,7 @@ fn sip_tls_missing_key_errors() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 transports = ["tls"]
 
 [sip.tls]
@@ -864,7 +864,7 @@ fn sip_tls_block_without_tls_transport_errors() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 transports = ["udp"]
 
 [sip.tls]
@@ -888,7 +888,7 @@ fn sip_tls_bad_listen_addr_errors() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 transports = ["tls"]
 
 [sip.tls]
@@ -917,7 +917,7 @@ fn webhooks_disabled_by_default() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 
 [bridge]
 ws_url = "wss://x/y"
@@ -938,7 +938,7 @@ fn webhooks_enabled_compiles_with_url_auth_and_allowlist() {
     let env = MapEnv::new([("WEBHOOK_TOKEN", "wh-xyz")]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 
 [bridge]
 ws_url = "wss://x/y"
@@ -976,7 +976,7 @@ fn webhooks_enabled_without_url_errors() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 
 [bridge]
 ws_url = "wss://x/y"
@@ -999,7 +999,7 @@ fn webhooks_disabled_tolerates_missing_url() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 
 [bridge]
 ws_url = "wss://x/y"
@@ -1021,7 +1021,7 @@ fn observability_disabled_by_default() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 
 [bridge]
 ws_url = "wss://x/y"
@@ -1041,7 +1041,7 @@ fn observability_enabled_compiles_with_listen_addr() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 
 [bridge]
 ws_url = "wss://x/y"
@@ -1065,7 +1065,7 @@ fn observability_enabled_without_listen_errors() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 
 [bridge]
 ws_url = "wss://x/y"
@@ -1087,7 +1087,7 @@ fn observability_bad_listen_addr_errors() {
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
-listen = "0.0.0.0:5060"
+listen = "127.0.0.1:5060"
 
 [bridge]
 ws_url = "wss://x/y"
@@ -1112,7 +1112,35 @@ any = true
 #[test]
 fn defaults_kick_in_when_optional_blocks_omitted() {
     // Smallest valid config: just sip + bridge. Everything else
-    // gets a sensible default.
+    // gets a sensible default. The bind has to be a real IP (not
+    // 0.0.0.0) because the SDP answer needs a routable
+    // [node].public_address — see
+    // CompileError::PublicAddressRequiredForWildcardListen.
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[bridge]
+ws_url = "wss://x/y"
+"#;
+    let cfg = load_from_str_with_env(toml, &env).unwrap();
+    assert_eq!(cfg.node.id, "siphon-ai");
+    assert_eq!(cfg.node.public_address, "127.0.0.1");
+    assert_eq!(cfg.sip.transports, vec![SipTransport::Udp]);
+    assert_eq!(cfg.bridge_defaults.codecs, vec![Codec::Pcmu, Codec::Pcma]);
+    assert_eq!(cfg.bridge_defaults.dtmf_payload_type, Some(101));
+    assert_eq!(cfg.bridge_defaults.connect_timeout, Duration::from_secs(5));
+    assert!(cfg.bridge_defaults.forward_headers.is_empty());
+}
+
+#[test]
+fn wildcard_listen_without_public_address_is_rejected() {
+    // The bug this guards: binding 0.0.0.0 with no
+    // [node].public_address would otherwise produce an SDP
+    // answer with c=IN IP4 0.0.0.0, which RTP can't route to.
+    // Refuse loudly at config compile rather than silently
+    // shipping a misconfig to prod.
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
@@ -1121,11 +1149,43 @@ listen = "0.0.0.0:5060"
 [bridge]
 ws_url = "wss://x/y"
 "#;
+    let err = load_from_str_with_env(toml, &env).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("public_address") && msg.contains("unspecified"),
+        "expected the new wildcard-bind error, got: {msg}"
+    );
+}
+
+#[test]
+fn wildcard_listen_with_public_address_works() {
+    // Same bind, but with public_address spelled out — fine.
+    let env = MapEnv::new([]);
+    let toml = r#"
+[node]
+public_address = "203.0.113.4"
+
+[sip]
+listen = "0.0.0.0:5060"
+
+[bridge]
+ws_url = "wss://x/y"
+"#;
     let cfg = load_from_str_with_env(toml, &env).unwrap();
-    assert_eq!(cfg.node.id, "siphon-ai");
-    assert_eq!(cfg.sip.transports, vec![SipTransport::Udp]);
-    assert_eq!(cfg.bridge_defaults.codecs, vec![Codec::Pcmu, Codec::Pcma]);
-    assert_eq!(cfg.bridge_defaults.dtmf_payload_type, Some(101));
-    assert_eq!(cfg.bridge_defaults.connect_timeout, Duration::from_secs(5));
-    assert!(cfg.bridge_defaults.forward_headers.is_empty());
+    assert_eq!(cfg.node.public_address, "203.0.113.4");
+}
+
+#[test]
+fn ipv6_wildcard_listen_without_public_address_is_rejected() {
+    // Mirror of the v4 case: `::` is also unspecified.
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "[::]:5060"
+
+[bridge]
+ws_url = "wss://x/y"
+"#;
+    let err = load_from_str_with_env(toml, &env).unwrap_err();
+    assert!(err.to_string().contains("public_address"));
 }

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -548,6 +548,57 @@ struct InstalledTransfer {
     dialog_manager: Arc<DialogManager>,
 }
 
+/// Carried into the post-controller cleanup task. Same Arc'd UAC +
+/// DialogManager as REFER uses; we send the closing BYE through this
+/// when a call ends without the peer having sent BYE first. `None`
+/// when `install_transfer` was never called — see `run_call`.
+struct TeardownContext {
+    uac: Arc<IntegratedUAC>,
+    dialog_manager: Arc<DialogManager>,
+}
+
+/// Send an outbound BYE on the confirmed dialog for `sip_call_id`,
+/// if we have the plumbing for it. Logs the outcome and returns —
+/// the cleanup task can't recover from a BYE failure, so this is
+/// best-effort. `bridge_call_id` is only used for log correlation.
+async fn send_outbound_bye(
+    teardown: Option<&TeardownContext>,
+    sip_call_id: &str,
+    bridge_call_id: &str,
+) {
+    let Some(ctx) = teardown else {
+        warn!(
+            call_id = %bridge_call_id,
+            sip_call_id = %sip_call_id,
+            "controller exited without remote BYE but no UAC is installed; \
+             SIP dialog will linger until session-expires"
+        );
+        return;
+    };
+    let Some(dialog) = ctx.dialog_manager.find_by_call_id(sip_call_id) else {
+        debug!(
+            call_id = %bridge_call_id,
+            sip_call_id = %sip_call_id,
+            "no dialog to BYE — already torn down at the dialog layer"
+        );
+        return;
+    };
+    match ctx.uac.bye(&dialog).await {
+        Ok(resp) => debug!(
+            call_id = %bridge_call_id,
+            sip_call_id = %sip_call_id,
+            status = resp.code(),
+            "outbound BYE sent"
+        ),
+        Err(e) => warn!(
+            call_id = %bridge_call_id,
+            sip_call_id = %sip_call_id,
+            error = %e,
+            "outbound BYE failed; SIP dialog may linger"
+        ),
+    }
+}
+
 impl BridgingAcceptor {
     pub fn new(media: Arc<MediaSetup>, defaults: BridgeDefaults, registry: CallRegistry) -> Self {
         Self {
@@ -897,37 +948,23 @@ impl CallAcceptor for BridgingAcceptor {
             .await
         {
             Ok(prepared) => {
-                // 200 OK with the negotiated SDP via the canonical
-                // upstream helper (siphon-rs PR #35). This builds the
-                // response, auto-fills Via/Contact/User-Agent, sends
-                // it through the transaction handle, AND registers
-                // the confirmed dialog with the dialog manager that
-                // `dispatch` consults — so the follow-up BYE finds
-                // it instead of falling through to "unknown dialog".
                 let uas = self
                     .uas
                     .get()
                     .ok_or_else(|| anyhow::anyhow!(
                         "BridgingAcceptor::install_uas was not called; on_matched cannot accept INVITE without the IntegratedUAS handle"
                     ))?;
-                uas.accept_invite(
-                    call.request,
-                    &call.handle,
-                    call.transport,
-                    Some(&prepared.answer.answer_text),
-                )
-                .await
-                .map_err(|e| anyhow::anyhow!("failed to accept INVITE: {e}"))?;
 
-                // Start forge's RTP forwarding loop — this is what
-                // decodes inbound audio, runs the RFC-2833 detector,
-                // and publishes ForgeEvent::DtmfDigitDetected to the
-                // EventBus our taps subscribe to. Skipping it would
-                // leave the call silent and DTMF unheard, even though
-                // the SDP/200-OK round-trip looks healthy. forge's
-                // internal state requires Initializing → Active here;
-                // calling twice errors loudly, so do it exactly once
-                // per accepted INVITE.
+                // Start forge's RTP forwarding loop BEFORE the 200 OK.
+                // Decoding inbound audio, the RFC-2833 detector, and
+                // ForgeEvent::DtmfDigitDetected all depend on this
+                // step running. If it fails AFTER we accept the
+                // INVITE we have a confirmed SIP dialog with no media
+                // — RFC-3261's worst silent failure mode. Doing it
+                // first means a failure rejects the INVITE with 500
+                // and rolls back the forge session, no zombie call.
+                // forge's state machine requires Initializing →
+                // Active exactly once; we own that single call here.
                 if let Err(e) = self
                     .media
                     .session_manager()
@@ -937,8 +974,68 @@ impl CallAcceptor for BridgingAcceptor {
                     warn!(
                         call_id = %prepared.bridge_call_id,
                         error = %e,
-                        "forge start_session failed; call will be silent",
+                        "forge start_session failed; rejecting INVITE 500",
                     );
+                    // Roll back the forge session prepare_call
+                    // allocated so the RTP port is freed. Best-effort
+                    // — if stop_session itself fails the call is
+                    // already on its way out and a warn is the
+                    // operator's signal that something else is wrong.
+                    if let Err(stop_err) = self
+                        .media
+                        .session_manager()
+                        .stop_session(&prepared.forge_call_id)
+                        .await
+                    {
+                        warn!(
+                            call_id = %prepared.bridge_call_id,
+                            error = %stop_err,
+                            "stop_session after start_session failure also failed"
+                        );
+                    }
+                    let response = UserAgentServer::create_response(
+                        call.request,
+                        500,
+                        "Server Internal Error",
+                    );
+                    call.handle.send_final(response).await;
+                    metrics::counter!(INVITES_TOTAL, "result" => "rejected").increment(1);
+                    return Ok(());
+                }
+
+                // 200 OK with the negotiated SDP via the canonical
+                // upstream helper (siphon-rs PR #35). This builds the
+                // response, auto-fills Via/Contact/User-Agent, sends
+                // it through the transaction handle, AND registers
+                // the confirmed dialog with the dialog manager that
+                // `dispatch` consults — so the follow-up BYE finds
+                // it instead of falling through to "unknown dialog".
+                if let Err(e) = uas
+                    .accept_invite(
+                        call.request,
+                        &call.handle,
+                        call.transport,
+                        Some(&prepared.answer.answer_text),
+                    )
+                    .await
+                {
+                    // The 200 OK never reached the peer — roll back
+                    // the forge session we just activated so the
+                    // RTP port doesn't leak. Same best-effort policy
+                    // as the start_session error path above.
+                    if let Err(stop_err) = self
+                        .media
+                        .session_manager()
+                        .stop_session(&prepared.forge_call_id)
+                        .await
+                    {
+                        warn!(
+                            call_id = %prepared.bridge_call_id,
+                            error = %stop_err,
+                            "stop_session after accept_invite failure also failed"
+                        );
+                    }
+                    return Err(anyhow::anyhow!("failed to accept INVITE: {e}"));
                 }
 
                 metrics::counter!(INVITES_TOTAL, "result" => "accepted").increment(1);
@@ -988,6 +1085,12 @@ impl BridgingAcceptor {
             },
         };
 
+        // Clone the handle BEFORE moving it into the registry — the
+        // cleanup task needs it to consult `remote_bye_received()`
+        // so it knows whether to send an outbound BYE. `CallHandle`
+        // is cheap (Arc-of-Notify + Arc-of-AtomicBool inside).
+        let cleanup_handle = prepared.handle.clone();
+
         // Register before spawning so a BYE arriving on the very
         // next packet finds an entry to wake. Cache the answer SDP
         // we sent so a future re-INVITE (hold/resume) can rebuild a
@@ -1031,6 +1134,18 @@ impl BridgingAcceptor {
         let registry = self.registry.clone();
         let cdr_sink = Arc::clone(&self.cdr_sink);
         let webhook_sink = Arc::clone(&self.webhook_sink);
+        // Daemon-wide UAC + DialogManager Arc clones so the cleanup
+        // task can send an outbound BYE when teardown was driven
+        // locally (WS `hangup`, admin force-hangup, bridge ended).
+        // When `install_transfer` was never called these are `None`
+        // and we log + skip the BYE — the SIP leg lingers until the
+        // peer's own session-expires fires, which is the previous
+        // behaviour, but at least the registry no longer claims the
+        // call is dead while the dialog stays up.
+        let teardown = self.transfer.get().map(|t| TeardownContext {
+            uac: Arc::clone(&t.uac),
+            dialog_manager: Arc::clone(&t.dialog_manager),
+        });
 
         tokio::spawn(async move {
             let run_result = controller.run().await;
@@ -1040,6 +1155,15 @@ impl BridgingAcceptor {
                 cause = ?view.cause,
                 "call ended"
             );
+            // Send outbound BYE if the peer didn't already drive it.
+            // Order: BYE first, registry remove second, forge stop
+            // third. That way a follow-up BYE retransmit from the
+            // peer (which would be racing our outbound BYE in the
+            // wild) still finds the entry and gets a 200 OK instead
+            // of "unknown dialog".
+            if !cleanup_handle.remote_bye_received() {
+                send_outbound_bye(teardown.as_ref(), &sip_call_id, bridge_call_id.as_str()).await;
+            }
             registry.remove(&sip_call_id);
             if let Err(e) = media.session_manager().stop_session(&forge_call_id).await {
                 warn!(

--- a/crates/core/src/call.rs
+++ b/crates/core/src/call.rs
@@ -55,6 +55,7 @@
 //!   yet — they're logged. Hangup terminates the call.
 //! - No CDR / webhook emission.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use sip_core::SipUri;
@@ -173,6 +174,12 @@ pub enum CallError {
 pub struct CallHandle {
     notify: std::sync::Arc<Notify>,
     call_id: CallId,
+    /// Set when the peer drove teardown by sending a BYE on the
+    /// confirmed dialog. The acceptor's post-controller cleanup
+    /// consults this to decide whether to send an outbound BYE —
+    /// without it, a WS-side `hangup` would leave the SIP leg up
+    /// because the controller only stops the WS/tap path.
+    remote_bye: std::sync::Arc<AtomicBool>,
 }
 
 impl CallHandle {
@@ -180,6 +187,7 @@ impl CallHandle {
         Self {
             notify: std::sync::Arc::new(Notify::new()),
             call_id,
+            remote_bye: std::sync::Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -188,6 +196,19 @@ impl CallHandle {
     /// return.
     pub fn shutdown(&self) {
         self.notify.notify_one();
+    }
+
+    /// Record that the SIP peer has sent (or implicitly already
+    /// completed) the BYE leg of teardown. Callers that initiate
+    /// teardown locally (e.g., WS server `hangup`, admin force-
+    /// hangup) leave this `false` so the acceptor knows it still
+    /// owes the peer an outbound BYE.
+    pub fn mark_remote_bye(&self) {
+        self.remote_bye.store(true, Ordering::Release);
+    }
+
+    pub fn remote_bye_received(&self) -> bool {
+        self.remote_bye.load(Ordering::Acquire)
     }
 
     pub fn call_id(&self) -> &CallId {

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -143,6 +143,25 @@ impl DialogTerminator for CallRegistry {
             None => false,
         }
     }
+
+    /// BYE-driven shutdown: same as [`Self::terminate`], plus mark
+    /// the handle so the post-controller cleanup knows the peer
+    /// has already taken down the SIP dialog and skips sending an
+    /// outbound BYE. Without this, a controller that exited because
+    /// of a remote BYE would still try to BYE the peer back —
+    /// harmless but redundant. The asymmetry with CANCEL is
+    /// deliberate: a CANCEL is pre-2xx and the dialog never confirms,
+    /// so no outbound BYE is needed there either.
+    fn terminate_from_bye(&self, sip_call_id: &str) -> bool {
+        match self.lookup(sip_call_id) {
+            Some(handle) => {
+                handle.mark_remote_bye();
+                handle.shutdown();
+                true
+            }
+            None => false,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -288,4 +307,55 @@ mod tests {
     // exercised end-to-end in `tests/controller_lifecycle.rs` —
     // here the structural test (`cloned_registry_shares_state`)
     // pins the shared-Arc invariant and is enough.
+
+    #[test]
+    fn terminate_from_bye_marks_handle_then_signals_shutdown() {
+        // The acceptor's cleanup task reads `remote_bye_received()`
+        // to decide whether it needs to send an outbound BYE.
+        // Confirm the registry's BYE path flips that flag — without
+        // it, every BYE-terminated call would also send a redundant
+        // outbound BYE to the peer.
+        let reg = CallRegistry::new();
+        let handle = fresh_handle("siphon-1");
+        assert!(!handle.remote_bye_received());
+
+        reg.insert(
+            "abc@pbx",
+            CallEntry {
+                handle: handle.clone(),
+                answer_text: None,
+            },
+        );
+
+        let signalled = reg.terminate_from_bye("abc@pbx");
+        assert!(signalled);
+        assert!(handle.remote_bye_received());
+    }
+
+    #[test]
+    fn terminate_does_not_mark_remote_bye() {
+        // CANCEL goes through `terminate`, not `terminate_from_bye`,
+        // because CANCEL is pre-2xx and the dialog never confirmed.
+        // The flag must stay false so the cleanup task sees "local
+        // shutdown" semantics.
+        let reg = CallRegistry::new();
+        let handle = fresh_handle("siphon-2");
+        reg.insert(
+            "xyz@pbx",
+            CallEntry {
+                handle: handle.clone(),
+                answer_text: None,
+            },
+        );
+
+        let signalled = reg.terminate("xyz@pbx");
+        assert!(signalled);
+        assert!(!handle.remote_bye_received());
+    }
+
+    #[test]
+    fn terminate_from_bye_unknown_returns_false() {
+        let reg = CallRegistry::new();
+        assert!(!reg.terminate_from_bye("never-seen@pbx"));
+    }
 }

--- a/crates/sip-glue/src/dialog.rs
+++ b/crates/sip-glue/src/dialog.rs
@@ -54,6 +54,16 @@ pub trait DialogTerminator: Send + Sync {
     /// `true` if a call was found and signalled, `false` if no
     /// matching call exists. Implementations MUST NOT block.
     fn terminate(&self, sip_call_id: &str) -> bool;
+
+    /// Variant of [`Self::terminate`] for the case where teardown was
+    /// driven by an inbound BYE. Implementations must record that
+    /// fact on the call entry so the eventual post-controller
+    /// cleanup task knows it does NOT need to send an outbound BYE
+    /// — the peer has already done it. The default delegates to
+    /// [`Self::terminate`] for impls that don't care to distinguish.
+    fn terminate_from_bye(&self, sip_call_id: &str) -> bool {
+        self.terminate(sip_call_id)
+    }
 }
 
 /// Decide what to send back for a BYE.
@@ -68,7 +78,7 @@ pub fn dispatch_bye(terminator: &dyn DialogTerminator, request: &Request) -> Dia
         .get_smol("Call-ID")
         .map(|s| s.to_string())
         .unwrap_or_default();
-    let signalled = terminator.terminate(&sip_call_id);
+    let signalled = terminator.terminate_from_bye(&sip_call_id);
     if signalled {
         info!(sip_call_id = %sip_call_id, "BYE → controller shutdown");
     } else {
@@ -145,6 +155,7 @@ mod tests {
     #[derive(Default)]
     struct RecordingTerminator {
         terminated: parking_lot::Mutex<Vec<String>>,
+        terminated_from_bye: parking_lot::Mutex<Vec<String>>,
         return_match: AtomicBool,
     }
 
@@ -161,10 +172,17 @@ mod tests {
             self.terminated.lock().push(sip_call_id.to_string());
             self.return_match.load(Ordering::Relaxed)
         }
+
+        fn terminate_from_bye(&self, sip_call_id: &str) -> bool {
+            self.terminated_from_bye
+                .lock()
+                .push(sip_call_id.to_string());
+            self.return_match.load(Ordering::Relaxed)
+        }
     }
 
     #[test]
-    fn bye_sends_200_and_calls_terminator_with_call_id() {
+    fn bye_sends_200_and_calls_terminate_from_bye_with_call_id() {
         let term = RecordingTerminator::matching();
         let request = req(Method::Bye, "abc-123@pbx");
         match dispatch_bye(&term, &request) {
@@ -173,7 +191,14 @@ mod tests {
                 assert_eq!(resp.reason(), "OK");
             }
         }
-        assert_eq!(*term.terminated.lock(), vec!["abc-123@pbx".to_string()]);
+        // BYE must go through the BYE-flavoured variant so the
+        // registry can mark the handle and the acceptor's cleanup
+        // task knows not to send a duplicate outbound BYE.
+        assert_eq!(
+            *term.terminated_from_bye.lock(),
+            vec!["abc-123@pbx".to_string()]
+        );
+        assert!(term.terminated.lock().is_empty());
     }
 
     #[test]
@@ -186,7 +211,19 @@ mod tests {
                 assert_eq!(resp.code(), 200);
             }
         }
-        assert_eq!(*term.terminated.lock(), vec!["ghost@pbx".to_string()]);
+        assert_eq!(
+            *term.terminated_from_bye.lock(),
+            vec!["ghost@pbx".to_string()]
+        );
+    }
+
+    #[test]
+    fn default_terminate_from_bye_delegates_to_terminate() {
+        // Impls that don't override `terminate_from_bye` get the
+        // trait default — which is `terminate`. The NullDialogTerminator
+        // is the canonical example.
+        let n = NullDialogTerminator;
+        assert!(!n.terminate_from_bye("anything"));
     }
 
     #[test]
@@ -221,6 +258,6 @@ mod tests {
         match dispatch_bye(&term, &request) {
             DialogAction::SendFinal(resp) => assert_eq!(resp.code(), 200),
         }
-        assert_eq!(*term.terminated.lock(), vec!["".to_string()]);
+        assert_eq!(*term.terminated_from_bye.lock(), vec!["".to_string()]);
     }
 }


### PR DESCRIPTION
## Summary

Four release-blockers from code review. #3 (re-INVITE) was already
fixed in PR #17 — confirmed and not changed. The other three are
addressed here in one bundle since they share the call-teardown
code path.

### #1 — Server-driven hangup left the SIP dialog up
\`BridgeIn::Hangup\` only stopped the WS / controller path. The PBX
leg stayed established until session-expires.

- \`CallHandle\` gains a \`remote_bye\` AtomicBool flag with
  \`mark_remote_bye()\` / \`remote_bye_received()\`.
- \`DialogTerminator\` gains a \`terminate_from_bye\` variant with a
  default that delegates to \`terminate\` — preserves existing impls.
- \`dispatch_bye\` calls \`terminate_from_bye\`; \`dispatch_cancel\` keeps
  \`terminate\` (CANCEL is pre-2xx, no dialog to BYE).
- \`CallRegistry\` overrides \`terminate_from_bye\` to flip the flag
  on the looked-up handle, then signal shutdown.
- \`BridgingAcceptor::run_call\`'s post-controller cleanup task
  consults \`remote_bye_received()\` and sends an outbound BYE
  through the daemon-wide \`IntegratedUAC\` when the peer didn't
  already drive teardown. Best-effort; logs on failure.

### #2 — \`start_session\` failure accepted the INVITE anyway
The \"call will be silent\" warning was followed by the controller
spawn. RFC-3261 worst silent failure: confirmed SIP dialog, no
media path.

- Reorder so \`start_session\` runs BEFORE \`accept_invite\`.
- On failure: reject the INVITE with 500 Server Internal Error,
  \`stop_session\` to roll back the forge session.
- Symmetric \`stop_session\` cleanup added for the
  \`accept_invite\`-failure path (newly possible with the reorder).

### #4 — \`public_address\` fallback could emit \`c=IN IP4 0.0.0.0\`
\`compile_node\` fell back to the SIP bind IP. Binding \`0.0.0.0\`
with no \`[node].public_address\` produced unroutable RTP.

- New \`CompileError::PublicAddressRequiredForWildcardListen\`
  variant — rejected at config load.
- Covers IPv4 (\`0.0.0.0\`) and IPv6 (\`::\`).
- Existing test fixtures using \`0.0.0.0:5060\` updated to
  \`127.0.0.1:5060\` (32 tests, mechanical change).
- Three new tests pin the rejection / acceptance matrix.

## Test plan
- [x] \`cargo test --workspace\` — all green
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — one
  pre-existing warning in registration.rs, unrelated
- [x] \`cargo fmt --all -- --check\` — clean
- [x] New unit tests: \`dispatch_bye\` calls \`terminate_from_bye\`;
  \`CallRegistry::terminate_from_bye\` flips the handle flag;
  \`CallRegistry::terminate\` does NOT flip the flag (CANCEL path);
  default \`terminate_from_bye\` delegates to \`terminate\`;
  \`wildcard_listen_without_public_address_is_rejected\` (v4 + v6);
  \`wildcard_listen_with_public_address_works\`.
- [ ] Manual SIPp scenario: WS server sends \`hangup\` mid-call →
  verify outbound BYE appears on the wire (logged at debug under
  \`siphon_ai_core::acceptor\`).
- [ ] Manual: bind \`0.0.0.0:5060\` with no \`[node].public_address\`
  → daemon refuses to start with a clear error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)