### PR TITLE
refactor(config): drop bridge.audio_sample_rate; reject opus at load

### DIFF
--- a/bins/siphon-ai/tests/fixtures/local-dev.toml
+++ b/bins/siphon-ai/tests/fixtures/local-dev.toml
@@ -25,7 +25,6 @@ rtp_port_range = [${TEST_RTP_MIN}, ${TEST_RTP_MAX}]
 [bridge]
 ws_url = "wss://example.test/sip-bridge"
 ws_connect_timeout_ms = 1000
-audio_sample_rate = 8000
 
 [[route]]
 name = "default"

--- a/configs/local-dev.toml
+++ b/configs/local-dev.toml
@@ -14,7 +14,6 @@ rtp_port_range = [40000, 40100]
 [bridge]
 ws_url = "ws://127.0.0.1:8765/"
 ws_connect_timeout_ms = 3000
-audio_sample_rate = 8000
 
 [observability]
 enabled = true

--- a/crates/config/src/compile.rs
+++ b/crates/config/src/compile.rs
@@ -7,7 +7,9 @@
 //! - At least one transport is enabled, and every name is one of
 //!   `udp` / `tcp` / `tls`.
 //! - Every codec name parses via [`Codec::from_encoding_name`].
-//! - `[bridge].audio_sample_rate`, when set, is `8000` or `16000`.
+//! - `[bridge].codecs` parse to known encodings via
+//!   `Codec::from_encoding_name`. Opus is rejected here — see
+//!   [`CompileError::CodecRequiresResampling`].
 //! - Every regex in the dialplan compiles (delegated to the routes
 //!   compiler).
 //! - A trailing default route (`any = true`) is recommended but not
@@ -218,6 +220,13 @@ pub enum CompileError {
     #[error("[media].codecs has unknown codec {0:?}")]
     UnknownCodec(String),
 
+    #[error(
+        "[media].codecs lists {0:?}, which is not supported on the WS audio path \
+         (samples at 48 kHz; the bridge ships PCM16 at 8 kHz or 16 kHz). Resampling \
+         is post-v1 work — drop the codec from the list for now."
+    )]
+    CodecRequiresResampling(String),
+
     #[error("[media].dtmf is {0:?}; expected \"rfc2833\" or \"off\"")]
     UnknownDtmfMode(String),
 
@@ -226,9 +235,6 @@ pub enum CompileError {
 
     #[error("[media].rtp_port_range {min}-{max} is invalid (min must be < max and even)")]
     BadRtpPortRange { min: u16, max: u16 },
-
-    #[error("[bridge].audio_sample_rate {0} not supported (8000 or 16000)")]
-    BadSampleRate(u32),
 
     #[error("[cdr.file].path is required when [cdr.file].enabled = true")]
     CdrFilePathRequired,
@@ -441,11 +447,6 @@ fn compile_bridge(raw: RawBridge, media: &RawMedia) -> Result<BridgeDefaults, Co
         Some("off") => None,
         Some(other) => return Err(CompileError::UnknownDtmfMode(other.to_string())),
     };
-    if let Some(rate) = raw.audio_sample_rate {
-        if rate != 8000 && rate != 16000 {
-            return Err(CompileError::BadSampleRate(rate));
-        }
-    }
     let connect_timeout = raw
         .ws_connect_timeout_ms
         .map(Duration::from_millis)
@@ -499,11 +500,27 @@ fn parse_codecs(names: &[String]) -> Result<Vec<Codec>, CompileError> {
     for name in names {
         let codec = Codec::from_encoding_name(name)
             .ok_or_else(|| CompileError::UnknownCodec(name.clone()))?;
+        // The bridge audio path only handles 8 kHz and 16 kHz PCM16
+        // (CLAUDE.md §4.2 pins the WS protocol's audio shape). Opus
+        // produces 48 kHz; without resampling in the media engine
+        // the call would 488 at SDP-negotiate time or — worse — 200
+        // OK then fail at tap attach. Refuse at load time so the
+        // operator sees the limitation before a single INVITE.
+        if !is_ws_compatible(codec) {
+            return Err(CompileError::CodecRequiresResampling(name.clone()));
+        }
         if !out.contains(&codec) {
             out.push(codec);
         }
     }
     Ok(out)
+}
+
+/// Codecs whose post-decode PCM rate the WS audio path supports.
+/// G.722 is 16 kHz audio despite its 8 kHz rtpmap quirk; the rest of
+/// our supported set is 8 kHz. Opus is the lone outlier today.
+fn is_ws_compatible(codec: Codec) -> bool {
+    matches!(codec.audio_sample_rate(), 8000 | 16000)
 }
 
 fn default_codecs() -> Vec<Codec> {

--- a/crates/config/src/raw.rs
+++ b/crates/config/src/raw.rs
@@ -316,13 +316,6 @@ pub struct RawBridge {
     /// WS handshake timeout. Default: 5000 ms.
     #[serde(default)]
     pub ws_connect_timeout_ms: Option<u64>,
-    /// `8000` or `16000`. Default: 8000. (Per-route can still
-    /// override via `[route.bridge].audio_sample_rate`, but the
-    /// negotiated codec ultimately decides — this is a *preference*
-    /// hint that becomes the answer's first-choice when our caps
-    /// support multiple rates.)
-    #[serde(default)]
-    pub audio_sample_rate: Option<u32>,
     /// SIP headers to forward on the bridge `start.sip.headers`.
     /// Names are case-insensitive at lookup time.
     #[serde(default)]

--- a/crates/config/tests/load.rs
+++ b/crates/config/tests/load.rs
@@ -41,7 +41,7 @@ transports = ["udp", "tcp"]
 user_agent = "SiphonAI/0.1.0-test"
 
 [media]
-codecs = ["pcmu", "pcma", "opus"]
+codecs = ["pcmu", "pcma"]
 dtmf = "rfc2833"
 rtp_port_range = [16384, 32768]
 
@@ -49,7 +49,6 @@ rtp_port_range = [16384, 32768]
 ws_url = "wss://default.example.com/sip-bridge"
 ws_auth_header = "Bearer ${BRIDGE_TOKEN}"
 ws_connect_timeout_ms = 3000
-audio_sample_rate = 16000
 forward_headers = ["User-Agent", "X-Tenant-Id"]
 
 [[route]]
@@ -100,10 +99,7 @@ fn representative_config_compiles_into_consumable_pieces() {
         cfg.bridge_defaults.connect_timeout,
         Duration::from_millis(3000)
     );
-    assert_eq!(
-        cfg.bridge_defaults.codecs,
-        vec![Codec::Pcmu, Codec::Pcma, Codec::Opus],
-    );
+    assert_eq!(cfg.bridge_defaults.codecs, vec![Codec::Pcmu, Codec::Pcma]);
     assert_eq!(cfg.bridge_defaults.dtmf_payload_type, Some(101));
     assert_eq!(
         cfg.bridge_defaults.forward_headers,
@@ -217,18 +213,29 @@ ws_url = "wss://x/y"
 }
 
 #[test]
-fn audio_sample_rate_must_be_8k_or_16k() {
+fn opus_in_codec_list_is_rejected_at_load() {
+    // The WS audio path is PCM16 at 8 kHz or 16 kHz (CLAUDE.md
+    // §4.2). Opus samples at 48 kHz and would crash forge tap
+    // attach with `UnsupportedSampleRate(48000)`. Refuse at config
+    // compile so the operator sees the limitation before any
+    // INVITE arrives.
     let env = MapEnv::new([]);
     let toml = r#"
 [sip]
 listen = "127.0.0.1:5060"
 
+[media]
+codecs = ["pcmu", "opus"]
+
 [bridge]
 ws_url = "wss://x/y"
-audio_sample_rate = 44100
 "#;
     let err = load_from_str_with_env(toml, &env).unwrap_err();
-    assert!(err.to_string().contains("44100"));
+    let msg = err.to_string();
+    assert!(
+        msg.contains("opus") && msg.contains("48"),
+        "expected opus-rejection error, got: {msg}"
+    );
 }
 
 #[test]

--- a/crates/routes/src/raw.rs
+++ b/crates/routes/src/raw.rs
@@ -83,7 +83,6 @@ pub struct RawRouteMatch {
 pub struct BridgeOverride {
     pub ws_url: Option<String>,
     pub ws_auth_header: Option<String>,
-    pub audio_sample_rate: Option<u32>,
     pub audio_direction: Option<String>,
     pub on_ws_failure: Option<String>,
     pub on_ws_failure_prompt: Option<String>,

--- a/crates/routes/tests/match_grammar.rs
+++ b/crates/routes/tests/match_grammar.rs
@@ -179,7 +179,6 @@ fn bridge_overrides_round_trip_through_compile() {
         request_uri_user = "5000"
         [route.bridge]
         ws_url = "wss://reception.example.com/sip-bridge"
-        audio_sample_rate = 16000
 
         [route.bridge.barge_in]
         enabled = true
@@ -191,7 +190,6 @@ fn bridge_overrides_round_trip_through_compile() {
         route.bridge.ws_url.as_deref(),
         Some("wss://reception.example.com/sip-bridge")
     );
-    assert_eq!(route.bridge.audio_sample_rate, Some(16000));
     assert_eq!(route.bridge.barge_in.enabled, Some(true));
     assert_eq!(route.bridge.barge_in.debounce_ms, Some(120));
 }

--- a/docker/local-dev.toml
+++ b/docker/local-dev.toml
@@ -41,7 +41,6 @@ rtp_port_range = [40000, 40100]
 [bridge]
 ws_url = "ws://echo-ws:8765/"
 ws_connect_timeout_ms = 3000
-audio_sample_rate = 8000
 
 [observability]
 enabled = true

--- a/docs/DEV_PLAN.md
+++ b/docs/DEV_PLAN.md
@@ -471,7 +471,7 @@ expires_secs = 1800
 # ─── Media defaults (per-route can override) ─────────────────────────────
 [media]
 rtp_port_range = [16384, 32768]
-codecs = ["pcmu", "pcma", "opus"]    # offered priority
+codecs = ["pcmu", "pcma"]            # offered priority. Opus is post-v1 (needs 48k→16k resampling in forge).
 dtmf = "rfc2833"                     # rfc2833 | info | both
 inactivity_timeout_secs = 60
 
@@ -481,8 +481,10 @@ aggressiveness = 2                   # 0-3
 speech_pad_ms = 50
 
 # ─── Bridge defaults (per-route can override) ────────────────────────────
+# Audio sample rate on the WS path is determined by the negotiated codec
+# (PCMU/PCMA = 8 kHz, G.722 = 16 kHz). It is NOT a configurable knob — see
+# CLAUDE.md §4.2 and the v1 protocol's fixed PCM16/8k|16k contract.
 [bridge]
-audio_sample_rate = 8000             # 8000 | 16000
 audio_direction = "bidirectional"    # bidirectional | inbound_only
 on_ws_failure = "hangup"             # hangup | play_prompt
 on_ws_failure_prompt = "/etc/siphon-ai/prompts/trouble.wav"
@@ -505,7 +507,6 @@ request_uri_user = "5000"            # exact match on user part of Request-URI
 [route.bridge]
 ws_url = "wss://reception.example.com/sip-bridge"
 ws_auth_header = "Bearer ${BRIDGE_TOKEN_RECEPTION}"
-audio_sample_rate = 16000
 
 [[route]]
 name = "sales_team"
@@ -738,7 +739,7 @@ For a typical call: caller speaks → server's AI responds → caller hears it.
 1. Implement `bridge` crate: `tokio-tungstenite` client, protocol types (`BridgeIn`/`BridgeOut`), connection lifecycle
 2. Implement `start` event with full call metadata (including `traceparent`)
 3. Wire `MediaTap`: inbound forge frames → WS binary; WS binary → forge-injection
-4. Resampling (8k ↔ 16k via forge-resampler) based on `bridge.audio_sample_rate`
+4. (Reserved.) WS audio rate is fixed by the negotiated codec in v1; resampling for codecs whose audio rate is not 8 kHz / 16 kHz (e.g., Opus 48 kHz) is post-v1 work in `forge-resampler`.
 5. Implement `routes` crate: TOML loading, match evaluation (string/regex/header/register_source), per-route override merging
 6. Wire route lookup into the call flow: INVITE → match → use route's bridge config (not global)
 7. Handle `clear` (drop pending playback buffer)
@@ -1252,7 +1253,7 @@ A reasonable user can:
 
 These don't block kickoff but should be answered before the relevant week:
 
-1. **Codec offer ordering:** Default to `[pcmu, pcma, opus]` — but should Opus be first if both sides support it? Pro: better quality. Con: forces transcoding to/from PCM16 at the WS edge if WS server prefers 8 kHz. **Recommendation:** PCMU first (matches PSTN), Opus available, configurable.
+1. **Codec offer ordering:** v1 default is `[pcmu, pcma]`. Opus is *not* offered in v1 — its 48 kHz audio rate doesn't fit the bridge's PCM16 / 8k|16k contract, and adding resampling lives in forge-media, not here. Reopen when forge-resampler ships.
 2. **WS reconnect mid-call:** Punted to post-v1. Worth gathering user feedback before designing.
 3. **Outbound originated calls (UAC INVITE for `make this call`):** Not in v1, but WS server `transfer` is close — should there be a `dial` control message in v1.x?
 4. **Recording:** Forge already has it. Easy add post-v1 — server requests recording via control message, file is stored locally or pushed to S3.

--- a/docs/DIALPLAN.md
+++ b/docs/DIALPLAN.md
@@ -32,7 +32,6 @@ name = "main_reception"
 request_uri_user = "5000"
 [route.bridge]
 ws_url = "wss://reception.example.com/sip-bridge"
-audio_sample_rate = 16000
 
 [[route]]
 name = "default"

--- a/examples/homer-stack/siphon-ai-hep.toml
+++ b/examples/homer-stack/siphon-ai-hep.toml
@@ -39,7 +39,6 @@ rtp_port_range = [40000, 40100]
 [bridge]
 ws_url = "ws://echo-ws:8765/"
 ws_connect_timeout_ms = 3000
-audio_sample_rate = 8000
 
 [observability]
 enabled = true


### PR DESCRIPTION
## Summary
- `bridge.audio_sample_rate` (and the per-route override) was parsed and validated, then dropped on the floor — `build_start_msg` always read the negotiated codec's rate. Field removed everywhere it was defined.
- Opus is offered by the SDP layer but the WS audio path is fixed at PCM16 / 8 kHz | 16 kHz (CLAUDE.md §4.2). `Codec::Opus.audio_sample_rate() = 48000` made `MediaTap::attach` fail with `UnsupportedSampleRate(48000)` — every Opus-negotiated call hit 500 at SDP setup. Now rejected at config load via new `CompileError::CodecRequiresResampling`.

## Breaking change
TOML files with `audio_sample_rate = …` no longer parse (`deny_unknown_fields`). The field never did anything in practice, so this is honest cleanup, not a semantic shift. All example TOMLs in the repo were updated.

## Test plan
- [x] `cargo test --workspace` — all green
- [x] `cargo clippy --workspace --all-targets` — clean (only the pre-existing `too_many_arguments` warning)
- [x] `cargo fmt --all -- --check` — clean
- [x] New: `opus_in_codec_list_is_rejected_at_load` pins the new rejection message
- [x] Removed: `audio_sample_rate_must_be_8k_or_16k` (the validation it covered no longer exists)
- [x] Example TOMLs in `configs/`, `docker/`, `examples/homer-stack/`, and `bins/siphon-ai/tests/fixtures/` updated
- [x] DEV_PLAN.md / DIALPLAN.md updated to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)