### PR TITLE
feat(media): wire on_ws_failure + inactivity_timeout_secs

### DIFF
--- a/crates/config/src/compile.rs
+++ b/crates/config/src/compile.rs
@@ -227,6 +227,12 @@ pub enum CompileError {
     )]
     CodecRequiresResampling(String),
 
+    #[error(
+        "route {route:?} sets [route.bridge].on_ws_failure = {value:?}; expected \
+         \"hangup\" (play_prompt is post-v1)"
+    )]
+    UnknownOnWsFailure { route: String, value: String },
+
     #[error("[media].dtmf is {0:?}; expected \"rfc2833\" or \"off\"")]
     UnknownDtmfMode(String),
 
@@ -459,6 +465,15 @@ fn compile_bridge(raw: RawBridge, media: &RawMedia) -> Result<BridgeDefaults, Co
 
     let barge_in = compile_barge_in_default(&raw.barge_in)?;
 
+    // `None` → 60 s default; `Some(0)` → watchdog off. The merge
+    // step in `resolve_inactivity_timeout` handles per-route 0 →
+    // disabled the same way.
+    let inactivity_timeout = match media.inactivity_timeout_secs {
+        None => Some(Duration::from_secs(60)),
+        Some(0) => None,
+        Some(n) => Some(Duration::from_secs(n)),
+    };
+
     Ok(BridgeDefaults {
         ws_url: raw.ws_url.filter(|s| !s.is_empty()),
         auth_bearer,
@@ -467,6 +482,7 @@ fn compile_bridge(raw: RawBridge, media: &RawMedia) -> Result<BridgeDefaults, Co
         dtmf_payload_type,
         forward_headers: raw.forward_headers.unwrap_or_default(),
         barge_in,
+        inactivity_timeout,
     })
 }
 
@@ -539,7 +555,22 @@ fn strip_bearer_prefix(value: &str) -> String {
 
 fn compile_dialplan(routes: Vec<siphon_ai_routes::RawRoute>) -> Result<RouteSet, CompileError> {
     let raw_file = RawRouteFile { routes };
-    Ok(compile_routes(raw_file)?)
+    let set = compile_routes(raw_file)?;
+    // Walk each route's `[route.bridge]` overrides for fields that
+    // need an enum check beyond what the routes crate already does.
+    // Today: `on_ws_failure` is "hangup" only — the play_prompt
+    // path needs a forge-driven prompt player that isn't built.
+    for route in set.iter() {
+        if let Some(mode) = route.bridge.on_ws_failure.as_deref() {
+            if !mode.eq_ignore_ascii_case("hangup") {
+                return Err(CompileError::UnknownOnWsFailure {
+                    route: route.name.clone(),
+                    value: mode.to_string(),
+                });
+            }
+        }
+    }
+    Ok(set)
 }
 
 fn compile_webhooks(raw: RawWebhooks) -> Result<WebhooksConfig, CompileError> {

--- a/crates/config/src/raw.rs
+++ b/crates/config/src/raw.rs
@@ -120,8 +120,7 @@ fn default_transports() -> Vec<String> {
     vec!["udp".to_string()]
 }
 
-/// `[media]` — codecs + DTMF + RTP port range. v1 ignores
-/// `inactivity_timeout_secs` (forge-engine has its own setting).
+/// `[media]` — codecs + DTMF + RTP port range + inactivity watchdog.
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RawMedia {
@@ -135,6 +134,12 @@ pub struct RawMedia {
     /// unset, forge's default range is used.
     #[serde(default)]
     pub rtp_port_range: Option<(u16, u16)>,
+    /// Tear the call down after this many seconds with no inbound RTP.
+    /// `None` (unset) → defaults to 60 s at compile time. `Some(0)` →
+    /// watchdog disabled. Per-route `[route.media].inactivity_timeout_secs`
+    /// overrides this value.
+    #[serde(default)]
+    pub inactivity_timeout_secs: Option<u64>,
 }
 
 /// `[cdr]` — call detail record sinks. v1 supports a JSONL file

--- a/crates/config/tests/load.rs
+++ b/crates/config/tests/load.rs
@@ -213,6 +213,127 @@ ws_url = "wss://x/y"
 }
 
 #[test]
+fn on_ws_failure_only_accepts_hangup() {
+    // v1 supports "hangup" only — `play_prompt` would need a
+    // forge-driven prompt player that isn't built. Reject the
+    // unsupported mode at load time instead of silently ignoring it.
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[bridge]
+ws_url = "wss://x/y"
+
+[[route]]
+name = "default"
+[route.match]
+any = true
+[route.bridge]
+on_ws_failure = "play_prompt"
+"#;
+    let err = load_from_str_with_env(toml, &env).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("on_ws_failure") && msg.contains("play_prompt"),
+        "expected on_ws_failure rejection, got: {msg}"
+    );
+}
+
+#[test]
+fn on_ws_failure_hangup_compiles() {
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[bridge]
+ws_url = "wss://x/y"
+
+[[route]]
+name = "default"
+[route.match]
+any = true
+[route.bridge]
+on_ws_failure = "hangup"
+"#;
+    let cfg = load_from_str_with_env(toml, &env).expect("hangup is the v1 supported mode");
+    assert!(cfg.routes.has_default());
+}
+
+#[test]
+fn inactivity_timeout_defaults_to_60s_when_absent() {
+    // The watchdog default in `BridgeDefaults::default()` is 60s so
+    // an operator who never wrote the field still gets a sensible
+    // safety net against zombie calls.
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[bridge]
+ws_url = "wss://x/y"
+
+[[route]]
+name = "default"
+[route.match]
+any = true
+"#;
+    let cfg = load_from_str_with_env(toml, &env).unwrap();
+    assert_eq!(
+        cfg.bridge_defaults.inactivity_timeout,
+        Some(Duration::from_secs(60)),
+    );
+}
+
+#[test]
+fn inactivity_timeout_zero_disables_watchdog() {
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[media]
+inactivity_timeout_secs = 0
+
+[bridge]
+ws_url = "wss://x/y"
+
+[[route]]
+name = "default"
+[route.match]
+any = true
+"#;
+    let cfg = load_from_str_with_env(toml, &env).unwrap();
+    assert_eq!(cfg.bridge_defaults.inactivity_timeout, None);
+}
+
+#[test]
+fn inactivity_timeout_explicit_value_compiles() {
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[media]
+inactivity_timeout_secs = 45
+
+[bridge]
+ws_url = "wss://x/y"
+
+[[route]]
+name = "default"
+[route.match]
+any = true
+"#;
+    let cfg = load_from_str_with_env(toml, &env).unwrap();
+    assert_eq!(
+        cfg.bridge_defaults.inactivity_timeout,
+        Some(Duration::from_secs(45)),
+    );
+}
+
+#[test]
 fn opus_in_codec_list_is_rejected_at_load() {
     // The WS audio path is PCM16 at 8 kHz or 16 kHz (CLAUDE.md
     // §4.2). Opus samples at 48 kHz and would crash forge tap

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -117,6 +117,13 @@ pub struct BridgeDefaults {
     /// just forwards `speech_started` and leaves the decision to
     /// the WS server.
     pub barge_in: BargeInConfig,
+    /// Tear the call down after this many seconds of no inbound RTP.
+    /// `None` disables the watchdog entirely (the per-route
+    /// `[route.media].inactivity_timeout_secs = 0` opt-out resolves
+    /// to `None` here). Default in `Default::default()` is 60 s —
+    /// enough to weather a flap, short enough that an abandoned call
+    /// after PBX network failure releases its forge session quickly.
+    pub inactivity_timeout: Option<Duration>,
 }
 
 /// What the daemon does when forge-vad reports speech-started.
@@ -162,6 +169,7 @@ impl Default for BridgeDefaults {
             dtmf_payload_type: Some(101),
             forward_headers: Vec::new(),
             barge_in: BargeInConfig::default(),
+            inactivity_timeout: Some(Duration::from_secs(60)),
         }
     }
 }
@@ -418,6 +426,20 @@ fn parse_barge_in_mode_route(s: &str) -> Option<BargeInMode> {
         "auto_clear" => Some(BargeInMode::AutoClear),
         "notify_only" => Some(BargeInMode::NotifyOnly),
         _ => None,
+    }
+}
+
+/// Resolve the inactivity watchdog for one call. Route value wins
+/// when set, with `Some(0)` meaning "disabled for this route";
+/// otherwise the daemon default applies.
+pub fn resolve_inactivity_timeout(
+    defaults: &BridgeDefaults,
+    route: &CompiledRoute,
+) -> Option<Duration> {
+    match route.media.inactivity_timeout_secs {
+        None => defaults.inactivity_timeout,
+        Some(0) => None,
+        Some(n) => Some(Duration::from_secs(n)),
     }
 }
 
@@ -790,6 +812,7 @@ fn tap_detail(res: Option<Result<TapDisconnect, MediaTapError>>) -> String {
         None => String::new(),
         Some(Ok(TapDisconnect::CallEnded)) => "call_ended".into(),
         Some(Ok(TapDisconnect::ControllerHungUp)) => "controller_hung_up".into(),
+        Some(Ok(TapDisconnect::InactivityTimeout)) => "inactivity_timeout".into(),
         Some(Err(e)) => format!("error: {e}"),
     }
 }
@@ -1295,6 +1318,7 @@ impl BridgingAcceptor {
                 from_tag: None,
                 to_tag: None,
                 barge_in_action: barge_in_to_tap_action(&resolve_barge_in(&self.defaults, route)),
+                inactivity_timeout: resolve_inactivity_timeout(&self.defaults, route),
             })
             .await?;
 
@@ -1631,6 +1655,78 @@ a=sendrecv\r\n";
             ..BridgeDefaults::default()
         };
         assert_eq!(resolve_codecs(&defaults, route), vec![Codec::Pcmu]);
+    }
+
+    // ─── resolve_inactivity_timeout ────────────────────────────────
+
+    #[test]
+    fn inactivity_timeout_route_overrides_default() {
+        let routes = first_route(
+            r#"
+            [[route]]
+            name = "r"
+            [route.match]
+            any = true
+            [route.bridge]
+            ws_url = "wss://x/y"
+            [route.media]
+            inactivity_timeout_secs = 30
+            "#,
+        );
+        let route = routes.find_match(&dummy_call_info()).unwrap();
+        let defaults = BridgeDefaults {
+            inactivity_timeout: Some(Duration::from_secs(60)),
+            ..BridgeDefaults::default()
+        };
+        assert_eq!(
+            resolve_inactivity_timeout(&defaults, route),
+            Some(Duration::from_secs(30)),
+        );
+    }
+
+    #[test]
+    fn inactivity_timeout_zero_on_route_disables_watchdog() {
+        let routes = first_route(
+            r#"
+            [[route]]
+            name = "r"
+            [route.match]
+            any = true
+            [route.bridge]
+            ws_url = "wss://x/y"
+            [route.media]
+            inactivity_timeout_secs = 0
+            "#,
+        );
+        let route = routes.find_match(&dummy_call_info()).unwrap();
+        let defaults = BridgeDefaults {
+            inactivity_timeout: Some(Duration::from_secs(60)),
+            ..BridgeDefaults::default()
+        };
+        assert_eq!(resolve_inactivity_timeout(&defaults, route), None);
+    }
+
+    #[test]
+    fn inactivity_timeout_unset_route_inherits_default() {
+        let routes = first_route(
+            r#"
+            [[route]]
+            name = "r"
+            [route.match]
+            any = true
+            [route.bridge]
+            ws_url = "wss://x/y"
+            "#,
+        );
+        let route = routes.find_match(&dummy_call_info()).unwrap();
+        let defaults = BridgeDefaults {
+            inactivity_timeout: Some(Duration::from_secs(45)),
+            ..BridgeDefaults::default()
+        };
+        assert_eq!(
+            resolve_inactivity_timeout(&defaults, route),
+            Some(Duration::from_secs(45)),
+        );
     }
 
     // ─── resolve_dtmf_pt ──────────────────────────────────────────

--- a/crates/media-glue/Cargo.toml
+++ b/crates/media-glue/Cargo.toml
@@ -31,3 +31,7 @@ forge-dtmf.workspace   = true
 # `chrono` is in our forge_core::ForgeEvent::DtmfDigitDetected
 # `timestamp` field, used in tests that publish synthesised events.
 chrono.workspace = true
+# `test-util` is required for `#[tokio::test(start_paused = true)]`
+# and `tokio::time::advance` — used in the inactivity-watchdog test.
+# `"full"` (the workspace default) deliberately omits this feature.
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/media-glue/src/setup.rs
+++ b/crates/media-glue/src/setup.rs
@@ -96,6 +96,10 @@ pub struct InboundCall<'a> {
     /// `[BargeInAction::AutoClear]` (drop pending outbound playout
     /// before forwarding). Set from `[bridge].barge_in.mode`.
     pub barge_in_action: BargeInAction,
+    /// Tear the call down after this many seconds of no inbound RTP.
+    /// `None` disables the watchdog. Resolved by the acceptor from
+    /// `[media].inactivity_timeout_secs` and the route's override.
+    pub inactivity_timeout: Option<std::time::Duration>,
 }
 
 /// What [`MediaSetup::accept_inbound`] hands back on success.
@@ -253,7 +257,8 @@ impl MediaSetup {
             call.call_id.clone(),
             answer.negotiated_audio_sample_rate,
             call.barge_in_action,
-        )?;
+        )?
+        .with_inactivity_timeout(call.inactivity_timeout);
 
         guard.disarm();
 
@@ -374,6 +379,7 @@ mod tests {
                 from_tag: None,
                 to_tag: None,
                 barge_in_action: BargeInAction::Notify,
+                inactivity_timeout: None,
             })
             .await;
 

--- a/crates/media-glue/src/tap.rs
+++ b/crates/media-glue/src/tap.rs
@@ -179,6 +179,12 @@ pub enum TapDisconnect {
     /// Equivalent to "the bridge is gone, so there's no point reading
     /// or writing audio anymore".
     ControllerHungUp,
+    /// No inbound RTP for the configured
+    /// `[media].inactivity_timeout_secs` window. RFC-3550 says
+    /// nothing about how long a stalled stream is "stalled enough,"
+    /// so this is operator policy: a peer that's gone away on the
+    /// network shouldn't keep a forge session alive forever.
+    InactivityTimeout,
 }
 
 /// Bidirectional audio tap attached to one call's `MediaBridgeHandle`.
@@ -211,6 +217,12 @@ pub struct MediaTap {
     /// that don't care about barge-in don't have to thread it
     /// through.
     barge_in_action: BargeInAction,
+    /// RTP watchdog window. `None` disables the watchdog entirely;
+    /// `Some(d)` means "if no inbound frame arrives within `d`,
+    /// return `TapDisconnect::InactivityTimeout`." Settable on the
+    /// fully-built tap via [`Self::with_inactivity_timeout`] so the
+    /// 4-arg `attach()` form in tests stays terse.
+    inactivity_timeout: Option<Duration>,
 }
 
 impl std::fmt::Debug for MediaTap {
@@ -271,7 +283,16 @@ impl MediaTap {
             events_rx,
             events_keepalive: None,
             barge_in_action,
+            inactivity_timeout: None,
         })
+    }
+
+    /// Override the inactivity watchdog window. The acceptor calls
+    /// this after `attach_with_barge_in` so the route's resolved
+    /// `inactivity_timeout_secs` lands on the tap before `run` starts.
+    pub fn with_inactivity_timeout(mut self, timeout: Option<Duration>) -> Self {
+        self.inactivity_timeout = timeout;
+        self
     }
 
     pub fn sample_rate(&self) -> u32 {
@@ -313,6 +334,15 @@ impl MediaTap {
         let mut frames_sent_to_forge: u64 = 0;
         let mut first_audio_pushed_at: Option<Instant> = None;
 
+        // RTP watchdog. Pinned so we can reset the deadline in place
+        // every time an inbound frame arrives. When the timeout is
+        // `None` we still pin a far-future sleep so the select arm
+        // is structurally identical — the arm just never fires.
+        let inactivity = self.inactivity_timeout;
+        let watchdog_initial = inactivity.unwrap_or(Duration::from_secs(86_400));
+        let watchdog = tokio::time::sleep(watchdog_initial);
+        tokio::pin!(watchdog);
+
         loop {
             tokio::select! {
                 biased;
@@ -323,6 +353,20 @@ impl MediaTap {
                 _ = caller_audio_tx.closed() => {
                     debug!("caller_audio_tx receiver dropped; ending tap");
                     return Ok(TapDisconnect::ControllerHungUp);
+                }
+
+                // RTP watchdog. `if inactivity.is_some()` makes the
+                // arm un-selectable when the operator turned the
+                // watchdog off — `tokio::select!` skips the arm
+                // entirely rather than registering its waker, so the
+                // far-future sleep never costs anything.
+                _ = &mut watchdog, if inactivity.is_some() => {
+                    warn!(
+                        call_id = %self.call_id,
+                        timeout_ms = inactivity.unwrap().as_millis() as u64,
+                        "no inbound RTP within inactivity window; tearing down",
+                    );
+                    return Ok(TapDisconnect::InactivityTimeout);
                 }
 
                 // Server → caller: bytes from the WS into forge's playout.
@@ -369,6 +413,11 @@ impl MediaTap {
                             expected: self.sample_rate,
                             got: frame.sample_rate,
                         });
+                    }
+                    // Reset the inactivity deadline on every received
+                    // frame. Cheap; `Sleep::reset` reuses the timer.
+                    if let Some(d) = inactivity {
+                        watchdog.as_mut().reset(tokio::time::Instant::now() + d);
                     }
                     reframer.push(&frame.samples);
                     while let Some(samples) = reframer.pop_frame() {
@@ -713,5 +762,79 @@ mod tests {
         )
         .unwrap_err();
         assert!(matches!(err, MediaTapError::AttachFailed(_)));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn inactivity_watchdog_fires_when_no_inbound_frame() {
+        // `start_paused = true` lets us advance virtual time
+        // deterministically — no real wall-clock sleeps in the test.
+        // Attach a tap, hand it inactivity = 100 ms, and watch the
+        // watchdog arm fire when no frame arrives. forge never sends
+        // a frame in this fixture (no session driver), which is
+        // exactly the "RTP stopped" scenario.
+        let manager = Arc::new(MediaBridgeManager::new());
+        let call = CallId::new("c-watchdog");
+        let tap = MediaTap::attach(
+            &manager,
+            &::std::sync::Arc::new(forge_core::EventBus::new()),
+            call,
+            8000,
+        )
+        .expect("attach")
+        .with_inactivity_timeout(Some(Duration::from_millis(100)));
+
+        let (caller_tx, mut caller_rx) = mpsc::channel(4);
+        let (_playout_tx, playout_rx) = mpsc::channel(4);
+        let (events_tx, mut events_rx) = mpsc::channel(4);
+        let (_cmd_tx, cmd_rx) = mpsc::channel(4);
+
+        let join = tokio::spawn(tap.run(caller_tx, playout_rx, events_tx, cmd_rx));
+
+        // Advance virtual time past the deadline. The watchdog arm
+        // fires and `run` returns `Ok(InactivityTimeout)`.
+        tokio::time::advance(Duration::from_millis(200)).await;
+
+        let outcome = join.await.expect("join").expect("ok");
+        assert_eq!(outcome, TapDisconnect::InactivityTimeout);
+
+        // No audio / events should have been emitted — we exited
+        // straight from the watchdog arm.
+        assert!(caller_rx.try_recv().is_err());
+        assert!(events_rx.try_recv().is_err());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn inactivity_watchdog_off_when_timeout_none() {
+        // With `inactivity_timeout = None` the watchdog arm is
+        // disabled — `tap.run` should NOT exit just because virtual
+        // time advanced past any deadline. We tear it down by
+        // dropping the caller_audio_tx receiver to confirm the loop
+        // is still alive and responsive.
+        let manager = Arc::new(MediaBridgeManager::new());
+        let tap = MediaTap::attach(
+            &manager,
+            &::std::sync::Arc::new(forge_core::EventBus::new()),
+            CallId::new("c-no-watchdog"),
+            8000,
+        )
+        .expect("attach")
+        .with_inactivity_timeout(None);
+
+        let (caller_tx, caller_rx) = mpsc::channel(4);
+        let (_playout_tx, playout_rx) = mpsc::channel(4);
+        let (events_tx, _events_rx) = mpsc::channel(4);
+        let (_cmd_tx, cmd_rx) = mpsc::channel(4);
+
+        let join = tokio::spawn(tap.run(caller_tx, playout_rx, events_tx, cmd_rx));
+
+        // Way past any plausible default — still no exit.
+        tokio::time::advance(Duration::from_secs(3600)).await;
+        // Drop the receiver to wake the `caller_audio_tx.closed()` arm.
+        drop(caller_rx);
+        // Allow the runtime to step.
+        tokio::task::yield_now().await;
+
+        let outcome = join.await.expect("join").expect("ok");
+        assert_eq!(outcome, TapDisconnect::ControllerHungUp);
     }
 }

--- a/crates/media-glue/tests/setup.rs
+++ b/crates/media-glue/tests/setup.rs
@@ -71,6 +71,7 @@ fn pcmu_call(call_id: &str, offer: &'static str) -> InboundCall<'static> {
         from_tag: Some("from-tag-1".to_string()),
         to_tag: Some("to-tag-1".to_string()),
         barge_in_action: ::siphon_ai_media_glue::BargeInAction::Notify,
+        inactivity_timeout: None,
     }
 }
 
@@ -228,6 +229,7 @@ async fn no_common_codec_rolls_back_session() {
             from_tag: None,
             to_tag: None,
             barge_in_action: ::siphon_ai_media_glue::BargeInAction::Notify,
+            inactivity_timeout: None,
         })
         .await;
     assert!(matches!(
@@ -263,6 +265,7 @@ async fn malformed_offer_does_not_allocate_ports() {
             from_tag: None,
             to_tag: None,
             barge_in_action: ::siphon_ai_media_glue::BargeInAction::Notify,
+            inactivity_timeout: None,
         })
         .await
         .unwrap_err();

--- a/crates/routes/src/raw.rs
+++ b/crates/routes/src/raw.rs
@@ -85,7 +85,6 @@ pub struct BridgeOverride {
     pub ws_auth_header: Option<String>,
     pub audio_direction: Option<String>,
     pub on_ws_failure: Option<String>,
-    pub on_ws_failure_prompt: Option<String>,
     pub ws_connect_timeout_ms: Option<u64>,
 
     #[serde(default)]

--- a/docs/DEV_PLAN.md
+++ b/docs/DEV_PLAN.md
@@ -486,8 +486,7 @@ speech_pad_ms = 50
 # CLAUDE.md §4.2 and the v1 protocol's fixed PCM16/8k|16k contract.
 [bridge]
 audio_direction = "bidirectional"    # bidirectional | inbound_only
-on_ws_failure = "hangup"             # hangup | play_prompt
-on_ws_failure_prompt = "/etc/siphon-ai/prompts/trouble.wav"
+on_ws_failure = "hangup"             # v1: "hangup" only; "play_prompt" is post-v1
 ws_reconnect_enabled = false         # post-v1
 ws_connect_timeout_ms = 3000
 


### PR DESCRIPTION
## Summary
Two more half-wired config fields are now honest:

**on_ws_failure** (per-route): only `\"hangup\"` is supported in v1. Reject any other value (notably `\"play_prompt\"`, which needs a forge-driven prompt player that isn't built) at config compile via the new `CompileError::UnknownOnWsFailure`. Runtime behavior already defaults to hangup. Also drops the unused `on_ws_failure_prompt` field.

**inactivity_timeout_secs** (`[media]` + per-route override): wire the RTP watchdog the dev plan called for in Week 5.
- Default 60s when unset; `0` disables; per-route override.
- `BridgeDefaults` carries the daemon default; `resolve_inactivity_timeout` merges per-route.
- `MediaTap` gains a `with_inactivity_timeout(Option<Duration>)` builder and a pinned `tokio::time::sleep` arm in the run loop. Deadline resets on every inbound frame. When the timeout is `None` the arm is structurally skipped.
- New `TapDisconnect::InactivityTimeout` variant flows through `tap_detail` to CDRs as `\"inactivity_timeout\"`.

## Breaking change
TOMLs with `[route.bridge].on_ws_failure = \"play_prompt\"` no longer load — it never worked anyway. `on_ws_failure_prompt` removed (was already unused). All example TOMLs in the repo were already free of these.

## Test plan
- [x] `cargo test --workspace` — 52 + 39 config / core tests, all green
- [x] `cargo clippy --workspace --all-targets` — clean (only pre-existing `too_many_arguments` warning in `registration.rs`)
- [x] `cargo fmt --all -- --check` — clean
- [x] Config: `inactivity_timeout_defaults_to_60s_when_absent`, `inactivity_timeout_zero_disables_watchdog`, `inactivity_timeout_explicit_value_compiles`, `on_ws_failure_only_accepts_hangup`, `on_ws_failure_hangup_compiles`
- [x] Resolver: `inactivity_timeout_route_overrides_default`, `inactivity_timeout_zero_on_route_disables_watchdog`, `inactivity_timeout_unset_route_inherits_default`
- [x] Watchdog: `inactivity_watchdog_fires_when_no_inbound_frame`, `inactivity_watchdog_off_when_timeout_none` (deterministic via `tokio::test(start_paused)` + `tokio::time::advance`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)