### PR TITLE
feat(session-timer): RFC 4028 wiring + soak-validated teardown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2325,7 +2325,7 @@ dependencies = [
 [[package]]
 name = "sip-auth"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#09c33e2de9cbd9581f8309e42b09a81bfb921d3e"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#62fe4da697dc8f908c00670250be74f36b6014b8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2333,7 +2333,7 @@ dependencies = [
  "dashmap",
  "hex",
  "md5",
- "rand 0.8.6",
+ "rand 0.9.4",
  "sha2",
  "sip-core",
  "sip-parse",
@@ -2348,7 +2348,7 @@ dependencies = [
 [[package]]
 name = "sip-core"
 version = "0.7.6"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#09c33e2de9cbd9581f8309e42b09a81bfb921d3e"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#62fe4da697dc8f908c00670250be74f36b6014b8"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2361,14 +2361,14 @@ dependencies = [
 [[package]]
 name = "sip-dialog"
 version = "0.3.3"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#09c33e2de9cbd9581f8309e42b09a81bfb921d3e"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#62fe4da697dc8f908c00670250be74f36b6014b8"
 dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
  "dashmap",
  "parking_lot",
- "rand 0.8.6",
+ "rand 0.9.4",
  "sip-core",
  "sip-parse",
  "smol_str",
@@ -2379,12 +2379,12 @@ dependencies = [
 [[package]]
 name = "sip-dns"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#09c33e2de9cbd9581f8309e42b09a81bfb921d3e"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#62fe4da697dc8f908c00670250be74f36b6014b8"
 dependencies = [
  "anyhow",
  "async-trait",
  "hickory-resolver",
- "rand 0.8.6",
+ "rand 0.9.4",
  "sip-core",
  "smol_str",
  "tokio",
@@ -2393,7 +2393,7 @@ dependencies = [
 [[package]]
 name = "sip-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#09c33e2de9cbd9581f8309e42b09a81bfb921d3e"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#62fe4da697dc8f908c00670250be74f36b6014b8"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -2404,7 +2404,7 @@ dependencies = [
 [[package]]
 name = "sip-observe"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#09c33e2de9cbd9581f8309e42b09a81bfb921d3e"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#62fe4da697dc8f908c00670250be74f36b6014b8"
 dependencies = [
  "once_cell",
  "tracing",
@@ -2413,7 +2413,7 @@ dependencies = [
 [[package]]
 name = "sip-parse"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#09c33e2de9cbd9581f8309e42b09a81bfb921d3e"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#62fe4da697dc8f908c00670250be74f36b6014b8"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2427,7 +2427,7 @@ dependencies = [
 [[package]]
 name = "sip-ratelimit"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#09c33e2de9cbd9581f8309e42b09a81bfb921d3e"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#62fe4da697dc8f908c00670250be74f36b6014b8"
 dependencies = [
  "dashmap",
  "parking_lot",
@@ -2447,7 +2447,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#09c33e2de9cbd9581f8309e42b09a81bfb921d3e"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#62fe4da697dc8f908c00670250be74f36b6014b8"
 dependencies = [
  "nom",
  "smol_str",
@@ -2456,14 +2456,14 @@ dependencies = [
 [[package]]
 name = "sip-transaction"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#09c33e2de9cbd9581f8309e42b09a81bfb921d3e"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#62fe4da697dc8f908c00670250be74f36b6014b8"
 dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
  "dashmap",
  "parking_lot",
- "rand 0.8.6",
+ "rand 0.9.4",
  "sip-core",
  "sip-parse",
  "sip-transport",
@@ -2475,7 +2475,7 @@ dependencies = [
 [[package]]
 name = "sip-transport"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#09c33e2de9cbd9581f8309e42b09a81bfb921d3e"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#62fe4da697dc8f908c00670250be74f36b6014b8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2494,13 +2494,13 @@ dependencies = [
 [[package]]
 name = "sip-uac"
 version = "0.4.2"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#09c33e2de9cbd9581f8309e42b09a81bfb921d3e"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#62fe4da697dc8f908c00670250be74f36b6014b8"
 dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
  "hex",
- "rand 0.8.6",
+ "rand 0.9.4",
  "sha1",
  "sip-auth",
  "sip-core",
@@ -2519,12 +2519,12 @@ dependencies = [
 [[package]]
 name = "sip-uas"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#09c33e2de9cbd9581f8309e42b09a81bfb921d3e"
+source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#62fe4da697dc8f908c00670250be74f36b6014b8"
 dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
- "rand 0.8.6",
+ "rand 0.9.4",
  "sip-auth",
  "sip-core",
  "sip-dialog",

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -203,10 +203,22 @@ impl Runtime {
         // an Arc to this acceptor. We close the cycle below via
         // `acceptor.install_uas(...)` once the UAS exists.
         let registry = CallRegistry::new();
+        // Translate `[sip].min_session_expires_secs` /
+        // `preferred_session_expires_secs` into the upstream policy
+        // every accepted INVITE negotiates against. v1 always picks
+        // refresher=uac (the peer drives refreshes) — gateway-style
+        // UASes don't initiate UPDATE refreshes themselves, so this
+        // matches the implementation.
+        let session_timer_policy = sip_uas::SessionTimerPolicy {
+            min_se: sip.min_session_expires,
+            preferred_se: sip.preferred_session_expires,
+            force_refresher: Some(sip_core::RefresherRole::Uac),
+        };
         let acceptor = Arc::new(
             BridgingAcceptor::new(media_setup, bridge_defaults, registry.clone())
                 .with_cdr_sink(cdr_sink)
-                .with_webhook_sink(webhook_sink),
+                .with_webhook_sink(webhook_sink)
+                .with_session_timer_policy(session_timer_policy),
         );
 
         // ─── Registration manager ──────────────────────────────────

--- a/configs/soak.toml
+++ b/configs/soak.toml
@@ -1,0 +1,30 @@
+[node]
+id = "siphon-ai-soak"
+
+[sip]
+listen = "127.0.0.1:5060"
+transports = ["udp"]
+user_agent = "SiphonAI/soak"
+
+[media]
+codecs = ["pcma", "pcmu"]
+dtmf = "rfc2833"
+# 500 calls × 2 ports each = 1000. Widen the range so the burst
+# scenario doesn't 503 on port-pool exhaustion.
+rtp_port_range = [40000, 41100]
+# Disabled for the burst (no RTP flowing); the long_call scenario
+# streams PCMA so the watchdog would never fire anyway.
+inactivity_timeout_secs = 0
+
+[bridge]
+ws_url = "ws://127.0.0.1:8765/"
+ws_connect_timeout_ms = 3000
+
+[observability]
+enabled = true
+http_listen = "127.0.0.1:9091"
+
+[[route]]
+name = "default"
+[route.match]
+any = true

--- a/crates/config/src/compile.rs
+++ b/crates/config/src/compile.rs
@@ -171,6 +171,13 @@ pub struct SipConfig {
     /// transports list. `None` when TLS isn't enabled. Daemon
     /// loads cert/key from these paths at startup.
     pub tls: Option<SipTlsConfig>,
+    /// RFC 4028 Min-SE for the UAS (`[sip].min_session_expires_secs`).
+    /// Defaults to 90 (RFC minimum).
+    pub min_session_expires: Duration,
+    /// Optional cap on Session-Expires when negotiating
+    /// (`[sip].preferred_session_expires_secs`). `None` = honour
+    /// the peer's value uncapped.
+    pub preferred_session_expires: Option<Duration>,
 }
 
 #[derive(Debug, Clone)]
@@ -278,6 +285,12 @@ pub enum CompileError {
     #[error("[hep].capture_id is required when [hep].enabled = true")]
     HepCaptureIdRequired,
 
+    #[error(
+        "[sip].min_session_expires_secs = {0} is below the RFC 4028 floor of 90 \
+         seconds; raise it or omit the field to use the 90 s default"
+    )]
+    SessionTimerMinSeTooSmall(u32),
+
     #[error("[[register]] block at index {index} has empty name")]
     RegisterEmptyName { index: usize },
 
@@ -359,12 +372,25 @@ fn compile_sip(raw: RawSip) -> Result<SipConfig, CompileError> {
     let tls_enabled = transports.contains(&SipTransport::Tls);
     let tls = compile_sip_tls(raw.tls, tls_enabled, &listen_addr)?;
 
+    // RFC 4028: 90 s is the floor (Min-SE). An operator setting
+    // something smaller is asking for trouble; reject at load.
+    let min_session_expires = match raw.min_session_expires_secs {
+        None => Duration::from_secs(90),
+        Some(n) if n < 90 => return Err(CompileError::SessionTimerMinSeTooSmall(n)),
+        Some(n) => Duration::from_secs(n as u64),
+    };
+    let preferred_session_expires = raw
+        .preferred_session_expires_secs
+        .map(|n| Duration::from_secs(n as u64));
+
     Ok(SipConfig {
         listen_addr,
         transports,
         user_agent: raw.user_agent,
         contact: raw.contact,
         tls,
+        min_session_expires,
+        preferred_session_expires,
     })
 }
 

--- a/crates/config/src/raw.rs
+++ b/crates/config/src/raw.rs
@@ -94,6 +94,15 @@ pub struct RawSip {
     /// for UDP-only deployments.
     #[serde(default)]
     pub tls: RawSipTls,
+    /// RFC 4028 Min-SE we'll enforce on inbound INVITEs. Defaults
+    /// to 90 (RFC minimum). Smaller values are rejected with 422.
+    #[serde(default)]
+    pub min_session_expires_secs: Option<u32>,
+    /// Optional UAS preference for Session-Expires. When the peer's
+    /// request exceeds this value the negotiated timer is capped
+    /// here. Unset = honour the peer's value uncapped.
+    #[serde(default)]
+    pub preferred_session_expires_secs: Option<u32>,
 }
 
 /// `[sip.tls]` — TLS server configuration. Required when

--- a/crates/config/tests/load.rs
+++ b/crates/config/tests/load.rs
@@ -213,6 +213,70 @@ ws_url = "wss://x/y"
 }
 
 #[test]
+fn session_timer_defaults_to_90s_floor() {
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[bridge]
+ws_url = "wss://x/y"
+
+[[route]]
+name = "default"
+[route.match]
+any = true
+"#;
+    let cfg = load_from_str_with_env(toml, &env).unwrap();
+    assert_eq!(cfg.sip.min_session_expires, Duration::from_secs(90));
+    assert_eq!(cfg.sip.preferred_session_expires, None);
+}
+
+#[test]
+fn session_timer_below_90s_rejected_at_load() {
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+min_session_expires_secs = 30
+
+[bridge]
+ws_url = "wss://x/y"
+"#;
+    let err = load_from_str_with_env(toml, &env).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("90") && msg.contains("30"),
+        "expected RFC 4028 floor rejection, got: {msg}"
+    );
+}
+
+#[test]
+fn session_timer_explicit_values_compile() {
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+min_session_expires_secs = 300
+preferred_session_expires_secs = 1800
+
+[bridge]
+ws_url = "wss://x/y"
+
+[[route]]
+name = "default"
+[route.match]
+any = true
+"#;
+    let cfg = load_from_str_with_env(toml, &env).unwrap();
+    assert_eq!(cfg.sip.min_session_expires, Duration::from_secs(300));
+    assert_eq!(
+        cfg.sip.preferred_session_expires,
+        Some(Duration::from_secs(1800)),
+    );
+}
+
+#[test]
 fn on_ws_failure_only_accepts_hangup() {
     // v1 supports "hangup" only — `play_prompt` would need a
     // forge-driven prompt player that isn't built. Reject the

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -49,16 +49,19 @@
 //!   caller passes a list, but the daemon doesn't read it from
 //!   config yet.
 
+use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use parking_lot::RwLock;
 use sip_core::Request;
-use sip_dialog::DialogManager;
+use sip_dialog::session_timer_manager::{SessionTimerEvent, SessionTimerManager};
+use sip_dialog::{DialogId, DialogManager};
 use sip_uac::integrated::IntegratedUAC;
-use sip_uas::integrated::IntegratedUAS;
-use sip_uas::UserAgentServer;
+use sip_uas::integrated::{AcceptInviteAsyncOutcome, IntegratedUAS};
+use sip_uas::{NegotiatedSessionTimer, SessionTimerPolicy, UserAgentServer};
 use siphon_ai_bridge::{
     AudioEncoding, AudioFormat, BridgeConfig, CallId as BridgeCallId, Direction, DisconnectReason,
     SipMeta, StartMsg, PROTOCOL_VERSION,
@@ -562,12 +565,39 @@ pub struct BridgingAcceptor {
     cdr_sink: CdrSinkHandle,
     webhook_sink: WebhookSinkHandle,
     call_id_factory: CallIdFactory,
+    /// RFC 4028 negotiation policy used on every inbound INVITE.
+    /// Defaults to the upstream `SessionTimerPolicy::default()` (90 s
+    /// floor, no preference, no force-refresher) until the daemon's
+    /// `[sip]` config calls `with_session_timer_policy`.
+    session_timer_policy: SessionTimerPolicy,
+    /// Authoritative timer for every dialog we accepted with session
+    /// timers. The fan-out task subscribed in `new()` reads its event
+    /// stream and dispatches `SessionExpired` to the per-dialog
+    /// handle in `dialog_handles` — turning a timer event into a
+    /// controller shutdown that, via PR #19's path, sends an outbound
+    /// BYE to the peer.
+    session_timer_manager: Arc<SessionTimerManager>,
+    /// `DialogId → CallHandle` map populated when a call is accepted
+    /// with timers and drained when it ends. Read by the fan-out
+    /// task; written by `on_matched` and `run_call`'s cleanup arm.
+    dialog_handles: Arc<RwLock<HashMap<DialogId, crate::call::CallHandle>>>,
 }
 
 /// Daemon-wide REFER plumbing (shared across every accepted call).
 struct InstalledTransfer {
     uac: Arc<IntegratedUAC>,
     dialog_manager: Arc<DialogManager>,
+}
+
+/// Pair handed to [`BridgingAcceptor::run_call`] when a call was
+/// accepted via the session-timer-aware path. `dialog` keys the
+/// session-timer registry; `timer` is `Some` iff RFC 4028
+/// negotiated successfully on this INVITE. Tests that drive
+/// `run_call` directly (without the full acceptor flow) pass
+/// `None` for the outer Option and skip session-timer wiring.
+pub struct AcceptedSession {
+    pub dialog: sip_dialog::Dialog,
+    pub timer: Option<NegotiatedSessionTimer>,
 }
 
 /// Carried into the post-controller cleanup task. Same Arc'd UAC +
@@ -623,6 +653,58 @@ async fn send_outbound_bye(
 
 impl BridgingAcceptor {
     pub fn new(media: Arc<MediaSetup>, defaults: BridgeDefaults, registry: CallRegistry) -> Self {
+        let session_timer_manager = Arc::new(SessionTimerManager::new());
+        let dialog_handles: Arc<RwLock<HashMap<DialogId, crate::call::CallHandle>>> =
+            Arc::new(RwLock::new(HashMap::new()));
+
+        // Fan-out: drain the manager's event stream and dispatch
+        // `SessionExpired` to the per-dialog handle. The subscribe()
+        // call is one-shot upstream (last subscriber wins), so doing
+        // it here at construction guarantees nobody else can race us
+        // for the receiver. Spawning in sync code is fine because
+        // every callsite (daemon main, integration tests) runs inside
+        // a tokio runtime — if a caller forgets to set one up the
+        // panic surfaces immediately.
+        let mgr_for_fanout = Arc::clone(&session_timer_manager);
+        let map_for_fanout = Arc::clone(&dialog_handles);
+        tokio::spawn(async move {
+            let mut events = mgr_for_fanout.subscribe().await;
+            while let Some(ev) = events.recv().await {
+                match ev {
+                    SessionTimerEvent::SessionExpired(dialog_id) => {
+                        let handle = map_for_fanout.read().get(&dialog_id).cloned();
+                        if let Some(handle) = handle {
+                            info!(
+                                sip_call_id = %dialog_id.call_id(),
+                                "RFC 4028 session expired; tearing down call"
+                            );
+                            handle.shutdown();
+                        } else {
+                            debug!(
+                                sip_call_id = %dialog_id.call_id(),
+                                "session expired for unknown dialog — already torn down"
+                            );
+                        }
+                    }
+                    SessionTimerEvent::RefreshNeeded(dialog_id) => {
+                        // We default to `refresher=uac`, so this only
+                        // fires when an operator forced the UAS to be
+                        // the refresher AND the half-deadline elapsed
+                        // without a refresh re-INVITE going out. v1
+                        // doesn't initiate refreshes, so log and let
+                        // the same dialog's `SessionExpired` fire at
+                        // the full deadline.
+                        warn!(
+                            sip_call_id = %dialog_id.call_id(),
+                            "RFC 4028 refresh due but UAS-initiated refresh \
+                             is not implemented in v1 — call will tear down \
+                             at session-expires"
+                        );
+                    }
+                }
+            }
+        });
+
         Self {
             media,
             defaults,
@@ -632,6 +714,9 @@ impl BridgingAcceptor {
             cdr_sink: Arc::new(NullSink),
             webhook_sink: Arc::new(WebhookNullSink),
             call_id_factory: default_call_id_factory(),
+            session_timer_policy: SessionTimerPolicy::default(),
+            session_timer_manager,
+            dialog_handles,
         }
     }
 
@@ -686,6 +771,15 @@ impl BridgingAcceptor {
     /// an HTTP sink based on `[webhooks]` config.
     pub fn with_webhook_sink(mut self, sink: WebhookSinkHandle) -> Self {
         self.webhook_sink = sink;
+        self
+    }
+
+    /// Replace the RFC 4028 negotiation policy. The daemon builds
+    /// one from `[sip].min_session_expires_secs` and
+    /// `[sip].preferred_session_expires_secs` at startup; tests
+    /// override it for focused coverage.
+    pub fn with_session_timer_policy(mut self, policy: SessionTimerPolicy) -> Self {
+        self.session_timer_policy = policy;
         self
     }
 
@@ -942,14 +1036,52 @@ impl CallAcceptor for BridgingAcceptor {
                 "BridgingAcceptor::install_uas was not called; on_reinvite cannot accept INVITE"
             )
         })?;
-        uas.accept_invite(
-            call.request,
-            &call.handle,
-            call.transport,
-            Some(&new_answer),
-        )
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to accept re-INVITE: {e}"))?;
+        let outcome = uas
+            .accept_invite_with_session_timer(
+                call.request,
+                &call.handle,
+                call.transport,
+                Some(&new_answer),
+                &self.session_timer_policy,
+            )
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to accept re-INVITE: {e}"))?;
+
+        // If the refresh re-INVITE carried Session-Expires (whether
+        // hold/resume or a pure timer refresh), reset the per-dialog
+        // timer to the freshly-negotiated value. A 422-too-small
+        // outcome here means the peer's refresh asks for a shorter
+        // session than our Min-SE; the helper already sent the 422,
+        // and the original timer keeps running — the peer is
+        // expected to retry with a larger value.
+        match outcome {
+            AcceptInviteAsyncOutcome::Accepted {
+                dialog,
+                session_timer: Some(timer),
+            } => {
+                self.session_timer_manager.refresh_timer(
+                    dialog.id().clone(),
+                    timer.session_expires,
+                    matches!(timer.refresher, sip_core::RefresherRole::Uas),
+                );
+                debug!(
+                    sip_call_id = %call.sip_call_id,
+                    session_expires_secs = timer.session_expires.as_secs(),
+                    "re-INVITE refreshed RFC 4028 timer"
+                );
+            }
+            AcceptInviteAsyncOutcome::Accepted { .. } => { /* no timer renegotiated */ }
+            AcceptInviteAsyncOutcome::SessionIntervalTooSmall { required_min_se } => {
+                warn!(
+                    sip_call_id = %call.sip_call_id,
+                    required_min_se_secs = required_min_se.as_secs(),
+                    "re-INVITE rejected 422: refresh Session-Expires below Min-SE"
+                );
+                // Keep the existing dialog + timer running; the peer
+                // can resend with a larger value.
+                return Ok(());
+            }
+        }
 
         debug!(
             sip_call_id = %call.sip_call_id,
@@ -999,23 +1131,12 @@ impl CallAcceptor for BridgingAcceptor {
                         error = %e,
                         "forge start_session failed; rejecting INVITE 500",
                     );
-                    // Roll back the forge session prepare_call
-                    // allocated so the RTP port is freed. Best-effort
-                    // — if stop_session itself fails the call is
-                    // already on its way out and a warn is the
-                    // operator's signal that something else is wrong.
-                    if let Err(stop_err) = self
-                        .media
-                        .session_manager()
-                        .stop_session(&prepared.forge_call_id)
-                        .await
-                    {
-                        warn!(
-                            call_id = %prepared.bridge_call_id,
-                            error = %stop_err,
-                            "stop_session after start_session failure also failed"
-                        );
-                    }
+                    self.rollback_forge_session(
+                        &prepared.bridge_call_id,
+                        &prepared.forge_call_id,
+                        "start_session",
+                    )
+                    .await;
                     let response = UserAgentServer::create_response(
                         call.request,
                         500,
@@ -1027,42 +1148,84 @@ impl CallAcceptor for BridgingAcceptor {
                 }
 
                 // 200 OK with the negotiated SDP via the canonical
-                // upstream helper (siphon-rs PR #35). This builds the
-                // response, auto-fills Via/Contact/User-Agent, sends
-                // it through the transaction handle, AND registers
-                // the confirmed dialog with the dialog manager that
-                // `dispatch` consults — so the follow-up BYE finds
-                // it instead of falling through to "unknown dialog".
-                if let Err(e) = uas
-                    .accept_invite(
+                // session-timer-aware upstream helper (siphon-rs
+                // PR #40). This builds the response, parses any
+                // `Session-Expires` header for RFC 4028 negotiation,
+                // appends `Session-Expires` + `Require: timer` to
+                // the 2xx when timers are in play, auto-fills
+                // Via/Contact/User-Agent, sends through the
+                // transaction handle, AND registers the confirmed
+                // dialog with the dialog manager that `dispatch`
+                // consults.
+                let accept_outcome = match uas
+                    .accept_invite_with_session_timer(
                         call.request,
                         &call.handle,
                         call.transport,
                         Some(&prepared.answer.answer_text),
+                        &self.session_timer_policy,
                     )
                     .await
                 {
-                    // The 200 OK never reached the peer — roll back
-                    // the forge session we just activated so the
-                    // RTP port doesn't leak. Same best-effort policy
-                    // as the start_session error path above.
-                    if let Err(stop_err) = self
-                        .media
-                        .session_manager()
-                        .stop_session(&prepared.forge_call_id)
-                        .await
-                    {
+                    Ok(o) => o,
+                    Err(e) => {
+                        // The 200 OK never reached the peer — roll back
+                        // the forge session we just activated so the
+                        // RTP port doesn't leak.
+                        self.rollback_forge_session(
+                            &prepared.bridge_call_id,
+                            &prepared.forge_call_id,
+                            "accept_invite",
+                        )
+                        .await;
+                        return Err(anyhow::anyhow!("failed to accept INVITE: {e}"));
+                    }
+                };
+
+                let (dialog, session_timer) = match accept_outcome {
+                    AcceptInviteAsyncOutcome::Accepted {
+                        dialog,
+                        session_timer,
+                    } => (dialog, session_timer),
+                    AcceptInviteAsyncOutcome::SessionIntervalTooSmall { required_min_se } => {
+                        // The helper already sent the 422; we just need
+                        // to release the forge session that prepare_call
+                        // / start_session set up. No dialog, no call.
                         warn!(
                             call_id = %prepared.bridge_call_id,
-                            error = %stop_err,
-                            "stop_session after accept_invite failure also failed"
+                            required_min_se_secs = required_min_se.as_secs(),
+                            "rejecting INVITE 422: Session-Expires below configured Min-SE"
                         );
+                        self.rollback_forge_session(
+                            &prepared.bridge_call_id,
+                            &prepared.forge_call_id,
+                            "session_interval_too_small",
+                        )
+                        .await;
+                        metrics::counter!(INVITES_TOTAL, "result" => "rejected").increment(1);
+                        return Ok(());
                     }
-                    return Err(anyhow::anyhow!("failed to accept INVITE: {e}"));
+                };
+
+                if let Some(ref timer) = session_timer {
+                    debug!(
+                        call_id = %prepared.bridge_call_id,
+                        sip_call_id = %dialog.id().call_id(),
+                        session_expires_secs = timer.session_expires.as_secs(),
+                        refresher = ?timer.refresher,
+                        "RFC 4028 session timer negotiated"
+                    );
                 }
 
                 metrics::counter!(INVITES_TOTAL, "result" => "accepted").increment(1);
-                self.run_call(prepared, call.route.name.as_str());
+                self.run_call(
+                    prepared,
+                    call.route.name.as_str(),
+                    Some(AcceptedSession {
+                        dialog,
+                        timer: session_timer,
+                    }),
+                );
                 Ok(())
             }
             Err(e) => {
@@ -1088,10 +1251,38 @@ impl BridgingAcceptor {
     /// stops the forge session, and emits the CDR. Returns the
     /// `JoinHandle` of the spawned task — production callers
     /// (`on_matched`) drop it; tests `await` it.
+    /// Best-effort `stop_session` cleanup. Called from every error
+    /// path between `prepare_call` (which allocates the forge
+    /// session) and a successful controller spawn — start_session
+    /// failure, accept_invite failure, and 422-too-small. Logs a
+    /// warning if `stop_session` itself errors and otherwise stays
+    /// quiet.
+    async fn rollback_forge_session(
+        &self,
+        bridge_call_id: &BridgeCallId,
+        forge_call_id: &forge_core::CallId,
+        reason: &'static str,
+    ) {
+        if let Err(stop_err) = self
+            .media
+            .session_manager()
+            .stop_session(forge_call_id)
+            .await
+        {
+            warn!(
+                call_id = %bridge_call_id,
+                error = %stop_err,
+                reason,
+                "stop_session after {reason} failure also failed"
+            );
+        }
+    }
+
     pub fn run_call(
         &self,
         prepared: PreparedCall,
         route_name: &str,
+        accepted: Option<AcceptedSession>,
     ) -> tokio::task::JoinHandle<()> {
         let call_start = CallStart {
             bridge_call_id: prepared.bridge_call_id.clone(),
@@ -1113,6 +1304,30 @@ impl BridgingAcceptor {
         // so it knows whether to send an outbound BYE. `CallHandle`
         // is cheap (Arc-of-Notify + Arc-of-AtomicBool inside).
         let cleanup_handle = prepared.handle.clone();
+
+        // Wire the RFC 4028 timer if negotiation produced one. The
+        // fan-out task spawned in `new()` reads `SessionExpired`
+        // events from the manager and looks the handle up in
+        // `dialog_handles` to drive teardown. Stopping the timer is
+        // the cleanup task's job below.
+        let session_timer_key = match accepted.as_ref() {
+            Some(AcceptedSession {
+                dialog,
+                timer: Some(timer),
+            }) => {
+                let id = dialog.id().clone();
+                self.dialog_handles
+                    .write()
+                    .insert(id.clone(), cleanup_handle.clone());
+                self.session_timer_manager.start_timer(
+                    id.clone(),
+                    timer.session_expires,
+                    matches!(timer.refresher, sip_core::RefresherRole::Uas),
+                );
+                Some(id)
+            }
+            _ => None,
+        };
 
         // Register before spawning so a BYE arriving on the very
         // next packet finds an entry to wake. Cache the answer SDP
@@ -1169,6 +1384,9 @@ impl BridgingAcceptor {
             uac: Arc::clone(&t.uac),
             dialog_manager: Arc::clone(&t.dialog_manager),
         });
+        let session_timer_manager = Arc::clone(&self.session_timer_manager);
+        let dialog_handles = Arc::clone(&self.dialog_handles);
+        let cleanup_session_timer_key = session_timer_key;
 
         tokio::spawn(async move {
             let run_result = controller.run().await;
@@ -1178,6 +1396,14 @@ impl BridgingAcceptor {
                 cause = ?view.cause,
                 "call ended"
             );
+            // Stop the RFC 4028 timer and drop the handle map entry
+            // first — otherwise a `SessionExpired` racing the
+            // controller exit would try to shutdown an already-gone
+            // controller. Cheap when no timer was negotiated.
+            if let Some(dialog_id) = cleanup_session_timer_key.as_ref() {
+                session_timer_manager.stop_timer(dialog_id);
+                dialog_handles.write().remove(dialog_id);
+            }
             // Send outbound BYE if the peer didn't already drive it.
             // Order: BYE first, registry remove second, forge stop
             // third. That way a follow-up BYE retransmit from the

--- a/crates/core/tests/acceptor_cdr.rs
+++ b/crates/core/tests/acceptor_cdr.rs
@@ -163,7 +163,7 @@ async fn run_call_emits_cdr_when_controller_exits() {
 
     // Drive the call. Trigger the BYE-style shutdown a moment
     // later so the controller exits via LocalShutdown.
-    let run_handle = acceptor.run_call(prepared, "main_reception");
+    let run_handle = acceptor.run_call(prepared, "main_reception", None);
 
     // Give the bridge time to handshake and send `start`.
     tokio::time::sleep(Duration::from_millis(150)).await;
@@ -242,7 +242,7 @@ async fn null_sink_is_the_default_when_no_sink_configured() {
         .await
         .expect("prepare");
 
-    let run_handle = acceptor.run_call(prepared, "main_reception");
+    let run_handle = acceptor.run_call(prepared, "main_reception", None);
     tokio::time::sleep(Duration::from_millis(150)).await;
     let h = registry
         .lookup("abc-cdr@pbx.example.com")

--- a/crates/core/tests/acceptor_metrics.rs
+++ b/crates/core/tests/acceptor_metrics.rs
@@ -167,7 +167,7 @@ async fn full_call_lifecycle_emits_expected_metrics() {
     // Mirror what on_matched does on the accept path so the
     // accepted-counter increment is exercised here too.
     metrics::counter!(INVITES_TOTAL, "result" => "accepted").increment(1);
-    let run_handle = acceptor.run_call(prepared, "metrics_route");
+    let run_handle = acceptor.run_call(prepared, "metrics_route", None);
 
     tokio::time::sleep(Duration::from_millis(150)).await;
     let h = registry.lookup("abc-metrics@pbx").expect("registered");

--- a/crates/core/tests/acceptor_webhooks.rs
+++ b/crates/core/tests/acceptor_webhooks.rs
@@ -154,7 +154,7 @@ async fn run_call_emits_call_start_then_call_end() {
         .prepare_call(&req, route, &facts)
         .await
         .expect("prepare");
-    let run_handle = acceptor.run_call(prepared, "webhook_route");
+    let run_handle = acceptor.run_call(prepared, "webhook_route", None);
 
     tokio::time::sleep(Duration::from_millis(150)).await;
     let h = registry.lookup("abc-webhook@pbx").expect("registered");
@@ -236,7 +236,7 @@ async fn null_webhook_sink_is_the_default() {
         .await
         .expect("prepare");
 
-    let run_handle = acceptor.run_call(prepared, "webhook_route");
+    let run_handle = acceptor.run_call(prepared, "webhook_route", None);
     tokio::time::sleep(Duration::from_millis(150)).await;
     let h = registry.lookup("abc-null@pbx").expect("registered");
     h.shutdown();

--- a/test-harness/sipp-scenarios/run-all.sh
+++ b/test-harness/sipp-scenarios/run-all.sh
@@ -58,6 +58,7 @@ scenarios=(
     basic_call_then_bye.xml
     caller_cancels_during_setup.xml
     unsupported_codec_488.xml
+    session_timer_echo.xml
 )
 
 run_scenario() {

--- a/test-harness/sipp-scenarios/session_timer_echo.xml
+++ b/test-harness/sipp-scenarios/session_timer_echo.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  session_timer_echo — UAC sends INVITE with Session-Expires=300 +
+  refresher=uac and Supported: timer. UAS (SiphonAI) must echo
+  Session-Expires back on the 2xx with Require: timer so the peer
+  knows timer support was honoured. Validates the wire-level
+  contract from the RFC 4028 plumbing (siphon-rs PR #40, siphon-ai
+  acceptor wiring).
+
+  The scenario doesn't drive any refresh — that's the soak harness's
+  job. Here we just confirm:
+    1. INVITE with Session-Expires negotiates successfully.
+    2. The 2xx carries Session-Expires + Require:timer.
+    3. BYE flows clean.
+-->
+<scenario name="session_timer_echo">
+  <send retrans="500">
+<![CDATA[
+INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+Max-Forwards: 70
+From: <sip:sipp-timer@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:sipp-timer@[local_ip]:[local_port]>
+Supported: timer
+Session-Expires: 300;refresher=uac
+Min-SE: 90
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=user1 53655765 2353687637 IN IP4 [local_ip]
+s=-
+c=IN IP4 [local_ip]
+t=0 0
+m=audio [auto_media_port] RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+]]>
+  </send>
+
+  <recv response="100" optional="true"/>
+  <recv response="180" optional="true"/>
+  <recv response="183" optional="true"/>
+
+  <!--
+    The 2xx MUST carry both `Session-Expires` and `Require: timer`.
+    `regexp_match` evaluates against the received message body +
+    headers; "Session-Expires:" and "Require:" both appear in the
+    daemon's response per the upstream PR. SIPp fails the scenario
+    if the regex doesn't match.
+  -->
+  <recv response="200" rtd="true">
+    <action>
+      <!-- check_it_inverse fails the scenario when the regex does
+           NOT match; assign_to is a no-op sink (the parser needs
+           a slot but we never reference the captured value). -->
+      <ereg regexp="Session-Expires:[ \t]*[0-9]+"
+            search_in="msg"
+            check_it="true"
+            assign_to="se_capture"/>
+      <log message="captured Session-Expires=[$se_capture]"/>
+      <ereg regexp="Require:[ \t]*[A-Za-z0-9_, \t]*timer"
+            search_in="msg"
+            check_it="true"
+            assign_to="req_capture"/>
+      <log message="captured Require=[$req_capture]"/>
+    </action>
+  </recv>
+
+  <send>
+<![CDATA[
+ACK sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]-ack
+Max-Forwards: 70
+From: <sip:sipp-timer@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="500"/>
+
+  <send retrans="500">
+<![CDATA[
+BYE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]-bye
+Max-Forwards: 70
+From: <sip:sipp-timer@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 BYE
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="200"/>
+
+  <ResponseTimeRepartition value="200, 500, 1000"/>
+</scenario>


### PR DESCRIPTION
## Summary
Wires SiphonAI to honour RFC 4028 session timers on every inbound INVITE via the upstream siphon-rs PR #40 plumbing. The call tears down at the deadline when the peer doesn't refresh — the missing piece that would have caused Asterisk/CUCM trunks to drop the call after 15–30 minutes of silence.

## What's new
- **Config**: \`[sip].min_session_expires_secs\` (default 90, sub-90 refuses to load — RFC 4028 floor) and \`[sip].preferred_session_expires_secs\` (optional cap).
- **\`BridgingAcceptor\`** gains a \`SessionTimerManager\` + a daemon-wide fan-out task spawned at \`new()\`. The fan-out maps \`SessionExpired(dialog_id)\` to the per-call \`CallHandle\` via a registry populated on accept.
- **\`accept_invite_with_session_timer\`** is plumbed through the INVITE path. New \`AcceptInviteAsyncOutcome\` branches on Accepted (start the timer) vs SessionIntervalTooSmall (helper already sent 422, roll back the forge session, count as rejected).
- **\`on_reinvite\`** is also session-timer-aware so a refresh re-INVITE (hold/resume or pure timer refresh) resets the per-dialog timer via \`refresh_timer\`.
- **\`rollback_forge_session\`** extracts the existing \`stop_session\`-with-warn pattern that start_session, accept_invite, and now 422 error paths share.
- **\`run_call\`** takes \`Option<AcceptedSession>\` so tests opt out of session-timer wiring; the daemon path passes \`Some({dialog, timer})\`. Cleanup task calls \`stop_timer\` before the outbound BYE so racing \`SessionExpired\` events can't shutdown an already-gone controller.

The daemon always picks \`refresher=uac\` (force_refresher policy). Gateway-style UASes don't initiate UPDATE refreshes, so v1 never has to send one. \`RefreshNeeded\` events are logged and ignored.

## Soak validation
Drove a 90-second Session-Expires call through SIPp with no refresh:

\`\`\`text
15:08:27.371931  RFC 4028 session timer negotiated session_expires_secs=90 refresher=Uac
15:09:57.373260  RFC 4028 session expired; tearing down call          ← T+90s exactly
15:09:57.373291  controller shutdown requested
15:09:57.373471  call ended cause=LocalShutdown
15:09:57.373798  outbound BYE sent status=200                          ← PR #19 path
\`\`\`

SIPp recorded \`Successful call: 1\` — the daemon's BYE reached it. The full path (start_timer → 90s sleep → SessionExpired → fan-out → handle.shutdown → controller exit → outbound BYE → peer 200 OK) works end-to-end.

## Test plan
- [x] \`cargo test --workspace\` — green
- [x] \`cargo clippy --workspace --all-targets\` — clean (pre-existing \`too_many_arguments\` warning in registration.rs only)
- [x] \`cargo fmt --all --check\` — clean
- [x] Config: \`session_timer_defaults_to_90s_floor\`, \`session_timer_below_90s_rejected_at_load\`, \`session_timer_explicit_values_compile\`
- [x] SIPp regression: \`session_timer_echo.xml\` added to \`run-all.sh\` — validates the 2xx echo contract (\`Session-Expires:\` + \`Require: timer\` on the response)
- [x] Manual soak: \`configs/soak.toml\` + \`/tmp/short_se_no_refresh.xml\` drove the 90s timer to expiry — daemon shuts down the call and BYE's the peer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)