### PR TITLE
fix: re-INVITE validation, BYE→caller_hangup wire reason, clippy gate

### DIFF
--- a/bins/siphon-ai/src/registration.rs
+++ b/bins/siphon-ai/src/registration.rs
@@ -150,6 +150,13 @@ fn spawn_one(
 /// Inner loop. Returns `Err` only on unrecoverable setup failures
 /// (UAC builder rejected the config). Per-attempt failures stay in
 /// the loop and roll over to a backoff retry.
+///
+/// 8 args is over clippy's 7-arg threshold; each is independent
+/// daemon-side plumbing (manager, cfg, two transaction/transport
+/// arcs, resolver, local addr, webhook sink, shutdown). Bundling
+/// them into a `Drive Context` struct buys nothing — the call site
+/// is one place and each arg is named at construction.
+#[allow(clippy::too_many_arguments)]
 #[instrument(skip_all, fields(name = %cfg.name, server = %cfg.server_addr))]
 async fn drive(
     manager: &RegistrationManager,

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -927,6 +927,142 @@ fn sdp_audio_direction(
         .and_then(siphon_ai_media_glue::MediaDirection::from_attr)
 }
 
+/// Audio payload-type list from a parsed SDP. Used by re-INVITE
+/// handling to confirm the peer's new offer still proposes a codec
+/// we accepted on the initial INVITE. Empty when there's no audio
+/// media.
+fn sdp_audio_payload_types(session: &forge_sdp::SessionDescription) -> Vec<String> {
+    use forge_sdp::MediaType;
+    session
+        .find_media(MediaType::Audio)
+        .map(|m| m.formats.iter().map(|s| s.to_string()).collect())
+        .unwrap_or_default()
+}
+
+/// Rejection signal returned by [`prepare_reinvite_answer`] when
+/// the re-INVITE offer can't be safely answered with the cached
+/// SDP — the caller sends the carried response and exits.
+#[derive(Debug)]
+struct ReinviteRejection {
+    code: u16,
+    reason: &'static str,
+}
+
+/// Inputs to the canonical accept_invite_with_session_timer call
+/// for a re-INVITE. Built by [`prepare_reinvite_answer`].
+struct ReinviteAnswer {
+    /// SDP body to put in the 2xx (a direction-flipped version of
+    /// the cached initial answer, or the cached answer verbatim on
+    /// a body-less re-INVITE).
+    answer_sdp: String,
+    /// `None` for body-less re-INVITEs. Only used for the closing
+    /// debug log; otherwise the new SDP carries the same media as
+    /// the cached one by construction.
+    offer_direction: Option<siphon_ai_media_glue::MediaDirection>,
+    answer_direction: Option<siphon_ai_media_glue::MediaDirection>,
+}
+
+/// Validate an inbound re-INVITE against the cached initial answer
+/// and produce the SDP for the 200 OK. Rejects (instead of producing
+/// a 200 with stale SDP) when:
+///
+/// - The body is present but malformed → 400 Bad Request.
+/// - The offer parses but lists payload types we never accepted →
+///   488 Not Acceptable Here (mid-call codec change is post-v1).
+///
+/// A body-less re-INVITE is treated as a session-timer refresh per
+/// RFC 3261 §14.2 — the cached answer stands.
+fn prepare_reinvite_answer(
+    request: &Request,
+    prev_answer: &str,
+    sip_call_id: &str,
+) -> Result<ReinviteAnswer, ReinviteRejection> {
+    let offer_text = match extract_offer_sdp(request) {
+        Ok(t) => t,
+        Err(OfferError::NoBody) => {
+            // RFC 3261 §14.2: body-less re-INVITE refreshes the
+            // session without renegotiating media. Echo the cached
+            // answer so the peer keeps the same media path.
+            debug!(
+                sip_call_id = %sip_call_id,
+                "re-INVITE has no SDP body — treating as session-timer refresh"
+            );
+            return Ok(ReinviteAnswer {
+                answer_sdp: prev_answer.to_string(),
+                offer_direction: None,
+                answer_direction: None,
+            });
+        }
+        Err(e) => {
+            warn!(
+                sip_call_id = %sip_call_id,
+                error = %e,
+                "re-INVITE rejected 400: malformed body"
+            );
+            return Err(ReinviteRejection {
+                code: 400,
+                reason: "Bad Request",
+            });
+        }
+    };
+
+    let offer_session = siphon_ai_media_glue::parse_offer(offer_text).map_err(|e| {
+        warn!(
+            sip_call_id = %sip_call_id,
+            error = %e,
+            "re-INVITE rejected 488: offer parse failed"
+        );
+        ReinviteRejection {
+            code: 488,
+            reason: "Not Acceptable Here",
+        }
+    })?;
+
+    // The previously-sent answer parses through the same routine
+    // since it's a valid SDP we generated. Failure here would be
+    // a daemon bug.
+    let cached_session = siphon_ai_media_glue::parse_offer(prev_answer).map_err(|e| {
+        warn!(
+            sip_call_id = %sip_call_id,
+            error = %e,
+            "cached answer failed to re-parse — rejecting 500"
+        );
+        ReinviteRejection {
+            code: 500,
+            reason: "Server Internal Error",
+        }
+    })?;
+
+    let offer_pts = sdp_audio_payload_types(&offer_session);
+    let cached_pts = sdp_audio_payload_types(&cached_session);
+    let has_common_pt =
+        !cached_pts.is_empty() && offer_pts.iter().any(|pt| cached_pts.contains(pt));
+    if !has_common_pt {
+        warn!(
+            sip_call_id = %sip_call_id,
+            offer_pts = ?offer_pts,
+            cached_pts = ?cached_pts,
+            "re-INVITE rejected 488: payload types diverge from accepted call \
+             (mid-call codec change unsupported in v1)"
+        );
+        return Err(ReinviteRejection {
+            code: 488,
+            reason: "Not Acceptable Here",
+        });
+    }
+
+    // RFC 3264 §6.1 direction mirror.
+    let offer_direction = sdp_audio_direction(&offer_session).unwrap_or_default();
+    let answer_direction = mirror_direction(offer_direction);
+    let answer_sdp = rewrite_sdp_direction(prev_answer, answer_direction);
+
+    Ok(ReinviteAnswer {
+        answer_sdp,
+        offer_direction: Some(offer_direction),
+        answer_direction: Some(answer_direction),
+    })
+}
+
 /// RFC 3264 §6.1 direction mirror. Hold/resume re-INVITE answering
 /// depends on this — see `BridgingAcceptor::on_reinvite`.
 fn mirror_direction(
@@ -1008,26 +1144,29 @@ impl CallAcceptor for BridgingAcceptor {
             return Ok(());
         };
 
-        // Determine the offer's new direction. Anything malformed
-        // or missing the audio media falls back to sendrecv per
-        // RFC 4566 §6.
-        let offer_direction = extract_offer_sdp(call.request)
-            .ok()
-            .and_then(|t| siphon_ai_media_glue::parse_offer(t).ok())
-            .as_ref()
-            .and_then(sdp_audio_direction)
-            .unwrap_or_default();
-
-        // RFC 3264 §6.1 mirror: offer sendonly → answer recvonly,
-        // offer recvonly → answer sendonly, offer inactive →
-        // answer inactive, offer sendrecv → answer sendrecv.
-        let answer_direction = mirror_direction(offer_direction);
-
-        // Take the cached answer SDP and flip its direction
-        // attribute. Re-using everything else (port, codecs,
-        // payload types) keeps forge's session intact — hold/
-        // resume by design only changes the `a=` line.
-        let new_answer = rewrite_sdp_direction(&prev_answer, answer_direction);
+        // Strict offer validation. The cached `prev_answer` only
+        // carries direction; mirroring the offer's `a=` line is
+        // safe ONLY when the offer still proposes the same codec /
+        // PT we negotiated on the initial INVITE. v1 doesn't
+        // implement mid-call codec / port renegotiation, so anything
+        // beyond a direction change gets a clean 488 instead of a
+        // 200 OK with an SDP that doesn't correspond to the offer.
+        //
+        // RFC 3261 §14.2 permits a body-less re-INVITE as a session-
+        // timer refresh; the previous answer stands unchanged on
+        // that path.
+        let reinvite = match prepare_reinvite_answer(call.request, &prev_answer, &call.sip_call_id)
+        {
+            Ok(r) => r,
+            Err(ReinviteRejection { code, reason }) => {
+                let response = UserAgentServer::create_response(call.request, code, reason);
+                call.handle.send_final(response).await;
+                return Ok(());
+            }
+        };
+        let new_answer = reinvite.answer_sdp;
+        let offer_direction = reinvite.offer_direction;
+        let answer_direction = reinvite.answer_direction;
 
         // Send 200 OK via the canonical helper so the dialog
         // manager gets the updated CSeq / route-set.
@@ -2243,5 +2382,112 @@ a=sendrecv\r\n";
         assert!(out.contains("a=sendonly\n"));
         // No spurious CR added.
         assert!(!out.contains("\r"));
+    }
+
+    // ─── prepare_reinvite_answer ───────────────────────────────────
+
+    /// SDP we'd cache after accepting an initial INVITE that offered
+    /// PCMU. Matches what `build_answer` would produce shape-wise.
+    fn cached_answer_pcmu() -> &'static str {
+        "v=0\r\n\
+o=siphon 1 1 IN IP4 192.168.1.10\r\n\
+s=-\r\n\
+c=IN IP4 192.168.1.10\r\n\
+t=0 0\r\n\
+m=audio 20100 RTP/AVP 0\r\n\
+a=rtpmap:0 PCMU/8000\r\n\
+a=sendrecv\r\n"
+    }
+
+    #[test]
+    fn reinvite_matching_pt_with_hold_returns_mirrored_answer() {
+        // Peer puts the call on hold by sending a re-INVITE with
+        // sendonly + same PT (PCMU). We should answer recvonly and
+        // keep the same media line otherwise.
+        let req = invite_with(
+            Some("application/sdp"),
+            "v=0\r\n\
+o=alice 2 2 IN IP4 10.0.0.5\r\n\
+s=t\r\n\
+c=IN IP4 10.0.0.5\r\n\
+t=0 0\r\n\
+m=audio 7000 RTP/AVP 0\r\n\
+a=rtpmap:0 PCMU/8000\r\n\
+a=sendonly\r\n",
+        );
+        let outcome = prepare_reinvite_answer(&req, cached_answer_pcmu(), "abc-123@pbx")
+            .expect("re-INVITE should be accepted");
+        assert_eq!(
+            outcome.offer_direction,
+            Some(siphon_ai_media_glue::MediaDirection::SendOnly)
+        );
+        assert_eq!(
+            outcome.answer_direction,
+            Some(siphon_ai_media_glue::MediaDirection::RecvOnly)
+        );
+        assert!(outcome.answer_sdp.contains("a=recvonly"));
+        // Media line preserved.
+        assert!(outcome.answer_sdp.contains("m=audio 20100 RTP/AVP 0"));
+    }
+
+    #[test]
+    fn reinvite_with_unsupported_pt_rejected_488() {
+        // Original call negotiated PCMU (PT 0). Peer's re-INVITE
+        // proposes only G.722 (PT 9). v1 doesn't renegotiate
+        // codecs mid-call — must be 488, not a stale 200.
+        let req = invite_with(
+            Some("application/sdp"),
+            "v=0\r\n\
+o=alice 2 2 IN IP4 10.0.0.5\r\n\
+s=t\r\n\
+c=IN IP4 10.0.0.5\r\n\
+t=0 0\r\n\
+m=audio 7000 RTP/AVP 9\r\n\
+a=rtpmap:9 G722/8000\r\n\
+a=sendrecv\r\n",
+        );
+        match prepare_reinvite_answer(&req, cached_answer_pcmu(), "abc-123@pbx") {
+            Err(ReinviteRejection { code, reason }) => {
+                assert_eq!(code, 488);
+                assert_eq!(reason, "Not Acceptable Here");
+            }
+            Ok(_) => panic!("expected 488 rejection on codec divergence"),
+        }
+    }
+
+    #[test]
+    fn reinvite_with_malformed_body_rejected_488() {
+        // Body is non-SDP — parse fails. RFC 3261 §13.3 maps a
+        // failed offer to 488 (we choose 488 over 400 because the
+        // peer SENT a body and we just can't accept it).
+        let req = invite_with(Some("application/sdp"), "not actually sdp\r\n");
+        match prepare_reinvite_answer(&req, cached_answer_pcmu(), "abc-123@pbx") {
+            Err(ReinviteRejection { code, .. }) => assert_eq!(code, 488),
+            Ok(_) => panic!("expected rejection on parse failure"),
+        }
+    }
+
+    #[test]
+    fn reinvite_without_content_type_but_with_body_rejected_400() {
+        // No Content-Type header but a body is present — that's
+        // malformed SIP (RFC 3261 §20.15). 400 Bad Request, not 488.
+        let req = invite_with(None, "v=0\r\n");
+        match prepare_reinvite_answer(&req, cached_answer_pcmu(), "abc-123@pbx") {
+            Err(ReinviteRejection { code, .. }) => assert_eq!(code, 400),
+            Ok(_) => panic!("expected 400 on missing Content-Type"),
+        }
+    }
+
+    #[test]
+    fn reinvite_without_body_treated_as_session_refresh() {
+        // RFC 3261 §14.2: body-less re-INVITE is permitted for
+        // session refresh. We answer with the unchanged cached SDP
+        // and no direction info (nothing to mirror).
+        let req = invite_with(None, "");
+        let outcome = prepare_reinvite_answer(&req, cached_answer_pcmu(), "abc-123@pbx")
+            .expect("body-less re-INVITE should be accepted");
+        assert_eq!(outcome.offer_direction, None);
+        assert_eq!(outcome.answer_direction, None);
+        assert_eq!(outcome.answer_sdp, cached_answer_pcmu());
     }
 }

--- a/crates/core/src/call.rs
+++ b/crates/core/src/call.rs
@@ -327,12 +327,26 @@ impl CallController {
             tokio::select! {
                 biased;
 
-                // External cancel — drive cooperative teardown.
+                // External cancel — drive cooperative teardown. The
+                // stop reason on the WS reflects who actually drove
+                // teardown: a remote-side BYE flips `remote_bye` on
+                // the handle (via `CallRegistry::terminate_from_bye`
+                // from PR #19), so the controller can distinguish
+                // `caller_hangup` from `server_hangup` per
+                // PROTOCOL.md §6. Anything else that wakes
+                // `shutdown` (admin force-hangup, RFC 4028 session
+                // expiry) is daemon-initiated and maps to
+                // `server_hangup` from the WS server's point of view.
                 _ = shutdown.notified() => {
-                    info!(call_id = %call_id, "controller shutdown requested");
+                    let reason = if handle.remote_bye_received() {
+                        StopReason::CallerHangup
+                    } else {
+                        StopReason::ServerHangup
+                    };
+                    info!(call_id = %call_id, ?reason, "controller shutdown requested");
                     termination = CallTermination::LocalShutdown;
                     let _ = control_out_tx
-                        .send(OutgoingEvent::Stop { reason: StopReason::ServerHangup })
+                        .send(OutgoingEvent::Stop { reason })
                         .await;
                     break;
                 }

--- a/crates/core/tests/registry_bye.rs
+++ b/crates/core/tests/registry_bye.rs
@@ -73,6 +73,42 @@ async fn server_acks_start_then_idles(port_tx: tokio::sync::oneshot::Sender<u16>
     }
 }
 
+/// Same as [`server_acks_start_then_idles`] but captures the `reason`
+/// field of the controller's `stop` event and reports it back. Used
+/// to verify PROTOCOL.md §6: BYE → `caller_hangup`, WS hangup →
+/// `server_hangup`.
+async fn server_capture_stop_reason(
+    port_tx: tokio::sync::oneshot::Sender<u16>,
+    reason_tx: tokio::sync::oneshot::Sender<String>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    let _ = port_tx.send(port);
+    let (stream, _) = listener.accept().await.expect("accept");
+    let mut ws = tokio_tungstenite::accept_hdr_async(stream, echo_subprotocol)
+        .await
+        .expect("ws accept");
+
+    let mut reason_tx = Some(reason_tx);
+    while let Some(msg) = ws.next().await {
+        match msg {
+            Ok(Message::Text(t)) => {
+                let v: Value = serde_json::from_str(&t).unwrap();
+                if v["type"] == "stop" {
+                    if let Some(tx) = reason_tx.take() {
+                        let r = v["reason"].as_str().unwrap_or("").to_string();
+                        let _ = tx.send(r);
+                    }
+                    let _ = ws.send(Message::Close(None)).await;
+                    break;
+                }
+            }
+            Ok(Message::Close(_)) | Err(_) => break,
+            _ => {}
+        }
+    }
+}
+
 fn bye_request(call_id: &str) -> Request {
     let uri = SipUri::parse("sip:5000@siphon.example.com").unwrap();
     let mut h = Headers::new();
@@ -166,6 +202,91 @@ async fn dispatch_bye_wakes_running_controller_via_registry() {
         .expect("task didn't panic")
         .expect("controller returns Ok");
     assert_eq!(outcome.termination, CallTermination::LocalShutdown);
+}
+
+#[tokio::test]
+async fn bye_drives_wire_stop_with_caller_hangup_reason() {
+    // PROTOCOL.md §6: `caller_hangup` means the SIP peer sent BYE.
+    // The shutdown.notified() arm in call.rs reads
+    // `handle.remote_bye_received()` to disambiguate; this end-to-
+    // end check goes from BYE → registry → controller exit and
+    // observes the `reason` field on the WS `stop` frame.
+    let (port_tx, port_rx) = tokio::sync::oneshot::channel();
+    let (reason_tx, reason_rx) = tokio::sync::oneshot::channel();
+    tokio::spawn(server_capture_stop_reason(port_tx, reason_tx));
+    let port = port_rx.await.expect("server announces port");
+
+    let manager = Arc::new(MediaBridgeManager::new());
+    let forge_call_id = ForgeCallId::new("siphon-bye-reason");
+    let tap = MediaTap::attach(
+        &manager,
+        &::std::sync::Arc::new(forge_core::EventBus::new()),
+        forge_call_id,
+        8000,
+    )
+    .expect("attach");
+    let cfg = CallControllerConfig {
+        call_id: BridgeCallId::new("siphon-bye-reason"),
+        bridge: BridgeConfig {
+            ws_url: format!("ws://127.0.0.1:{port}/"),
+            connect_timeout: Duration::from_secs(2),
+            ..Default::default()
+        },
+        start: StartMsg {
+            version: "1".into(),
+            call_id: BridgeCallId::new("siphon-bye-reason"),
+            seq: 0,
+            from: "+13125551234".into(),
+            to: "5000".into(),
+            direction: Direction::Inbound,
+            audio: AudioFormat {
+                encoding: AudioEncoding::Pcm16le,
+                sample_rate: 8000,
+                channels: 1,
+                frame_ms: 20,
+            },
+            sip: SipMeta {
+                call_id: "bye-reason@pbx".into(),
+                headers: HashMap::new(),
+            },
+        },
+        media_tap: tap,
+        transfer: None,
+    };
+    let (controller, handle) = CallController::new(cfg);
+
+    let registry = CallRegistry::new();
+    registry.insert(
+        "bye-reason@pbx",
+        siphon_ai_core::registry::CallEntry {
+            handle,
+            answer_text: None,
+        },
+    );
+
+    let run = tokio::spawn(async move { controller.run().await });
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Dispatch via the BYE path — `terminate_from_bye` flips
+    // `remote_bye` on the handle before signalling shutdown.
+    let bye = bye_request("bye-reason@pbx");
+    let _ = dispatch_bye(&registry, &bye);
+
+    let outcome = tokio::time::timeout(Duration::from_secs(3), run)
+        .await
+        .expect("controller exits after BYE")
+        .expect("task didn't panic")
+        .expect("controller returns Ok");
+    assert_eq!(outcome.termination, CallTermination::LocalShutdown);
+
+    let reason = tokio::time::timeout(Duration::from_secs(2), reason_rx)
+        .await
+        .expect("WS observed stop")
+        .expect("server sent reason");
+    assert_eq!(
+        reason, "caller_hangup",
+        "BYE-driven teardown must surface as caller_hangup on the WS"
+    );
 }
 
 #[tokio::test]

--- a/crates/media-glue/tests/tap.rs
+++ b/crates/media-glue/tests/tap.rs
@@ -760,8 +760,9 @@ async fn clear_command_does_not_kill_tap() {
 
     cmd_tx.send(TapCommand::Clear).await.expect("send clear");
 
-    // Drain whatever the Clear pushed (Flush).
-    let _ = tokio::time::timeout(Duration::from_millis(300), async {
+    // Drain whatever the Clear pushed (Flush). `expect` returns
+    // unit, so no binding — just propagate the timeout assertion.
+    tokio::time::timeout(Duration::from_millis(300), async {
         loop {
             if let Some(req) = manager.try_recv_outbound_request(&call).await {
                 if matches!(req, OutboundMediaRequest::Flush { .. }) {


### PR DESCRIPTION
## Summary
Three findings from a code-review audit:

### 1. re-INVITE was 200-OK'ing with recycled SDP regardless of the offer
\`on_reinvite\` swallowed parse/body errors via \`.ok()\` chains and only rewrote the cached answer's direction line. Peer sending a codec change, malformed body, or no body got a stale SDP back. Real interop defect.

**Fixed** via a new \`prepare_reinvite_answer\` validator:
- malformed body → 400 Bad Request
- parse failure or payload-type divergence from the cached answer → 488 Not Acceptable Here (mid-call codec change is post-v1)
- body-less → RFC 3261 §14.2 session-timer refresh: cached answer stands
- direction-only → mirror per RFC 3264 §6.1 (the existing happy path)

### 2. BYE → \`server_hangup\` on the WS (should be \`caller_hangup\`)
PROTOCOL.md §6 says \`caller_hangup\` is SIP peer BYE; \`server_hangup\` is WS-initiated. The \`shutdown.notified()\` arm in \`call.rs\` emitted ServerHangup unconditionally.

**Fixed** by reading \`handle.remote_bye_received()\` (the flag from PR #19's outbound-BYE plumbing) in the arm. BYE → CallerHangup; admin / session-timer / etc → ServerHangup.

### 3. \`cargo clippy --workspace --all-targets -- -D warnings\` failed
Two violations:
- \`let _ = …expect(…)\` in \`media-glue/tests/tap.rs:764\` (let-unit-value) — dropped the binding.
- \`async fn drive\` in \`registration.rs\` was 8 args. Bundling each independent piece of daemon-side plumbing into a context struct adds ceremony without saving anything; \`#[allow(clippy::too_many_arguments)]\` with a comment.

## Tests
- 5 new unit tests in acceptor.rs covering the re-INVITE validator paths (matching PT + hold, unsupported PT, malformed body, missing Content-Type, body-less refresh).
- New integration test \`bye_drives_wire_stop_with_caller_hangup_reason\` spins up a WS server that captures the \`stop\` frame's reason field and asserts \`caller_hangup\` on a BYE-driven teardown.

## Test plan
- [x] \`cargo test --workspace\` — all green
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all -- --check\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)