### PR TITLE
test(sipp): re-INVITE E2E scenarios; doc(sip-glue): drop stale 501 note

### DIFF
--- a/crates/sip-glue/src/handler.rs
+++ b/crates/sip-glue/src/handler.rs
@@ -19,10 +19,14 @@
 //! ## Re-INVITE
 //!
 //! Routing only applies to *new* calls (`dialog: None`). Mid-dialog
-//! re-INVITEs (hold/resume, codec change) belong to the
-//! `CallController`, not the routing layer. Until core lands, this
-//! handler responds 501 to re-INVITEs — see CLAUDE.md §8 for what's
-//! deferred to Week 3+.
+//! re-INVITEs belong to the `CallController`'s acceptor — the
+//! routing handler dispatches them via `CallAcceptor::on_reinvite`,
+//! which validates the offer, mirrors the direction (hold / resume),
+//! and answers 200 OK. The trait's default `on_reinvite` still
+//! responds 501 for acceptors that didn't override it; production
+//! impls (e.g., `BridgingAcceptor`) override and answer for real.
+//! Mid-call codec / port renegotiation is rejected with 488 per
+//! `BridgingAcceptor::on_reinvite` — that's a post-v1 feature.
 //!
 //! ## Contact / User-Agent on the 404
 //!

--- a/test-harness/sipp-scenarios/reinvite_hold_resume.xml
+++ b/test-harness/sipp-scenarios/reinvite_hold_resume.xml
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  reinvite_hold_resume — end-to-end coverage of the hold/resume
+  re-INVITE path through the SIP stack.
+
+  Sequence:
+    1. INVITE  with PCMU + sendrecv      → 200 OK (sendrecv)
+    2. ACK
+    3. re-INVITE with PCMU + sendonly    → 200 OK MUST carry recvonly
+       (RFC 3264 §6.1 mirror; PR #17 + PR #24)
+    4. ACK
+    5. re-INVITE with PCMU + sendrecv    → 200 OK MUST carry sendrecv
+    6. ACK
+    7. BYE                                → 200 OK
+
+  The two re-INVITEs reuse the call's existing payload type (PCMU)
+  to stay on the "direction-only change" code path; the codec
+  divergence path is covered by `reinvite_unsupported_codec_488.xml`.
+-->
+<scenario name="reinvite_hold_resume">
+  <!-- Initial INVITE -->
+  <send>
+<![CDATA[
+INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+Max-Forwards: 70
+From: <sip:sipp-hold@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:sipp-hold@[local_ip]:[local_port]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=user1 53655765 2353687637 IN IP4 [local_ip]
+s=-
+c=IN IP4 [local_ip]
+t=0 0
+m=audio 9000 RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+a=sendrecv
+]]>
+  </send>
+
+  <recv response="100" optional="true"/>
+  <recv response="180" optional="true"/>
+  <recv response="183" optional="true"/>
+  <recv response="200" rtd="true"/>
+
+  <send>
+<![CDATA[
+ACK sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]-ack
+Max-Forwards: 70
+From: <sip:sipp-hold@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="200"/>
+
+  <!-- HOLD: same codec, direction = sendonly. -->
+  <send>
+<![CDATA[
+INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]-hold
+Max-Forwards: 70
+From: <sip:sipp-hold@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 INVITE
+Contact: <sip:sipp-hold@[local_ip]:[local_port]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=user1 53655765 2353687638 IN IP4 [local_ip]
+s=-
+c=IN IP4 [local_ip]
+t=0 0
+m=audio 9000 RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+a=sendonly
+]]>
+  </send>
+
+  <recv response="100" optional="true"/>
+  <!-- 200 OK MUST carry recvonly (mirror of sendonly). -->
+  <recv response="200" rtd="true">
+    <action>
+      <ereg regexp="a=recvonly"
+            search_in="msg"
+            check_it="true"
+            assign_to="hold_dir"/>
+      <log message="hold answer captured: a=[$hold_dir]"/>
+    </action>
+  </recv>
+
+  <send>
+<![CDATA[
+ACK sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]-hold-ack
+Max-Forwards: 70
+From: <sip:sipp-hold@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 ACK
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="200"/>
+
+  <!-- RESUME: same codec, direction = sendrecv. -->
+  <send>
+<![CDATA[
+INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]-resume
+Max-Forwards: 70
+From: <sip:sipp-hold@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 3 INVITE
+Contact: <sip:sipp-hold@[local_ip]:[local_port]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=user1 53655765 2353687639 IN IP4 [local_ip]
+s=-
+c=IN IP4 [local_ip]
+t=0 0
+m=audio 9000 RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+a=sendrecv
+]]>
+  </send>
+
+  <recv response="100" optional="true"/>
+  <recv response="200" rtd="true">
+    <action>
+      <ereg regexp="a=sendrecv"
+            search_in="msg"
+            check_it="true"
+            assign_to="resume_dir"/>
+      <log message="resume answer captured: a=[$resume_dir]"/>
+    </action>
+  </recv>
+
+  <send>
+<![CDATA[
+ACK sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]-resume-ack
+Max-Forwards: 70
+From: <sip:sipp-hold@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 3 ACK
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="200"/>
+
+  <!-- Tear down cleanly. -->
+  <send>
+<![CDATA[
+BYE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]-bye
+Max-Forwards: 70
+From: <sip:sipp-hold@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 4 BYE
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="200" rtd="true"/>
+
+  <ResponseTimeRepartition value="200, 500, 1000"/>
+</scenario>

--- a/test-harness/sipp-scenarios/reinvite_unsupported_codec_488.xml
+++ b/test-harness/sipp-scenarios/reinvite_unsupported_codec_488.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  reinvite_unsupported_codec_488 — the call is set up with PCMU; the
+  peer then sends a re-INVITE that proposes only G.722 (PT 9). v1
+  doesn't renegotiate codecs mid-call, so the daemon MUST reject
+  with 488 Not Acceptable Here and leave the original call alive.
+
+  Validates PR #24's `prepare_reinvite_answer` payload-type check
+  end-to-end through the SIP stack.
+-->
+<scenario name="reinvite_unsupported_codec_488">
+  <send>
+<![CDATA[
+INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+Max-Forwards: 70
+From: <sip:sipp-codec@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:sipp-codec@[local_ip]:[local_port]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=user1 53655765 2353687637 IN IP4 [local_ip]
+s=-
+c=IN IP4 [local_ip]
+t=0 0
+m=audio 9000 RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+]]>
+  </send>
+
+  <recv response="100" optional="true"/>
+  <recv response="200" rtd="true"/>
+
+  <send>
+<![CDATA[
+ACK sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]-ack
+Max-Forwards: 70
+From: <sip:sipp-codec@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="200"/>
+
+  <!-- re-INVITE proposing G.722 only — daemon answered PCMU on
+       the initial INVITE, so this is a codec-change request that
+       v1 doesn't support. -->
+  <send>
+<![CDATA[
+INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]-reinv
+Max-Forwards: 70
+From: <sip:sipp-codec@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 INVITE
+Contact: <sip:sipp-codec@[local_ip]:[local_port]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=user1 53655765 2353687638 IN IP4 [local_ip]
+s=-
+c=IN IP4 [local_ip]
+t=0 0
+m=audio 9000 RTP/AVP 9
+a=rtpmap:9 G722/8000
+a=sendrecv
+]]>
+  </send>
+
+  <recv response="100" optional="true"/>
+  <!-- MUST be 488. The original call stays up. -->
+  <recv response="488" rtd="true"/>
+
+  <send>
+<![CDATA[
+ACK sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]-reinv-ack
+Max-Forwards: 70
+From: <sip:sipp-codec@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 ACK
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="200"/>
+
+  <!-- The original call should still be alive — BYE proves it. -->
+  <send>
+<![CDATA[
+BYE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]-bye
+Max-Forwards: 70
+From: <sip:sipp-codec@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 3 BYE
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="200" rtd="true"/>
+
+  <ResponseTimeRepartition value="200, 500, 1000"/>
+</scenario>

--- a/test-harness/sipp-scenarios/run-all.sh
+++ b/test-harness/sipp-scenarios/run-all.sh
@@ -59,6 +59,8 @@ scenarios=(
     caller_cancels_during_setup.xml
     unsupported_codec_488.xml
     session_timer_echo.xml
+    reinvite_hold_resume.xml
+    reinvite_unsupported_codec_488.xml
 )
 
 run_scenario() {


### PR DESCRIPTION
## Summary
Closes the two residual issues flagged on PR #24:

### 1. End-to-end re-INVITE coverage was missing
Unit tests on \`prepare_reinvite_answer\` shipped with PR #24, but nothing drove a real mid-dialog re-INVITE through the SIP stack. Two new SIPp scenarios fix that:

- **\`reinvite_hold_resume.xml\`** — INVITE + ACK, then re-INVITE with \`sendonly\` (hold), \`<ereg check_it="true">\` asserts \`a=recvonly\` on the 2xx, ACK, re-INVITE with \`sendrecv\` (resume), assert \`a=sendrecv\`, ACK, BYE. The regex action fails the scenario if the mirror is missing — wire-level assertion.
- **\`reinvite_unsupported_codec_488.xml\`** — INVITE with PCMU, re-INVITE with G.722 only (PT 9). Daemon must reject 488 (PR #24's payload-type intersection check) and the original call must stay alive (proven by a follow-up BYE that gets 200 OK).

Both wired into \`run-all.sh\`. Manual run against the local daemon:

\`\`\`text
re-INVITE rejected 488: payload types diverge from accepted call
  (mid-call codec change unsupported in v1) offer_pts=["9"] cached_pts=["0"]
\`\`\`

### 2. Stale module-level comment in handler.rs
The header doc said re-INVITEs get a 501 "until core lands". The trait default still does that for impls that don't override, but the production \`BridgingAcceptor::on_reinvite\` (PR #17, PR #24) handles hold/resume + 488 for codec changes. Reworded to describe the actual current behaviour.

## Test plan
- [x] Run both new scenarios against a local daemon — both record \`Successful call: 1\`.
- [x] Daemon log shows the expected 488 path with \`offer_pts=["9"] cached_pts=["0"]\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)