### PR TITLE
feat(reinvite): emit Hold/Resume on WS + push peer RTP addr to forge

### DIFF
--- a/crates/bridge/src/conn.rs
+++ b/crates/bridge/src/conn.rs
@@ -122,6 +122,15 @@ pub enum OutgoingEvent {
     Mark {
         name: String,
     },
+    /// Mid-dialog re-INVITE flipped peer audio direction to
+    /// something other than `sendrecv`. The conn stamps `seq` and
+    /// emits [`BridgeOut::Hold`].
+    Hold {
+        /// `"sendonly"`, `"recvonly"`, or `"inactive"` per RFC 3264.
+        direction: String,
+    },
+    /// Direction returned to `sendrecv` after a [`Self::Hold`].
+    Resume,
     Stop {
         reason: StopReason,
     },
@@ -416,6 +425,12 @@ fn build_bridge_out(event: OutgoingEvent, call_id: CallId, seq: Seq) -> BridgeOu
             method,
         },
         OutgoingEvent::Mark { name } => BridgeOut::Mark { call_id, seq, name },
+        OutgoingEvent::Hold { direction } => BridgeOut::Hold {
+            call_id,
+            seq,
+            direction,
+        },
+        OutgoingEvent::Resume => BridgeOut::Resume { call_id, seq },
         OutgoingEvent::Stop { reason } => BridgeOut::Stop {
             call_id,
             seq,

--- a/crates/bridge/src/protocol.rs
+++ b/crates/bridge/src/protocol.rs
@@ -80,6 +80,24 @@ pub enum BridgeOut {
         duration_ms: u64,
     },
 
+    /// Mid-dialog re-INVITE flipped the audio direction to
+    /// something other than `sendrecv` — typically a soft-phone
+    /// hold (`sendonly`) or full pause (`inactive`). The server
+    /// SHOULD stop sending audio for the duration; the peer isn't
+    /// listening. The matching `Resume` event arrives when the
+    /// direction returns to `sendrecv`.
+    Hold {
+        call_id: CallId,
+        seq: Seq,
+        /// One of `"sendonly"`, `"recvonly"`, `"inactive"` —
+        /// mirrors the peer's offered direction per RFC 3264 §6.1.
+        direction: String,
+    },
+
+    /// Direction returned to `sendrecv` after a [`BridgeOut::Hold`].
+    /// The server may resume sending audio.
+    Resume { call_id: CallId, seq: Seq },
+
     /// The caller pressed a DTMF key.
     Dtmf {
         call_id: CallId,

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -64,7 +64,7 @@ use sip_uas::integrated::{AcceptInviteAsyncOutcome, IntegratedUAS};
 use sip_uas::{NegotiatedSessionTimer, SessionTimerPolicy, UserAgentServer};
 use siphon_ai_bridge::{
     AudioEncoding, AudioFormat, BridgeConfig, CallId as BridgeCallId, Direction, DisconnectReason,
-    SipMeta, StartMsg, PROTOCOL_VERSION,
+    OutgoingEvent, SipMeta, StartMsg, PROTOCOL_VERSION,
 };
 use siphon_ai_cdr::{
     AudioInfo as CdrAudioInfo, CdrRecord, CdrSinkHandle, Direction as CdrDirection, NullSink,
@@ -939,6 +939,19 @@ fn sdp_audio_payload_types(session: &forge_sdp::SessionDescription) -> Vec<Strin
         .unwrap_or_default()
 }
 
+/// Resolve the peer's RTP endpoint from an offer SDP. Media-level
+/// `c=` overrides the session-level `c=` per RFC 4566 §5.7. Returns
+/// `None` when neither carries a valid IP address or when audio is
+/// absent. Used by `on_reinvite` to push a `remote_addr` update to
+/// forge when the peer changes its RTP endpoint mid-call.
+fn sdp_audio_remote_addr(session: &forge_sdp::SessionDescription) -> Option<std::net::SocketAddr> {
+    use forge_sdp::MediaType;
+    let media = session.find_media(MediaType::Audio)?;
+    let conn = media.connection.as_ref().or(session.connection.as_ref())?;
+    let ip: std::net::IpAddr = conn.connection_address.as_str().parse().ok()?;
+    Some(std::net::SocketAddr::new(ip, media.port))
+}
+
 /// Rejection signal returned by [`prepare_reinvite_answer`] when
 /// the re-INVITE offer can't be safely answered with the cached
 /// SDP — the caller sends the carried response and exits.
@@ -960,6 +973,12 @@ struct ReinviteAnswer {
     /// the cached one by construction.
     offer_direction: Option<siphon_ai_media_glue::MediaDirection>,
     answer_direction: Option<siphon_ai_media_glue::MediaDirection>,
+    /// Peer's audio RTP endpoint advertised in the offer's media
+    /// `c=` / `m=` lines. `None` for body-less re-INVITEs. The
+    /// acceptor pushes this to forge so RTP follows the peer to
+    /// the new address instead of relying on symmetric-RTP
+    /// latching.
+    remote_addr: Option<std::net::SocketAddr>,
 }
 
 /// Validate an inbound re-INVITE against the cached initial answer
@@ -991,6 +1010,7 @@ fn prepare_reinvite_answer(
                 answer_sdp: prev_answer.to_string(),
                 offer_direction: None,
                 answer_direction: None,
+                remote_addr: None,
             });
         }
         Err(e) => {
@@ -1055,11 +1075,13 @@ fn prepare_reinvite_answer(
     let offer_direction = sdp_audio_direction(&offer_session).unwrap_or_default();
     let answer_direction = mirror_direction(offer_direction);
     let answer_sdp = rewrite_sdp_direction(prev_answer, answer_direction);
+    let remote_addr = sdp_audio_remote_addr(&offer_session);
 
     Ok(ReinviteAnswer {
         answer_sdp,
         offer_direction: Some(offer_direction),
         answer_direction: Some(answer_direction),
+        remote_addr,
     })
 }
 
@@ -1167,6 +1189,7 @@ impl CallAcceptor for BridgingAcceptor {
         let new_answer = reinvite.answer_sdp;
         let offer_direction = reinvite.offer_direction;
         let answer_direction = reinvite.answer_direction;
+        let new_remote_addr = reinvite.remote_addr;
 
         // Send 200 OK via the canonical helper so the dialog
         // manager gets the updated CSeq / route-set.
@@ -1219,6 +1242,77 @@ impl CallAcceptor for BridgingAcceptor {
                 // Keep the existing dialog + timer running; the peer
                 // can resend with a larger value.
                 return Ok(());
+            }
+        }
+
+        // Push the peer's new RTP endpoint to forge if the offer
+        // advertised one. Forge would otherwise fall back to
+        // symmetric-RTP latching — adequate when the peer keeps
+        // sending from the latched address, but brittle when the
+        // peer switches port (a soft-phone reconfigure, NAT pinhole
+        // shift) and pauses sending. The explicit update closes
+        // that gap. Best-effort: a session that just ended races
+        // with the cleanup task, so we log + ignore on miss.
+        if let (Some(addr), Some(forge_call_id)) = (new_remote_addr, entry.forge_call_id.as_ref()) {
+            if let Some(session) = self.media.session_manager().get_session(forge_call_id) {
+                let update = forge_engine::ParticipantMediaUpdate {
+                    remote_addr: Some(Some(addr)),
+                    ..Default::default()
+                };
+                match session
+                    .update_participant_media(forge_engine::ParticipantLabel::A, update)
+                    .await
+                {
+                    Ok(_) => debug!(
+                        sip_call_id = %call.sip_call_id,
+                        remote_addr = %addr,
+                        "pushed peer RTP endpoint to forge"
+                    ),
+                    Err(e) => warn!(
+                        sip_call_id = %call.sip_call_id,
+                        error = %e,
+                        "failed to push peer RTP endpoint to forge; \
+                         relying on symmetric-RTP latching"
+                    ),
+                }
+            }
+        }
+
+        // Hold / Resume emission. The cached `entry.current_direction`
+        // started at SendRecv on the initial INVITE; on each accepted
+        // re-INVITE we update it and emit a transition event when
+        // we cross the SendRecv ↔ non-SendRecv boundary. Body-less
+        // re-INVITEs (session-timer refresh) don't carry a direction
+        // and don't generate a transition.
+        if let Some(new_direction) = offer_direction {
+            let mut current = entry.current_direction.write();
+            let prev = *current;
+            *current = new_direction;
+            drop(current);
+            let was_held = prev.is_held();
+            let now_held = new_direction.is_held();
+            match (was_held, now_held) {
+                (false, true) => {
+                    debug!(
+                        sip_call_id = %call.sip_call_id,
+                        direction = new_direction.as_attr(),
+                        "emitting Hold on WS bridge"
+                    );
+                    entry.handle.push_bridge_event(OutgoingEvent::Hold {
+                        direction: new_direction.as_attr().to_string(),
+                    });
+                }
+                (true, false) => {
+                    debug!(
+                        sip_call_id = %call.sip_call_id,
+                        "emitting Resume on WS bridge"
+                    );
+                    entry.handle.push_bridge_event(OutgoingEvent::Resume);
+                }
+                _ => {
+                    // No transition (held→held with different flavor,
+                    // or sendrecv→sendrecv). No event needed.
+                }
             }
         }
 
@@ -1474,10 +1568,11 @@ impl BridgingAcceptor {
         // matching answer with just the direction flipped.
         self.registry.insert(
             prepared.sip_call_id.clone(),
-            crate::registry::CallEntry {
-                handle: prepared.handle,
-                answer_text: Some(prepared.answer.answer_text.clone()),
-            },
+            crate::registry::CallEntry::new(
+                prepared.handle,
+                Some(prepared.answer.answer_text.clone()),
+            )
+            .with_forge_call_id(prepared.forge_call_id.clone()),
         );
 
         // Per-route counter is owned-by-route — bounded cardinality
@@ -2489,5 +2584,51 @@ a=sendrecv\r\n",
         assert_eq!(outcome.offer_direction, None);
         assert_eq!(outcome.answer_direction, None);
         assert_eq!(outcome.answer_sdp, cached_answer_pcmu());
+        assert_eq!(outcome.remote_addr, None);
+    }
+
+    // ─── sdp_audio_remote_addr ─────────────────────────────────────
+
+    #[test]
+    fn reinvite_remote_addr_extracted_from_offer() {
+        // Peer changed RTP endpoint mid-call (port + connection
+        // address). prepare_reinvite_answer must surface the new
+        // address so the acceptor can push it to forge.
+        let req = invite_with(
+            Some("application/sdp"),
+            "v=0\r\n\
+o=alice 2 2 IN IP4 10.0.0.99\r\n\
+s=t\r\n\
+c=IN IP4 10.0.0.99\r\n\
+t=0 0\r\n\
+m=audio 19999 RTP/AVP 0\r\n\
+a=rtpmap:0 PCMU/8000\r\n\
+a=sendrecv\r\n",
+        );
+        let outcome = prepare_reinvite_answer(&req, cached_answer_pcmu(), "abc-123@pbx")
+            .expect("re-INVITE should be accepted");
+        let addr = outcome.remote_addr.expect("remote_addr present");
+        assert_eq!(addr.to_string(), "10.0.0.99:19999");
+    }
+
+    #[test]
+    fn reinvite_remote_addr_media_level_connection_wins() {
+        // RFC 4566 §5.7: media-level `c=` overrides session-level.
+        let req = invite_with(
+            Some("application/sdp"),
+            "v=0\r\n\
+o=alice 2 2 IN IP4 10.0.0.5\r\n\
+s=t\r\n\
+c=IN IP4 10.0.0.5\r\n\
+t=0 0\r\n\
+m=audio 7000 RTP/AVP 0\r\n\
+c=IN IP4 192.168.42.5\r\n\
+a=rtpmap:0 PCMU/8000\r\n\
+a=sendrecv\r\n",
+        );
+        let outcome = prepare_reinvite_answer(&req, cached_answer_pcmu(), "abc-123@pbx")
+            .expect("re-INVITE should be accepted");
+        let addr = outcome.remote_addr.expect("remote_addr present");
+        assert_eq!(addr.to_string(), "192.168.42.5:7000");
     }
 }

--- a/crates/core/src/call.rs
+++ b/crates/core/src/call.rs
@@ -180,14 +180,22 @@ pub struct CallHandle {
     /// without it, a WS-side `hangup` would leave the SIP leg up
     /// because the controller only stops the WS/tap path.
     remote_bye: std::sync::Arc<AtomicBool>,
+    /// External-event push channel. The acceptor's `on_reinvite`
+    /// uses this to surface mid-dialog state changes (currently
+    /// `Hold` / `Resume`) to the WS bridge without going through
+    /// the controller's main select loop. Cloned from the same
+    /// sender the controller and tap push onto, so all three
+    /// producers feed one consumer (the bridge task).
+    bridge_events_tx: mpsc::Sender<OutgoingEvent>,
 }
 
 impl CallHandle {
-    fn new(call_id: CallId) -> Self {
+    fn new(call_id: CallId, bridge_events_tx: mpsc::Sender<OutgoingEvent>) -> Self {
         Self {
             notify: std::sync::Arc::new(Notify::new()),
             call_id,
             remote_bye: std::sync::Arc::new(AtomicBool::new(false)),
+            bridge_events_tx,
         }
     }
 
@@ -214,23 +222,48 @@ impl CallHandle {
     pub fn call_id(&self) -> &CallId {
         &self.call_id
     }
+
+    /// Push an event to the WS bridge from outside the controller's
+    /// own select loop. Used by the acceptor's `on_reinvite` to
+    /// emit `Hold` / `Resume` events when peer direction changes
+    /// without having to route through the controller. `try_send`
+    /// rather than `send` so a backed-up control channel (which
+    /// means the bridge is in trouble) doesn't block the SIP
+    /// dispatch thread. Drop with a warn — re-INVITE events are
+    /// informational and a missed Hold/Resume isn't fatal.
+    pub fn push_bridge_event(&self, event: OutgoingEvent) {
+        if let Err(e) = self.bridge_events_tx.try_send(event) {
+            tracing::warn!(
+                call_id = %self.call_id,
+                error = %e,
+                "bridge_events_tx full or closed; dropping external event"
+            );
+        }
+    }
 }
 
 /// The controller itself.
 pub struct CallController {
     cfg: CallControllerConfig,
     handle: CallHandle,
+    /// Receiver side of the OutgoingEvent channel whose sender
+    /// is on the handle. Lives here until `run()` hands it to the
+    /// bridge task.
+    control_out_rx: mpsc::Receiver<OutgoingEvent>,
 }
 
 impl CallController {
     /// Construct a controller. Returns it together with a
     /// [`CallHandle`] the spawner can use to signal shutdown.
     pub fn new(cfg: CallControllerConfig) -> (Self, CallHandle) {
-        let handle = CallHandle::new(cfg.call_id.clone());
+        let (control_out_tx, control_out_rx) =
+            mpsc::channel::<OutgoingEvent>(CONTROL_CHANNEL_CAPACITY);
+        let handle = CallHandle::new(cfg.call_id.clone(), control_out_tx);
         (
             Self {
                 cfg,
                 handle: handle.clone(),
+                control_out_rx,
             },
             handle,
         )
@@ -246,7 +279,11 @@ impl CallController {
     /// [`CallOutcome`] is the source of truth for what happened.
     #[instrument(skip(self), fields(call_id = %self.cfg.call_id))]
     pub async fn run(self) -> Result<CallOutcome, CallError> {
-        let CallController { cfg, handle } = self;
+        let CallController {
+            cfg,
+            handle,
+            control_out_rx,
+        } = self;
         let CallControllerConfig {
             call_id,
             bridge,
@@ -262,9 +299,11 @@ impl CallController {
         let (caller_audio_tx, caller_audio_rx) = mpsc::channel::<Vec<u8>>(AUDIO_CHANNEL_CAPACITY);
         // bridge → tap: 20 ms PCM16 frames from server (playout)
         let (playout_audio_tx, playout_audio_rx) = mpsc::channel::<Vec<u8>>(AUDIO_CHANNEL_CAPACITY);
-        // controller → bridge: outgoing events (Stop, Mark, …)
-        let (control_out_tx, control_out_rx) =
-            mpsc::channel::<OutgoingEvent>(CONTROL_CHANNEL_CAPACITY);
+        // controller → bridge: outgoing events (Stop, Mark, …). The
+        // sender lives on the CallHandle so external callers
+        // (acceptor's on_reinvite) can push too. The controller
+        // gets its own clone via the handle.
+        let control_out_tx = handle.bridge_events_tx.clone();
         // bridge → controller: BridgeIn from server
         let (control_in_tx, mut control_in_rx) =
             mpsc::channel::<BridgeIn>(CONTROL_CHANNEL_CAPACITY);

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -43,6 +43,8 @@ use siphon_ai_sip_glue::DialogTerminator;
 use tracing::{debug, warn};
 
 use crate::call::CallHandle;
+use forge_core::CallId as ForgeCallId;
+use siphon_ai_media_glue::MediaDirection;
 
 /// Per-call session state the registry tracks. Beyond the shutdown
 /// handle, we cache the answer SDP we sent for the initial INVITE so
@@ -56,6 +58,40 @@ pub struct CallEntry {
     /// `None` for legacy tests / callers that don't track it; the
     /// re-INVITE handler returns 501 in that case.
     pub answer_text: Option<String>,
+    /// The audio direction the call is currently in. Set to
+    /// `SendRecv` on accept; updated to the new offer's direction
+    /// on every accepted re-INVITE. Lets the acceptor emit
+    /// `Hold` / `Resume` only on transitions rather than on every
+    /// mid-dialog re-INVITE.
+    pub current_direction: Arc<RwLock<MediaDirection>>,
+    /// Forge engine's per-call id. Needed by `on_reinvite` to push
+    /// a peer RTP-address update through `SessionManager::get_session`
+    /// when the peer's m=audio port or c= address changes
+    /// mid-call. `None` for test fixtures that don't drive
+    /// re-INVITE.
+    pub forge_call_id: Option<ForgeCallId>,
+}
+
+impl CallEntry {
+    /// Build a fresh entry for a just-accepted call. Initial
+    /// direction is `SendRecv` (the only direction we accept on
+    /// the initial INVITE in v1). `forge_call_id` is `None` here;
+    /// production callers set it via [`Self::with_forge_call_id`].
+    pub fn new(handle: CallHandle, answer_text: Option<String>) -> Self {
+        Self {
+            handle,
+            answer_text,
+            current_direction: Arc::new(RwLock::new(MediaDirection::SendRecv)),
+            forge_call_id: None,
+        }
+    }
+
+    /// Attach the forge engine call id so re-INVITE handling can
+    /// push remote_addr updates through `SessionManager`.
+    pub fn with_forge_call_id(mut self, forge_call_id: ForgeCallId) -> Self {
+        self.forge_call_id = Some(forge_call_id);
+        self
+    }
 }
 
 /// Process-wide handle table. Cheap to clone (`Arc` inside).
@@ -182,10 +218,7 @@ mod tests {
     /// `CallController`. Cheaper than mocking and exercises the
     /// actual handle plumbing.
     fn fresh_entry(bridge_call_id: &str) -> CallEntry {
-        CallEntry {
-            handle: fresh_handle(bridge_call_id),
-            answer_text: None,
-        }
+        CallEntry::new(fresh_handle(bridge_call_id), None)
     }
 
     fn fresh_handle(bridge_call_id: &str) -> CallHandle {
@@ -237,13 +270,7 @@ mod tests {
         assert_eq!(reg.len(), 0);
 
         let h = fresh_handle("siphon-1");
-        reg.insert(
-            "abc@pbx",
-            CallEntry {
-                handle: h.clone(),
-                answer_text: None,
-            },
-        );
+        reg.insert("abc@pbx", CallEntry::new(h.clone(), None));
         assert_eq!(reg.len(), 1);
 
         let looked_up = reg.lookup("abc@pbx").expect("present");
@@ -319,13 +346,7 @@ mod tests {
         let handle = fresh_handle("siphon-1");
         assert!(!handle.remote_bye_received());
 
-        reg.insert(
-            "abc@pbx",
-            CallEntry {
-                handle: handle.clone(),
-                answer_text: None,
-            },
-        );
+        reg.insert("abc@pbx", CallEntry::new(handle.clone(), None));
 
         let signalled = reg.terminate_from_bye("abc@pbx");
         assert!(signalled);
@@ -340,13 +361,7 @@ mod tests {
         // shutdown" semantics.
         let reg = CallRegistry::new();
         let handle = fresh_handle("siphon-2");
-        reg.insert(
-            "xyz@pbx",
-            CallEntry {
-                handle: handle.clone(),
-                answer_text: None,
-            },
-        );
+        reg.insert("xyz@pbx", CallEntry::new(handle.clone(), None));
 
         let signalled = reg.terminate("xyz@pbx");
         assert!(signalled);

--- a/crates/core/tests/acceptor_prepare.rs
+++ b/crates/core/tests/acceptor_prepare.rs
@@ -284,10 +284,10 @@ async fn prepare_exposes_handle_and_sip_call_id_for_registry_use() {
     // Mirror the on_matched register step.
     registry.insert(
         prepared.sip_call_id.clone(),
-        siphon_ai_core::registry::CallEntry {
-            handle: prepared.handle,
-            answer_text: Some(prepared.answer.answer_text.clone()),
-        },
+        siphon_ai_core::registry::CallEntry::new(
+            prepared.handle,
+            Some(prepared.answer.answer_text.clone()),
+        ),
     );
     let looked_up = registry.lookup("abc-123@pbx.example.com").expect("present");
     assert_eq!(looked_up.call_id().as_str(), "siphon-test-fixed");

--- a/crates/core/tests/hold_resume.rs
+++ b/crates/core/tests/hold_resume.rs
@@ -1,0 +1,151 @@
+//! Integration: hold/resume → WS `hold` and `resume` events.
+//!
+//! Covers the path that the unit tests on `prepare_reinvite_answer`
+//! can't reach: the actual `OutgoingEvent` channel from
+//! `CallHandle::push_bridge_event` through the bridge task and out
+//! onto the WS as a JSON event. The acceptor's `on_reinvite` uses
+//! `push_bridge_event` to emit `Hold` / `Resume` on direction
+//! transitions; this test pins that wiring.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use forge_core::CallId as ForgeCallId;
+use forge_engine::MediaBridgeManager;
+use futures::{SinkExt, StreamExt};
+use serde_json::Value;
+use siphon_ai_bridge::{
+    AudioEncoding, AudioFormat, BridgeConfig, CallId as BridgeCallId, Direction, OutgoingEvent,
+    SipMeta, StartMsg,
+};
+use siphon_ai_core::{CallController, CallControllerConfig};
+use siphon_ai_media_glue::MediaTap;
+use tokio::net::TcpListener;
+use tokio_tungstenite::tungstenite::handshake::server::{
+    ErrorResponse as HsErrorResponse, Request as HsRequest, Response as HsResponse,
+};
+use tokio_tungstenite::tungstenite::http::HeaderValue;
+use tokio_tungstenite::tungstenite::Message;
+
+#[allow(clippy::result_large_err)]
+fn echo_subprotocol(req: &HsRequest, mut resp: HsResponse) -> Result<HsResponse, HsErrorResponse> {
+    if let Some(offered) = req.headers().get("Sec-WebSocket-Protocol") {
+        resp.headers_mut().insert(
+            "Sec-WebSocket-Protocol",
+            HeaderValue::from_bytes(offered.as_bytes()).unwrap(),
+        );
+    }
+    Ok(resp)
+}
+
+/// WS server that captures every text frame's `type` + relevant
+/// payload fields, reports them back over a channel, and closes
+/// when a `stop` arrives. Used to assert event ordering and
+/// payload shape on hold/resume.
+async fn server_capture_events(
+    port_tx: tokio::sync::oneshot::Sender<u16>,
+    events_tx: tokio::sync::mpsc::UnboundedSender<Value>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    let _ = port_tx.send(port);
+    let (stream, _) = listener.accept().await.expect("accept");
+    let mut ws = tokio_tungstenite::accept_hdr_async(stream, echo_subprotocol)
+        .await
+        .expect("ws accept");
+
+    while let Some(msg) = ws.next().await {
+        match msg {
+            Ok(Message::Text(t)) => {
+                let v: Value = serde_json::from_str(&t).unwrap_or(Value::Null);
+                let _ = events_tx.send(v.clone());
+                if v["type"] == "stop" {
+                    let _ = ws.send(Message::Close(None)).await;
+                    break;
+                }
+            }
+            Ok(Message::Close(_)) | Err(_) => break,
+            _ => {}
+        }
+    }
+}
+
+#[tokio::test]
+async fn push_bridge_event_emits_hold_and_resume_on_ws() {
+    // 1. WS server that captures every JSON event.
+    let (port_tx, port_rx) = tokio::sync::oneshot::channel();
+    let (events_tx, mut events_rx) = tokio::sync::mpsc::unbounded_channel();
+    tokio::spawn(server_capture_events(port_tx, events_tx));
+    let port = port_rx.await.expect("server announces port");
+
+    // 2. Build a controller around a real MediaTap + WS bridge.
+    let manager = Arc::new(MediaBridgeManager::new());
+    let forge_call_id = ForgeCallId::new("siphon-hold-resume");
+    let tap = MediaTap::attach(
+        &manager,
+        &Arc::new(forge_core::EventBus::new()),
+        forge_call_id,
+        8000,
+    )
+    .expect("attach");
+    let cfg = CallControllerConfig {
+        call_id: BridgeCallId::new("siphon-hold-resume"),
+        bridge: BridgeConfig {
+            ws_url: format!("ws://127.0.0.1:{port}/"),
+            connect_timeout: Duration::from_secs(2),
+            ..Default::default()
+        },
+        start: StartMsg {
+            version: "1".into(),
+            call_id: BridgeCallId::new("siphon-hold-resume"),
+            seq: 0,
+            from: "+13125551234".into(),
+            to: "5000".into(),
+            direction: Direction::Inbound,
+            audio: AudioFormat {
+                encoding: AudioEncoding::Pcm16le,
+                sample_rate: 8000,
+                channels: 1,
+                frame_ms: 20,
+            },
+            sip: SipMeta {
+                call_id: "hold-resume@pbx".into(),
+                headers: HashMap::new(),
+            },
+        },
+        media_tap: tap,
+        transfer: None,
+    };
+    let (controller, handle) = CallController::new(cfg);
+    let run = tokio::spawn(async move { controller.run().await });
+
+    // 3. Wait for the `start` to land, then drive hold/resume from
+    //    "outside" the controller exactly the way `on_reinvite` does.
+    let start = tokio::time::timeout(Duration::from_secs(2), events_rx.recv())
+        .await
+        .expect("start event arrives")
+        .expect("channel open");
+    assert_eq!(start["type"], "start");
+
+    handle.push_bridge_event(OutgoingEvent::Hold {
+        direction: "sendonly".into(),
+    });
+    let hold = tokio::time::timeout(Duration::from_secs(2), events_rx.recv())
+        .await
+        .expect("hold event arrives")
+        .expect("channel open");
+    assert_eq!(hold["type"], "hold");
+    assert_eq!(hold["direction"], "sendonly");
+
+    handle.push_bridge_event(OutgoingEvent::Resume);
+    let resume = tokio::time::timeout(Duration::from_secs(2), events_rx.recv())
+        .await
+        .expect("resume event arrives")
+        .expect("channel open");
+    assert_eq!(resume["type"], "resume");
+
+    // 4. Drive cleanup so the controller exits.
+    handle.shutdown();
+    let _ = tokio::time::timeout(Duration::from_secs(3), run).await;
+}

--- a/crates/core/tests/registry_bye.rs
+++ b/crates/core/tests/registry_bye.rs
@@ -173,10 +173,7 @@ async fn dispatch_bye_wakes_running_controller_via_registry() {
     let registry = CallRegistry::new();
     registry.insert(
         "abc-123@pbx.example.com",
-        siphon_ai_core::registry::CallEntry {
-            handle,
-            answer_text: None,
-        },
+        siphon_ai_core::registry::CallEntry::new(handle, None),
     );
 
     let run = tokio::spawn(async move { controller.run().await });
@@ -258,10 +255,7 @@ async fn bye_drives_wire_stop_with_caller_hangup_reason() {
     let registry = CallRegistry::new();
     registry.insert(
         "bye-reason@pbx",
-        siphon_ai_core::registry::CallEntry {
-            handle,
-            answer_text: None,
-        },
+        siphon_ai_core::registry::CallEntry::new(handle, None),
     );
 
     let run = tokio::spawn(async move { controller.run().await });

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -148,7 +148,27 @@ Emitted only when `bridge.vad = true` is configured. Default off.
 
 `ts_ms` is monotonic milliseconds since `start` was sent (NOT wall-clock).
 
-### 3.3 `dtmf` — caller pressed a key
+### 3.3 `hold` / `resume` — peer paused or resumed media
+
+Emitted when a mid-dialog re-INVITE flips the audio direction
+across the `sendrecv` boundary. SiphonAI mirrors the peer's
+direction per RFC 3264 §6.1 and reports the transition here so the
+server can stop / resume sending audio. Servers SHOULD pause
+outbound audio for the duration of the hold — the peer isn't
+listening — and resume on `resume`.
+
+```json
+{ "type": "hold", "call_id": "...", "seq": 95, "direction": "sendonly" }
+{ "type": "resume", "call_id": "...", "seq": 142 }
+```
+
+`direction` is one of `"sendonly"`, `"recvonly"`, or `"inactive"`.
+Transitions between non-`sendrecv` states (e.g. `sendonly` →
+`inactive`) do NOT emit a second `hold` — the server already knows
+the call is paused. The matching `resume` arrives when the peer
+returns to `sendrecv`.
+
+### 3.4 `dtmf` — caller pressed a key
 
 ```json
 { "type": "dtmf", "call_id": "...", "seq": 88, "digit": "5", "duration_ms": 120, "method": "rfc2833" }
@@ -157,7 +177,7 @@ Emitted only when `bridge.vad = true` is configured. Default off.
 `digit` is one of `0-9 * # A B C D`.
 `method` is `"rfc2833"` or `"inband"` — depending on detection source.
 
-### 3.4 `mark` — playback marker fired
+### 3.5 `mark` — playback marker fired
 
 The acknowledgement to a server-initiated `mark` (§4.2). SiphonAI emits
 this when the audio queued *before* the server's `mark` request has
@@ -167,7 +187,7 @@ been fully played out into the call.
 { "type": "mark", "call_id": "...", "seq": 91, "name": "greeting_done" }
 ```
 
-### 3.5 `stop` — call ended
+### 3.6 `stop` — call ended
 
 ```json
 { "type": "stop", "call_id": "...", "seq": 200, "reason": "caller_hangup" }
@@ -186,7 +206,7 @@ been fully played out into the call.
 `stop` is the last message SiphonAI sends on the connection. SiphonAI
 then closes the WebSocket cleanly (close code 1000).
 
-### 3.6 `error` — fatal error
+### 3.7 `error` — fatal error
 
 ```json
 { "type": "error", "call_id": "...", "seq": 201, "code": "rtp_timeout", "message": "no RTP for 30s on leg A" }

--- a/examples/echo-ws-server-python/server.py
+++ b/examples/echo-ws-server-python/server.py
@@ -189,7 +189,15 @@ async def handle(connection: ServerConnection, opts: Options) -> None:
                 # simply drop out of the loop.
                 break
 
-            elif mtype in {"speech_started", "speech_stopped", "dtmf", "mark", "error"}:
+            elif mtype in {
+                "speech_started",
+                "speech_stopped",
+                "dtmf",
+                "mark",
+                "hold",
+                "resume",
+                "error",
+            }:
                 LOG.info("%s: %s", mtype, _redact(msg))
 
             else:


### PR DESCRIPTION
## Summary
Two residual hold/resume gaps from the code-review audit:

### 1. Hold/resume was signaling-only — no WS state event
PROTOCOL.md had no hold/resume event, and \`MediaDirection::is_held\` was a dead-letter helper. A sendonly/inactive re-INVITE got 200 OK on the wire and the WS server kept sending audio at a peer that wasn't listening — missing DEV_PLAN.md §9 Week-3 acceptance ("Hold via softphone causes WS audio to pause").

- New \`BridgeOut::Hold { direction }\` and \`BridgeOut::Resume\` events (additive, no version bump). Documented in PROTOCOL.md §3.3.
- \`CallHandle\` gains a \`bridge_events_tx\` cloned from the same OutgoingEvent channel the controller and tap push onto. New \`push_bridge_event\` lets the acceptor inject events without spawning a sub-task.
- \`CallEntry\` tracks \`current_direction\` so the acceptor emits Hold/Resume only on transitions across the \`sendrecv\` boundary.
- \`on_reinvite\` reads the cached direction, updates it, pushes the right event when crossing the boundary.
- echo-ws example logs \`hold\` and \`resume\`.

### 2. peer RTP address change wasn't pushed to forge
Same-codec re-INVITE that moved the peer's m=audio port or c= line: daemon answered 200 OK and left forge on symmetric-RTP latching. A peer that changes port and pauses sending (NAT rebind, soft-phone reconfigure) was unreachable until it re-sent.

- New \`sdp_audio_remote_addr\` helper resolves the peer endpoint per RFC 4566 §5.7 (media-level \`c=\` wins over session-level).
- \`prepare_reinvite_answer\` returns the address on the outcome.
- \`CallEntry\` carries the forge \`CallId\` so on_reinvite drives \`SessionManager::get_session(...).update_participant_media(ParticipantLabel::A, { remote_addr: Some(Some(addr)), .. })\`. Best-effort — race losses log + continue, the 200 OK still goes out.

## Test plan
- [x] 2 unit tests: \`reinvite_remote_addr_extracted_from_offer\`, \`reinvite_remote_addr_media_level_connection_wins\` (RFC 4566 §5.7).
- [x] 1 integration test \`hold_resume.rs\`: WS server captures JSON events, asserts \`type: hold\` + \`direction: "sendonly"\` then \`type: resume\` after \`push_bridge_event(Hold/Resume)\`.
- [x] \`cargo test --workspace\` — all green.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean.
- [x] \`cargo fmt --all -- --check\` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)