### PR TITLE
feat(trunk): [[trunk]] allowlist + 403 at the SIP layer

### DIFF
--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -139,6 +139,7 @@ impl Runtime {
             bridge_defaults,
             routes,
             registrations,
+            trunks,
             cdr,
             observability,
             webhooks,
@@ -239,11 +240,21 @@ impl Runtime {
 
         // ─── SIP routing handler ───────────────────────────────────
         let dialog_terminator: DialogTerminatorHandle = Arc::new(registry);
-        let routing_handler = Arc::new(
+        // Trunk allowlist gate. Installed only when the operator
+        // declared one or more `[[trunk]]` blocks; with zero blocks
+        // we leave the gate unset and the routing handler accepts
+        // INVITEs from any source (legacy posture, documented as
+        // dev / behind-firewall only).
+        let mut routing_handler_builder =
             RoutingHandler::new(Arc::new(routes), Arc::clone(&acceptor))
                 .with_dialog_terminator(dialog_terminator)
-                .with_register_source_resolver(register_source_resolver(&registration_mgr)),
-        );
+                .with_register_source_resolver(register_source_resolver(&registration_mgr));
+        if !trunks.is_empty() {
+            let gate: Arc<dyn siphon_ai_sip_glue::TrunkAllowlist> =
+                Arc::new(ConfigTrunkAllowlist::new(trunks));
+            routing_handler_builder = routing_handler_builder.with_trunk_gate(gate);
+        }
+        let routing_handler = Arc::new(routing_handler_builder);
 
         // ─── SIP transports + transaction manager ──────────────────
         // Bind UDP eagerly so a port-busy error surfaces here, not
@@ -594,6 +605,78 @@ fn register_source_resolver(mgr: &RegistrationManager) -> RegisterSourceResolver
         Some(name) => name,
         None => "trunk".to_string(),
     })
+}
+
+/// `[[trunk]]` allowlist consulted by the routing handler on every
+/// new INVITE. Walks the operator-declared list in order: an entry
+/// matches when its source-IP allowlist (if any) AND its
+/// From-host allowlist (if any) both match. The first matching
+/// trunk's name becomes the call's `register_source`. No match →
+/// the handler responds 403. See `docs/CONFIG.md` §11 for the
+/// threat model.
+struct ConfigTrunkAllowlist {
+    trunks: Vec<siphon_ai_config::TrunkConfig>,
+}
+
+impl ConfigTrunkAllowlist {
+    fn new(trunks: Vec<siphon_ai_config::TrunkConfig>) -> Self {
+        Self { trunks }
+    }
+
+    /// Extract the host part of the inbound INVITE's `From:` URI,
+    /// lowercased for case-insensitive match. Returns `None` when
+    /// the header is missing or the URI doesn't parse — those
+    /// requests can still match an IP-only trunk but never a
+    /// from_hosts-only one.
+    fn extract_from_host(request: &sip_core::Request) -> Option<String> {
+        let raw = request.headers().get_smol("From")?;
+        // SIP `From` headers look like `"Display" <sip:user@host:port>;tag=…`
+        // or bare `sip:user@host` — pull out whatever is between the
+        // first `@` and the next `;` / `>` / end-of-string.
+        let s = raw.as_str();
+        let at = s.find('@')?;
+        let after_at = &s[at + 1..];
+        let end = after_at
+            .find(['>', ';', ' ', '\t'])
+            .unwrap_or(after_at.len());
+        let host_with_port = &after_at[..end];
+        // Strip optional `:port`.
+        let host = match host_with_port.rfind(':') {
+            Some(colon) => &host_with_port[..colon],
+            None => host_with_port,
+        };
+        if host.is_empty() {
+            return None;
+        }
+        Some(host.to_ascii_lowercase())
+    }
+}
+
+impl siphon_ai_sip_glue::TrunkAllowlist for ConfigTrunkAllowlist {
+    fn identify(
+        &self,
+        request: &sip_core::Request,
+        ctx: &sip_transaction::TransportContext,
+    ) -> Option<String> {
+        let peer_ip = ctx.peer().ip();
+        let from_host = Self::extract_from_host(request);
+        for trunk in &self.trunks {
+            let ip_ok = trunk.peer_addrs.is_empty()
+                || trunk
+                    .peer_addrs
+                    .iter()
+                    .any(|cidr: &siphon_ai_config::TrunkCidr| cidr.contains(peer_ip));
+            let host_ok = trunk.from_hosts.is_empty()
+                || from_host
+                    .as_deref()
+                    .map(|h| trunk.from_hosts.iter().any(|allowed| allowed == h))
+                    .unwrap_or(false);
+            if ip_ok && host_ok {
+                return Some(trunk.name.clone());
+            }
+        }
+        None
+    }
 }
 
 /// Load the TLS server config (cert + key) from disk paths in
@@ -1012,3 +1095,158 @@ impl TransportDispatcher for MultiTransportDispatcher {
 /// — but reserved for the future drain-active-calls path.
 #[allow(dead_code)]
 pub const SHUTDOWN_GRACE: Duration = Duration::from_secs(2);
+
+#[cfg(test)]
+mod trunk_allowlist_tests {
+    use super::*;
+    use bytes::Bytes;
+    use sip_core::{Headers as SipHeaders, Method, Request, RequestLine, SipUri};
+    use siphon_ai_config::{TrunkCidr, TrunkConfig};
+
+    fn invite_with_from(from_header: &str) -> Request {
+        let uri = SipUri::parse("sip:9000@siphon.example.com").unwrap();
+        let mut h = SipHeaders::new();
+        h.push("Via", "SIP/2.0/UDP test;branch=z9hG4bK1").unwrap();
+        h.push("From", from_header).unwrap();
+        h.push("To", "<sip:9000@siphon.example.com>").unwrap();
+        h.push("Call-ID", "trunk-test").unwrap();
+        h.push("CSeq", "1 INVITE").unwrap();
+        Request::new(RequestLine::new(Method::Invite, uri), h, Bytes::new()).unwrap()
+    }
+
+    #[test]
+    fn extract_from_host_handles_bracketed_uri() {
+        let req = invite_with_from("\"Alice\" <sip:alice@10.0.0.10:5060>;tag=abc");
+        assert_eq!(
+            ConfigTrunkAllowlist::extract_from_host(&req).as_deref(),
+            Some("10.0.0.10"),
+        );
+    }
+
+    #[test]
+    fn extract_from_host_handles_bare_uri() {
+        let req = invite_with_from("sip:carrier@sip.carrier.example;tag=xyz");
+        assert_eq!(
+            ConfigTrunkAllowlist::extract_from_host(&req).as_deref(),
+            Some("sip.carrier.example"),
+        );
+    }
+
+    #[test]
+    fn extract_from_host_lowercases() {
+        let req = invite_with_from("<sip:bob@SIP.CARRIER.EXAMPLE>;tag=t");
+        assert_eq!(
+            ConfigTrunkAllowlist::extract_from_host(&req).as_deref(),
+            Some("sip.carrier.example"),
+        );
+    }
+
+    fn allowlist(trunks: Vec<TrunkConfig>) -> ConfigTrunkAllowlist {
+        ConfigTrunkAllowlist::new(trunks)
+    }
+
+    fn ctx(peer: &str) -> sip_transaction::TransportContext {
+        sip_transaction::TransportContext::new(
+            sip_transaction::TransportKind::Udp,
+            peer.parse().unwrap(),
+            None,
+        )
+    }
+
+    #[test]
+    fn ip_only_trunk_matches_in_range() {
+        let trunks = vec![TrunkConfig {
+            name: "fs".into(),
+            peer_addrs: vec![TrunkCidr::parse("10.0.0.0/24").unwrap()],
+            from_hosts: vec![],
+        }];
+        let gate = allowlist(trunks);
+        let req = invite_with_from("<sip:caller@somewhere>;tag=t");
+        assert_eq!(
+            siphon_ai_sip_glue::TrunkAllowlist::identify(&gate, &req, &ctx("10.0.0.5:5060")),
+            Some("fs".to_string()),
+        );
+        assert_eq!(
+            siphon_ai_sip_glue::TrunkAllowlist::identify(&gate, &req, &ctx("10.0.1.5:5060")),
+            None,
+        );
+    }
+
+    #[test]
+    fn from_host_only_trunk_matches_regardless_of_ip() {
+        let trunks = vec![TrunkConfig {
+            name: "carrier".into(),
+            peer_addrs: vec![],
+            from_hosts: vec!["sip.carrier.example".into()],
+        }];
+        let gate = allowlist(trunks);
+        let req = invite_with_from("<sip:in@sip.carrier.example>;tag=t");
+        assert_eq!(
+            siphon_ai_sip_glue::TrunkAllowlist::identify(&gate, &req, &ctx("203.0.113.99:5060")),
+            Some("carrier".to_string()),
+        );
+        // Wrong From host → no match even if IP would have been ok
+        // (which it isn't here since we didn't set peer_addrs).
+        let bad_req = invite_with_from("<sip:in@evil.example>;tag=t");
+        assert_eq!(
+            siphon_ai_sip_glue::TrunkAllowlist::identify(
+                &gate,
+                &bad_req,
+                &ctx("203.0.113.99:5060")
+            ),
+            None,
+        );
+    }
+
+    #[test]
+    fn ip_and_from_host_both_required_when_both_set() {
+        let trunks = vec![TrunkConfig {
+            name: "strict".into(),
+            peer_addrs: vec![TrunkCidr::parse("10.0.0.10").unwrap()],
+            from_hosts: vec!["sip.carrier.example".into()],
+        }];
+        let gate = allowlist(trunks);
+        let good_req = invite_with_from("<sip:in@sip.carrier.example>;tag=t");
+        let bad_host_req = invite_with_from("<sip:in@evil.example>;tag=t");
+        assert_eq!(
+            siphon_ai_sip_glue::TrunkAllowlist::identify(&gate, &good_req, &ctx("10.0.0.10:5060")),
+            Some("strict".to_string()),
+        );
+        // Right IP, wrong From → 403.
+        assert_eq!(
+            siphon_ai_sip_glue::TrunkAllowlist::identify(
+                &gate,
+                &bad_host_req,
+                &ctx("10.0.0.10:5060"),
+            ),
+            None,
+        );
+        // Right From, wrong IP → 403.
+        assert_eq!(
+            siphon_ai_sip_glue::TrunkAllowlist::identify(&gate, &good_req, &ctx("10.0.0.11:5060")),
+            None,
+        );
+    }
+
+    #[test]
+    fn first_matching_trunk_wins() {
+        let trunks = vec![
+            TrunkConfig {
+                name: "first".into(),
+                peer_addrs: vec![TrunkCidr::parse("10.0.0.0/16").unwrap()],
+                from_hosts: vec![],
+            },
+            TrunkConfig {
+                name: "second".into(),
+                peer_addrs: vec![TrunkCidr::parse("10.0.0.0/8").unwrap()],
+                from_hosts: vec![],
+            },
+        ];
+        let gate = allowlist(trunks);
+        let req = invite_with_from("<sip:c@x>;tag=t");
+        assert_eq!(
+            siphon_ai_sip_glue::TrunkAllowlist::identify(&gate, &req, &ctx("10.0.5.1:5060")),
+            Some("first".to_string()),
+        );
+    }
+}

--- a/configs/trunk-403-test.toml
+++ b/configs/trunk-403-test.toml
@@ -1,0 +1,25 @@
+[node]
+id = "siphon-trunk-test"
+
+[sip]
+listen = "127.0.0.1:5060"
+transports = ["udp"]
+
+[media]
+codecs = ["pcmu", "pcma"]
+rtp_port_range = [40600, 40700]
+inactivity_timeout_secs = 0
+
+[bridge]
+ws_url = "ws://127.0.0.1:8765/"
+
+# Allowlist that DOESN'T cover 127.0.0.1 — every loopback INVITE
+# should hit the 403 path. Used by trunk_unauthorized_403.xml.
+[[trunk]]
+name = "lan-only"
+peer_addrs = ["10.0.0.0/8"]
+
+[[route]]
+name = "default"
+[route.match]
+any = true

--- a/crates/config/src/compile.rs
+++ b/crates/config/src/compile.rs
@@ -54,6 +54,12 @@ pub struct Config {
     pub bridge_defaults: BridgeDefaults,
     pub routes: RouteSet,
     pub registrations: Vec<RegisterConfig>,
+    /// `[[trunk]]` allowlist. Empty when no trunk blocks were
+    /// declared (daemon accepts INVITEs from any source —
+    /// "legacy" posture, documented as dev / behind-firewall
+    /// only). Non-empty enables strict-allowlist mode: every
+    /// inbound INVITE must match a trunk or it's 403'd.
+    pub trunks: Vec<TrunkConfig>,
     pub cdr: CdrConfig,
     pub observability: ObservabilityConfig,
     pub webhooks: WebhooksConfig,
@@ -82,6 +88,108 @@ pub struct RegisterConfig {
     pub realm: Option<String>,
     pub expires: Duration,
     pub register_on_startup: bool,
+}
+
+/// Compiled `[[trunk]]` allowlist entry. The daemon's sip-glue
+/// `TrunkMatcher` walks these in order on each inbound INVITE;
+/// when both `peer_addrs` and `from_hosts` are populated, both
+/// must match (defense in depth).
+#[derive(Debug, Clone)]
+pub struct TrunkConfig {
+    pub name: String,
+    /// Allowed source addresses as parsed CIDR ranges. An exact
+    /// IP is stored as a `/32` (IPv4) or `/128` (IPv6).
+    /// Empty when `peer_addrs` was unset in the raw config — the
+    /// matcher then skips the IP check for this trunk.
+    pub peer_addrs: Vec<TrunkCidr>,
+    /// Allowed From-URI hostnames, lowercased. Empty = skip
+    /// From-host check.
+    pub from_hosts: Vec<String>,
+}
+
+/// CIDR range matcher used by [`TrunkConfig::peer_addrs`]. Stored
+/// pre-parsed at config-load time so the per-INVITE match is a
+/// few bit-and / compare ops rather than re-parsing strings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TrunkCidr {
+    pub network: std::net::IpAddr,
+    /// Prefix length in bits. 32 for an exact IPv4, 128 for IPv6.
+    pub prefix_len: u8,
+}
+
+impl TrunkCidr {
+    /// Parse `"a.b.c.d"` or `"a.b.c.d/n"`. Hosts-only strings get
+    /// an implicit `/32` (IPv4) or `/128` (IPv6).
+    pub fn parse(s: &str) -> Result<Self, TrunkCidrParseError> {
+        let (host, prefix) = match s.find('/') {
+            Some(slash) => {
+                let prefix: u8 = s[slash + 1..]
+                    .parse()
+                    .map_err(|_| TrunkCidrParseError::BadPrefix(s.to_string()))?;
+                (&s[..slash], Some(prefix))
+            }
+            None => (s, None),
+        };
+        let ip: std::net::IpAddr = host
+            .parse()
+            .map_err(|_| TrunkCidrParseError::BadAddress(s.to_string()))?;
+        let prefix_len = match (ip, prefix) {
+            (std::net::IpAddr::V4(_), Some(p)) if p > 32 => {
+                return Err(TrunkCidrParseError::PrefixOutOfRange(s.to_string()));
+            }
+            (std::net::IpAddr::V6(_), Some(p)) if p > 128 => {
+                return Err(TrunkCidrParseError::PrefixOutOfRange(s.to_string()));
+            }
+            (std::net::IpAddr::V4(_), Some(p)) => p,
+            (std::net::IpAddr::V6(_), Some(p)) => p,
+            (std::net::IpAddr::V4(_), None) => 32,
+            (std::net::IpAddr::V6(_), None) => 128,
+        };
+        Ok(TrunkCidr {
+            network: ip,
+            prefix_len,
+        })
+    }
+
+    /// True iff `candidate` falls inside this CIDR.
+    pub fn contains(&self, candidate: std::net::IpAddr) -> bool {
+        match (self.network, candidate) {
+            (std::net::IpAddr::V4(net), std::net::IpAddr::V4(c)) => {
+                let net_bits = u32::from(net);
+                let c_bits = u32::from(c);
+                let shift = 32u32.saturating_sub(self.prefix_len as u32);
+                if shift == 32 {
+                    // /0 — matches everything.
+                    return true;
+                }
+                let mask = u32::MAX.checked_shl(shift).unwrap_or(0);
+                (net_bits & mask) == (c_bits & mask)
+            }
+            (std::net::IpAddr::V6(net), std::net::IpAddr::V6(c)) => {
+                let net_bits = u128::from(net);
+                let c_bits = u128::from(c);
+                let shift = 128u128.saturating_sub(self.prefix_len as u128);
+                if shift == 128 {
+                    return true;
+                }
+                let mask = u128::MAX.checked_shl(shift as u32).unwrap_or(0);
+                (net_bits & mask) == (c_bits & mask)
+            }
+            _ => false, // v4 ↔ v6 never match
+        }
+    }
+}
+
+/// Errors `TrunkCidr::parse` can surface. Wrapped by
+/// `CompileError::BadTrunkPeerAddr` at the config layer.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum TrunkCidrParseError {
+    #[error("not a valid IP address: {0:?}")]
+    BadAddress(String),
+    #[error("not a valid prefix length: {0:?}")]
+    BadPrefix(String),
+    #[error("prefix length out of range: {0:?}")]
+    PrefixOutOfRange(String),
 }
 
 /// Resolved lifecycle-webhook plan. The daemon binary turns this
@@ -291,6 +399,32 @@ pub enum CompileError {
     )]
     SessionTimerMinSeTooSmall(u32),
 
+    #[error("[[trunk]] block at index {index} has empty name")]
+    TrunkEmptyName { index: usize },
+
+    #[error("two [[trunk]] blocks share name {name:?} (#{first} and #{second})")]
+    TrunkDuplicateName {
+        name: String,
+        first: usize,
+        second: usize,
+    },
+
+    #[error(
+        "[[trunk]] {name:?} declares neither peer_addrs nor from_hosts — a trunk \
+         must identify its peer by IP, From-URI host, or both"
+    )]
+    TrunkNoMatchCriteria { name: String },
+
+    #[error("[[trunk]] {name:?} peer_addrs entry {value:?} is invalid: {err}")]
+    TrunkBadPeerAddr {
+        name: String,
+        value: String,
+        err: TrunkCidrParseError,
+    },
+
+    #[error("[[trunk]] {name:?} from_hosts entry {value:?} is empty / whitespace-only")]
+    TrunkEmptyFromHost { name: String, value: String },
+
     #[error("[[register]] block at index {index} has empty name")]
     RegisterEmptyName { index: usize },
 
@@ -323,6 +457,7 @@ pub fn compile(raw: RawConfig) -> Result<Config, CompileError> {
     let bridge_defaults = compile_bridge(raw.bridge, &raw.media)?;
     let routes = compile_dialplan(raw.routes)?;
     let registrations = compile_registrations(raw.registrations)?;
+    let trunks = compile_trunks(raw.trunks)?;
     let cdr = compile_cdr(raw.cdr)?;
     let observability = compile_observability(raw.observability)?;
     let webhooks = compile_webhooks(raw.webhooks)?;
@@ -341,6 +476,7 @@ pub fn compile(raw: RawConfig) -> Result<Config, CompileError> {
         bridge_defaults,
         routes,
         registrations,
+        trunks,
         cdr,
         observability,
         webhooks,
@@ -617,6 +753,65 @@ fn compile_webhooks(raw: RawWebhooks) -> Result<WebhooksConfig, CompileError> {
         retry_max: raw.retry_max.unwrap_or(3),
         timeout: Duration::from_millis(raw.timeout_ms.unwrap_or(5000)),
     })
+}
+
+fn compile_trunks(raw: Vec<crate::raw::RawTrunk>) -> Result<Vec<TrunkConfig>, CompileError> {
+    let mut compiled: Vec<TrunkConfig> = Vec::with_capacity(raw.len());
+    for (i, t) in raw.into_iter().enumerate() {
+        if t.name.trim().is_empty() {
+            return Err(CompileError::TrunkEmptyName { index: i });
+        }
+        for (j, prior) in compiled.iter().enumerate() {
+            if prior.name == t.name {
+                return Err(CompileError::TrunkDuplicateName {
+                    name: t.name.clone(),
+                    first: j,
+                    second: i,
+                });
+            }
+        }
+        let peer_addrs = match t.peer_addrs {
+            None => Vec::new(),
+            Some(values) => {
+                let mut out = Vec::with_capacity(values.len());
+                for v in values {
+                    let cidr =
+                        TrunkCidr::parse(&v).map_err(|err| CompileError::TrunkBadPeerAddr {
+                            name: t.name.clone(),
+                            value: v.clone(),
+                            err,
+                        })?;
+                    out.push(cidr);
+                }
+                out
+            }
+        };
+        let from_hosts = match t.from_hosts {
+            None => Vec::new(),
+            Some(values) => {
+                let mut out = Vec::with_capacity(values.len());
+                for v in values {
+                    if v.trim().is_empty() {
+                        return Err(CompileError::TrunkEmptyFromHost {
+                            name: t.name.clone(),
+                            value: v,
+                        });
+                    }
+                    out.push(v.trim().to_ascii_lowercase());
+                }
+                out
+            }
+        };
+        if peer_addrs.is_empty() && from_hosts.is_empty() {
+            return Err(CompileError::TrunkNoMatchCriteria { name: t.name });
+        }
+        compiled.push(TrunkConfig {
+            name: t.name,
+            peer_addrs,
+            from_hosts,
+        });
+    }
+    Ok(compiled)
 }
 
 fn compile_registrations(raw: Vec<RawRegister>) -> Result<Vec<RegisterConfig>, CompileError> {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -36,12 +36,12 @@ use thiserror::Error;
 pub use compile::{
     compile, CdrConfig, CdrFileConfig, CdrWebhookConfig, CompileError, Config, HepConfig,
     MediaConfig, NodeConfig, ObservabilityConfig, RegisterConfig, SipConfig, SipTlsConfig,
-    SipTransport, WebhooksConfig,
+    SipTransport, TrunkCidr, TrunkCidrParseError, TrunkConfig, WebhooksConfig,
 };
 pub use env::{expand, expand_cow, EnvError, EnvSource, ProcessEnv};
 pub use raw::{
     RawBridge, RawCdr, RawCdrFile, RawCdrWebhook, RawConfig, RawHep, RawMedia, RawNode,
-    RawObservability, RawRegister, RawSip, RawSipTls, RawWebhooks,
+    RawObservability, RawRegister, RawSip, RawSipTls, RawTrunk, RawWebhooks,
 };
 
 /// Top-level error type. Loaders surface this; consumers match on

--- a/crates/config/src/raw.rs
+++ b/crates/config/src/raw.rs
@@ -39,6 +39,16 @@ pub struct RawConfig {
     #[serde(default, rename = "register")]
     pub registrations: Vec<RawRegister>,
 
+    /// `[[trunk]]` — peer-trunk allowlist. Identifies inbound SIP
+    /// peers by source IP and/or From-URI host. When zero blocks
+    /// are declared, the daemon accepts INVITEs from any source
+    /// (legacy / dev posture). When one or more are declared,
+    /// every inbound INVITE must match a trunk or it's rejected
+    /// 403. See `docs/CONFIG.md` for the full grammar and threat
+    /// model.
+    #[serde(default, rename = "trunk")]
+    pub trunks: Vec<RawTrunk>,
+
     #[serde(default)]
     pub cdr: RawCdr,
 
@@ -237,6 +247,32 @@ pub struct RawRegister {
     /// during outages). Default `true`.
     #[serde(default)]
     pub register_on_startup: Option<bool>,
+}
+
+/// `[[trunk]]` — peer-trunk allowlist entry. Identifies inbound
+/// SIP peers by source IP (CIDR) and/or From-URI host. A trunk
+/// MUST declare at least one of the two fields; if both are set,
+/// BOTH must match (defense in depth). The matched trunk's `name`
+/// becomes the call's `register_source`, so routes can scope per
+/// trunk via the existing `[route.match].register_source = "..."`
+/// matcher.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawTrunk {
+    pub name: String,
+    /// Allowed source addresses. Each entry is either an exact IP
+    /// (`"203.0.113.10"`) or a CIDR (`"10.0.0.0/24"`, `"2001:db8::/32"`).
+    /// Empty / unset means "don't constrain by IP" — but the trunk
+    /// must then declare `from_hosts` instead.
+    #[serde(default)]
+    pub peer_addrs: Option<Vec<String>>,
+    /// Allowed `From:` URI hostnames (case-insensitive). Useful for
+    /// trunks whose egress IP rotates but the SIP From domain is
+    /// stable (carrier federation). From-host matching is forgeable
+    /// by an on-path attacker — pair with `peer_addrs` where
+    /// possible. See `docs/CONFIG.md` for the threat model.
+    #[serde(default)]
+    pub from_hosts: Option<Vec<String>>,
 }
 
 /// `[webhooks]` — out-of-band lifecycle events (call_start /

--- a/crates/config/tests/load.rs
+++ b/crates/config/tests/load.rs
@@ -423,6 +423,191 @@ ws_url = "wss://x/y"
     );
 }
 
+// ─── [[trunk]] allowlist ───────────────────────────────────────
+
+#[test]
+fn no_trunks_means_no_gate() {
+    // Zero [[trunk]] blocks → daemon stays in legacy "accept any
+    // source" mode. The compiled `trunks` list is empty.
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[bridge]
+ws_url = "wss://x/y"
+
+[[route]]
+name = "default"
+[route.match]
+any = true
+"#;
+    let cfg = load_from_str_with_env(toml, &env).unwrap();
+    assert!(cfg.trunks.is_empty());
+}
+
+#[test]
+fn trunk_with_ip_only_compiles() {
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[bridge]
+ws_url = "wss://x/y"
+
+[[trunk]]
+name = "freeswitch-main"
+peer_addrs = ["10.0.0.10", "10.0.1.0/24"]
+
+[[route]]
+name = "default"
+[route.match]
+any = true
+"#;
+    let cfg = load_from_str_with_env(toml, &env).unwrap();
+    assert_eq!(cfg.trunks.len(), 1);
+    let t = &cfg.trunks[0];
+    assert_eq!(t.name, "freeswitch-main");
+    assert_eq!(t.peer_addrs.len(), 2);
+    // Exact IP normalises to /32; CIDR keeps its prefix.
+    assert_eq!(t.peer_addrs[0].prefix_len, 32);
+    assert_eq!(t.peer_addrs[1].prefix_len, 24);
+    assert!(t.from_hosts.is_empty());
+}
+
+#[test]
+fn trunk_with_from_hosts_only_compiles() {
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[bridge]
+ws_url = "wss://x/y"
+
+[[trunk]]
+name = "carrier-a"
+from_hosts = ["sip.carrier-a.example", "BACKUP.CARRIER-A.example"]
+
+[[route]]
+name = "default"
+[route.match]
+any = true
+"#;
+    let cfg = load_from_str_with_env(toml, &env).unwrap();
+    let t = &cfg.trunks[0];
+    assert!(t.peer_addrs.is_empty());
+    // Lowercased + trim'd.
+    assert_eq!(
+        t.from_hosts,
+        vec!["sip.carrier-a.example", "backup.carrier-a.example"]
+    );
+}
+
+#[test]
+fn trunk_without_match_criteria_rejected() {
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[bridge]
+ws_url = "wss://x/y"
+
+[[trunk]]
+name = "anonymous"
+
+[[route]]
+name = "default"
+[route.match]
+any = true
+"#;
+    let err = load_from_str_with_env(toml, &env).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("anonymous") && msg.contains("neither peer_addrs nor from_hosts"),
+        "got: {msg}"
+    );
+}
+
+#[test]
+fn trunk_with_bad_cidr_rejected() {
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[bridge]
+ws_url = "wss://x/y"
+
+[[trunk]]
+name = "broken"
+peer_addrs = ["not-an-ip"]
+
+[[route]]
+name = "default"
+[route.match]
+any = true
+"#;
+    let err = load_from_str_with_env(toml, &env).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("broken") && msg.contains("not-an-ip"),
+        "got: {msg}"
+    );
+}
+
+#[test]
+fn duplicate_trunk_names_rejected() {
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[bridge]
+ws_url = "wss://x/y"
+
+[[trunk]]
+name = "twice"
+peer_addrs = ["10.0.0.1"]
+
+[[trunk]]
+name = "twice"
+peer_addrs = ["10.0.0.2"]
+
+[[route]]
+name = "default"
+[route.match]
+any = true
+"#;
+    let err = load_from_str_with_env(toml, &env).unwrap_err();
+    assert!(err.to_string().contains("twice"));
+}
+
+#[test]
+fn trunk_cidr_contains_v4() {
+    use siphon_ai_config::TrunkCidr;
+    let cidr = TrunkCidr::parse("10.0.0.0/24").unwrap();
+    assert!(cidr.contains("10.0.0.5".parse().unwrap()));
+    assert!(cidr.contains("10.0.0.255".parse().unwrap()));
+    assert!(!cidr.contains("10.0.1.0".parse().unwrap()));
+    let exact = TrunkCidr::parse("203.0.113.10").unwrap();
+    assert_eq!(exact.prefix_len, 32);
+    assert!(exact.contains("203.0.113.10".parse().unwrap()));
+    assert!(!exact.contains("203.0.113.11".parse().unwrap()));
+}
+
+#[test]
+fn trunk_cidr_contains_v6() {
+    use siphon_ai_config::TrunkCidr;
+    let cidr = TrunkCidr::parse("2001:db8::/32").unwrap();
+    assert!(cidr.contains("2001:db8:1::1".parse().unwrap()));
+    assert!(!cidr.contains("2001:db9::1".parse().unwrap()));
+    // v4 ↔ v6 never match.
+    assert!(!cidr.contains("10.0.0.1".parse().unwrap()));
+}
+
 #[test]
 fn dtmf_off_disables_payload_type() {
     let env = MapEnv::new([]);

--- a/crates/sip-glue/src/handler.rs
+++ b/crates/sip-glue/src/handler.rs
@@ -65,6 +65,28 @@ use crate::route::{route_invite, RouteDecision};
 /// that consults the daemon's registration registry.
 pub type RegisterSourceResolver = Arc<dyn Fn(&Request, &TransportContext) -> String + Send + Sync>;
 
+/// Allowlist gate consulted on every inbound INVITE (new dialogs
+/// only — re-INVITEs use the previously-established register
+/// source). Implementations identify the peer by source IP, From
+/// URI host, or both. When configured and the peer does not match
+/// any trunk, the routing handler rejects the INVITE with
+/// `403 Forbidden` BEFORE any route matching or media setup runs.
+///
+/// `RoutingHandler::new` installs no gate (legacy "accept any
+/// source" posture). The daemon's runtime installs a real impl
+/// when `[[trunk]]` blocks are declared in the TOML config.
+pub trait TrunkAllowlist: Send + Sync {
+    /// Identify the inbound peer. `Some(register_source)` means
+    /// the peer matched a trunk and the daemon should treat the
+    /// call as originating from that trunk's name. `None` means
+    /// no trunk matched and the routing handler should respond
+    /// `403 Forbidden`.
+    fn identify(&self, request: &Request, ctx: &TransportContext) -> Option<String>;
+}
+
+/// Convenience alias for the trait-object form.
+pub type TrunkAllowlistHandle = Arc<dyn TrunkAllowlist>;
+
 /// What [`dispatch_invite`] decided the daemon should do.
 #[derive(Debug)]
 pub enum RouteAction<'a> {
@@ -173,6 +195,11 @@ pub struct RoutingHandler<A> {
     acceptor: Arc<A>,
     resolver: RegisterSourceResolver,
     terminator: DialogTerminatorHandle,
+    /// Trunk gate. `None` means "no `[[trunk]]` blocks declared"
+    /// — accept INVITEs from any source (legacy posture). `Some`
+    /// flips the daemon into strict-allowlist mode: an INVITE
+    /// that doesn't match any trunk gets 403.
+    trunk_gate: Option<TrunkAllowlistHandle>,
 }
 
 impl<A> RoutingHandler<A> {
@@ -188,6 +215,7 @@ impl<A> RoutingHandler<A> {
             acceptor,
             resolver: default_resolver(),
             terminator: Arc::new(NullDialogTerminator),
+            trunk_gate: None,
         }
     }
 
@@ -204,6 +232,15 @@ impl<A> RoutingHandler<A> {
     /// `CallAcceptor` registers handles into.
     pub fn with_dialog_terminator(mut self, terminator: DialogTerminatorHandle) -> Self {
         self.terminator = terminator;
+        self
+    }
+
+    /// Install the trunk allowlist gate. Pass `None` (or simply
+    /// don't call this method) to keep legacy "accept any source"
+    /// behaviour. The daemon constructs an impl from the TOML
+    /// `[[trunk]]` blocks.
+    pub fn with_trunk_gate(mut self, gate: TrunkAllowlistHandle) -> Self {
+        self.trunk_gate = Some(gate);
         self
     }
 
@@ -250,7 +287,27 @@ impl<A: CallAcceptor + 'static> UasRequestHandler for RoutingHandler<A> {
                 .await;
         }
 
-        let register_source = (self.resolver)(request, ctx);
+        // Trunk allowlist gate, when configured. Runs BEFORE route
+        // matching so a rejected peer never reaches media setup or
+        // the per-call task. When no gate is installed (legacy
+        // mode), fall back to the resolver — typically "trunk".
+        let register_source = if let Some(gate) = self.trunk_gate.as_ref() {
+            match gate.identify(request, ctx) {
+                Some(name) => name,
+                None => {
+                    warn!(
+                        peer = %ctx.peer(),
+                        "INVITE rejected: no trunk matched (403 Forbidden)"
+                    );
+                    let response = UserAgentServer::create_response(request, 403, "Forbidden");
+                    handle.send_final(response).await;
+                    return Ok(());
+                }
+            }
+        } else {
+            (self.resolver)(request, ctx)
+        };
+
         match dispatch_invite(&self.routes, &register_source, request) {
             RouteAction::SendFinal(response) => {
                 handle.send_final(response).await;

--- a/crates/sip-glue/src/lib.rs
+++ b/crates/sip-glue/src/lib.rs
@@ -32,7 +32,7 @@ pub use dialog::{
 };
 pub use handler::{
     dispatch_invite, CallAcceptor, MatchedCall, RegisterSourceResolver, ReinviteCall, RouteAction,
-    RoutingHandler,
+    RoutingHandler, TrunkAllowlist, TrunkAllowlistHandle,
 };
 pub use invite::InviteFacts;
 pub use register::{

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -121,6 +121,76 @@ exponential backoff (5s → 5 min cap) on failure.
 | `expires_secs`         | integer | `3600`                  | Registration lifetime. |
 | `register_on_startup`  | bool    | `true`                  | `false` keeps the block configured-but-idle (useful for incident response). |
 
+## `[[trunk]]` — peer-trunk allowlist
+
+Identifies inbound SIP peers (other PBXes / carriers) by source IP
+and/or `From:` URI host. Acts as a 403 gate at the SIP layer so
+the daemon doesn't have to rely on a firewall in front of it for
+trust decisions.
+
+| Field        | Type     | Default      | Notes |
+|--------------|----------|--------------|-------|
+| `name`       | string   | required, unique | Dialplan handle. Becomes the call's `register_source` when this trunk matches. |
+| `peer_addrs` | string[] | unset        | Allowed source addresses. Each entry is either an exact IP (`"203.0.113.10"`) or a CIDR (`"10.0.0.0/24"`, `"2001:db8::/32"`). Exact IPs are stored as `/32` (IPv4) or `/128` (IPv6). |
+| `from_hosts` | string[] | unset        | Allowed `From:` URI hostnames, case-insensitive. For trunks whose egress IP rotates but the SIP From domain is stable. |
+
+```toml
+[[trunk]]
+name       = "freeswitch-main"
+peer_addrs = ["10.0.0.10"]
+
+[[trunk]]
+name       = "lab-pbx"
+peer_addrs = ["10.1.0.0/24"]
+
+[[trunk]]
+name       = "carrier-b"
+from_hosts = ["sip.carrier-b.example"]   # rotating IPs; pin by domain
+
+[[route]]
+name = "fs-9000"
+[route.match]
+register_source = "freeswitch-main"      # scope route to this trunk
+request_uri_user = "9000"
+```
+
+### Semantics
+
+- A trunk MUST declare at least one of `peer_addrs` / `from_hosts`.
+  A trunk with neither is refused at config load (an empty trunk
+  would accept anything claiming its name).
+- When both fields are populated, **both must match** (defense
+  in depth). For an OR relationship, declare two `[[trunk]]`
+  blocks.
+- Trunks are walked in declaration order; first match wins.
+- **Zero `[[trunk]]` blocks defined**: the daemon stays in legacy
+  "accept any source" mode. `register_source` defaults to
+  `"trunk"` for unregistered inbound (matching today's behavior).
+  Documented as **dev / behind-firewall only** — production
+  deployments should declare trunks.
+- **One or more `[[trunk]]` blocks defined**: an INVITE that
+  matches no trunk is rejected with `403 Forbidden` at the
+  routing layer, before any media setup or per-call task runs.
+  Logged at WARN with peer IP for diagnostics.
+
+### Threat model
+
+- `peer_addrs` is strong against off-path attackers. Weak against
+  on-path attackers (anyone who can spoof IPv4 source addresses on
+  your network) and against attackers who can reach you from any
+  IP inside the allowlisted CIDR.
+- `from_hosts` is a shared-secret-in-a-header pattern. Any peer
+  that can reach you on UDP 5060 can forge `From: <sip:x@your-host>`.
+  Useful as a *second factor* alongside `peer_addrs`; marginally
+  useful alone if a trusted upstream firewall validates From
+  rewrites.
+- The strong combination is `peer_addrs` + `from_hosts` + TLS
+  transport. Internet-facing deployments with `from_hosts`-only
+  trunks should pin TLS at the transport (`transports = ["tls"]`
+  with the carrier's cert pinned by the OS trust store).
+- Digest auth on inbound INVITEs (RFC 3261 §22) is the proper
+  "no trust in network" answer; it's a post-v1 feature.
+
 ## `[cdr]`
 
 ```toml

--- a/docs/FREESWITCH_INTEGRATION.md
+++ b/docs/FREESWITCH_INTEGRATION.md
@@ -50,9 +50,17 @@ inactivity_timeout_secs = 60
 ws_url                = "ws://10.0.0.30:8080/"
 ws_connect_timeout_ms = 3000
 
+# Trunk allowlist — INVITEs from any other peer get 403.
+# Required for production. See docs/CONFIG.md §"[[trunk]]" for
+# the threat model.
+[[trunk]]
+name       = "freeswitch-main"
+peer_addrs = ["10.0.0.10"]              # FreeSWITCH server
+
 [[route]]
 name = "freeswitch-9000"
 [route.match]
+register_source = "freeswitch-main"     # only accept from this trunk
 request_uri_user = "9000"
 [route.bridge]
 # Per-route override: an auth header if the bot wants it.
@@ -61,8 +69,16 @@ ws_auth_header = "Bearer ${BOT_TOKEN}"
 [[route]]
 name = "default"
 [route.match]
-any = true
+register_source = "freeswitch-main"     # still scoped to the trunk
+any             = true
 ```
+
+The trunk gate runs *before* route matching, so by the time a
+route is consulted the INVITE has already been authenticated as
+coming from `freeswitch-main`. Scoping each route by
+`register_source` isn't required for security — it's clarity:
+operators looking at the dialplan can see which routes belong
+to which trunk without having to cross-reference the gate.
 
 `BOT_TOKEN` lives in `/etc/siphon-ai/env` (see install guide
 §5). Apply with `sudo systemctl restart siphon-ai`.
@@ -86,10 +102,11 @@ isn't accepting FreeSWITCH's source IP — fix and retry.
 
 ### Gateway (peer trunk, no REGISTER)
 
-SiphonAI doesn't authenticate trunk peers in v1 — IP allowlist on
-the SiphonAI host firewall is the boundary. So the gateway here
-is "peer mode": no `register`, no `username`/`password`. Put this
-in `/etc/freeswitch/sip_profiles/external/siphon-ai.xml`:
+SiphonAI's `[[trunk]]` allowlist (above) handles peer
+identification by IP. SIP-digest auth on inbound INVITEs is
+post-v1, so the FreeSWITCH gateway runs in "peer mode": no
+`register`, no `username`/`password`. Put this in
+`/etc/freeswitch/sip_profiles/external/siphon-ai.xml`:
 
 ```xml
 <include>

--- a/docs/INSTALL_DEBIAN13.md
+++ b/docs/INSTALL_DEBIAN13.md
@@ -143,6 +143,23 @@ ws_connect_timeout_ms = 3000
 enabled     = true
 http_listen = "127.0.0.1:9091"
 
+# ─── Trunk allowlist ─────────────────────────────────────────
+# Required for production. Identifies inbound peers by source IP
+# and/or From-URI host. Anything not matching a [[trunk]] block
+# is rejected with 403 Forbidden at the SIP layer. Omit [[trunk]]
+# entirely to accept INVITEs from ANY source — dev / behind-
+# firewall only. See docs/CONFIG.md §"[[trunk]]" for the threat
+# model and CIDR / from_hosts grammar.
+[[trunk]]
+name       = "freeswitch-main"
+peer_addrs = ["10.0.0.10"]     # FreeSWITCH server
+
+[[route]]
+name = "fs-9000"
+[route.match]
+register_source = "freeswitch-main"
+request_uri_user = "9000"
+
 [[route]]
 name = "default"
 [route.match]
@@ -215,17 +232,23 @@ typo never makes it past `systemctl start`.
 
 ## 7. Firewall
 
-The daemon binds SIP UDP and the RTP pool. Open both inbound from
-the PBX / softphone network, plus the observability port from the
-ops network only (`/admin/*` is unauthenticated in v1 — do NOT
-expose to the public internet):
+Two layers of trust:
+
+1. **SiphonAI's `[[trunk]]` block** (above) is the primary
+   identity gate. Anything not matching a trunk gets `403
+   Forbidden` at the SIP layer, before media setup.
+2. **Host firewall** is defense in depth — it stops abuse (port
+   scans, UDP floods) from reaching SiphonAI in the first place.
+   Don't rely on the firewall alone for *identity* — flat ACLs
+   drift, and SiphonAI's log line for a 403 is more useful than
+   `nftables drop`.
 
 ```bash
-# Replace 10.0.0.0/24 with your trunk peer's address.
+# Replace 10.0.0.10 with your trunk peer's address.
 sudo nft add table inet siphon_ai
 sudo nft add chain inet siphon_ai input '{ type filter hook input priority 0; }'
-sudo nft add rule inet siphon_ai input udp dport 5060           ip saddr 10.0.0.0/24 accept
-sudo nft add rule inet siphon_ai input udp dport 40000-40500    ip saddr 10.0.0.0/24 accept
+sudo nft add rule inet siphon_ai input udp dport 5060           ip saddr 10.0.0.10 accept
+sudo nft add rule inet siphon_ai input udp dport 40000-40500    ip saddr 10.0.0.10 accept
 sudo nft add rule inet siphon_ai input tcp dport 9091           ip saddr 10.0.0.0/24 accept
 ```
 

--- a/test-harness/sipp-scenarios/trunk_unauthorized_403.xml
+++ b/test-harness/sipp-scenarios/trunk_unauthorized_403.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  trunk_unauthorized_403 — daemon with a `[[trunk]]` allowlist
+  receives an INVITE from a peer that doesn't match any trunk
+  (neither IP nor From-URI host). MUST reject with 403 Forbidden
+  at the routing layer before any media setup runs.
+
+  This scenario is paired with `trunk_unauthorized_403.toml` —
+  the regression runner's daemon must be started with a config
+  that declares a [[trunk]] block whose peer_addrs DON'T include
+  127.0.0.1 (so this scenario's source — SIPp on loopback —
+  fails the gate). See run-trunk-403.sh for the standalone
+  driver, or run by hand:
+
+    siphon-ai --config trunk_unauthorized_403.toml &
+    sipp -sf trunk_unauthorized_403.xml -m 1 -p 5080 \
+         -s 9000 -timeout 10s 127.0.0.1:5060
+-->
+<scenario name="trunk_unauthorized_403">
+  <send retrans="500">
+<![CDATA[
+INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+Max-Forwards: 70
+From: <sip:sipp-unauthorized@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:sipp-unauthorized@[local_ip]:[local_port]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=user1 53655765 2353687637 IN IP4 [local_ip]
+s=-
+c=IN IP4 [local_ip]
+t=0 0
+m=audio 9000 RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+]]>
+  </send>
+
+  <recv response="100" optional="true"/>
+
+  <!-- MUST be 403, before any media setup. The daemon log should
+       show `INVITE rejected: no trunk matched` at WARN. The
+       transaction layer auto-ACKs non-2xx finals (RFC 3261
+       §17.1.1.3) so the scenario stops after the 403. -->
+  <recv response="403" rtd="true"/>
+
+  <ResponseTimeRepartition value="200, 500, 1000"/>
+</scenario>


### PR DESCRIPTION
## Summary
SIP-layer trust gate so operators don't have to rely on the host firewall for identity decisions. New \`[[trunk]]\` block identifies inbound peers by source IP and/or From-URI host; unmatched INVITEs get 403 Forbidden before any media setup runs.

\`\`\`toml
[[trunk]]
name       = "freeswitch-main"
peer_addrs = ["10.0.0.10"]              # exact IP or CIDR

[[trunk]]
name       = "carrier-b"
from_hosts = ["sip.carrier-b.example"]  # for rotating-IP trunks

[[route]]
name = "fs-9000"
[route.match]
register_source = "freeswitch-main"     # routes scope per trunk
request_uri_user = "9000"
\`\`\`

## Backward compatibility
**Zero \`[[trunk]]\` blocks** keeps today's behavior (accept any source, default \`register_source = "trunk"\`). Existing deployments don't need to change anything to keep working. Documented as dev / behind-firewall only.

**One or more \`[[trunk]]\` blocks** enables strict mode: unmatched INVITEs → 403. The matching trunk's name becomes the call's \`register_source\`, so existing routes can scope per-trunk via the matcher that already exists.

## Threat model (full discussion in CONFIG.md)
- \`peer_addrs\`: strong off-path, weak against on-path spoofing.
- \`from_hosts\`: shared-secret-in-a-header. Useful as a second factor with \`peer_addrs\`, marginally useful alone behind a trusted upstream firewall.
- Strong combo: \`peer_addrs\` + \`from_hosts\` + TLS transport.
- Digest auth on inbound INVITEs (RFC 3261 §22) is post-v1.

## Tests
- [x] 8 config-load tests covering all error / success paths.
- [x] 7 daemon-side tests for the From-host parser + IP/host/AND matchers.
- [x] SIPp scenario \`trunk_unauthorized_403.xml\` paired with \`configs/trunk-403-test.toml\` — verified end-to-end: daemon logs \`INVITE rejected: no trunk matched (403 Forbidden)\` and SIPp records \`Successful call: 1\`.
- [x] Full existing SIPp regression (6 scenarios) still passes byte-identically — no \`[[trunk]]\` blocks in those daemon configs means legacy mode.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] \`cargo fmt --all -- --check\` clean.

## Docs updated
- \`CONFIG.md\` — new \`[[trunk]]\` section with field table, semantics, threat model.
- \`INSTALL_DEBIAN13.md\` — default config ships with a \`[[trunk]]\`; firewall section reframed as defense-in-depth.
- \`FREESWITCH_INTEGRATION.md\` — uses \`[[trunk]]\` for the FS peer; old "no SIP-layer auth" claim removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)