### PR TITLE
docs(security): fail2ban policy for repeat-offender SIP scanners

### DIFF
--- a/contrib/fail2ban/filter.d/siphon-ai.conf
+++ b/contrib/fail2ban/filter.d/siphon-ai.conf
@@ -1,0 +1,30 @@
+# Fail2Ban filter for SiphonAI.
+#
+# Matches the 403-Forbidden log line that the routing handler emits
+# when an INVITE arrives from a peer that doesn't match any
+# [[trunk]] block. Internet-exposed daemons see this constantly
+# from SIP scanners; the filter feeds fail2ban so repeat offenders
+# get dropped at the firewall.
+#
+# Install:
+#   cp filter.d/siphon-ai.conf  /etc/fail2ban/filter.d/
+#   cp jail.d/siphon-ai.local   /etc/fail2ban/jail.d/
+#   systemctl restart fail2ban
+#
+# See docs/SECURITY_FAIL2BAN.md for the full walkthrough.
+
+[Definition]
+
+# The exact log message body emitted by
+# crates/sip-glue/src/handler.rs when the trunk allowlist rejects.
+# Tracing's `peer=` field repeats twice on the line (once in the
+# instrument-span prefix, once in the message body); matching the
+# explicit message-body occurrence is more stable since the prefix
+# is tracing-version sensitive.
+failregex = INVITE rejected: no trunk matched \(403 Forbidden\) peer=<HOST>:\d+
+
+ignoreregex =
+
+# The fail2ban journald backend pulls from systemd directly, so
+# there's no file path to configure. See jail.d/siphon-ai.local.
+journalmatch = _SYSTEMD_UNIT=siphon-ai.service

--- a/contrib/fail2ban/jail.d/recidive.local
+++ b/contrib/fail2ban/jail.d/recidive.local
@@ -1,0 +1,33 @@
+# Recidive jail — bans IPs that have already been banned by
+# other jails repeatedly. Acts as a second tier on top of the
+# per-jail policy: a bot that gets siphon-ai-banned 3 times in
+# a week lands here for a week, then a month, etc.
+#
+# Watches fail2ban's OWN journal (`fail2ban.service`) for
+# `[<jail>] Ban <IP>` events. Filter ships with the fail2ban
+# package — no custom regex needed.
+#
+# Drop in /etc/fail2ban/jail.d/ alongside siphon-ai.local.
+
+[recidive]
+enabled      = true
+filter       = recidive
+backend      = systemd
+journalmatch = _SYSTEMD_UNIT=fail2ban.service
+
+# How many *bans* (not failed logins — bans!) before recidive
+# escalates. 3 across the findtime window. Bots that come back
+# day after day land here quickly.
+maxretry     = 3
+
+# 1 week sliding window for counting prior bans.
+findtime     = 604800
+
+# 1 week initial ban from recidive. Combined with
+# `bantime.increment = true` in fail2ban.conf, the 2nd hit lands
+# at ~24 weeks, the 3rd at ~year (capped to bantime.maxtime).
+bantime      = 604800
+
+# All-ports drop, same as the siphon-ai jail. A repeat-offender
+# bot shouldn't get to keep probing other services either.
+action       = nftables-allports[name=recidive]

--- a/contrib/fail2ban/jail.d/siphon-ai.local
+++ b/contrib/fail2ban/jail.d/siphon-ai.local
@@ -1,0 +1,28 @@
+# SiphonAI jail. Drop in /etc/fail2ban/jail.d/.
+#
+# Tunables you might want to adjust per deployment:
+#   maxretry — how many 403s before banning. 5 is conservative;
+#              busy internet endpoints might want 3.
+#   findtime — sliding window (seconds). 600 (10 min) suits the
+#              "slow scanner" pattern in field logs.
+#   bantime  — how long a banned IP stays in the drop list. 24 h
+#              is reasonable; `-1` means permanent (compose with
+#              `bantime.increment = true` in fail2ban.conf for
+#              repeat-offender escalation).
+#
+# `nftables-allports` drops the offender from ALL ports, not just
+# 5060. A bot that's hammering SIP isn't somebody you want
+# poking at SSH either. If you use iptables instead, swap the
+# action to `iptables-allports[name=siphon-ai]`.
+
+[siphon-ai]
+enabled      = true
+port         = 5060
+protocol     = udp
+filter       = siphon-ai
+backend      = systemd
+journalmatch = _SYSTEMD_UNIT=siphon-ai.service
+maxretry     = 5
+findtime     = 600
+bantime      = 86400
+action       = nftables-allports[name=siphon-ai]

--- a/docs/INSTALL_DEBIAN13.md
+++ b/docs/INSTALL_DEBIAN13.md
@@ -255,6 +255,15 @@ sudo nft add rule inet siphon_ai input tcp dport 9091           ip saddr 10.0.0.
 (`ufw` / `iptables` / cloud SG equivalents work too; the
 permission set is what matters.)
 
+### Fail2ban for repeat offenders
+
+The `[[trunk]]` allowlist 403s every scanner INVITE at the SIP
+layer, but scanners retry forever and fill the journal. For
+internet-facing deployments, set up fail2ban to drop repeat
+offenders at the kernel after N strikes — see
+`docs/SECURITY_FAIL2BAN.md` for the filter, jail config, and
+walkthrough. ~5 minutes; recommended for any public IP.
+
 ---
 
 ## 8. Verify

--- a/docs/SECURITY_FAIL2BAN.md
+++ b/docs/SECURITY_FAIL2BAN.md
@@ -18,11 +18,12 @@ the trust gate; fail2ban is the noise filter.
 ```
 contrib/fail2ban/
 ├── filter.d/siphon-ai.conf      # regex that matches our 403 log line
-└── jail.d/siphon-ai.local       # ban policy (5 strikes / 10 min / 24 h)
+├── jail.d/siphon-ai.local       # primary jail (5 strikes / 10 min / 24 h)
+└── jail.d/recidive.local        # second-tier jail for repeat offenders
 ```
 
-Both files are short and operator-tunable. Read them — they
-explain the trade-offs inline.
+All three files are short and operator-tunable. Read them —
+they explain the trade-offs inline.
 
 ---
 
@@ -35,6 +36,7 @@ SiphonAI logging to journald via systemd.
 sudo apt install -y fail2ban
 sudo cp /opt/siphon-ai-src/contrib/fail2ban/filter.d/siphon-ai.conf  /etc/fail2ban/filter.d/
 sudo cp /opt/siphon-ai-src/contrib/fail2ban/jail.d/siphon-ai.local   /etc/fail2ban/jail.d/
+sudo cp /opt/siphon-ai-src/contrib/fail2ban/jail.d/recidive.local    /etc/fail2ban/jail.d/
 sudo systemctl enable --now fail2ban
 sudo systemctl status fail2ban --no-pager
 ```
@@ -42,9 +44,13 @@ sudo systemctl status fail2ban --no-pager
 Replace `/opt/siphon-ai-src` with your clone path.
 
 The default jail bans after **5 failed INVITEs from the same IP
-in 10 minutes** for **24 hours**. Tune `maxretry`/`findtime`/`bantime`
-in `siphon-ai.local` to taste. For a busy internet endpoint hit
-by carrier-grade scanner farms you might drop to `maxretry = 3`.
+in 10 minutes** for **24 hours**. The recidive jail re-bans IPs
+that have already been banned 3+ times in a week for **a week
+each subsequent hit** — see §"Recidive: long bans for repeat
+offenders" below. Tune `maxretry`/`findtime`/`bantime` in each
+jail file to taste. For a busy internet endpoint hit by
+carrier-grade scanner farms you might drop the primary jail to
+`maxretry = 3`.
 
 ---
 
@@ -93,12 +99,29 @@ sudo fail2ban-regex \
 
 ---
 
-## Escalation: permanent bans for repeat offenders
+## Recidive: long bans for repeat offenders
 
-The default 24 h ban resets after the offender's been quiet for
-the ban duration. For abuse-heavy networks you probably want
-repeat offenders to get progressively longer bans, eventually
-permanent. Enable in `/etc/fail2ban/fail2ban.conf`:
+The primary jail's 24 h ban resets after the offender has been
+quiet for the ban duration. A bot that comes back the next day
+starts fresh and only gets dropped after another 5 strikes.
+That's noise you don't need.
+
+`recidive.local` (shipped in this PR) is a second-tier jail
+that watches fail2ban's OWN log for ban events. When an IP gets
+banned by the `siphon-ai` jail 3 or more times in a week,
+recidive picks it up and bans it for a *week*. Combined with
+`bantime.increment` (below), the second recidive hit lands at
+~24 weeks and the third at the year cap. A persistent botnet IP
+is effectively gone after two appearances.
+
+The recidive filter is bundled with the fail2ban package
+(`/etc/fail2ban/filter.d/recidive.conf`); we only ship the jail
+snippet.
+
+### Stack the two
+
+To get progressively longer recidive bans, enable
+`bantime.increment` in `/etc/fail2ban/fail2ban.conf`:
 
 ```ini
 [DEFAULT]
@@ -107,10 +130,37 @@ bantime.factor     = 24
 bantime.maxtime    = 31536000   # 1 year
 ```
 
-`bantime.factor = 24` with the jail's `bantime = 86400` means
-the second offense lands at 24 days, the third at ~576 days
-(capped to `maxtime`). A botnet IP that comes back tomorrow gets
-shut out for a month.
+With `bantime.increment = true` applied to recidive's
+`bantime = 604800` (1 week):
+
+| Offense in recidive | Ban duration                 |
+|---------------------|------------------------------|
+| 1st                 | 1 week                       |
+| 2nd                 | ~24 weeks                    |
+| 3rd+                | 1 year (`maxtime` cap)       |
+
+The same setting also escalates the primary `siphon-ai` jail's
+24 h ban, but recidive matters more — it's the long-tail
+filter.
+
+### Inspect recidive
+
+```bash
+sudo fail2ban-client status recidive
+# Status for the jail: recidive
+# |- Filter
+# |  |- Currently failed: 0
+# |  |- Total failed:     12
+# |  `- Journal matches:  _SYSTEMD_UNIT=fail2ban.service
+# `- Actions
+#    |- Currently banned: 2
+#    |- Total banned:     4
+#    `- Banned IP list:   31.70.66.9 31.70.75.115
+```
+
+Two banned IPs in the example output have shown up three or
+more times across the past week, so they're locked out for a
+week (or longer if `bantime.increment` is on).
 
 ---
 

--- a/docs/SECURITY_FAIL2BAN.md
+++ b/docs/SECURITY_FAIL2BAN.md
@@ -1,0 +1,158 @@
+# Fail2Ban policy for SiphonAI
+
+An internet-facing SIP endpoint sees constant scan traffic —
+botnets walking IP space looking for open trunks to abuse for
+toll fraud. The `[[trunk]]` allowlist already 403s every one of
+them at the SIP layer (`docs/CONFIG.md` §`[[trunk]]`), so they
+can't *do* anything, but they keep retrying forever and fill
+your journal. Fail2ban watches the journal for the 403 log line
+and drops the offender at the firewall after N strikes.
+
+This is defense in depth on top of `[[trunk]]`. The allowlist is
+the trust gate; fail2ban is the noise filter.
+
+---
+
+## What's in this repo
+
+```
+contrib/fail2ban/
+├── filter.d/siphon-ai.conf      # regex that matches our 403 log line
+└── jail.d/siphon-ai.local       # ban policy (5 strikes / 10 min / 24 h)
+```
+
+Both files are short and operator-tunable. Read them — they
+explain the trade-offs inline.
+
+---
+
+## Install
+
+Assumes you've followed `docs/INSTALL_DEBIAN13.md` and have
+SiphonAI logging to journald via systemd.
+
+```bash
+sudo apt install -y fail2ban
+sudo cp /opt/siphon-ai-src/contrib/fail2ban/filter.d/siphon-ai.conf  /etc/fail2ban/filter.d/
+sudo cp /opt/siphon-ai-src/contrib/fail2ban/jail.d/siphon-ai.local   /etc/fail2ban/jail.d/
+sudo systemctl enable --now fail2ban
+sudo systemctl status fail2ban --no-pager
+```
+
+Replace `/opt/siphon-ai-src` with your clone path.
+
+The default jail bans after **5 failed INVITEs from the same IP
+in 10 minutes** for **24 hours**. Tune `maxretry`/`findtime`/`bantime`
+in `siphon-ai.local` to taste. For a busy internet endpoint hit
+by carrier-grade scanner farms you might drop to `maxretry = 3`.
+
+---
+
+## Verify
+
+After a few minutes (or after a scanner has tried 5+ times),
+list the active bans:
+
+```bash
+sudo fail2ban-client status siphon-ai
+# Status for the jail: siphon-ai
+# |- Filter
+# |  |- Currently failed: 7
+# |  |- Total failed:     142
+# |  `- Journal matches:  _SYSTEMD_UNIT=siphon-ai.service
+# `- Actions
+#    |- Currently banned: 4
+#    |- Total banned:     17
+#    `- Banned IP list:   31.70.75.115 31.70.66.9 5.196.63.60 87.98.242.75
+```
+
+The banned IPs are dropped at the kernel level — no more
+INVITEs from them reach SiphonAI, so the journal stops growing
+from those sources.
+
+Confirm with `sudo nft list ruleset | grep -A5 f2b-siphon-ai`:
+the chain is populated with `ip saddr <BANNED> drop` entries.
+
+---
+
+## Unban / inspect
+
+```bash
+# Pull one IP out of jail
+sudo fail2ban-client set siphon-ai unbanip 1.2.3.4
+
+# See exactly which log lines triggered the most recent bans
+sudo fail2ban-client status siphon-ai
+sudo journalctl -u fail2ban -n 50 --no-pager
+
+# Re-test the filter regex against a sample log line
+sudo fail2ban-regex \
+    'INVITE rejected: no trunk matched (403 Forbidden) peer=1.2.3.4:5060' \
+    /etc/fail2ban/filter.d/siphon-ai.conf
+```
+
+---
+
+## Escalation: permanent bans for repeat offenders
+
+The default 24 h ban resets after the offender's been quiet for
+the ban duration. For abuse-heavy networks you probably want
+repeat offenders to get progressively longer bans, eventually
+permanent. Enable in `/etc/fail2ban/fail2ban.conf`:
+
+```ini
+[DEFAULT]
+bantime.increment  = true
+bantime.factor     = 24
+bantime.maxtime    = 31536000   # 1 year
+```
+
+`bantime.factor = 24` with the jail's `bantime = 86400` means
+the second offense lands at 24 days, the third at ~576 days
+(capped to `maxtime`). A botnet IP that comes back tomorrow gets
+shut out for a month.
+
+---
+
+## What this DOESN'T do
+
+- **Doesn't replace the `[[trunk]]` allowlist.** Without trunks,
+  every INVITE is accepted at the SIP layer; fail2ban would have
+  nothing to ban on (since the log line it keys off only fires
+  on the 403 path). Trunks + fail2ban is the combo; fail2ban
+  alone isn't enough.
+- **Doesn't help with credentialed-trunk abuse.** If a real
+  carrier credential leaks and an attacker reaches you from an
+  allowlisted IP, the 403 never fires and fail2ban stays quiet.
+  Rotate creds, prefer per-trunk IPs to wide CIDRs.
+- **Doesn't help with on-path attackers.** Anyone who can
+  arrange traffic to appear to come from a trusted source IP
+  bypasses the allowlist and the ban filter. TLS transport
+  (`transports = ["tls"]` + pinned certs) is the answer there;
+  fail2ban is for the abusive-but-not-on-path noise.
+- **Doesn't help with UDP floods.** A DDoS at line rate
+  saturates the kernel UDP path before SiphonAI sees the
+  packets; fail2ban only reacts to logged events. For DoS
+  resilience use a connection-tracked rate-limit at the
+  firewall:
+
+  ```nft
+  # Rate-limit per source IP to 50 packets/sec on the SIP port.
+  # Adjust by deployment.
+  add rule inet siphon_ai input udp dport 5060 \
+      meter sip-rate { ip saddr limit rate 50/second } accept
+  ```
+
+---
+
+## What's documented separately
+
+- `docs/CONFIG.md` §`[[trunk]]` — the primary trust gate.
+- `docs/INSTALL_DEBIAN13.md` §7 — host-firewall layer.
+- `docs/OPERATIONS.md` — the §11.8 ten-questions audit for
+  diagnostic visibility.
+
+The recommended production stance: `[[trunk]]` allowlist (you
+already have this), fail2ban (this doc), host firewall (install
+guide §7), and TLS where the peer supports it. Each layer
+covers a different threat.


### PR DESCRIPTION
Internet-facing deployments see constant SIP-scan traffic. The `[[trunk]]` allowlist 403s every one at the SIP layer, but they keep retrying and fill the journal. Fail2ban + the allowlist together kill the noise.

Ships:
- `contrib/fail2ban/filter.d/siphon-ai.conf` — regex matching our 403 log line; pulls from journald via `_SYSTEMD_UNIT=siphon-ai.service`.
- `contrib/fail2ban/jail.d/siphon-ai.local` — example jail (5 strikes / 10 min / 24h ban via nftables-allports), all tunables documented inline.
- `docs/SECURITY_FAIL2BAN.md` — install walkthrough, verification, unban, escalation via `bantime.increment`, honest about what it doesn't cover (credential abuse, on-path, UDP floods).
- `docs/INSTALL_DEBIAN13.md` §7 links to the new doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)