### PR TITLE
fix(bot): polyfill globalThis.WebSocket for Node 22's undici WebSocket

### DIFF
--- a/docs/BOT_LOCALHOST_SETUP.md
+++ b/docs/BOT_LOCALHOST_SETUP.md
@@ -222,6 +222,27 @@ The bot enforces `pcm16le / 20 ms / 8 kHz or 16 kHz` from the
 codec — PCMU produces 8 kHz, G.722 produces 16 kHz. Anything
 else would mean a daemon-side bug; report it.
 
+### Bot crashes on the first call with `Invalid Sec-WebSocket-Protocol value`
+
+Stack ends in `at new WebSocket (node:internal/deps/undici/undici:…)`
+and `at openDeepgramStt`. Symptom on the daemon side is the same
+fast-fail signature as a missing bot — `state=Active` →
+`cause=BridgeEnded` in microseconds, no `bridge connected`
+between them, because the bot died mid-handshake.
+
+The bot's `server.js` polyfills `globalThis.WebSocket` to the
+`ws` package's class before requiring the Deepgram SDK, which
+should prevent this. If you see the crash anyway, check the top
+of `server.js` includes:
+
+```js
+const { WebSocket, WebSocketServer } = require('ws');
+globalThis.WebSocket = WebSocket;
+```
+
+…and that it appears BEFORE `require('@deepgram/sdk')`. Pulling
+the latest from `main` picks up the fix.
+
 ### Bot prints `TTS error` repeatedly
 
 Usually a Deepgram API key issue — wrong key, expired, exceeded

--- a/examples/deepgram-openai-bot-node/server.js
+++ b/examples/deepgram-openai-bot-node/server.js
@@ -29,7 +29,19 @@
 //   BOT_SYSTEM_PROMPT       optional override
 //   BOT_GREETING            optional override
 
-const { WebSocketServer } = require('ws');
+// Force the Deepgram SDK to use the `ws` package's WebSocket
+// instead of Node 22's built-in (undici) one. Node 22 ships a
+// global `WebSocket` that's stricter about the
+// `Sec-WebSocket-Protocol` header — when the SDK constructs a
+// live client it ends up passing an empty / unset value and
+// undici throws `Invalid Sec-WebSocket-Protocol value`. The `ws`
+// package tolerates the same call shape.
+//
+// This MUST happen before requiring `@deepgram/sdk` so the SDK
+// sees the polyfilled global at module-load time.
+const { WebSocket, WebSocketServer } = require('ws');
+globalThis.WebSocket = WebSocket;
+
 const { createClient } = require('@deepgram/sdk');
 const OpenAI = require('openai');
 


### PR DESCRIPTION
Bot crashes on first inbound call with `Invalid Sec-WebSocket-Protocol value` from undici's built-in WebSocket (Node 22). The Deepgram SDK's live clients trip undici's strict header validation; the `ws` package (already a dep) tolerates the same call shape.

Polyfills `globalThis.WebSocket = require('ws').WebSocket` BEFORE `require('@deepgram/sdk')` so the SDK's `new WebSocket(...)` lands on the `ws` implementation. `BOT_LOCALHOST_SETUP.md` gets a troubleshooting entry keyed off the exact symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)