### PR TITLE
fix(bot): delete globalThis.WebSocket so Deepgram SDK takes the header-auth path

### DIFF
--- a/docs/BOT_LOCALHOST_SETUP.md
+++ b/docs/BOT_LOCALHOST_SETUP.md
@@ -222,26 +222,36 @@ The bot enforces `pcm16le / 20 ms / 8 kHz or 16 kHz` from the
 codec — PCMU produces 8 kHz, G.722 produces 16 kHz. Anything
 else would mean a daemon-side bug; report it.
 
-### Bot crashes on the first call with `Invalid Sec-WebSocket-Protocol value`
+### Bot crashes on the first call with `Invalid Sec-WebSocket-Protocol value` or `invalid or duplicated subprotocol`
 
-Stack ends in `at new WebSocket (node:internal/deps/undici/undici:…)`
-and `at openDeepgramStt`. Symptom on the daemon side is the same
+Stack ends in `new WebSocket` from either undici
+(`node:internal/deps/undici/undici:…`) or `ws`
+(`node_modules/ws/lib/websocket.js`), called from
+`@deepgram/sdk/.../AbstractLiveClient.js` via the bot's
+`openDeepgramStt`. Symptom on the daemon side is the same
 fast-fail signature as a missing bot — `state=Active` →
 `cause=BridgeEnded` in microseconds, no `bridge connected`
 between them, because the bot died mid-handshake.
 
-The bot's `server.js` polyfills `globalThis.WebSocket` to the
-`ws` package's class before requiring the Deepgram SDK, which
-should prevent this. If you see the crash anyway, check the top
-of `server.js` includes:
+The Deepgram SDK's live client detects `globalThis.WebSocket` and
+takes a code path that passes the API key as a subprotocol —
+which both undici and `ws` reject as malformed (real API keys
+contain characters that aren't valid in a `Sec-WebSocket-Protocol`
+token). The bot's `server.js` deletes the global before requiring
+the SDK so the SDK falls through to the `require('ws')` path with
+`Authorization`-header auth, which works.
+
+If you see the crash anyway, confirm the top of `server.js`
+includes:
 
 ```js
-const { WebSocket, WebSocketServer } = require('ws');
-globalThis.WebSocket = WebSocket;
+delete globalThis.WebSocket;
+const { WebSocketServer } = require('ws');
+const { createClient } = require('@deepgram/sdk');
 ```
 
-…and that it appears BEFORE `require('@deepgram/sdk')`. Pulling
-the latest from `main` picks up the fix.
+…in that order. The `delete` must run BEFORE the SDK loads.
+Pulling the latest from `main` picks up the fix.
 
 ### Bot prints `TTS error` repeatedly
 

--- a/examples/deepgram-openai-bot-node/server.js
+++ b/examples/deepgram-openai-bot-node/server.js
@@ -29,19 +29,26 @@
 //   BOT_SYSTEM_PROMPT       optional override
 //   BOT_GREETING            optional override
 
-// Force the Deepgram SDK to use the `ws` package's WebSocket
-// instead of Node 22's built-in (undici) one. Node 22 ships a
-// global `WebSocket` that's stricter about the
-// `Sec-WebSocket-Protocol` header — when the SDK constructs a
-// live client it ends up passing an empty / unset value and
-// undici throws `Invalid Sec-WebSocket-Protocol value`. The `ws`
-// package tolerates the same call shape.
+// Hide Node 22's built-in `globalThis.WebSocket` from the
+// Deepgram SDK. The SDK detects native-WebSocket availability
+// via `typeof WebSocket !== "undefined"` and, when true, opens
+// its live client with `new WebSocket(url, ["token", apiKey])` —
+// passing the API key as a Sec-WebSocket-Protocol value.
+// Subprotocol tokens are RFC-2616 tokens (no whitespace, limited
+// punctuation), so a real Deepgram API key fails the validation
+// in both undici (`Invalid Sec-WebSocket-Protocol value`) and
+// the `ws` package (`invalid or duplicated subprotocol`).
 //
-// This MUST happen before requiring `@deepgram/sdk` so the SDK
-// sees the polyfilled global at module-load time.
-const { WebSocket, WebSocketServer } = require('ws');
-globalThis.WebSocket = WebSocket;
+// Deleting the global flips the SDK's detection to the fallback
+// branch, which `require('ws')` and authenticates via the
+// `Authorization` header instead — the working path.
+//
+// MUST run before `require('@deepgram/sdk')` so the SDK's
+// module-load-time `NATIVE_WEBSOCKET_AVAILABLE` constant sees
+// the deletion.
+delete globalThis.WebSocket;
 
+const { WebSocketServer } = require('ws');
 const { createClient } = require('@deepgram/sdk');
 const OpenAI = require('openai');
 


### PR DESCRIPTION
PR #32's polyfill was the wrong direction. The Deepgram SDK has two branches:

```js
if (NATIVE_WEBSOCKET_AVAILABLE) {                       // native path — uses subprotocol auth
    this.conn = new WebSocket(url, ['token', apiKey]);  //   ← real keys fail RFC-2616 token validation
} else {                                                // fallback — uses Authorization header
    require('ws') …                                     //   ← works
}
```

Setting `globalThis.WebSocket = require('ws').WebSocket` (PR #32) kept the SDK on the broken branch, just swapping undici's error for `ws`'s. The fix is to `delete globalThis.WebSocket` so the detection flips to false and the SDK uses the header-auth fallback.

Verified by running the SDK's detection logic after the delete: `NATIVE_WEBSOCKET_AVAILABLE === false`.

Troubleshooting in `BOT_LOCALHOST_SETUP.md` updated with the new stack signatures and the corrected fix snippet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)