### PR TITLE
fix(bot): bail clearly on placeholder / non-ASCII API keys

### DIFF
--- a/docs/BOT_LOCALHOST_SETUP.md
+++ b/docs/BOT_LOCALHOST_SETUP.md
@@ -72,11 +72,24 @@ since it holds API credentials.
 ## 4. Smoke test in the foreground
 
 Before wiring systemd, run it directly so you can see what it
-prints on the first call:
+prints on the first call. Two ways to feed the env file you
+created in §3:
 
 ```bash
 cd /opt/siphon-ai-src/examples/deepgram-openai-bot-node
-DEEPGRAM_API_KEY=… OPENAI_API_KEY=… BOT_BIND=127.0.0.1:8080 node server.js
+
+# Option A — source the env file you wrote in §3.
+set -a; sudo --preserve-env=PATH bash -c 'set -a; . /etc/siphon-bot/env; exec node server.js'
+
+# Option B — inline the keys (handy for one-off testing).
+# IMPORTANT: replace the literal ellipsis with your real keys.
+# Pasting `…` verbatim sneaks a Unicode character past the env
+# check; the bot bails with a clear "non-printable / non-ASCII
+# characters" message rather than crashing inside the WS library.
+DEEPGRAM_API_KEY='dg_real_key_here' \
+OPENAI_API_KEY='sk-real_key_here' \
+BOT_BIND=127.0.0.1:8080 \
+node server.js
 ```
 
 Expected output:

--- a/examples/deepgram-openai-bot-node/server.js
+++ b/examples/deepgram-openai-bot-node/server.js
@@ -57,14 +57,33 @@ const [BIND_HOST, BIND_PORT] = (process.env.BOT_BIND || '0.0.0.0:8080').split(':
 
 const DG_KEY = process.env.DEEPGRAM_API_KEY;
 const OPENAI_KEY = process.env.OPENAI_API_KEY;
-if (!DG_KEY) {
-  console.error('ERROR: DEEPGRAM_API_KEY not set.');
-  process.exit(1);
+
+/**
+ * Validate an API key env var. Bails on missing OR
+ * non-printable-ASCII values so a placeholder like `…` from the
+ * docs (Unicode U+2026, common copy-paste hazard) fails here with
+ * a clear message instead of three layers deeper inside the WS
+ * library as `Invalid character in header content`. Real API
+ * keys are ASCII tokens, so the check is sound.
+ */
+function requireKey(name, value) {
+  if (!value) {
+    console.error(`ERROR: ${name} not set.`);
+    process.exit(1);
+  }
+  // RFC 9110 §5.5 visible-ASCII range (0x20–0x7E) covers every
+  // real API key shape we've seen.
+  if (!/^[\x20-\x7E]+$/.test(value)) {
+    console.error(
+      `ERROR: ${name} contains non-printable / non-ASCII characters. ` +
+        `If you copy-pasted "…" or another placeholder from the docs, ` +
+        `replace it with your real key.`,
+    );
+    process.exit(1);
+  }
 }
-if (!OPENAI_KEY) {
-  console.error('ERROR: OPENAI_API_KEY not set.');
-  process.exit(1);
-}
+requireKey('DEEPGRAM_API_KEY', DG_KEY);
+requireKey('OPENAI_API_KEY', OPENAI_KEY);
 
 const SYSTEM_PROMPT =
   process.env.BOT_SYSTEM_PROMPT ||


### PR DESCRIPTION
User ran the smoke command verbatim — `DEEPGRAM_API_KEY=…` with the literal Unicode ellipsis — and crashed deep inside `ws` with `Invalid character in header content`. Adds a printable-ASCII check at startup and reworks the doc to use obvious `dg_real_key_here` placeholders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)