### PR TITLE
chore(bot): instrument playout + WS lifecycle for one-way-audio diagnosis

### DIFF
--- a/examples/deepgram-openai-bot-node/server.js
+++ b/examples/deepgram-openai-bot-node/server.js
@@ -127,9 +127,17 @@ function makePlayout(ws, sampleRate, log) {
   /** @type {Buffer} partial frame across chunks. */
   let carry = Buffer.alloc(0);
   let timer = null;
+  // Diagnostic counters — `playout summary` logs them on stop()
+  // so a silent caller can be distinguished from a non-firing
+  // pump. Reset on every start() so each TTS phrase reports its
+  // own batch.
+  let runSent = 0;
+  let runErrors = 0;
 
   function pump() {
-    if (ws.readyState !== ws.OPEN) {
+    const rs = ws.readyState;
+    if (rs !== ws.OPEN) {
+      log(`playout: ws not OPEN (readyState=${rs}), dropping ${frames.length} pending frames`);
       stop();
       return;
     }
@@ -138,11 +146,20 @@ function makePlayout(ws, sampleRate, log) {
       stop();
       return;
     }
-    ws.send(f);
+    try {
+      ws.send(f);
+      runSent++;
+    } catch (e) {
+      runErrors++;
+      log('playout: ws.send threw:', e?.message || e);
+    }
   }
 
   function start() {
     if (timer) return;
+    runSent = 0;
+    runErrors = 0;
+    log('playout: pump started');
     // 20 ms cadence. setInterval is rough at the ms boundary; for
     // production-quality timing you'd run a monotonic clock loop
     // (see `forge-media`'s playout loop), but for a demo the OS
@@ -154,6 +171,7 @@ function makePlayout(ws, sampleRate, log) {
     if (timer) {
       clearInterval(timer);
       timer = null;
+      log(`playout: pump stopped (sent=${runSent} errors=${runErrors} carry=${carry.length})`);
     }
   }
 
@@ -467,8 +485,9 @@ async function handleCall(ws, req) {
     }
   });
 
-  ws.on('close', () => {
-    log('WS closed');
+  ws.on('close', (code, reason) => {
+    const r = reason ? Buffer.from(reason).toString('utf8') : '';
+    log(`WS closed (code=${code} reason=${JSON.stringify(r)})`);
     try { dgStt?.requestClose(); } catch {}
     playout?.cancel();
   });
@@ -489,6 +508,9 @@ wss.on('listening', () => {
 });
 
 wss.on('connection', (ws, req) => {
+  const remote = req.socket?.remoteAddress;
+  const subproto = ws.protocol || '(none)';
+  console.log(`[ws] connection from ${remote} subprotocol=${subproto}`);
   handleCall(ws, req).catch((err) => {
     console.error('handleCall threw:', err);
     try { ws.close(); } catch {}


### PR DESCRIPTION
## Summary

- Adds `playout: pump started` / `playout: pump stopped (sent=N errors=M carry=K)` log lines so a silent caller can be distinguished from a non-firing pump.
- Wraps `ws.send(f)` in `try/catch` — previously silent failures.
- Logs WS-close `code` and `reason` (it was previously bare `WS closed`), so we can see which side hung up.
- Logs the upgrade subprotocol on `wss.connection`.

No protocol or behavioural change. This is purely to diagnose the
\"TTS synthesised 29 KB, caller heard nothing\" pattern from the
real-world test.

## Test plan

- [x] \`node -c server.js\` parses
- [ ] User places a call; bot log now reports \`pump started\` → \`pump stopped (sent=92 errors=0 carry=0)\` for a 1.84 s greeting
- [ ] If \`sent\` < expected or \`errors > 0\`, we know the bot side is the problem. If \`sent\` matches, the issue is daemon → RTP → FreeSWITCH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)