### PR TITLE
fix(media-glue): seed leg-A remote_addr from offer SDP at INVITE accept

### DIFF
--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -943,13 +943,12 @@ fn sdp_audio_payload_types(session: &forge_sdp::SessionDescription) -> Vec<Strin
 /// `c=` overrides the session-level `c=` per RFC 4566 §5.7. Returns
 /// `None` when neither carries a valid IP address or when audio is
 /// absent. Used by `on_reinvite` to push a `remote_addr` update to
-/// forge when the peer changes its RTP endpoint mid-call.
+/// forge when the peer changes its RTP endpoint mid-call. The initial
+/// INVITE path uses the same helper through `media-glue`, applied at
+/// `accept_inbound` time so forge has the address before the answer
+/// goes out.
 fn sdp_audio_remote_addr(session: &forge_sdp::SessionDescription) -> Option<std::net::SocketAddr> {
-    use forge_sdp::MediaType;
-    let media = session.find_media(MediaType::Audio)?;
-    let conn = media.connection.as_ref().or(session.connection.as_ref())?;
-    let ip: std::net::IpAddr = conn.connection_address.as_str().parse().ok()?;
-    Some(std::net::SocketAddr::new(ip, media.port))
+    siphon_ai_media_glue::audio_remote_addr(session)
 }
 
 /// Rejection signal returned by [`prepare_reinvite_answer`] when

--- a/crates/media-glue/src/lib.rs
+++ b/crates/media-glue/src/lib.rs
@@ -12,8 +12,8 @@ pub mod setup;
 pub mod tap;
 
 pub use sdp::{
-    build_answer, negotiate_answer, parse_offer, AnswerOutcome, Codec, LocalCapabilities,
-    MediaDirection, SdpError,
+    audio_remote_addr, build_answer, negotiate_answer, parse_offer, AnswerOutcome, Codec,
+    LocalCapabilities, MediaDirection, SdpError,
 };
 pub use setup::{InboundAccepted, InboundCall, MediaSetup, SetupError};
 pub use tap::{BargeInAction, MediaTap, MediaTapError, TapCommand, TapDisconnect};

--- a/crates/media-glue/src/sdp.rs
+++ b/crates/media-glue/src/sdp.rs
@@ -312,6 +312,23 @@ pub fn parse_offer(sdp: &str) -> Result<SessionDescription, SdpError> {
     SessionDescription::from_str(sdp).map_err(|e| SdpError::Parse(e.to_string()))
 }
 
+/// The peer's audio RTP endpoint as advertised in an offer's `c=` /
+/// `m=audio` lines. The media-level `c=` wins over the session-level
+/// `c=` when both are present (RFC 4566 §5.7). Returns `None` if
+/// either is absent or the connection address doesn't parse as an IP.
+///
+/// We hand this to forge as `ParticipantMediaUpdate.remote_addr` so
+/// outbound RTP can begin the moment the call answers, instead of
+/// waiting for forge's symmetric-RTP latch to learn the address from
+/// the first inbound packet — that wait blocks the first ~500 ms of
+/// any greeting otherwise.
+pub fn audio_remote_addr(session: &SessionDescription) -> Option<std::net::SocketAddr> {
+    let media = session.find_media(MediaType::Audio)?;
+    let conn = media.connection.as_ref().or(session.connection.as_ref())?;
+    let ip: std::net::IpAddr = conn.connection_address.as_str().parse().ok()?;
+    Some(std::net::SocketAddr::new(ip, media.port))
+}
+
 /// Negotiate an answer for `offer` against `caps`. The answer's
 /// `c=` line and `m=audio` port reflect `caps.local_ip` and
 /// `caps.local_port`.
@@ -379,4 +396,42 @@ pub fn negotiate_answer(
 pub fn build_answer(offer_sdp: &str, caps: &LocalCapabilities) -> Result<AnswerOutcome, SdpError> {
     let offer = parse_offer(offer_sdp)?;
     negotiate_answer(&offer, caps)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SDP_SESSION_LEVEL_C: &str = "\
+v=0\r\n\
+o=- 1 1 IN IP4 198.51.100.10\r\n\
+s=-\r\n\
+c=IN IP4 198.51.100.10\r\n\
+t=0 0\r\n\
+m=audio 27492 RTP/AVP 0\r\n\
+a=rtpmap:0 PCMU/8000\r\n";
+
+    const SDP_MEDIA_LEVEL_C_WINS: &str = "\
+v=0\r\n\
+o=- 1 1 IN IP4 198.51.100.10\r\n\
+s=-\r\n\
+c=IN IP4 198.51.100.10\r\n\
+t=0 0\r\n\
+m=audio 27492 RTP/AVP 0\r\n\
+c=IN IP4 203.0.113.7\r\n\
+a=rtpmap:0 PCMU/8000\r\n";
+
+    #[test]
+    fn audio_remote_addr_from_session_level_connection() {
+        let s = parse_offer(SDP_SESSION_LEVEL_C).unwrap();
+        let addr = audio_remote_addr(&s).expect("address present");
+        assert_eq!(addr.to_string(), "198.51.100.10:27492");
+    }
+
+    #[test]
+    fn audio_remote_addr_prefers_media_level_connection() {
+        let s = parse_offer(SDP_MEDIA_LEVEL_C_WINS).unwrap();
+        let addr = audio_remote_addr(&s).expect("address present");
+        assert_eq!(addr.to_string(), "203.0.113.7:27492");
+    }
 }

--- a/crates/media-glue/src/setup.rs
+++ b/crates/media-glue/src/setup.rs
@@ -228,17 +228,27 @@ impl MediaSetup {
         };
         let answer = negotiate_answer(&offer, &caps)?;
 
-        // (4) Apply the negotiated codec to the SIP leg.
+        // (4) Apply the negotiated codec AND the peer's RTP endpoint
+        //     to the SIP leg. Pushing `remote_addr` here means forge's
+        //     scheduled-playout loop can fire as soon as the call
+        //     answers, rather than waiting for the symmetric-RTP latch
+        //     to learn the address from the first inbound packet
+        //     (~500 ms gap that swallows the start of any greeting).
         let codec_config = ParticipantCodecConfig {
             payload_type: answer.negotiated_payload_type,
             codec: forge_audio_codec(answer.negotiated_codec),
             clock_rate: answer.negotiated_clock_rate,
         };
+        let remote_addr = crate::sdp::audio_remote_addr(&offer);
         let media_update = ParticipantMediaUpdate {
             codec_config: Some(codec_config),
             telephone_event_payload_type: call.dtmf_payload_type,
+            remote_addr: remote_addr.map(Some),
             ..Default::default()
         };
+        if let Some(addr) = remote_addr {
+            debug!(remote_addr = %addr, "seeding leg A remote RTP address from offer SDP");
+        }
         self.session_manager
             .update_participant_media(&call.call_id, ParticipantLabel::A, media_update)
             .await

--- a/crates/media-glue/tests/setup.rs
+++ b/crates/media-glue/tests/setup.rs
@@ -137,6 +137,14 @@ async fn happy_path_returns_answer_session_and_attached_tap() {
     assert_eq!(media_state.payload_type, 0);
     assert_eq!(media_state.clock_rate, 8000);
     assert_eq!(media_state.telephone_event_payload_type, 101);
+
+    // (h) Peer RTP endpoint from the offer's c= / m= lines is pushed
+    //     to forge at accept time so outbound playout starts immediately
+    //     instead of waiting on the symmetric-RTP latch.
+    assert_eq!(
+        media_state.remote_rtp_addr,
+        Some("10.0.0.5:7078".parse().unwrap()),
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Real-world FreeSWITCH test: caller heard no greeting. tcpdump showed inbound RTP flowing at 50 pps from FS, near-zero outbound. Daemon log printed `forge_engine::forwarding: Skipping scheduled playout for session ... leg a - no remote address` until forge's symmetric-RTP latch finally learned the peer's address from an inbound packet — about 500 ms after the call answered. Enough to swallow the start of the greeting.

We already pushed `remote_addr` to forge on **re-INVITE** (task #105). The **initial INVITE** path never did. This PR closes that gap by moving the SDP→`SocketAddr` helper into `media-glue::sdp::audio_remote_addr` and calling it inside `accept_inbound`, so the same update that applies the negotiated codec to leg A also seeds the peer's RTP endpoint.

## Test plan

- [x] `cargo test --workspace` — all green
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] New unit tests for both session-level and media-level `c=` cases
- [x] `happy_path_returns_answer_session_and_attached_tap` asserts forge's `ParticipantMediaState.remote_rtp_addr` is `Some` post-accept
- [ ] User to retest the FS↔SiphonAI call — expectation: greeting plays immediately on call answer, tcpdump shows ~50 pps in both directions

🤖 Generated with [Claude Code](https://claude.com/claude-code)