### PR TITLE
docs: capture findings from real-world FS↔SiphonAI integration test

### DIFF
--- a/docs/BOT_LOCALHOST_SETUP.md
+++ b/docs/BOT_LOCALHOST_SETUP.md
@@ -282,6 +282,45 @@ to FreeSWITCH being blocked. Run `tcpdump -i any -n 'udp portrange
 see frames flowing both directions. If only inbound, FreeSWITCH's
 side has a firewall rule dropping our RTP.
 
+**Or** — if the FreeSWITCH dialplan is missing `bypass_media=true`,
+FS's anchored bridge silently drops the SiphonAI→softphone
+direction whenever the softphone offers `a=rtcp-mux` (most modern
+softphones do, Zoiper included). See `docs/FREESWITCH_INTEGRATION.md`
+§"Why bypass_media" for the full diagnosis. The fix is a one-line
+dialplan addition; the rest of the system is fine.
+
+### Bot speech cuts in and out every 1–2 seconds
+
+Bot keeps interrupting itself mid-sentence. The log shows lots
+of `barge-in: dropping playout + sending clear` lines back-to-back.
+
+This is acoustic feedback: caller is on speakerphone with the
+speaker right next to the mic, the bot's voice plays through the
+speaker, the mic picks it up, the daemon's VAD says
+`speech_started`, and the bot's `speech_started` handler cancels
+its own playout. The bot is barging in on itself.
+
+Options:
+
+1. **Use a headset on the softphone.** Eliminates the acoustic
+   loop instantly. This is the right answer for any production
+   caller (real phones have hardware AEC).
+2. **Switch the daemon's barge-in mode to `notify_only`.** The
+   daemon still emits `speech_started` to the bot but doesn't
+   auto-flush its playout buffer. The reference bot still does
+   its own cancel, so for a fully-tolerant demo you'd also want
+   to comment out the `playout.cancel()` line in the bot's
+   `speech_started` handler. In `/etc/siphon-ai/siphon-ai.toml`:
+   ```toml
+   [bridge.barge_in]
+   mode = "notify_only"
+   ```
+   Then `sudo systemctl restart siphon-ai`.
+
+Don't try to "fix" this in production by raising the VAD
+threshold — real callers' phones have AEC and the chop never
+appears. It's purely an artifact of the speakerphone test setup.
+
 ---
 
 ## What this skips

--- a/docs/FREESWITCH_INTEGRATION.md
+++ b/docs/FREESWITCH_INTEGRATION.md
@@ -134,6 +134,11 @@ In `/etc/freeswitch/dialplan/default/99_siphon_ai.xml`:
 <include>
   <extension name="siphon-ai-9000">
     <condition field="destination_number" expression="^9000$">
+      <!-- CRITICAL: take FreeSWITCH out of the audio path. With
+           anchored media, FS's bridge fails to relay one direction
+           when the legs have asymmetric attributes (softphone offers
+           rtcp-mux, SiphonAI doesn't). See "Why bypass_media" below. -->
+      <action application="set" data="bypass_media=true"/>
       <!-- Force PCMU on the trunk leg so SiphonAI doesn't have
            to deal with re-negotiation. -->
       <action application="set" data="absolute_codec_string=PCMU"/>
@@ -151,6 +156,51 @@ In `/etc/freeswitch/dialplan/default/99_siphon_ai.xml`:
   </extension>
 </include>
 ```
+
+### Why `bypass_media=true`
+
+Without `bypass_media`, FreeSWITCH anchors media in the middle of
+the call: softphone sends RTP to FS's port, FS re-emits to
+SiphonAI's port, and vice versa. This is the default and usually
+works fine — except in our specific shape.
+
+What goes wrong: most softphones (Zoiper among them) offer
+`a=rtcp-mux` and a bundle of codecs (Opus first, then PCMU,
+PCMA, …). FS accepts rtcp-mux on the softphone leg. On the
+outbound leg to SiphonAI, FS offers the same codec list but
+SiphonAI advertises only PCMU **without** `a=rtcp-mux` (the
+daemon does not negotiate rtcp-mux in v1). Both legs settle on
+PCMU so there is no transcoding required — but the FS bridge
+appears unable to relay the SiphonAI→softphone direction once
+this asymmetry is present. A tcpdump on the FS host confirms:
+
+| Direction               | RTP packets/sec |
+|-------------------------|-----------------|
+| softphone → FS          | ~50 ✓           |
+| FS → SiphonAI           | ~50 ✓           |
+| SiphonAI → FS           | ~50 ✓           |
+| **FS → softphone**      | **~0**          |
+
+`bypass_media=true` makes FS get out of the media path entirely:
+its 200 OK to the softphone advertises **SiphonAI's** RTP
+endpoint, and its INVITE to SiphonAI proxies through the
+softphone's SDP. RTP then flows directly between the softphone
+and SiphonAI, with FS only handling SIP signaling. Cleaner,
+fewer hops, and it sidesteps the anchored-bridge bug.
+
+**Caveat:** in bypass-media mode, neither endpoint can use
+mid-call FreeSWITCH features that need to inspect media
+(recording on FS, IVR menus, mod_avmd, etc.) on this call leg.
+Move those features to SiphonAI (which records via CDR + WS
+events) or the bot if you need them.
+
+**Caveat 2:** the softphone and SiphonAI must be able to reach
+each other directly over UDP for RTP. For a public-IP softphone
+(or one behind a cone NAT that opens a mapping on outbound
+traffic), this works out of the box. For a softphone behind
+symmetric NAT with no port forwarding, you'd need to revert to
+anchored media and find a different workaround — open an issue
+if you hit that shape.
 
 Reload:
 
@@ -223,20 +273,38 @@ RTP back to FreeSWITCH or a `c=` line advertising the wrong IP
 
 ### Common interop gotchas
 
+- **Caller hears nothing but FreeSWITCH echo (9196) works**: the
+  classic asymmetric-bridge symptom. With `bypass_media=true`
+  in the dialplan (above) this won't happen. If it does, you
+  forgot the `<action application="set" data="bypass_media=true"/>`
+  line. Diagnostic: tcpdump on the FS host showing 50 pps in
+  three of the four RTP directions but ~0 in the fourth.
 - **No audio one direction**: the side missing audio has a firewall
   blocking the other side's RTP. Test with `tcpdump -i any -n
-  udp portrange 40000-40500`.
+  udp portrange 40000-40500`. Remember that with `bypass_media`,
+  RTP goes directly softphone↔SiphonAI; the FS host is no longer
+  in the path, so test from the SiphonAI host.
 - **One-way then full audio**: symmetric-RTP latching kicked in
   after the first inbound frame. Acceptable, but it means the
-  peer changed RTP endpoints — PR #26 wires
-  `update_participant_media` so this should no longer happen on
-  re-INVITE; if it does on initial INVITE, check `[node].public_address`.
+  peer changed RTP endpoints. PR #38 seeds `remote_addr` from
+  the offer SDP at INVITE accept time so playout starts
+  immediately rather than waiting on the latch — if you still
+  see this on the initial INVITE, check `[node].public_address`
+  (must be a routable IP, not the placeholder).
 - **488 Not Acceptable Here**: FreeSWITCH and SiphonAI's `[media].codecs`
   don't intersect. With `absolute_codec_string=PCMU` and
   `codecs = ["pcmu"]` they will.
 - **No `start` event reaches the bot**: SiphonAI couldn't connect
   to `ws_url`. Check `journalctl -u siphon-ai -f` for
   `bridge connected` vs a connect error.
+- **Audio chops every 1–2 seconds during the bot's reply**: bot is
+  cancelling its own playout on self-feedback. Common when the
+  caller's softphone is on **speakerphone with no echo cancellation**
+  — the bot's voice plays out the speaker, the mic picks it up,
+  the daemon's VAD reports `speech_started`, and the bot does a
+  barge-in cancel. Fix: use a headset on the softphone, OR set
+  `[bridge.barge_in].mode = "notify_only"` in the daemon config
+  to keep the bot from auto-cancelling on detected speech.
 
 ---
 

--- a/docs/INSTALL_DEBIAN13.md
+++ b/docs/INSTALL_DEBIAN13.md
@@ -264,6 +264,20 @@ sudo nft add rule inet siphon_ai input tcp dport 9091           ip saddr 10.0.0.
 (`ufw` / `iptables` / cloud SG equivalents work too; the
 permission set is what matters.)
 
+> **RTP source IP caveat:** the SIP `dport 5060` rule above always
+> comes from the trunk peer (FreeSWITCH, ITSP, etc.) and is safe
+> to lock by source IP. The **RTP** `dport 40000-40500` rule
+> assumes RTP arrives from the same peer — which is true for
+> default FreeSWITCH bridges. If you use `bypass_media=true` in
+> the FS dialplan (recommended — see
+> `docs/FREESWITCH_INTEGRATION.md`), RTP flows **directly between
+> the original caller and SiphonAI**, bypassing FS. In that case
+> the RTP source IP is the caller's IP — which can be anywhere
+> — and you'll want either an open RTP source ACL (rely on
+> conntrack + rate-limiting for safety) or a wider CIDR matching
+> your expected caller pool. SIP identity is still gated by the
+> `[[trunk]]` allowlist, so this doesn't loosen auth.
+
 ### Fail2ban for repeat offenders
 
 The `[[trunk]]` allowlist 403s every scanner INVITE at the SIP


### PR DESCRIPTION
## Summary

Three doc updates from the field test that finally got a clean SIP→bot call working end-to-end. No code changes.

1. **`docs/FREESWITCH_INTEGRATION.md`** — \`bypass_media=true\` is now a **required** line in the 9000 dialplan extension. Without it, FS's anchored bridge silently drops the SiphonAI→softphone RTP direction whenever the softphone offers \`a=rtcp-mux\` (most do) while SiphonAI's answer omits it. Three of the four expected RTP directions flow at 50 pps; the fourth flatlines at 0. Symptom on the caller side is total silence from the bot, while STT still picks up caller voice fine. Added a \"Why bypass_media\" section with the diagnostic tcpdump table and the bypass-media caveats (no FS-side media features on that leg; symmetric NAT incompatibility).

2. **`docs/FREESWITCH_INTEGRATION.md` + `docs/BOT_LOCALHOST_SETUP.md`** — new troubleshooting entry for self-induced barge-in chop. When the test softphone is on speakerphone with no AEC, the bot's own playback feeds back through the mic, the daemon's VAD fires \`speech_started\`, and the bot cancels its own playout. Real callers with hardware AEC don't see this; documented the two operator options.

3. **`docs/INSTALL_DEBIAN13.md`** — clarifying note on the firewall section. The default RTP source-ACL rule assumes RTP comes from the trunk peer, which is correct for anchored bridges but NOT for \`bypass_media=true\` (RTP comes from the original caller's IP).

## Test plan

- [x] Sanity-render the three changed files
- [ ] Next fresh deployment using the guide should produce a working call without the multi-hour debugging session

🤖 Generated with [Claude Code](https://claude.com/claude-code)