### PR TITLE
docs(install): require rustup; bump workspace MSRV to 1.89

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 [workspace.package]
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.89"
 license = "MIT OR Apache-2.0"
 authors = ["SiphonAI contributors"]
 repository = "https://github.com/thevoiceguy/siphon-ai"

--- a/docs/INSTALL_DEBIAN13.md
+++ b/docs/INSTALL_DEBIAN13.md
@@ -34,19 +34,25 @@ ships SIPp v3.7 which is plenty new for the bundled scenarios.
 
 ### Rust toolchain
 
-Debian 13's `rustc` is current enough, but `rustup` makes
-toolchain bumps painless when a sibling crate moves its MSRV:
+**Use `rustup` — not Debian's `rustc` package.** Debian 13 ships
+`rustc 1.85`, which is too old: transitive deps from
+`forge-media` / `siphon-rs` (the `icu_*`, `smol_str`, `time`,
+etc. families) require `rustc 1.89` or newer. The workspace's
+`rust-toolchain.toml` pins the channel to `stable`, so rustup
+picks up the right version automatically; `apt install rustc`
+gets you a hard `error: rustc 1.85 is not supported` mid-build.
 
 ```bash
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
 source "$HOME/.cargo/env"
-rustc --version    # 1.85+ for the workspace
+rustc --version    # 1.89+ for the workspace
 ```
 
-If you'd rather use distro Rust:
+If `rustup` is already installed from an earlier setup, make
+sure stable is current:
 
 ```bash
-sudo apt install -y rustc cargo
+rustup update stable
 ```
 
 ---


### PR DESCRIPTION
## Summary

Fresh install on a clean Debian 13 box failed with:

\`\`\`
error: rustc 1.85.0 is not supported by the following packages:
  smol_str@0.3.6 requires rustc 1.89
  time@0.3.47 requires rustc 1.88.0
  icu_*@2.2.0 requires rustc 1.86
  …
\`\`\`

Debian 13 ships \`rustc 1.85\`. Transitive deps need 1.89. The workspace's \`rust-toolchain.toml\` already pins \`channel = \"stable\"\` so rustup users sail through; the trap was the install guide's \`apt install rustc cargo\` alternative.

- \`docs/INSTALL_DEBIAN13.md\`: rustup is the only documented path now, with explicit \"1.89+ required\" callout and a \`rustup update stable\` hint for re-runs.
- \`Cargo.toml\`: \`rust-version = \"1.89\"\` so the MSRV claim matches reality.

## Test plan

- [x] \`cargo build -p siphon-ai\` succeeds with current stable (verified 1.92)
- [ ] Fresh Debian 13 install using the new guide compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)