### PR TITLE
feat(bot): make the LLM provider configurable via env

### DIFF
--- a/docs/BOT_LOCALHOST_SETUP.md
+++ b/docs/BOT_LOCALHOST_SETUP.md
@@ -67,6 +67,59 @@ sudo chmod 0640 /etc/siphon-bot/env
 Replace the `xxxxxx` placeholders. Set the file mode to `0640`
 since it holds API credentials.
 
+### Choosing the LLM
+
+The bot uses the OpenAI SDK against an OpenAI-compatible chat-completions
+endpoint, so any provider that speaks that protocol drops in via env
+vars. STT and TTS stay on Deepgram regardless.
+
+| Variable | What it sets | Default |
+|---|---|---|
+| `BOT_LLM_MODEL` | Model name | `gpt-4o-mini` |
+| `BOT_LLM_BASE_URL` | OpenAI-compatible base URL | OpenAI's API |
+| `BOT_LLM_API_KEY` | API key for the LLM endpoint | falls back to `OPENAI_API_KEY` |
+| `BOT_LLM_MAX_TOKENS` | Cap response length | provider default |
+| `BOT_LLM_TEMPERATURE` | Sampling temperature | provider default |
+
+Recipes for popular providers:
+
+**OpenAI (default)** — no changes needed beyond `OPENAI_API_KEY`.
+
+**Groq (typically the lowest TTFT — 100-300 ms):**
+```
+BOT_LLM_BASE_URL=https://api.groq.com/openai/v1
+BOT_LLM_API_KEY=gsk_xxxxxxxxxxxxxxxxxxxxxxxx
+BOT_LLM_MODEL=llama-3.3-70b-versatile
+```
+
+**Anthropic Claude (via their OpenAI-compatible endpoint):**
+```
+BOT_LLM_BASE_URL=https://api.anthropic.com/v1/
+BOT_LLM_API_KEY=sk-ant-xxxxxxxxxxxxxxxxxxxxxxxx
+BOT_LLM_MODEL=claude-haiku-4-5-20251001
+```
+
+**OpenRouter (one key → 100+ models):**
+```
+BOT_LLM_BASE_URL=https://openrouter.ai/api/v1
+BOT_LLM_API_KEY=sk-or-xxxxxxxxxxxxxxxxxxxxxxxx
+BOT_LLM_MODEL=meta-llama/llama-3.3-70b-instruct
+```
+
+**Local Ollama:**
+```
+BOT_LLM_BASE_URL=http://127.0.0.1:11434/v1
+BOT_LLM_API_KEY=ollama        # any non-empty value
+BOT_LLM_MODEL=llama3.2:3b
+```
+
+On bot startup, the resolved configuration is logged so you can
+verify which provider is live:
+
+```
+[llm] model=llama-3.3-70b-versatile base_url=https://api.groq.com/openai/v1 max_tokens=(provider default) temperature=(provider default)
+```
+
 ---
 
 ## 4. Smoke test in the foreground

--- a/examples/deepgram-openai-bot-node/server.js
+++ b/examples/deepgram-openai-bot-node/server.js
@@ -56,7 +56,23 @@ const OpenAI = require('openai');
 const [BIND_HOST, BIND_PORT] = (process.env.BOT_BIND || '0.0.0.0:8080').split(':');
 
 const DG_KEY = process.env.DEEPGRAM_API_KEY;
-const OPENAI_KEY = process.env.OPENAI_API_KEY;
+
+// LLM: any OpenAI-compatible chat-completions endpoint works (OpenAI,
+// Groq, Together, OpenRouter, Fireworks, Anthropic's OAI-compat API,
+// local Ollama, …). `BOT_LLM_BASE_URL` switches providers without
+// touching code; `BOT_LLM_MODEL` picks the model name; the API key
+// can come from either `BOT_LLM_API_KEY` (preferred for non-OpenAI
+// providers) or the legacy `OPENAI_API_KEY` env var.
+const LLM_BASE_URL  = process.env.BOT_LLM_BASE_URL || undefined;
+const LLM_MODEL     = process.env.BOT_LLM_MODEL    || 'gpt-4o-mini';
+const LLM_API_KEY   = process.env.BOT_LLM_API_KEY  || process.env.OPENAI_API_KEY;
+const LLM_API_KEY_VAR = process.env.BOT_LLM_API_KEY ? 'BOT_LLM_API_KEY' : 'OPENAI_API_KEY';
+const LLM_MAX_TOKENS  = process.env.BOT_LLM_MAX_TOKENS
+  ? Number.parseInt(process.env.BOT_LLM_MAX_TOKENS, 10)
+  : undefined;
+const LLM_TEMPERATURE = process.env.BOT_LLM_TEMPERATURE
+  ? Number.parseFloat(process.env.BOT_LLM_TEMPERATURE)
+  : undefined;
 
 /**
  * Validate an API key env var. Bails on missing OR
@@ -83,7 +99,7 @@ function requireKey(name, value) {
   }
 }
 requireKey('DEEPGRAM_API_KEY', DG_KEY);
-requireKey('OPENAI_API_KEY', OPENAI_KEY);
+requireKey(LLM_API_KEY_VAR, LLM_API_KEY);
 
 const SYSTEM_PROMPT =
   process.env.BOT_SYSTEM_PROMPT ||
@@ -92,6 +108,12 @@ const SYSTEM_PROMPT =
     'Avoid markdown, lists, or formatting.';
 
 const GREETING = process.env.BOT_GREETING || 'Hi there! How can I help you today?';
+
+console.log(
+  `[llm] model=${LLM_MODEL} base_url=${LLM_BASE_URL || '(OpenAI default)'} ` +
+  `max_tokens=${LLM_MAX_TOKENS ?? '(provider default)'} ` +
+  `temperature=${LLM_TEMPERATURE ?? '(provider default)'}`,
+);
 
 // SiphonAI's protocol pins these: pcm16le, mono, 20 ms frames,
 // 8 kHz or 16 kHz. Anything else means a daemon misconfig or a
@@ -420,7 +442,10 @@ async function handleCall(ws, req) {
 
   // ─── Deepgram STT (built lazily, once we have the sample rate) ───
   const deepgram = createClient(DG_KEY);
-  const openai = new OpenAI({ apiKey: OPENAI_KEY });
+  const openai = new OpenAI({
+    apiKey: LLM_API_KEY,
+    ...(LLM_BASE_URL ? { baseURL: LLM_BASE_URL } : {}),
+  });
   let dgStt = null;
   let dgSttReady = false;
 
@@ -613,9 +638,11 @@ async function handleCall(ws, req) {
     try {
       if (turn) turn.markLlmStart();
       const stream = await openai.chat.completions.create({
-        model: 'gpt-4o-mini',
+        model: LLM_MODEL,
         messages: conversation,
         stream: true,
+        ...(LLM_MAX_TOKENS  != null ? { max_tokens:  LLM_MAX_TOKENS  } : {}),
+        ...(LLM_TEMPERATURE != null ? { temperature: LLM_TEMPERATURE } : {}),
       });
       for await (const chunk of stream) {
         const delta = chunk.choices?.[0]?.delta?.content;


### PR DESCRIPTION
## Summary

The bot now picks its LLM provider from env, with sane fallbacks:

| Variable | Sets | Default |
|---|---|---|
| \`BOT_LLM_MODEL\` | Model name | \`gpt-4o-mini\` |
| \`BOT_LLM_BASE_URL\` | OpenAI-compatible endpoint URL | OpenAI's API |
| \`BOT_LLM_API_KEY\` | API key for that endpoint | falls back to \`OPENAI_API_KEY\` |
| \`BOT_LLM_MAX_TOKENS\` | Cap response length | provider default |
| \`BOT_LLM_TEMPERATURE\` | Sampling temperature | provider default |

The OpenAI SDK already speaks the chat-completions protocol against any \`baseURL\` — so OpenAI, Groq, Together, OpenRouter, Fireworks, Anthropic's OpenAI-compat API, local Ollama all drop in without code changes.

## Why

Field test showed LLM TTFT was the dominant latency component (700-1800 ms on gpt-4o-mini). Groq + Llama-3 gets TTFT to 100-300 ms, which would cut end-to-end response latency by ~1 s.

## Test plan

- [x] \`node -c server.js\` parses
- [x] Smoke test: default config logs \`base_url=(OpenAI default)\`
- [x] Smoke test: Groq env vars log Groq URL + Llama model + max_tokens
- [ ] User redeploys with their preferred provider
- [ ] \`turn_summary\` shows lower \`llm_first_token_ms\` than the OpenAI baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)