### PR TITLE
chore(deps): pin siphon-rs and forge-media to commit revs (release blocker)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,7 +612,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 [[package]]
 name = "forge-codecs"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?branch=main#faf5e8bc450ec57ee71420c7328c22fa706cf373"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=faf5e8bc450e#faf5e8bc450ec57ee71420c7328c22fa706cf373"
 dependencies = [
  "ezk-g722",
  "lazy_static",
@@ -623,7 +623,7 @@ dependencies = [
 [[package]]
 name = "forge-core"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?branch=main#faf5e8bc450ec57ee71420c7328c22fa706cf373"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=faf5e8bc450e#faf5e8bc450ec57ee71420c7328c22fa706cf373"
 dependencies = [
  "chrono",
  "serde",
@@ -638,7 +638,7 @@ dependencies = [
 [[package]]
 name = "forge-dtmf"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?branch=main#faf5e8bc450ec57ee71420c7328c22fa706cf373"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=faf5e8bc450e#faf5e8bc450ec57ee71420c7328c22fa706cf373"
 dependencies = [
  "chrono",
  "forge-core",
@@ -650,7 +650,7 @@ dependencies = [
 [[package]]
 name = "forge-engine"
 version = "0.4.0"
-source = "git+https://github.com/thevoiceguy/forge-media?branch=main#faf5e8bc450ec57ee71420c7328c22fa706cf373"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=faf5e8bc450e#faf5e8bc450ec57ee71420c7328c22fa706cf373"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -680,7 +680,7 @@ dependencies = [
 [[package]]
 name = "forge-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/forge-media?branch=main#faf5e8bc450ec57ee71420c7328c22fa706cf373"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=faf5e8bc450e#faf5e8bc450ec57ee71420c7328c22fa706cf373"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -693,7 +693,7 @@ dependencies = [
 [[package]]
 name = "forge-injection"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?branch=main#faf5e8bc450ec57ee71420c7328c22fa706cf373"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=faf5e8bc450e#faf5e8bc450ec57ee71420c7328c22fa706cf373"
 dependencies = [
  "forge-core",
  "rubato",
@@ -706,7 +706,7 @@ dependencies = [
 [[package]]
 name = "forge-recorder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?branch=main#faf5e8bc450ec57ee71420c7328c22fa706cf373"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=faf5e8bc450e#faf5e8bc450ec57ee71420c7328c22fa706cf373"
 dependencies = [
  "bytes",
  "forge-core",
@@ -720,7 +720,7 @@ dependencies = [
 [[package]]
 name = "forge-resampler"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?branch=main#faf5e8bc450ec57ee71420c7328c22fa706cf373"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=faf5e8bc450e#faf5e8bc450ec57ee71420c7328c22fa706cf373"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -729,7 +729,7 @@ dependencies = [
 [[package]]
 name = "forge-rtp"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?branch=main#faf5e8bc450ec57ee71420c7328c22fa706cf373"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=faf5e8bc450e#faf5e8bc450ec57ee71420c7328c22fa706cf373"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -751,11 +751,11 @@ dependencies = [
 [[package]]
 name = "forge-sdp"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?branch=main#faf5e8bc450ec57ee71420c7328c22fa706cf373"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=faf5e8bc450e#faf5e8bc450ec57ee71420c7328c22fa706cf373"
 dependencies = [
  "chrono",
  "forge-core",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?branch=main)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=faf5e8bc450e)",
  "smol_str",
  "thiserror 2.0.18",
 ]
@@ -763,7 +763,7 @@ dependencies = [
 [[package]]
 name = "forge-transcoder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?branch=main#faf5e8bc450ec57ee71420c7328c22fa706cf373"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=faf5e8bc450e#faf5e8bc450ec57ee71420c7328c22fa706cf373"
 dependencies = [
  "bytes",
  "forge-codecs",
@@ -776,7 +776,7 @@ dependencies = [
 [[package]]
 name = "forge-vad"
 version = "0.1.0"
-source = "git+https://github.com/thevoiceguy/forge-media?branch=main#faf5e8bc450ec57ee71420c7328c22fa706cf373"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=faf5e8bc450e#faf5e8bc450ec57ee71420c7328c22fa706cf373"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -2325,7 +2325,7 @@ dependencies = [
 [[package]]
 name = "sip-auth"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#62fe4da697dc8f908c00670250be74f36b6014b8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=62fe4da697dc#62fe4da697dc8f908c00670250be74f36b6014b8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2348,7 +2348,7 @@ dependencies = [
 [[package]]
 name = "sip-core"
 version = "0.7.6"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#62fe4da697dc8f908c00670250be74f36b6014b8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=62fe4da697dc#62fe4da697dc8f908c00670250be74f36b6014b8"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2361,7 +2361,7 @@ dependencies = [
 [[package]]
 name = "sip-dialog"
 version = "0.3.3"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#62fe4da697dc8f908c00670250be74f36b6014b8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=62fe4da697dc#62fe4da697dc8f908c00670250be74f36b6014b8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2379,7 +2379,7 @@ dependencies = [
 [[package]]
 name = "sip-dns"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#62fe4da697dc8f908c00670250be74f36b6014b8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=62fe4da697dc#62fe4da697dc8f908c00670250be74f36b6014b8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2393,7 +2393,7 @@ dependencies = [
 [[package]]
 name = "sip-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#62fe4da697dc8f908c00670250be74f36b6014b8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=62fe4da697dc#62fe4da697dc8f908c00670250be74f36b6014b8"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -2404,7 +2404,7 @@ dependencies = [
 [[package]]
 name = "sip-observe"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#62fe4da697dc8f908c00670250be74f36b6014b8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=62fe4da697dc#62fe4da697dc8f908c00670250be74f36b6014b8"
 dependencies = [
  "once_cell",
  "tracing",
@@ -2413,7 +2413,7 @@ dependencies = [
 [[package]]
 name = "sip-parse"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#62fe4da697dc8f908c00670250be74f36b6014b8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=62fe4da697dc#62fe4da697dc8f908c00670250be74f36b6014b8"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2427,7 +2427,7 @@ dependencies = [
 [[package]]
 name = "sip-ratelimit"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#62fe4da697dc8f908c00670250be74f36b6014b8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=62fe4da697dc#62fe4da697dc8f908c00670250be74f36b6014b8"
 dependencies = [
  "dashmap",
  "parking_lot",
@@ -2438,7 +2438,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/forge-media?branch=main#faf5e8bc450ec57ee71420c7328c22fa706cf373"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=62fe4da697dc#62fe4da697dc8f908c00670250be74f36b6014b8"
 dependencies = [
  "nom",
  "smol_str",
@@ -2447,7 +2447,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#62fe4da697dc8f908c00670250be74f36b6014b8"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=faf5e8bc450e#faf5e8bc450ec57ee71420c7328c22fa706cf373"
 dependencies = [
  "nom",
  "smol_str",
@@ -2456,7 +2456,7 @@ dependencies = [
 [[package]]
 name = "sip-transaction"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#62fe4da697dc8f908c00670250be74f36b6014b8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=62fe4da697dc#62fe4da697dc8f908c00670250be74f36b6014b8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2475,7 +2475,7 @@ dependencies = [
 [[package]]
 name = "sip-transport"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#62fe4da697dc8f908c00670250be74f36b6014b8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=62fe4da697dc#62fe4da697dc8f908c00670250be74f36b6014b8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2494,7 +2494,7 @@ dependencies = [
 [[package]]
 name = "sip-uac"
 version = "0.4.2"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#62fe4da697dc8f908c00670250be74f36b6014b8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=62fe4da697dc#62fe4da697dc8f908c00670250be74f36b6014b8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2507,7 +2507,7 @@ dependencies = [
  "sip-dialog",
  "sip-dns",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?branch=main)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=62fe4da697dc)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -2519,7 +2519,7 @@ dependencies = [
 [[package]]
 name = "sip-uas"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?branch=main#62fe4da697dc8f908c00670250be74f36b6014b8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=62fe4da697dc#62fe4da697dc8f908c00670250be74f36b6014b8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2529,7 +2529,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?branch=main)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=62fe4da697dc)",
  "sip-transaction",
  "sip-transport",
  "smol_str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,21 +93,23 @@ uuid        = { version = "1", features = ["v4", "serde"] }
 chrono      = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 
 # ─── Upstream voice stack (separate repos, owned by us) ──────────────────────
-# These are git deps for now; once published to crates.io we'll switch to versioned
-# releases. For reproducibility, pin to a specific rev before v0.1.0 ships
-# (see CLAUDE.md §7.5 "Bumping Upstream Dep").
+# These are git deps for now; once published to crates.io we'll switch to
+# versioned releases. Pinned to specific commit revs for reproducibility —
+# `branch = "main"` would mean a tagged release could build different code
+# later if upstream moves. To bump, run `git ls-remote` for the upstream's
+# main branch and replace the rev hashes here (see CLAUDE.md §7.5).
 
 # siphon-rs — RFC 3261 SIP stack
-sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "main" }
-sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "main" }
-sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "main", features = ["tls"] }
-sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "main" }
-sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "main" }
-sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "main" }
-sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "main" }
-sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "main" }
-sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "main" }
-sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "main" }
+sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "62fe4da697dc" }
+sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "62fe4da697dc" }
+sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "62fe4da697dc", features = ["tls"] }
+sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "62fe4da697dc" }
+sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "62fe4da697dc" }
+sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "62fe4da697dc" }
+sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "62fe4da697dc" }
+sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "62fe4da697dc" }
+sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "62fe4da697dc" }
+sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "62fe4da697dc" }
 
 # forge-media — RTP / codecs / SDP / DTMF / engine.
 #
@@ -123,17 +125,26 @@ sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", branch = "
 # forge-ice, Cow/lifetime in forge-recorder), but the subset SiphonAI
 # pulls — forge-core, forge-rtp, forge-engine (g722 only), forge-codecs,
 # forge-sdp, forge-dtmf, forge-vad, forge-hep — all build cleanly.
-forge-core    = { git = "https://github.com/thevoiceguy/forge-media", branch = "main" }
-forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", branch = "main" }
-forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", branch = "main", default-features = false, features = ["g722"] }
-forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", branch = "main" }
-forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", branch = "main" }
-forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", branch = "main" }
-forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", branch = "main" }
-forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", branch = "main" }
+forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "faf5e8bc450e" }
+forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "faf5e8bc450e" }
+forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "faf5e8bc450e", default-features = false, features = ["g722"] }
+forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "faf5e8bc450e" }
+forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "faf5e8bc450e" }
+forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "faf5e8bc450e" }
+forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "faf5e8bc450e" }
+forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "faf5e8bc450e" }
 
 # hep-rs — HEP3 codec, transport, HepSink trait. Owned by the same
 # author as siphon-rs and forge-media; lives in its own repo.
+#
+# Kept on `branch = "main"` (NOT rev-pinned) on purpose: both
+# siphon-rs and forge-media depend on hep-rs as `branch = "main"`,
+# so pinning a `rev` here would create two distinct source URLs in
+# the dep graph (`?rev=X` vs `?branch=main`) — cargo treats those
+# as different crates, causing the classic "two different versions
+# of crate `hep_rs` are being used" build error.
+# Reproducibility for hep-rs is still enforced via the checked-in
+# Cargo.lock entry (`source = git+…hep-rs?branch=main#<commit>`).
 hep-rs = { git = "https://github.com/thevoiceguy/hep-rs", branch = "main" }
 
 [profile.release]


### PR DESCRIPTION
## Summary

Pre-v0.1.0 release blocker. Workspace \`Cargo.toml\` comment said the upstream git deps had to be pinned before tagging, but they were still tracking \`branch = \"main\"\`.

Pinned:
- \`siphon-rs\` → \`62fe4da697dc\` (all 10 sub-crates)
- \`forge-media\` → \`faf5e8bc450e\` (all 8 sub-crates)

\`hep-rs\` deliberately stays on \`branch = \"main\"\` — see the inline comment for why (cargo source-URL aliasing).

## Test plan

- [x] \`cargo build -p siphon-ai\` (clean build)
- [x] \`cargo test --workspace\` (all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)