### PR TITLE
fix(docker): bind admin port to host loopback only

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -73,8 +73,14 @@ services:
       - "5070:5070/udp"
       # SIP TCP — same port, different namespace.
       - "5070:5070/tcp"
-      # Prometheus metrics + /health + /ready.
-      - "9091:9091/tcp"
+      # Prometheus metrics + /health + /ready + /admin/*.
+      # Bound to 127.0.0.1 on the HOST side: the admin API has no
+      # built-in auth and can take calls down (see
+      # crates/telemetry/src/admin.rs §"Threat model"). Exposing
+      # it on the LAN would let anyone POST
+      # /admin/calls/<id>/hangup or PUT /admin/log. Keep it on
+      # loopback; reach it from the host via `curl 127.0.0.1:9091`.
+      - "127.0.0.1:9091:9091/tcp"
       # RTP port pool. forge's port allocator picks from this range
       # for the answer SDP's `m=audio` line; without these forwarded
       # the caller's media flows nowhere.

--- a/docker/local-dev.toml
+++ b/docker/local-dev.toml
@@ -44,6 +44,14 @@ ws_connect_timeout_ms = 3000
 
 [observability]
 enabled = true
+# Bound to the container's wildcard so the compose port mapping
+# can forward to it. The host side of that mapping is restricted
+# to 127.0.0.1 (see compose.yaml `ports:`), so /admin/* is
+# reachable from the docker host's loopback but NOT from the LAN.
+# The admin API has no built-in auth (see
+# crates/telemetry/src/admin.rs §"Threat model") and can take
+# calls down, so it MUST NOT be on a public interface. Front with
+# an authenticating reverse proxy if you want to expose it.
 http_listen = "0.0.0.0:9091"
 
 [[route]]


### PR DESCRIPTION
## Summary

Finding HIGH-1: the shipped Docker stack exposed \`/admin/*\` (no auth) on the LAN. The admin API can take calls down and change log levels remotely.

Fix: changed the host-side compose port mapping from \`9091:9091/tcp\` to \`127.0.0.1:9091:9091/tcp\`. Container still listens on \`0.0.0.0:9091\` so port forwarding works; only the docker host's loopback can reach it now.

Added inline comments in both \`docker/compose.yaml\` and \`docker/local-dev.toml\` pointing at the threat-model section and calling out the unauth nature explicitly.

## Test plan

- [x] \`docker compose config\` parses (verified with sed-replace + grep)
- [ ] After deploy: \`curl 127.0.0.1:9091/health\` works from docker host; \`curl <docker-host-LAN-ip>:9091/health\` refused

🤖 Generated with [Claude Code](https://claude.com/claude-code)