### PR TITLE
fix(scripts): handle unset EDITOR in install-bot-debian13 closing tip

### DIFF
--- a/scripts/install-bot-debian13.sh
+++ b/scripts/install-bot-debian13.sh
@@ -334,7 +334,7 @@ Bot listens on ws://${BOT_BIND}/  (running as user '${BOT_USER}')
 
 Tail logs:        sudo journalctl -u siphon-bot -f
 Restart:          sudo systemctl restart siphon-bot
-Edit env file:    sudo $EDITOR /etc/siphon-bot/env  (then restart)
+Edit env file:    sudo "\${EDITOR:-nano}" /etc/siphon-bot/env  (then restart)
 
 Next:
   1. If the script didn't repoint it for you: set


### PR DESCRIPTION
## Summary

Cosmetic install-script fix: \`set -u\` strict mode + an unset \`\$EDITOR\` crashed the closing tips heredoc with \`EDITOR: unbound variable\` after all install steps had already succeeded. Replaces with \`\${EDITOR:-nano}\` (escaped inside the heredoc so the operator sees the parameter-expansion form they should use).

## Test plan

- [x] Repro pattern in a sub-shell with \`unset EDITOR; set -u\` prints the tip cleanly
- [x] \`bash -n\` parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)