### PR TITLE
docs(readme): refresh for v0.1.0-rc

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,33 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-Pre-alpha. See `docs/DEV_PLAN.md` for the 7-week sprint plan.
+**v0.1.0-rc** — pre-release. The audio path, WS protocol, SIP signaling,
+HEP capture, CDR/webhook sinks, and trunk-allowlist gate are in. Real-world
+FreeSWITCH-bridged calls work with sub-second user-to-audio latency on a
+Groq LLM. A 500-concurrent burst soak completes with no rejections and no
+RSS growth past the working-set; a 1-hour long-call soak holds RSS within
+±32 KB.
+
+See `docs/DEV_PLAN.md` for what's deliberately out of scope for v1
+(recording, SRTP, mid-call WS reconnect, multi-tenancy, video).
+
+## Scope
+
+SiphonAI is the bridge layer between SIP and a WebSocket. The contract is:
+
+| | SiphonAI provides | Your responsibility |
+|---|---|---|
+| SIP signaling, RTP, codecs, jitter | ✓ | — |
+| WebSocket bridge protocol (`docs/PROTOCOL.md`) | ✓ | — |
+| Speech-start / DTMF / hold / resume events on the WS | ✓ | — |
+| Auto-clear of daemon-side playout on barge-in | `[bridge.barge_in].mode` config | — |
+| STT, LLM, TTS, conversation logic | — | ✓ |
+| What to do with a `speech_started` event | — | ✓ |
+| Acoustic echo cancellation | — | ✓ (handset or AEC) |
+
+The reference bot in `examples/deepgram-llm-bot-node/` is a working demo
+of the protocol, not the product. Tune it for your deployment or replace
+it entirely with your own WS server in any language.
 
 ## Quickstart (Docker)
 
@@ -78,6 +104,54 @@ For the full HEP/Homer end-to-end demo (SIP + RTCP + CDRs
 correlated in one call view), see
 [`examples/homer-stack/`](examples/homer-stack/).
 
+## Production install (Debian 13)
+
+Two scripts walk through `docs/INSTALL_DEBIAN13.md` and
+`docs/BOT_LOCALHOST_SETUP.md` end-to-end. Both are idempotent —
+re-running is safe.
+
+```sh
+git clone https://github.com/thevoiceguy/siphon-ai.git /opt/siphon-ai-src
+cd /opt/siphon-ai-src
+
+# Daemon: packages, rustup, build, systemd unit, working TOML config.
+TRUNK_PEER_IP=<FreeSWITCH-or-ITSP-IP> ./scripts/install-debian13.sh
+
+# Reference bot: Node 22, npm install, env file, systemd unit,
+# optional daemon ws_url repoint.
+DEEPGRAM_API_KEY=dg_xxx OPENAI_API_KEY=sk-xxx \
+    ./scripts/install-bot-debian13.sh
+```
+
+Trunking to FreeSWITCH? Read `docs/FREESWITCH_INTEGRATION.md` —
+the `bypass_media=true` dialplan setting is **required** for
+clean audio when the softphone offers `a=rtcp-mux` (most do).
+
+## Reference bot (`examples/deepgram-llm-bot-node/`)
+
+Working closed-loop voice agent in Node:
+caller → Deepgram STT → streaming LLM → Deepgram TTS → caller.
+
+The LLM is any OpenAI-compatible chat-completions endpoint,
+selected via env vars at startup:
+
+| Provider | `BOT_LLM_BASE_URL` |
+|---|---|
+| OpenAI (default) | (unset) |
+| Groq | `https://api.groq.com/openai/v1` |
+| Anthropic | `https://api.anthropic.com/v1/` |
+| OpenRouter | `https://openrouter.ai/api/v1` |
+| Local Ollama | `http://127.0.0.1:11434/v1` |
+
+In practice with Groq + `llama-3.3-70b-versatile`,
+user-stop-to-agent-audio runs ~600 ms steady-state, with the
+~1 s floor from Deepgram's `utterance_end_ms` minimum.
+
+Per-turn latency, LLM/TTS timings, barge-in counts, and dropped
+frames are emitted as one-line `metric` records in the bot's
+journal — grep `turn_summary` for SLO numbers. See
+`docs/BOT_LOCALHOST_SETUP.md` §4.
+
 ## Layout
 
 | Path | Purpose |
@@ -93,8 +167,9 @@ correlated in one call view), see
 | `crates/telemetry/`   | tracing + metrics + HEP wiring + admin endpoints |
 | `bins/siphon-ai/`     | The daemon binary |
 | `examples/`           | Reference WS servers and the local Homer stack |
+| `scripts/`            | Idempotent Debian 13 install scripts (daemon + bot) |
 | `test-harness/`       | SIPp scenarios, load tooling, HEP collector stub |
-| `docs/`               | Protocol, config, dialplan, HEP, deployment |
+| `docs/`               | Protocol, config, dialplan, HEP, deployment, FS integration |
 
 ## Building
 
@@ -104,12 +179,34 @@ cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
 ```
 
+## Observability
+
+| Surface | URL / location |
+|---|---|
+| Liveness / readiness | `GET /health`, `GET /ready` |
+| Prometheus metrics | `GET /metrics` |
+| Active calls | `GET /admin/calls` |
+| Per-call hangup | `POST /admin/calls/<id>/hangup` |
+| Runtime log filter | `PUT /admin/log` |
+| HEP test packet | `POST /admin/hep/test` |
+| CDR (JSONL file) | `/var/log/siphon-ai/cdr.jsonl` |
+| Lifecycle webhooks | `[webhooks]` block in the TOML |
+| Full SIP + RTCP + CDR correlation | HEP → Homer (see `docs/HEP.md`) |
+
+**The admin endpoints have no built-in auth** (per the v1 threat
+model in `crates/telemetry/src/admin.rs`). The shipped Docker
+compose binds them to `127.0.0.1` only; for any other deployment
+sit them behind an authenticating reverse proxy.
+
 ## Reading order for contributors
 
 1. `CLAUDE.md` — operating instructions (read first; re-check before
    non-trivial changes).
 2. `docs/DEV_PLAN.md` — what we're building and why.
 3. `docs/PROTOCOL.md` — the WebSocket bridge protocol contract.
+4. `docs/INSTALL_DEBIAN13.md` + `docs/FREESWITCH_INTEGRATION.md` +
+   `docs/BOT_LOCALHOST_SETUP.md` — the deploy-the-thing path.
+5. `docs/CONFIG.md` — every TOML field documented.
 
 ## Upstream dependencies
 


### PR DESCRIPTION
## Summary

Front-door discoverability pass on \`README.md\`:

- **Status** — pre-alpha → v0.1.0-rc, with the soak + real-call numbers.
- **Scope** — matrix of SiphonAI's responsibility vs. the bot author's. Reinforces that the reference bot is a demo, not the product.
- **Production install** — one-line invocations of \`scripts/install-debian13.sh\` and \`scripts/install-bot-debian13.sh\`.
- **Reference bot** — provider matrix (OpenAI / Groq / Anthropic / OpenRouter / Ollama) and where to find per-turn metrics.
- **Observability** — operator-facing surface table (probes, admin API, CDR, webhooks, HEP), with the no-builtin-auth warning next to the admin entries.
- **Layout** — \`scripts/\` row added.
- **Reading order** — install + config docs as steps 4–5.

No behavioural changes; pure docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)