### PR TITLE
fix(daemon): install rustls CryptoProvider so [sip.tls] doesn't panic on startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2550,6 +2550,7 @@ dependencies = [
  "forge-engine",
  "forge-rtp",
  "metrics 0.23.1",
+ "rustls",
  "sip-core",
  "sip-dns",
  "sip-parse",

--- a/bins/siphon-ai/Cargo.toml
+++ b/bins/siphon-ai/Cargo.toml
@@ -51,6 +51,16 @@ sip-dns.workspace         = true
 # sip_transport::load_rustls_server_config.
 tokio-rustls.workspace = true
 
+# rustls: pulled here only so `main()` can install a process-level
+# `CryptoProvider` before any TLS code path fires. Without this,
+# enabling `[sip.tls]` panics on startup with
+# "Could not automatically determine the process-level
+# CryptoProvider from Rustls crate features" — rustls 0.23+
+# requires either a feature-selected provider OR an explicit
+# install when both `aws-lc-rs` and `ring` end up in the dep
+# graph (they do, transitively).
+rustls = { version = "0.23", features = ["aws_lc_rs"] }
+
 # Upstream — forge-media (session manager, media bridge).
 forge-core.workspace   = true
 forge-engine.workspace = true

--- a/bins/siphon-ai/src/main.rs
+++ b/bins/siphon-ai/src/main.rs
@@ -34,6 +34,19 @@ struct Cli {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Install rustls' process-wide `CryptoProvider` before any TLS
+    // code path runs. Required from rustls 0.23 onward whenever the
+    // dep graph contains more than one provider crate — ours pulls
+    // both `aws-lc-rs` and `ring` transitively via different
+    // upstreams. Without this, enabling `[sip.tls]` panics on
+    // startup with:
+    //     "Could not automatically determine the process-level
+    //      CryptoProvider from Rustls crate features."
+    // `aws_lc_rs` is the BoringSSL-derived modern default; `.ok()`
+    // makes the call idempotent so a test harness that already
+    // installed a provider doesn't break the second install.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     let cli = Cli::parse();
     let log_filter = init_tracing(cli.log.as_deref());
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -49,6 +49,23 @@ before TOML parsing. Unset variables without a default fail the load.
 | `cert`   | path        | required when TLS on | PEM cert chain on disk. |
 | `key`    | path        | required when TLS on | PEM private key on disk. |
 
+> **Experimental — inbound listening only in v0.1.0.** The TLS
+> listener accepts connections and the daemon parses inbound SIP
+> requests correctly, but the upstream `siphon-rs` transport layer
+> doesn't yet reuse the established inbound TLS socket to send the
+> response. Real traffic that needs a response (INVITE, OPTIONS,
+> REGISTER) ends with the daemon logging:
+>
+> ```
+> ERROR sip_transaction::manager: server transport dispatch failed
+>   e=outbound Tls without an existing stream is not supported in v1
+> ```
+>
+> and the caller times out. Use UDP or TCP for production traffic
+> until bidirectional TLS streaming lands upstream. The
+> `cert`/`key`/`listen` config surface itself is stable — only the
+> transport-internal response path is missing.
+
 ## `[media]`
 
 | Field                       | Type             | Default                | Notes |


### PR DESCRIPTION
## Summary

Pre-v0.1.0 validation found: setting \`[sip].transports = [\"tls\"]\` plus \`[sip.tls].{cert,key}\` crashed the daemon on startup with the classic rustls 0.23 \"no CryptoProvider\" panic. The dep graph has both \`aws-lc-rs\` and \`ring\` transitively, so rustls won't auto-pick.

Fix: install \`aws-lc-rs\` as the process-wide default at the top of \`main()\`. After the fix the daemon binds TCP 5061, completes a TLS 1.3 handshake (verified with \`openssl s_client\`), and parses inbound SIP correctly.

## Drive-by docs

While testing I found a separate **upstream limitation in siphon-rs**: the inbound TLS socket isn't reused for sending the response, so real INVITE/OPTIONS/REGISTER over TLS parses but never gets a reply. The daemon logs:

\`\`\`
ERROR sip_transaction::manager: server transport dispatch failed
  e=outbound Tls without an existing stream is not supported in v1
\`\`\`

That's an upstream fix, not addressable here. \`docs/CONFIG.md\` §\`[sip.tls]\` now carries an experimental callout. UDP and TCP remain the production-supported transports for v0.1.0.

## Test plan

- [x] \`cargo build --release -p siphon-ai\` clean
- [x] \`cargo test --workspace\` green
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] Daemon binds TCP 5061 + UDP 5060 with `[sip.tls]` enabled (no panic)
- [x] \`openssl s_client -connect 127.0.0.1:5061\` completes TLS 1.3 handshake
- [x] SIP OPTIONS over TLS is received + parsed by the daemon (transaction logged); separate upstream issue prevents the response

🤖 Generated with [Claude Code](https://claude.com/claude-code)