### PR TITLE
fix(tls): reuse inbound TLS/TCP stream for response dispatch

### DIFF
--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -976,9 +976,13 @@ async fn handle_packet(
     uas: &Arc<IntegratedUAS>,
     packet: InboundPacket,
 ) {
-    let peer = packet.peer();
-    let transport = packet.transport();
-    let payload = packet.into_payload();
+    // For TCP/TLS the listener hands us the per-connection writer
+    // channel via `stream`; threading it into `TransportContext` is
+    // what lets the transaction manager send responses back over
+    // the same inbound socket instead of opening a fresh outbound
+    // connection (or, for TLS, failing outright because the
+    // dispatcher has no way to originate one).
+    let (transport, peer, payload, stream) = packet.into_parts();
 
     let Some(request) = parse_request(&payload) else {
         // Not a request. Try parsing as a response — the daemon's
@@ -996,7 +1000,7 @@ async fn handle_packet(
     };
 
     let tx_kind = map_transport_kind(transport);
-    let ctx = TransportContext::new(tx_kind, peer, None);
+    let ctx = TransportContext::new(tx_kind, peer, stream);
 
     if request.method().as_str() == "ACK" {
         // ACK doesn't open a server transaction; just notify the
@@ -1039,9 +1043,11 @@ fn map_transport_kind(kind: TpTransportKind) -> TxTransportKind {
 // We're inbound-only (UAS) in v1: every response goes back over the
 // same transport the request arrived on. For UDP we own the socket
 // and `send_udp` writes to the peer. For stream transports
-// (TCP/TLS), `run_tcp` / `run_tls` set `ctx.stream()` to the per-
-// connection writer channel; `send_stream` pushes the payload
-// through that channel back to the peer.
+// (TCP/TLS), `run_tcp` / `run_tls` hand us the per-connection
+// writer channel on the `InboundPacket`; `handle_packet` threads
+// it into `TransportContext`, and `send_stream` pushes the
+// response payload through that channel back to the peer over the
+// established socket.
 //
 // Outbound TCP/TLS connect (without a `stream` already set in
 // ctx) is what UAC mode would need — for v1 we error out cleanly

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -49,22 +49,11 @@ before TOML parsing. Unset variables without a default fail the load.
 | `cert`   | path        | required when TLS on | PEM cert chain on disk. |
 | `key`    | path        | required when TLS on | PEM private key on disk. |
 
-> **Experimental — inbound listening only in v0.1.0.** The TLS
-> listener accepts connections and the daemon parses inbound SIP
-> requests correctly, but the upstream `siphon-rs` transport layer
-> doesn't yet reuse the established inbound TLS socket to send the
-> response. Real traffic that needs a response (INVITE, OPTIONS,
-> REGISTER) ends with the daemon logging:
->
-> ```
-> ERROR sip_transaction::manager: server transport dispatch failed
->   e=outbound Tls without an existing stream is not supported in v1
-> ```
->
-> and the caller times out. Use UDP or TCP for production traffic
-> until bidirectional TLS streaming lands upstream. The
-> `cert`/`key`/`listen` config surface itself is stable — only the
-> transport-internal response path is missing.
+> **Inbound UAS only.** SiphonAI v0.1.0 is a UAS — it terminates
+> inbound TLS connections and writes responses back over the
+> established socket. Originating a new outbound TLS connection
+> (UAC mode) is not supported and will return a clear error to the
+> transaction manager rather than silently downgrading to UDP.
 
 ## `[media]`
 


### PR DESCRIPTION
## Summary

- Thread `InboundPacket.stream` into `TransportContext::new` in `handle_packet` so SIP responses go back over the same inbound socket the request arrived on.
- TLS now serves real traffic — previously the daemon listened but couldn't reply (the dispatcher returned _"outbound Tls without an existing stream is not supported in v1"_).
- TCP also benefits: it had been working only because `sip-transaction`'s pool fallback would open a *fresh outbound* TCP connection on send. Responses now reuse the inbound connection.
- Drop the experimental TLS warning from `docs/CONFIG.md`.

## Root cause

`crates/sip-transport/src/lib.rs` in siphon-rs correctly attaches the per-connection writer channel to every TLS/TCP `InboundPacket` (`stream: Some(writer_tx)`). The bug was on our side: `bins/siphon-ai/src/runtime.rs:999` constructed the `TransportContext` with `None` for the stream and dropped it on the floor. With no stream, the transaction manager handed the response to `MultiTransportDispatcher`, which has no outbound TLS connect path (we're UAS-only in v1) and returned the error.

The fix is a one-line wiring change — switch from `into_payload()` to `into_parts()` and pass the stream forward.

## Test plan

- [x] `cargo build -p siphon-ai`
- [x] `cargo test -p siphon-ai` — 16/16 pass (11 unit + 5 integration)
- [x] `cargo clippy -p siphon-ai --all-targets -- -D warnings` — clean
- [x] End-to-end TLS smoke: daemon up with `[sip.tls]`, OPTIONS sent over TLS via `openssl s_client`, **200 OK returned on the same TLS socket** (vs. previously: dispatch error + timeout)
- [x] No errors in daemon log other than the expected "peer closed without close_notify" when the test client times out

🤖 Generated with [Claude Code](https://claude.com/claude-code)