### PR TITLE
chore: apply rustfmt to over-long lines in bridge/conn + telemetry/http

### DIFF
--- a/crates/bridge/src/conn.rs
+++ b/crates/bridge/src/conn.rs
@@ -259,7 +259,9 @@ fn build_upgrade_request(
         headers.insert(
             "Authorization",
             HeaderValue::from_str(value).map_err(|e| {
-                BridgeError::InvalidConfig(format!("auth_header is not a valid HTTP header value: {e}"))
+                BridgeError::InvalidConfig(format!(
+                    "auth_header is not a valid HTTP header value: {e}"
+                ))
             })?,
         );
     }

--- a/crates/telemetry/src/http.rs
+++ b/crates/telemetry/src/http.rs
@@ -341,8 +341,12 @@ mod tests {
                     Connection: close\r\n\r\n";
         sock.write_all(head.as_bytes()).await.expect("write head");
         for _ in 0..8 {
-            sock.write_all(chunk_header.as_bytes()).await.expect("chunk header");
-            sock.write_all(chunk_payload.as_bytes()).await.expect("chunk body");
+            sock.write_all(chunk_header.as_bytes())
+                .await
+                .expect("chunk header");
+            sock.write_all(chunk_payload.as_bytes())
+                .await
+                .expect("chunk body");
             sock.write_all(b"\r\n").await.expect("chunk crlf");
         }
         sock.write_all(b"0\r\n\r\n").await.expect("terminator");


### PR DESCRIPTION
## Summary

- Two pre-existing lines in `crates/bridge/src/conn.rs` and `crates/telemetry/src/http.rs` were past rustfmt's 100-column wrap.
- Picked up by `cargo fmt --all` during unrelated work; lifting them into their own PR so they don't ride sideways on a feature change.

No functional change.

## Test plan

- [x] `cargo fmt --all -- --check` clean after this lands
- [x] `cargo build --workspace` (compiled cleanly during the TLS-fix run that produced these edits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)