### PR TITLE
fix(sip): wire RFC 3261 / RFC 3581 response compliance end-to-end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,7 +612,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 [[package]]
 name = "forge-codecs"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=faf5e8bc450e#faf5e8bc450ec57ee71420c7328c22fa706cf373"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=62be6237202a#62be6237202a90acab4805f41579cc43ca9a1d3d"
 dependencies = [
  "ezk-g722",
  "lazy_static",
@@ -623,7 +623,7 @@ dependencies = [
 [[package]]
 name = "forge-core"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=faf5e8bc450e#faf5e8bc450ec57ee71420c7328c22fa706cf373"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=62be6237202a#62be6237202a90acab4805f41579cc43ca9a1d3d"
 dependencies = [
  "chrono",
  "serde",
@@ -638,7 +638,7 @@ dependencies = [
 [[package]]
 name = "forge-dtmf"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=faf5e8bc450e#faf5e8bc450ec57ee71420c7328c22fa706cf373"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=62be6237202a#62be6237202a90acab4805f41579cc43ca9a1d3d"
 dependencies = [
  "chrono",
  "forge-core",
@@ -650,7 +650,7 @@ dependencies = [
 [[package]]
 name = "forge-engine"
 version = "0.4.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=faf5e8bc450e#faf5e8bc450ec57ee71420c7328c22fa706cf373"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=62be6237202a#62be6237202a90acab4805f41579cc43ca9a1d3d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -680,7 +680,7 @@ dependencies = [
 [[package]]
 name = "forge-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=faf5e8bc450e#faf5e8bc450ec57ee71420c7328c22fa706cf373"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=62be6237202a#62be6237202a90acab4805f41579cc43ca9a1d3d"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -693,7 +693,7 @@ dependencies = [
 [[package]]
 name = "forge-injection"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=faf5e8bc450e#faf5e8bc450ec57ee71420c7328c22fa706cf373"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=62be6237202a#62be6237202a90acab4805f41579cc43ca9a1d3d"
 dependencies = [
  "forge-core",
  "rubato",
@@ -706,7 +706,7 @@ dependencies = [
 [[package]]
 name = "forge-recorder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=faf5e8bc450e#faf5e8bc450ec57ee71420c7328c22fa706cf373"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=62be6237202a#62be6237202a90acab4805f41579cc43ca9a1d3d"
 dependencies = [
  "bytes",
  "forge-core",
@@ -720,7 +720,7 @@ dependencies = [
 [[package]]
 name = "forge-resampler"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=faf5e8bc450e#faf5e8bc450ec57ee71420c7328c22fa706cf373"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=62be6237202a#62be6237202a90acab4805f41579cc43ca9a1d3d"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -729,7 +729,7 @@ dependencies = [
 [[package]]
 name = "forge-rtp"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=faf5e8bc450e#faf5e8bc450ec57ee71420c7328c22fa706cf373"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=62be6237202a#62be6237202a90acab4805f41579cc43ca9a1d3d"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -751,11 +751,11 @@ dependencies = [
 [[package]]
 name = "forge-sdp"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=faf5e8bc450e#faf5e8bc450ec57ee71420c7328c22fa706cf373"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=62be6237202a#62be6237202a90acab4805f41579cc43ca9a1d3d"
 dependencies = [
  "chrono",
  "forge-core",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=faf5e8bc450e)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=62be6237202a)",
  "smol_str",
  "thiserror 2.0.18",
 ]
@@ -763,7 +763,7 @@ dependencies = [
 [[package]]
 name = "forge-transcoder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=faf5e8bc450e#faf5e8bc450ec57ee71420c7328c22fa706cf373"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=62be6237202a#62be6237202a90acab4805f41579cc43ca9a1d3d"
 dependencies = [
  "bytes",
  "forge-codecs",
@@ -776,7 +776,7 @@ dependencies = [
 [[package]]
 name = "forge-vad"
 version = "0.1.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=faf5e8bc450e#faf5e8bc450ec57ee71420c7328c22fa706cf373"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=62be6237202a#62be6237202a90acab4805f41579cc43ca9a1d3d"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -2325,7 +2325,7 @@ dependencies = [
 [[package]]
 name = "sip-auth"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=62fe4da697dc#62fe4da697dc8f908c00670250be74f36b6014b8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=39760e767ed9#39760e767ed9bc0898b405c1a17fa7b21e60b36c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2348,7 +2348,7 @@ dependencies = [
 [[package]]
 name = "sip-core"
 version = "0.7.6"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=62fe4da697dc#62fe4da697dc8f908c00670250be74f36b6014b8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=39760e767ed9#39760e767ed9bc0898b405c1a17fa7b21e60b36c"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2361,7 +2361,7 @@ dependencies = [
 [[package]]
 name = "sip-dialog"
 version = "0.3.3"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=62fe4da697dc#62fe4da697dc8f908c00670250be74f36b6014b8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=39760e767ed9#39760e767ed9bc0898b405c1a17fa7b21e60b36c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2379,7 +2379,7 @@ dependencies = [
 [[package]]
 name = "sip-dns"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=62fe4da697dc#62fe4da697dc8f908c00670250be74f36b6014b8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=39760e767ed9#39760e767ed9bc0898b405c1a17fa7b21e60b36c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2393,7 +2393,7 @@ dependencies = [
 [[package]]
 name = "sip-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=62fe4da697dc#62fe4da697dc8f908c00670250be74f36b6014b8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=39760e767ed9#39760e767ed9bc0898b405c1a17fa7b21e60b36c"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -2404,7 +2404,7 @@ dependencies = [
 [[package]]
 name = "sip-observe"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=62fe4da697dc#62fe4da697dc8f908c00670250be74f36b6014b8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=39760e767ed9#39760e767ed9bc0898b405c1a17fa7b21e60b36c"
 dependencies = [
  "once_cell",
  "tracing",
@@ -2413,7 +2413,7 @@ dependencies = [
 [[package]]
 name = "sip-parse"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=62fe4da697dc#62fe4da697dc8f908c00670250be74f36b6014b8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=39760e767ed9#39760e767ed9bc0898b405c1a17fa7b21e60b36c"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2427,7 +2427,7 @@ dependencies = [
 [[package]]
 name = "sip-ratelimit"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=62fe4da697dc#62fe4da697dc8f908c00670250be74f36b6014b8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=39760e767ed9#39760e767ed9bc0898b405c1a17fa7b21e60b36c"
 dependencies = [
  "dashmap",
  "parking_lot",
@@ -2438,7 +2438,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=62fe4da697dc#62fe4da697dc8f908c00670250be74f36b6014b8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=39760e767ed9#39760e767ed9bc0898b405c1a17fa7b21e60b36c"
 dependencies = [
  "nom",
  "smol_str",
@@ -2447,7 +2447,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=faf5e8bc450e#faf5e8bc450ec57ee71420c7328c22fa706cf373"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=62be6237202a#62be6237202a90acab4805f41579cc43ca9a1d3d"
 dependencies = [
  "nom",
  "smol_str",
@@ -2456,7 +2456,7 @@ dependencies = [
 [[package]]
 name = "sip-transaction"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=62fe4da697dc#62fe4da697dc8f908c00670250be74f36b6014b8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=39760e767ed9#39760e767ed9bc0898b405c1a17fa7b21e60b36c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2475,7 +2475,7 @@ dependencies = [
 [[package]]
 name = "sip-transport"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=62fe4da697dc#62fe4da697dc8f908c00670250be74f36b6014b8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=39760e767ed9#39760e767ed9bc0898b405c1a17fa7b21e60b36c"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2494,7 +2494,7 @@ dependencies = [
 [[package]]
 name = "sip-uac"
 version = "0.4.2"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=62fe4da697dc#62fe4da697dc8f908c00670250be74f36b6014b8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=39760e767ed9#39760e767ed9bc0898b405c1a17fa7b21e60b36c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2507,7 +2507,7 @@ dependencies = [
  "sip-dialog",
  "sip-dns",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=62fe4da697dc)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=39760e767ed9)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -2519,7 +2519,7 @@ dependencies = [
 [[package]]
 name = "sip-uas"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=62fe4da697dc#62fe4da697dc8f908c00670250be74f36b6014b8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=39760e767ed9#39760e767ed9bc0898b405c1a17fa7b21e60b36c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2529,7 +2529,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=62fe4da697dc)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=39760e767ed9)",
  "sip-transaction",
  "sip-transport",
  "smol_str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,16 +100,16 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 # main branch and replace the rev hashes here (see CLAUDE.md §7.5).
 
 # siphon-rs — RFC 3261 SIP stack
-sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "62fe4da697dc" }
-sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "62fe4da697dc" }
-sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "62fe4da697dc", features = ["tls"] }
-sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "62fe4da697dc" }
-sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "62fe4da697dc" }
-sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "62fe4da697dc" }
-sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "62fe4da697dc" }
-sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "62fe4da697dc" }
-sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "62fe4da697dc" }
-sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "62fe4da697dc" }
+sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "39760e767ed9" }
+sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "39760e767ed9" }
+sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "39760e767ed9", features = ["tls"] }
+sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "39760e767ed9" }
+sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "39760e767ed9" }
+sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "39760e767ed9" }
+sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "39760e767ed9" }
+sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "39760e767ed9" }
+sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "39760e767ed9" }
+sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "39760e767ed9" }
 
 # forge-media — RTP / codecs / SDP / DTMF / engine.
 #
@@ -125,14 +125,14 @@ sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "62f
 # forge-ice, Cow/lifetime in forge-recorder), but the subset SiphonAI
 # pulls — forge-core, forge-rtp, forge-engine (g722 only), forge-codecs,
 # forge-sdp, forge-dtmf, forge-vad, forge-hep — all build cleanly.
-forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "faf5e8bc450e" }
-forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "faf5e8bc450e" }
-forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "faf5e8bc450e", default-features = false, features = ["g722"] }
-forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "faf5e8bc450e" }
-forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "faf5e8bc450e" }
-forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "faf5e8bc450e" }
-forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "faf5e8bc450e" }
-forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "faf5e8bc450e" }
+forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "62be6237202a" }
+forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "62be6237202a" }
+forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "62be6237202a", default-features = false, features = ["g722"] }
+forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "62be6237202a" }
+forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "62be6237202a" }
+forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "62be6237202a" }
+forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "62be6237202a" }
+forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "62be6237202a" }
 
 # hep-rs — HEP3 codec, transport, HepSink trait. Owned by the same
 # author as siphon-rs and forge-media; lives in its own repo.

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -294,7 +294,7 @@ impl Runtime {
         // ─── Integrated UAS ────────────────────────────────────────
         let local_uri = sip_local_uri(&node, &sip);
         let contact_uri = sip.contact.as_deref().unwrap_or(&local_uri).to_string();
-        let uas: Arc<dyn UasRequestHandler> = routing_handler;
+        let uas: Arc<dyn UasRequestHandler> = Arc::clone(&routing_handler) as _;
         let mut uas_builder = IntegratedUAS::builder()
             .local_uri(&local_uri)
             .contact_uri(&contact_uri)
@@ -318,6 +318,17 @@ impl Runtime {
         // dialog_manager that `IntegratedUAS::dispatch` consults on
         // the follow-up BYE.
         acceptor.install_uas(Arc::clone(&uas));
+
+        // Wire the routing handler's response-auto-fill path. The
+        // trunk-rejection 403 and the route-no-match 404/488 paths
+        // build responses directly with `UserAgentServer::
+        // create_response` and bypass the auto-fill that the rest
+        // of the UAS dispatch loop applies (Contact / User-Agent /
+        // topmost-Via `rport` + `received`). The handler holds a
+        // `Weak<IntegratedUAS>` and upgrades it on every fill call,
+        // so this is a one-way reference that doesn't create a
+        // cycle with `IntegratedUAS::request_handler`.
+        routing_handler.install_uas_filler(Arc::downgrade(&uas));
 
         // ─── Daemon-wide REFER UAC ─────────────────────────────────
         // One IntegratedUAC instance handles every accepted call's

--- a/crates/media-glue/src/sdp.rs
+++ b/crates/media-glue/src/sdp.rs
@@ -173,6 +173,15 @@ impl LocalCapabilities {
                 .expect("telephone-event rtpmap");
         }
 
+        // siphon-ai always packetizes audio at 20 ms (160 samples
+        // @ 8 kHz / 320 @ 16 kHz — see CLAUDE.md §4.2). Declaring
+        // `a=ptime:20` in the local capabilities makes the
+        // upstream negotiator carry it into the answer so peers
+        // know what frame size to send.
+        let audio = audio
+            .add_attribute("ptime", "20")
+            .expect("ptime attribute is well-formed");
+
         // sendrecv is the v1 default; hold/resume re-INVITE flips
         // direction in a separate exchange.
         let audio = audio

--- a/crates/sip-glue/src/handler.rs
+++ b/crates/sip-glue/src/handler.rs
@@ -38,13 +38,13 @@
 //! responses; if a deployment needs it, the `RegisterSourceResolver`
 //! seam is the right place to plug in a Contact-aware finalizer.
 
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use async_trait::async_trait;
 use sip_core::{Request, Response};
 use sip_dialog::Dialog;
 use sip_transaction::{ServerTransactionHandle, TransportContext};
-use sip_uas::integrated::UasRequestHandler;
+use sip_uas::integrated::{IntegratedUAS, UasRequestHandler};
 use sip_uas::UserAgentServer;
 use siphon_ai_routes::{CompiledRoute, RouteSet};
 use tracing::{debug, info, instrument, warn};
@@ -200,6 +200,16 @@ pub struct RoutingHandler<A> {
     /// flips the daemon into strict-allowlist mode: an INVITE
     /// that doesn't match any trunk gets 403.
     trunk_gate: Option<TrunkAllowlistHandle>,
+    /// Weak ref to the `IntegratedUAS` we feed. Used to apply
+    /// `prepare_response` (rport / received / Contact / User-Agent
+    /// auto-fill) to responses the handler builds directly — the
+    /// trunk-rejection 403 and the route-no-match 404 / 488 paths
+    /// otherwise bypass the auto-fill that the rest of the UAS
+    /// applies via its dispatch loop. Weak avoids the cyclic
+    /// `Arc<UAS>` ↔ `Arc<RoutingHandler>` reference. Injected by
+    /// the daemon via `install_uas_filler` once the UAS exists;
+    /// `OnceLock` because the install is one-shot at startup.
+    uas_filler: std::sync::OnceLock<Weak<IntegratedUAS>>,
 }
 
 impl<A> RoutingHandler<A> {
@@ -216,6 +226,26 @@ impl<A> RoutingHandler<A> {
             resolver: default_resolver(),
             terminator: Arc::new(NullDialogTerminator),
             trunk_gate: None,
+            uas_filler: std::sync::OnceLock::new(),
+        }
+    }
+
+    /// Inject a weak reference to the `IntegratedUAS` whose
+    /// `prepare_response` (Contact / User-Agent / topmost-Via
+    /// `rport` + `received`) should be applied to responses the
+    /// handler builds directly. Set once at daemon startup once
+    /// both the UAS and the handler exist (the cycle is broken
+    /// by `Weak`). Calling again is a no-op.
+    pub fn install_uas_filler(&self, uas: Weak<IntegratedUAS>) {
+        let _ = self.uas_filler.set(uas);
+    }
+
+    /// Apply UAS auto-fill to a response the handler is about to
+    /// send. No-op when the daemon hasn't injected a UAS reference
+    /// (used in tests and as a fail-safe).
+    async fn fill_response(&self, response: &mut Response, ctx: &TransportContext) {
+        if let Some(uas) = self.uas_filler.get().and_then(Weak::upgrade) {
+            uas.prepare_response(response, ctx).await;
         }
     }
 
@@ -299,7 +329,9 @@ impl<A: CallAcceptor + 'static> UasRequestHandler for RoutingHandler<A> {
                         peer = %ctx.peer(),
                         "INVITE rejected: no trunk matched (403 Forbidden)"
                     );
-                    let response = UserAgentServer::create_response(request, 403, "Forbidden");
+                    let mut response =
+                        UserAgentServer::create_response(request, 403, "Forbidden");
+                    self.fill_response(&mut response, ctx).await;
                     handle.send_final(response).await;
                     return Ok(());
                 }
@@ -309,7 +341,8 @@ impl<A: CallAcceptor + 'static> UasRequestHandler for RoutingHandler<A> {
         };
 
         match dispatch_invite(&self.routes, &register_source, request) {
-            RouteAction::SendFinal(response) => {
+            RouteAction::SendFinal(mut response) => {
+                self.fill_response(&mut response, ctx).await;
                 handle.send_final(response).await;
                 Ok(())
             }


### PR DESCRIPTION
## Summary

A sngrep trace of a FreeSWITCH ↔ siphon-ai call surfaced six SIP signaling defects in the v0.1.0 daemon. Five are fixed upstream (siphon-rs PRs #41, #42, forge-media PR #51); this PR pulls those in and wires the remaining bits that only exist in siphon-ai's response paths.

## Changes

- **siphon-rs rev bump 62fe4da → 39760e7.** Brings in `create_response` To-tag enforcement (RFC 3261 §8.2.6.2), `auto_fill_headers` idempotent Contact + Via `rport`/`received` mutation (RFC 3581 §4), the new `UserAgentServer::accept_options` capability helper, and the `prepare_response` hook on `IntegratedUAS` that downstream handlers can call to apply the same enrichment.
- **forge-media rev bump faf5e8b → 62be623.** Picks up the matching siphon-rs submodule bump so `forge-sdp::SipSdpExt` uses the negotiate path that carries forward `a=fmtp:` and `a=ptime:`.
- **`LocalCapabilities::to_sdp` advertises `a=ptime:20`.** siphon-ai always packetizes audio at 20 ms; declaring it on the local capabilities lets the upstream negotiator carry ptime into the answer.
- **`RoutingHandler` holds `Weak<IntegratedUAS>` for auto-fill.** The trunk-rejection 403 and route-no-match 404 / 488 paths build responses directly and bypass `auto_fill_headers`. New `install_uas_filler` injects a `Weak<IntegratedUAS>` at daemon startup so those bypass paths can apply Contact / User-Agent / topmost-Via `rport` + `received` via `IntegratedUAS::prepare_response`. `Weak` keeps the routing handler ↔ UAS cycle from leaking.

## End-to-end verification

| Probe | Compliance fix observed |
|---|---|
| INVITE with `;rport` + telephone-event fmtp | one `Contact`, `To`-tag, `rport=5099` filled, `a=fmtp:101 0-16` echoed, `a=ptime:20` advertised |
| Scanner INVITE from sent-by `0.0.0.0`, real src 127.0.0.1, rejected by trunk gate | 403 has `received=127.0.0.1`, `rport=60208`, `To`-tag (stable across retransmits per §17.2.1), Contact, User-Agent |
| OPTIONS keepalive | full `Allow` / `Accept` / `Supported` / `Contact` / `User-Agent`, `rport=` filled, `To`-tag |

`cargo test --workspace` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Out of scope (deliberately deferred)

- BYE / CANCEL 200 OK Via mutation. `UasRequestHandler::on_bye` / `on_cancel` don't currently take `&TransportContext` upstream, so in-dialog responses still pass `;rport` through unchanged. Low impact — dialog is established by then, NAT mappings cached. Needs an upstream sip-uas trait signature change to fix cleanly.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — no regressions
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] End-to-end probes against the dev daemon (INVITE / OPTIONS / 403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)