### PR TITLE
fix(sip): apply prepare_response to BYE / CANCEL 200 OKs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,7 +612,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 [[package]]
 name = "forge-codecs"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=62be6237202a#62be6237202a90acab4805f41579cc43ca9a1d3d"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=a2e205b69281#a2e205b692814bd7e1499f8d5a1f27a3fdafa14e"
 dependencies = [
  "ezk-g722",
  "lazy_static",
@@ -623,7 +623,7 @@ dependencies = [
 [[package]]
 name = "forge-core"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=62be6237202a#62be6237202a90acab4805f41579cc43ca9a1d3d"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=a2e205b69281#a2e205b692814bd7e1499f8d5a1f27a3fdafa14e"
 dependencies = [
  "chrono",
  "serde",
@@ -638,7 +638,7 @@ dependencies = [
 [[package]]
 name = "forge-dtmf"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=62be6237202a#62be6237202a90acab4805f41579cc43ca9a1d3d"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=a2e205b69281#a2e205b692814bd7e1499f8d5a1f27a3fdafa14e"
 dependencies = [
  "chrono",
  "forge-core",
@@ -650,7 +650,7 @@ dependencies = [
 [[package]]
 name = "forge-engine"
 version = "0.4.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=62be6237202a#62be6237202a90acab4805f41579cc43ca9a1d3d"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=a2e205b69281#a2e205b692814bd7e1499f8d5a1f27a3fdafa14e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -680,7 +680,7 @@ dependencies = [
 [[package]]
 name = "forge-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=62be6237202a#62be6237202a90acab4805f41579cc43ca9a1d3d"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=a2e205b69281#a2e205b692814bd7e1499f8d5a1f27a3fdafa14e"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -693,7 +693,7 @@ dependencies = [
 [[package]]
 name = "forge-injection"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=62be6237202a#62be6237202a90acab4805f41579cc43ca9a1d3d"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=a2e205b69281#a2e205b692814bd7e1499f8d5a1f27a3fdafa14e"
 dependencies = [
  "forge-core",
  "rubato",
@@ -706,7 +706,7 @@ dependencies = [
 [[package]]
 name = "forge-recorder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=62be6237202a#62be6237202a90acab4805f41579cc43ca9a1d3d"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=a2e205b69281#a2e205b692814bd7e1499f8d5a1f27a3fdafa14e"
 dependencies = [
  "bytes",
  "forge-core",
@@ -720,7 +720,7 @@ dependencies = [
 [[package]]
 name = "forge-resampler"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=62be6237202a#62be6237202a90acab4805f41579cc43ca9a1d3d"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=a2e205b69281#a2e205b692814bd7e1499f8d5a1f27a3fdafa14e"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -729,7 +729,7 @@ dependencies = [
 [[package]]
 name = "forge-rtp"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=62be6237202a#62be6237202a90acab4805f41579cc43ca9a1d3d"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=a2e205b69281#a2e205b692814bd7e1499f8d5a1f27a3fdafa14e"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -751,11 +751,11 @@ dependencies = [
 [[package]]
 name = "forge-sdp"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=62be6237202a#62be6237202a90acab4805f41579cc43ca9a1d3d"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=a2e205b69281#a2e205b692814bd7e1499f8d5a1f27a3fdafa14e"
 dependencies = [
  "chrono",
  "forge-core",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=62be6237202a)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=a2e205b69281)",
  "smol_str",
  "thiserror 2.0.18",
 ]
@@ -763,7 +763,7 @@ dependencies = [
 [[package]]
 name = "forge-transcoder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=62be6237202a#62be6237202a90acab4805f41579cc43ca9a1d3d"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=a2e205b69281#a2e205b692814bd7e1499f8d5a1f27a3fdafa14e"
 dependencies = [
  "bytes",
  "forge-codecs",
@@ -776,7 +776,7 @@ dependencies = [
 [[package]]
 name = "forge-vad"
 version = "0.1.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=62be6237202a#62be6237202a90acab4805f41579cc43ca9a1d3d"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=a2e205b69281#a2e205b692814bd7e1499f8d5a1f27a3fdafa14e"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -2325,7 +2325,7 @@ dependencies = [
 [[package]]
 name = "sip-auth"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=39760e767ed9#39760e767ed9bc0898b405c1a17fa7b21e60b36c"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ae6713cf57f4#ae6713cf57f4f6f6c61744561d95e182f8964089"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2348,7 +2348,7 @@ dependencies = [
 [[package]]
 name = "sip-core"
 version = "0.7.6"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=39760e767ed9#39760e767ed9bc0898b405c1a17fa7b21e60b36c"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ae6713cf57f4#ae6713cf57f4f6f6c61744561d95e182f8964089"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2361,7 +2361,7 @@ dependencies = [
 [[package]]
 name = "sip-dialog"
 version = "0.3.3"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=39760e767ed9#39760e767ed9bc0898b405c1a17fa7b21e60b36c"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ae6713cf57f4#ae6713cf57f4f6f6c61744561d95e182f8964089"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2379,7 +2379,7 @@ dependencies = [
 [[package]]
 name = "sip-dns"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=39760e767ed9#39760e767ed9bc0898b405c1a17fa7b21e60b36c"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ae6713cf57f4#ae6713cf57f4f6f6c61744561d95e182f8964089"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2393,7 +2393,7 @@ dependencies = [
 [[package]]
 name = "sip-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=39760e767ed9#39760e767ed9bc0898b405c1a17fa7b21e60b36c"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ae6713cf57f4#ae6713cf57f4f6f6c61744561d95e182f8964089"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -2404,7 +2404,7 @@ dependencies = [
 [[package]]
 name = "sip-observe"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=39760e767ed9#39760e767ed9bc0898b405c1a17fa7b21e60b36c"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ae6713cf57f4#ae6713cf57f4f6f6c61744561d95e182f8964089"
 dependencies = [
  "once_cell",
  "tracing",
@@ -2413,7 +2413,7 @@ dependencies = [
 [[package]]
 name = "sip-parse"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=39760e767ed9#39760e767ed9bc0898b405c1a17fa7b21e60b36c"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ae6713cf57f4#ae6713cf57f4f6f6c61744561d95e182f8964089"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2427,7 +2427,7 @@ dependencies = [
 [[package]]
 name = "sip-ratelimit"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=39760e767ed9#39760e767ed9bc0898b405c1a17fa7b21e60b36c"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ae6713cf57f4#ae6713cf57f4f6f6c61744561d95e182f8964089"
 dependencies = [
  "dashmap",
  "parking_lot",
@@ -2438,7 +2438,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=39760e767ed9#39760e767ed9bc0898b405c1a17fa7b21e60b36c"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=a2e205b69281#a2e205b692814bd7e1499f8d5a1f27a3fdafa14e"
 dependencies = [
  "nom",
  "smol_str",
@@ -2447,7 +2447,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=62be6237202a#62be6237202a90acab4805f41579cc43ca9a1d3d"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ae6713cf57f4#ae6713cf57f4f6f6c61744561d95e182f8964089"
 dependencies = [
  "nom",
  "smol_str",
@@ -2456,7 +2456,7 @@ dependencies = [
 [[package]]
 name = "sip-transaction"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=39760e767ed9#39760e767ed9bc0898b405c1a17fa7b21e60b36c"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ae6713cf57f4#ae6713cf57f4f6f6c61744561d95e182f8964089"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2475,7 +2475,7 @@ dependencies = [
 [[package]]
 name = "sip-transport"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=39760e767ed9#39760e767ed9bc0898b405c1a17fa7b21e60b36c"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ae6713cf57f4#ae6713cf57f4f6f6c61744561d95e182f8964089"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2494,7 +2494,7 @@ dependencies = [
 [[package]]
 name = "sip-uac"
 version = "0.4.2"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=39760e767ed9#39760e767ed9bc0898b405c1a17fa7b21e60b36c"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ae6713cf57f4#ae6713cf57f4f6f6c61744561d95e182f8964089"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2507,7 +2507,7 @@ dependencies = [
  "sip-dialog",
  "sip-dns",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=39760e767ed9)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=ae6713cf57f4)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -2519,7 +2519,7 @@ dependencies = [
 [[package]]
 name = "sip-uas"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=39760e767ed9#39760e767ed9bc0898b405c1a17fa7b21e60b36c"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ae6713cf57f4#ae6713cf57f4f6f6c61744561d95e182f8964089"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2529,7 +2529,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=39760e767ed9)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=ae6713cf57f4)",
  "sip-transaction",
  "sip-transport",
  "smol_str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,16 +100,16 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 # main branch and replace the rev hashes here (see CLAUDE.md §7.5).
 
 # siphon-rs — RFC 3261 SIP stack
-sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "39760e767ed9" }
-sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "39760e767ed9" }
-sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "39760e767ed9", features = ["tls"] }
-sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "39760e767ed9" }
-sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "39760e767ed9" }
-sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "39760e767ed9" }
-sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "39760e767ed9" }
-sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "39760e767ed9" }
-sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "39760e767ed9" }
-sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "39760e767ed9" }
+sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ae6713cf57f4" }
+sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ae6713cf57f4" }
+sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ae6713cf57f4", features = ["tls"] }
+sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ae6713cf57f4" }
+sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ae6713cf57f4" }
+sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ae6713cf57f4" }
+sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ae6713cf57f4" }
+sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ae6713cf57f4" }
+sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ae6713cf57f4" }
+sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ae6713cf57f4" }
 
 # forge-media — RTP / codecs / SDP / DTMF / engine.
 #
@@ -125,14 +125,14 @@ sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "397
 # forge-ice, Cow/lifetime in forge-recorder), but the subset SiphonAI
 # pulls — forge-core, forge-rtp, forge-engine (g722 only), forge-codecs,
 # forge-sdp, forge-dtmf, forge-vad, forge-hep — all build cleanly.
-forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "62be6237202a" }
-forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "62be6237202a" }
-forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "62be6237202a", default-features = false, features = ["g722"] }
-forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "62be6237202a" }
-forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "62be6237202a" }
-forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "62be6237202a" }
-forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "62be6237202a" }
-forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "62be6237202a" }
+forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "a2e205b69281" }
+forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "a2e205b69281" }
+forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "a2e205b69281", default-features = false, features = ["g722"] }
+forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "a2e205b69281" }
+forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "a2e205b69281" }
+forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "a2e205b69281" }
+forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "a2e205b69281" }
+forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "a2e205b69281" }
 
 # hep-rs — HEP3 codec, transport, HepSink trait. Owned by the same
 # author as siphon-rs and forge-media; lives in its own repo.

--- a/crates/sip-glue/src/handler.rs
+++ b/crates/sip-glue/src/handler.rs
@@ -360,29 +360,33 @@ impl<A: CallAcceptor + 'static> UasRequestHandler for RoutingHandler<A> {
         }
     }
 
-    #[instrument(skip_all, fields(method = "BYE"))]
+    #[instrument(skip_all, fields(method = "BYE", peer = %ctx.peer()))]
     async fn on_bye(
         &self,
         request: &Request,
         handle: ServerTransactionHandle,
+        ctx: &TransportContext,
         _dialog: &Dialog,
     ) -> anyhow::Result<()> {
         match dispatch_bye(self.terminator.as_ref(), request) {
-            DialogAction::SendFinal(response) => {
+            DialogAction::SendFinal(mut response) => {
+                self.fill_response(&mut response, ctx).await;
                 handle.send_final(response).await;
                 Ok(())
             }
         }
     }
 
-    #[instrument(skip_all, fields(method = "CANCEL"))]
+    #[instrument(skip_all, fields(method = "CANCEL", peer = %ctx.peer()))]
     async fn on_cancel(
         &self,
         request: &Request,
         handle: ServerTransactionHandle,
+        ctx: &TransportContext,
     ) -> anyhow::Result<()> {
         match dispatch_cancel(self.terminator.as_ref(), request) {
-            DialogAction::SendFinal(response) => {
+            DialogAction::SendFinal(mut response) => {
+                self.fill_response(&mut response, ctx).await;
                 handle.send_final(response).await;
                 Ok(())
             }


### PR DESCRIPTION
## Summary

Picks up the new `&TransportContext` parameter on `UasRequestHandler::on_bye` and `on_cancel` (thevoiceguy/siphon-rs#43) and threads it through to `fill_response`, so in-dialog 200 OKs get the same RFC 3261 §18.2.1 / RFC 3581 §4 topmost-Via mutation (`rport=<src_port>` / `received=<src_ip>`) the other dispatch paths emit.

This was the last "Out of scope (deliberately deferred)" item from PR #60 — fixed now via the upstream trait surface change rather than a sip-glue workaround.

## Rev bumps

- siphon-rs `39760e7` → `ae6713cf` (siphon-rs#43)
- forge-media `62be623` → `a2e205b6` (forge-media#52, matching submodule bump)

## End-to-end verification

Full INVITE → 200 OK → ACK → BYE → 200 OK over UDP against the dev daemon at `127.0.0.1:5070`. BYE 200 OK now carries:

```
Via: SIP/2.0/UDP 127.0.0.1:5099;branch=z9hG4bK-bye-1;rport=5099
Contact: <sip:siphon@127.0.0.1:5070>
User-Agent: siphon-rs/0.1.0
To: <sip:9000@127.0.0.1>;tag=0FRgVrSOF9
```

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] End-to-end UDP smoke: INVITE/ACK/BYE/200 — BYE 200 OK has rport rewrite

🤖 Generated with [Claude Code](https://claude.com/claude-code)