### PR TITLE
chore: bump siphon-rs + forge-media for hickory 0.26 security fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -275,6 +275,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +365,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,6 +405,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -442,6 +482,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,24 +545,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -612,7 +660,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 [[package]]
 name = "forge-codecs"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=a2e205b69281#a2e205b692814bd7e1499f8d5a1f27a3fdafa14e"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=8f54cd32190e#8f54cd32190e94bc218352e0f14275cc2c1f9f90"
 dependencies = [
  "ezk-g722",
  "lazy_static",
@@ -623,7 +671,7 @@ dependencies = [
 [[package]]
 name = "forge-core"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=a2e205b69281#a2e205b692814bd7e1499f8d5a1f27a3fdafa14e"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=8f54cd32190e#8f54cd32190e94bc218352e0f14275cc2c1f9f90"
 dependencies = [
  "chrono",
  "serde",
@@ -638,7 +686,7 @@ dependencies = [
 [[package]]
 name = "forge-dtmf"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=a2e205b69281#a2e205b692814bd7e1499f8d5a1f27a3fdafa14e"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=8f54cd32190e#8f54cd32190e94bc218352e0f14275cc2c1f9f90"
 dependencies = [
  "chrono",
  "forge-core",
@@ -650,13 +698,13 @@ dependencies = [
 [[package]]
 name = "forge-engine"
 version = "0.4.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=a2e205b69281#a2e205b692814bd7e1499f8d5a1f27a3fdafa14e"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=8f54cd32190e#8f54cd32190e94bc218352e0f14275cc2c1f9f90"
 dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
  "chrono",
- "dashmap",
+ "dashmap 6.2.1",
  "forge-codecs",
  "forge-core",
  "forge-dtmf",
@@ -680,7 +728,7 @@ dependencies = [
 [[package]]
 name = "forge-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=a2e205b69281#a2e205b692814bd7e1499f8d5a1f27a3fdafa14e"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=8f54cd32190e#8f54cd32190e94bc218352e0f14275cc2c1f9f90"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -693,7 +741,7 @@ dependencies = [
 [[package]]
 name = "forge-injection"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=a2e205b69281#a2e205b692814bd7e1499f8d5a1f27a3fdafa14e"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=8f54cd32190e#8f54cd32190e94bc218352e0f14275cc2c1f9f90"
 dependencies = [
  "forge-core",
  "rubato",
@@ -706,7 +754,7 @@ dependencies = [
 [[package]]
 name = "forge-recorder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=a2e205b69281#a2e205b692814bd7e1499f8d5a1f27a3fdafa14e"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=8f54cd32190e#8f54cd32190e94bc218352e0f14275cc2c1f9f90"
 dependencies = [
  "bytes",
  "forge-core",
@@ -720,7 +768,7 @@ dependencies = [
 [[package]]
 name = "forge-resampler"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=a2e205b69281#a2e205b692814bd7e1499f8d5a1f27a3fdafa14e"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=8f54cd32190e#8f54cd32190e94bc218352e0f14275cc2c1f9f90"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -729,7 +777,7 @@ dependencies = [
 [[package]]
 name = "forge-rtp"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=a2e205b69281#a2e205b692814bd7e1499f8d5a1f27a3fdafa14e"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=8f54cd32190e#8f54cd32190e94bc218352e0f14275cc2c1f9f90"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -751,11 +799,11 @@ dependencies = [
 [[package]]
 name = "forge-sdp"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=a2e205b69281#a2e205b692814bd7e1499f8d5a1f27a3fdafa14e"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=8f54cd32190e#8f54cd32190e94bc218352e0f14275cc2c1f9f90"
 dependencies = [
  "chrono",
  "forge-core",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=a2e205b69281)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=8f54cd32190e)",
  "smol_str",
  "thiserror 2.0.18",
 ]
@@ -763,7 +811,7 @@ dependencies = [
 [[package]]
 name = "forge-transcoder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=a2e205b69281#a2e205b692814bd7e1499f8d5a1f27a3fdafa14e"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=8f54cd32190e#8f54cd32190e94bc218352e0f14275cc2c1f9f90"
 dependencies = [
  "bytes",
  "forge-codecs",
@@ -776,7 +824,7 @@ dependencies = [
 [[package]]
 name = "forge-vad"
 version = "0.1.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=a2e205b69281#a2e205b692814bd7e1499f8d5a1f27a3fdafa14e"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=8f54cd32190e#8f54cd32190e94bc218352e0f14275cc2c1f9f90"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -930,6 +978,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1017,23 +1066,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-proto"
-version = "0.25.2"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.9.4",
- "ring",
+ "jni",
+ "rand 0.10.1",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -1042,21 +1090,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.25.2"
+name = "hickory-proto"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
+ "ipnet",
+ "jni",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.9.4",
+ "rand 0.10.1",
  "resolv-conf",
  "smallvec",
+ "system-configuration",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1357,6 +1430,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -1379,6 +1455,55 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -1577,6 +1702,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,7 +1839,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -1741,6 +1872,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
 ]
 
 [[package]]
@@ -1884,6 +2026,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1920,6 +2073,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "raw-cpuid"
@@ -2079,6 +2238,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustfft"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2168,6 +2336,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2189,7 +2366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2282,7 +2459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2293,7 +2470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2323,14 +2500,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "sip-auth"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ae6713cf57f4#ae6713cf57f4f6f6c61744561d95e182f8964089"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=8e7fb19f0680#8e7fb19f068034ea2076e39b45cd711c7ddce545"
 dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
- "dashmap",
+ "dashmap 5.5.3",
  "hex",
  "md5",
  "rand 0.9.4",
@@ -2348,7 +2541,7 @@ dependencies = [
 [[package]]
 name = "sip-core"
 version = "0.7.6"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ae6713cf57f4#ae6713cf57f4f6f6c61744561d95e182f8964089"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=8e7fb19f0680#8e7fb19f068034ea2076e39b45cd711c7ddce545"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2361,12 +2554,12 @@ dependencies = [
 [[package]]
 name = "sip-dialog"
 version = "0.3.3"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ae6713cf57f4#ae6713cf57f4f6f6c61744561d95e182f8964089"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=8e7fb19f0680#8e7fb19f068034ea2076e39b45cd711c7ddce545"
 dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
- "dashmap",
+ "dashmap 5.5.3",
  "parking_lot",
  "rand 0.9.4",
  "sip-core",
@@ -2379,7 +2572,7 @@ dependencies = [
 [[package]]
 name = "sip-dns"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ae6713cf57f4#ae6713cf57f4f6f6c61744561d95e182f8964089"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=8e7fb19f0680#8e7fb19f068034ea2076e39b45cd711c7ddce545"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2393,7 +2586,7 @@ dependencies = [
 [[package]]
 name = "sip-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ae6713cf57f4#ae6713cf57f4f6f6c61744561d95e182f8964089"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=8e7fb19f0680#8e7fb19f068034ea2076e39b45cd711c7ddce545"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -2404,7 +2597,7 @@ dependencies = [
 [[package]]
 name = "sip-observe"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ae6713cf57f4#ae6713cf57f4f6f6c61744561d95e182f8964089"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=8e7fb19f0680#8e7fb19f068034ea2076e39b45cd711c7ddce545"
 dependencies = [
  "once_cell",
  "tracing",
@@ -2413,7 +2606,7 @@ dependencies = [
 [[package]]
 name = "sip-parse"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ae6713cf57f4#ae6713cf57f4f6f6c61744561d95e182f8964089"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=8e7fb19f0680#8e7fb19f068034ea2076e39b45cd711c7ddce545"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2427,9 +2620,9 @@ dependencies = [
 [[package]]
 name = "sip-ratelimit"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ae6713cf57f4#ae6713cf57f4f6f6c61744561d95e182f8964089"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=8e7fb19f0680#8e7fb19f068034ea2076e39b45cd711c7ddce545"
 dependencies = [
- "dashmap",
+ "dashmap 5.5.3",
  "parking_lot",
  "tokio",
  "tracing",
@@ -2438,7 +2631,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=a2e205b69281#a2e205b692814bd7e1499f8d5a1f27a3fdafa14e"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=8e7fb19f0680#8e7fb19f068034ea2076e39b45cd711c7ddce545"
 dependencies = [
  "nom",
  "smol_str",
@@ -2447,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ae6713cf57f4#ae6713cf57f4f6f6c61744561d95e182f8964089"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=8f54cd32190e#8f54cd32190e94bc218352e0f14275cc2c1f9f90"
 dependencies = [
  "nom",
  "smol_str",
@@ -2456,12 +2649,12 @@ dependencies = [
 [[package]]
 name = "sip-transaction"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ae6713cf57f4#ae6713cf57f4f6f6c61744561d95e182f8964089"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=8e7fb19f0680#8e7fb19f068034ea2076e39b45cd711c7ddce545"
 dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
- "dashmap",
+ "dashmap 5.5.3",
  "parking_lot",
  "rand 0.9.4",
  "sip-core",
@@ -2475,11 +2668,11 @@ dependencies = [
 [[package]]
 name = "sip-transport"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ae6713cf57f4#ae6713cf57f4f6f6c61744561d95e182f8964089"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=8e7fb19f0680#8e7fb19f068034ea2076e39b45cd711c7ddce545"
 dependencies = [
  "anyhow",
  "bytes",
- "dashmap",
+ "dashmap 5.5.3",
  "memchr",
  "rustls",
  "rustls-pki-types",
@@ -2494,7 +2687,7 @@ dependencies = [
 [[package]]
 name = "sip-uac"
 version = "0.4.2"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ae6713cf57f4#ae6713cf57f4f6f6c61744561d95e182f8964089"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=8e7fb19f0680#8e7fb19f068034ea2076e39b45cd711c7ddce545"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2507,7 +2700,7 @@ dependencies = [
  "sip-dialog",
  "sip-dns",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=ae6713cf57f4)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=8e7fb19f0680)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -2519,7 +2712,7 @@ dependencies = [
 [[package]]
 name = "sip-uas"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ae6713cf57f4#ae6713cf57f4f6f6c61744561d95e182f8964089"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=8e7fb19f0680#8e7fb19f068034ea2076e39b45cd711c7ddce545"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2529,7 +2722,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=ae6713cf57f4)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=8e7fb19f0680)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -3062,6 +3255,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3531,6 +3745,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3711,6 +3935,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,16 +100,16 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 # main branch and replace the rev hashes here (see CLAUDE.md §7.5).
 
 # siphon-rs — RFC 3261 SIP stack
-sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ae6713cf57f4" }
-sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ae6713cf57f4" }
-sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ae6713cf57f4", features = ["tls"] }
-sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ae6713cf57f4" }
-sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ae6713cf57f4" }
-sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ae6713cf57f4" }
-sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ae6713cf57f4" }
-sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ae6713cf57f4" }
-sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ae6713cf57f4" }
-sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ae6713cf57f4" }
+sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "8e7fb19f0680" }
+sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "8e7fb19f0680" }
+sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "8e7fb19f0680", features = ["tls"] }
+sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "8e7fb19f0680" }
+sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "8e7fb19f0680" }
+sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "8e7fb19f0680" }
+sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "8e7fb19f0680" }
+sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "8e7fb19f0680" }
+sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "8e7fb19f0680" }
+sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "8e7fb19f0680" }
 
 # forge-media — RTP / codecs / SDP / DTMF / engine.
 #
@@ -125,14 +125,14 @@ sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ae6
 # forge-ice, Cow/lifetime in forge-recorder), but the subset SiphonAI
 # pulls — forge-core, forge-rtp, forge-engine (g722 only), forge-codecs,
 # forge-sdp, forge-dtmf, forge-vad, forge-hep — all build cleanly.
-forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "a2e205b69281" }
-forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "a2e205b69281" }
-forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "a2e205b69281", default-features = false, features = ["g722"] }
-forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "a2e205b69281" }
-forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "a2e205b69281" }
-forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "a2e205b69281" }
-forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "a2e205b69281" }
-forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "a2e205b69281" }
+forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "8f54cd32190e" }
+forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "8f54cd32190e" }
+forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "8f54cd32190e", default-features = false, features = ["g722"] }
+forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "8f54cd32190e" }
+forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "8f54cd32190e" }
+forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "8f54cd32190e" }
+forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "8f54cd32190e" }
+forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "8f54cd32190e" }
 
 # hep-rs — HEP3 codec, transport, HepSink trait. Owned by the same
 # author as siphon-rs and forge-media; lives in its own repo.


### PR DESCRIPTION
## Summary

Resolves both open Dependabot advisories on this repo:

- **GHSA-3v94-mw7p-v465** (HIGH, CVSS 8.7) — `hickory-net` NSEC3 closest-encloser proof can loop unbounded on cross-zone responses
- **GHSA-q2qq-hmj6-3wpp** (MEDIUM, CVSS 6.9) — `hickory-proto` O(n²) name compression amplifies CPU exhaustion under DoS

Both fixed in `hickory-net 0.26.1` / `hickory-proto 0.26.1`. The resolver lookup path used by `sip-dns` (RFC 3263 NAPTR / SRV) needed an API migration upstream — no callsite changes here, just the rev bumps.

## Rev bumps

- siphon-rs `ae6713cf` → `8e7fb19f` (thevoiceguy/siphon-rs#44)
- forge-media `a2e205b6` → `8f54cd32` (thevoiceguy/forge-media#54, matching submodule bump)

## Verification

```
$ cargo tree -p hickory-proto | head -1
hickory-proto v0.26.1
$ cargo tree -p hickory-net | head -1
hickory-net v0.26.1
```

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)