### PR TITLE
chore: bump siphon-rs for honest 405 / OPTIONS Allow header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2518,7 +2518,7 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 [[package]]
 name = "sip-auth"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=700f3dc19ae1#700f3dc19ae1c2fc558e5a7ecf4224aa80c5efe8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ef59180819a3#ef59180819a3945506985c85009700fbe9fac659"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2541,7 +2541,7 @@ dependencies = [
 [[package]]
 name = "sip-core"
 version = "0.7.6"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=700f3dc19ae1#700f3dc19ae1c2fc558e5a7ecf4224aa80c5efe8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ef59180819a3#ef59180819a3945506985c85009700fbe9fac659"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2554,7 +2554,7 @@ dependencies = [
 [[package]]
 name = "sip-dialog"
 version = "0.3.3"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=700f3dc19ae1#700f3dc19ae1c2fc558e5a7ecf4224aa80c5efe8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ef59180819a3#ef59180819a3945506985c85009700fbe9fac659"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2572,7 +2572,7 @@ dependencies = [
 [[package]]
 name = "sip-dns"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=700f3dc19ae1#700f3dc19ae1c2fc558e5a7ecf4224aa80c5efe8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ef59180819a3#ef59180819a3945506985c85009700fbe9fac659"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2586,7 +2586,7 @@ dependencies = [
 [[package]]
 name = "sip-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=700f3dc19ae1#700f3dc19ae1c2fc558e5a7ecf4224aa80c5efe8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ef59180819a3#ef59180819a3945506985c85009700fbe9fac659"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -2597,7 +2597,7 @@ dependencies = [
 [[package]]
 name = "sip-observe"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=700f3dc19ae1#700f3dc19ae1c2fc558e5a7ecf4224aa80c5efe8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ef59180819a3#ef59180819a3945506985c85009700fbe9fac659"
 dependencies = [
  "once_cell",
  "tracing",
@@ -2606,7 +2606,7 @@ dependencies = [
 [[package]]
 name = "sip-parse"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=700f3dc19ae1#700f3dc19ae1c2fc558e5a7ecf4224aa80c5efe8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ef59180819a3#ef59180819a3945506985c85009700fbe9fac659"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2620,21 +2620,12 @@ dependencies = [
 [[package]]
 name = "sip-ratelimit"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=700f3dc19ae1#700f3dc19ae1c2fc558e5a7ecf4224aa80c5efe8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ef59180819a3#ef59180819a3945506985c85009700fbe9fac659"
 dependencies = [
  "dashmap 5.5.3",
  "parking_lot",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "sip-sdp"
-version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=700f3dc19ae1#700f3dc19ae1c2fc558e5a7ecf4224aa80c5efe8"
-dependencies = [
- "nom",
- "smol_str",
 ]
 
 [[package]]
@@ -2647,9 +2638,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sip-sdp"
+version = "0.3.0"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ef59180819a3#ef59180819a3945506985c85009700fbe9fac659"
+dependencies = [
+ "nom",
+ "smol_str",
+]
+
+[[package]]
 name = "sip-transaction"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=700f3dc19ae1#700f3dc19ae1c2fc558e5a7ecf4224aa80c5efe8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ef59180819a3#ef59180819a3945506985c85009700fbe9fac659"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2668,7 +2668,7 @@ dependencies = [
 [[package]]
 name = "sip-transport"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=700f3dc19ae1#700f3dc19ae1c2fc558e5a7ecf4224aa80c5efe8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ef59180819a3#ef59180819a3945506985c85009700fbe9fac659"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2687,7 +2687,7 @@ dependencies = [
 [[package]]
 name = "sip-uac"
 version = "0.4.2"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=700f3dc19ae1#700f3dc19ae1c2fc558e5a7ecf4224aa80c5efe8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ef59180819a3#ef59180819a3945506985c85009700fbe9fac659"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2700,7 +2700,7 @@ dependencies = [
  "sip-dialog",
  "sip-dns",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=700f3dc19ae1)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=ef59180819a3)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -2712,7 +2712,7 @@ dependencies = [
 [[package]]
 name = "sip-uas"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=700f3dc19ae1#700f3dc19ae1c2fc558e5a7ecf4224aa80c5efe8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ef59180819a3#ef59180819a3945506985c85009700fbe9fac659"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2722,7 +2722,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=700f3dc19ae1)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=ef59180819a3)",
  "sip-transaction",
  "sip-transport",
  "smol_str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,16 +100,16 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 # main branch and replace the rev hashes here (see CLAUDE.md §7.5).
 
 # siphon-rs — RFC 3261 SIP stack
-sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "700f3dc19ae1" }
-sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "700f3dc19ae1" }
-sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "700f3dc19ae1", features = ["tls"] }
-sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "700f3dc19ae1" }
-sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "700f3dc19ae1" }
-sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "700f3dc19ae1" }
-sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "700f3dc19ae1" }
-sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "700f3dc19ae1" }
-sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "700f3dc19ae1" }
-sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "700f3dc19ae1" }
+sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ef59180819a3" }
+sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ef59180819a3" }
+sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ef59180819a3", features = ["tls"] }
+sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ef59180819a3" }
+sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ef59180819a3" }
+sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ef59180819a3" }
+sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ef59180819a3" }
+sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ef59180819a3" }
+sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ef59180819a3" }
+sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ef59180819a3" }
 
 # forge-media — RTP / codecs / SDP / DTMF / engine.
 #


### PR DESCRIPTION
Bumps siphon-rs `700f3dc` → `ef59180`, picking up [siphon-rs#46](https://github.com/thevoiceguy/siphon-rs/pull/46).

## What this fixes

A scanner sending `REGISTER` (or any unsupported method) got a `405` whose `Allow` header advertised methods the daemon does **not** support:

```
SIP/2.0 405 Method Not Allowed
Allow: INVITE, ACK, BYE, CANCEL, OPTIONS, REGISTER, SUBSCRIBE, NOTIFY, REFER, UPDATE, PRACK, INFO
```

Every one of `REGISTER, SUBSCRIBE, NOTIFY, REFER, UPDATE, PRACK, INFO` is itself answered with `405` by siphon-ai's `RoutingHandler` — so the `Allow` list both violated RFC 3261 §20.5 / §21.4.6 (Allow must list the methods the UAS *supports*) and handed scanners a false capability map. The `OPTIONS` response had the same defect (plus `MESSAGE, PUBLISH`).

## Upstream change

siphon-rs#46 makes the `Allow` header handler-derived via the new `UasRequestHandler::supported_methods()` / `allow_header()` trait methods. Both have defaults, so it is a **non-breaking** addition.

## Impact on siphon-ai

**No glue changes required.** `RoutingHandler` overrides only `on_invite` / `on_bye` / `on_cancel` and takes the trait defaults for everything else, so its `405` and `OPTIONS` responses now advertise exactly the methods it actually answers:

```
Allow: INVITE, ACK, BYE, CANCEL, OPTIONS
```

## Verification

- `cargo build --workspace` — clean
- `cargo test --workspace` — 38 test binaries pass
- SIPp regression suite — **7/7** pass including `--with-transfer` (`basic_call_then_bye`, `caller_cancels_during_setup`, `unsupported_codec_488`, `session_timer_echo`, `reinvite_hold_resume`, `reinvite_unsupported_codec_488`, `blind_transfer`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)