### PR TITLE
refactor: pre-release code-quality cleanup (5 findings)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2787,15 +2787,11 @@ name = "siphon-ai-cdr"
 version = "0.0.0"
 dependencies = [
  "async-trait",
- "bytes",
  "chrono",
  "hep-rs",
- "http-body-util",
- "hyper",
- "hyper-util",
- "reqwest",
  "serde",
  "serde_json",
+ "siphon-ai-http",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -2809,6 +2805,7 @@ version = "0.0.0"
 dependencies = [
  "regex",
  "serde",
+ "siphon-ai-bridge",
  "siphon-ai-core",
  "siphon-ai-media-glue",
  "siphon-ai-routes",
@@ -2851,6 +2848,21 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "siphon-ai-http"
+version = "0.0.0"
+dependencies = [
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2933,15 +2945,11 @@ name = "siphon-ai-webhooks"
 version = "0.0.0"
 dependencies = [
  "async-trait",
- "bytes",
  "chrono",
- "http-body-util",
- "hyper",
- "hyper-util",
  "parking_lot",
- "reqwest",
  "serde",
  "serde_json",
+ "siphon-ai-http",
  "thiserror 1.0.69",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/cdr",
     "crates/config",
     "crates/core",
+    "crates/http",
     "crates/media-glue",
     "crates/routes",
     "crates/sip-glue",
@@ -28,6 +29,7 @@ siphon-ai-bridge      = { path = "crates/bridge" }
 siphon-ai-cdr         = { path = "crates/cdr" }
 siphon-ai-config      = { path = "crates/config" }
 siphon-ai-core        = { path = "crates/core" }
+siphon-ai-http        = { path = "crates/http" }
 siphon-ai-media-glue  = { path = "crates/media-glue" }
 siphon-ai-routes      = { path = "crates/routes" }
 siphon-ai-sip-glue    = { path = "crates/sip-glue" }

--- a/crates/bridge/src/conn.rs
+++ b/crates/bridge/src/conn.rs
@@ -251,11 +251,11 @@ fn build_upgrade_request(
         })?,
     );
     if let Some(value) = &config.auth_header {
-        // Sent verbatim — `core::acceptor::normalize_auth_header`
-        // already prepended `Bearer ` for the bare-token case, and
-        // any pre-existing scheme (`Bearer`, `Basic`, `Digest`,
-        // custom) survives untouched. Reformatting here would
-        // double-prefix non-Bearer schemes.
+        // Sent verbatim — `normalize_auth_header` already prepended
+        // `Bearer ` for the bare-token case, and any pre-existing
+        // scheme (`Bearer`, `Basic`, `Digest`, custom) survives
+        // untouched. Reformatting here would double-prefix
+        // non-Bearer schemes.
         headers.insert(
             "Authorization",
             HeaderValue::from_str(value).map_err(|e| {
@@ -267,6 +267,33 @@ fn build_upgrade_request(
     }
 
     Ok(request)
+}
+
+/// Normalize a configured WS auth header into the full `Authorization`
+/// value the bridge sends verbatim on the WS handshake (see
+/// [`build_request`]).
+///
+/// - `"Bearer xxx"`, `"Basic abc"`, `"Digest …"` → returned as-is.
+///   Any RFC 9110 scheme works; the conn layer sends what it is
+///   handed without reformatting.
+/// - `"xxx"` (a bare token with no whitespace) → `"Bearer xxx"`.
+///   Preserves the historic UX where operators wrote just the token
+///   for Bearer-auth WS servers.
+///
+/// This lives in `siphon-ai-bridge` — the crate that owns the
+/// wire-header behavior — so `siphon-ai-config` (which reads the
+/// `ws_auth_header` TOML key) and `siphon-ai-core` (which merges
+/// route overrides onto the default) produce identical bytes from a
+/// single implementation rather than two copies kept in sync by hand.
+pub fn normalize_auth_header(value: &str) -> String {
+    let trimmed = value.trim();
+    // A bare token has no inner whitespace; an `Authorization`
+    // header always has a scheme keyword followed by a space.
+    if trimmed.contains(char::is_whitespace) {
+        trimmed.to_string()
+    } else {
+        format!("Bearer {trimmed}")
+    }
 }
 
 type WsStream = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
@@ -522,5 +549,40 @@ mod tests {
         ] {
             assert!(!bridge_in_call_id(&msg).is_empty());
         }
+    }
+
+    // ─── normalize_auth_header ─────────────────────────────────────
+
+    #[test]
+    fn normalize_auth_header_passes_bearer_through() {
+        assert_eq!(normalize_auth_header("Bearer abc"), "Bearer abc");
+    }
+
+    #[test]
+    fn normalize_auth_header_passes_basic_through() {
+        assert_eq!(
+            normalize_auth_header("Basic dXNlcjpwYXNz"),
+            "Basic dXNlcjpwYXNz"
+        );
+    }
+
+    #[test]
+    fn normalize_auth_header_passes_digest_through() {
+        assert_eq!(
+            normalize_auth_header("Digest username=\"foo\""),
+            "Digest username=\"foo\""
+        );
+    }
+
+    #[test]
+    fn normalize_auth_header_promotes_bare_token_to_bearer() {
+        // Historic UX: operators wrote just the token for Bearer auth.
+        assert_eq!(normalize_auth_header("xyz123"), "Bearer xyz123");
+    }
+
+    #[test]
+    fn normalize_auth_header_trims_outer_whitespace() {
+        assert_eq!(normalize_auth_header("  Bearer abc  "), "Bearer abc");
+        assert_eq!(normalize_auth_header("  xyz123  "), "Bearer xyz123");
     }
 }

--- a/crates/bridge/src/lib.rs
+++ b/crates/bridge/src/lib.rs
@@ -12,7 +12,8 @@ pub use audio::{
     FRAME_DURATION_MS,
 };
 pub use conn::{
-    connect_and_run, BridgeChannels, BridgeConfig, BridgeError, DisconnectReason, OutgoingEvent,
+    connect_and_run, normalize_auth_header, BridgeChannels, BridgeConfig, BridgeError,
+    DisconnectReason, OutgoingEvent,
 };
 pub use protocol::{
     AudioEncoding, AudioFormat, BridgeIn, BridgeOut, CallId, Direction, DtmfMethod, ErrorCode,

--- a/crates/cdr/Cargo.toml
+++ b/crates/cdr/Cargo.toml
@@ -13,18 +13,15 @@ tokio.workspace       = true
 async-trait.workspace = true
 serde.workspace       = true
 serde_json.workspace  = true
-reqwest.workspace     = true
 chrono.workspace      = true
 uuid.workspace        = true
 thiserror.workspace   = true
 tracing.workspace     = true
+# Internal — shared retrying JSON-POST transport behind the webhook sink.
+siphon-ai-http.workspace = true
 # HEP3 emission target for `HepCdrSink`. Optional dep so deployments
 # that don't want HEP shipping don't pull `hep-rs` + tokio sub-deps.
 hep-rs.workspace      = true
 
 [dev-dependencies]
 tempfile = "3"
-hyper.workspace          = true
-hyper-util.workspace     = true
-http-body-util.workspace = true
-bytes.workspace          = true

--- a/crates/cdr/src/webhook.rs
+++ b/crates/cdr/src/webhook.rs
@@ -1,12 +1,11 @@
-//! HTTP POST sink with retry + exponential backoff.
+//! CDR webhook sink — a thin [`CdrSink`] adapter over
+//! [`siphon_ai_http::RetryingPoster`].
 //!
-//! Each `emit` spawns a background task that runs the POST out of
-//! the per-call task's hot path. The spawned task retries
-//! transient failures (connect errors, 5xx) up to `retry_max`,
-//! then logs and gives up. 4xx are NOT retried — those mean the
-//! receiver is rejecting our payload shape, and retrying would
-//! just amplify load. Per CLAUDE.md §4.7 the sink never panics
-//! and never blocks the controller.
+//! Each `emit` spawns the retrying POST onto a background task so the
+//! per-call cleanup that calls us never blocks on network I/O
+//! (CLAUDE.md §4.7). The retry budget, exponential backoff,
+//! transient-status classification, and `Authorization` header all
+//! live in `siphon-ai-http`, shared with the lifecycle webhook sink.
 //!
 //! ## What we don't do (yet)
 //!
@@ -15,14 +14,12 @@
 //!   the same record stream and tail it on the receiver side.
 //! - **No HMAC signature.** A future webhook secret would be a
 //!   computed `X-SiphonAI-Signature` header; CLAUDE.md §11.6 sketches
-//!   this. v1 callers either trust the network or use mTLS upstream.
-
-use std::time::Duration;
+//!   this. When it lands it belongs in `siphon-ai-http` so both
+//!   webhook sinks gain it at once.
 
 use async_trait::async_trait;
-use reqwest::{Client, StatusCode};
 use serde::{Deserialize, Serialize};
-use tracing::{debug, warn};
+use siphon_ai_http::{BuildError, PostLog, RetryingPoster, DEFAULT_RETRY_MAX, DEFAULT_TIMEOUT_MS};
 
 use crate::schema::CdrRecord;
 use crate::sink::CdrSink;
@@ -46,10 +43,10 @@ pub struct WebhookSinkConfig {
 }
 
 fn default_retry_max() -> u32 {
-    3
+    DEFAULT_RETRY_MAX
 }
 fn default_timeout_ms() -> u64 {
-    5000
+    DEFAULT_TIMEOUT_MS
 }
 
 impl WebhookSinkConfig {
@@ -57,334 +54,53 @@ impl WebhookSinkConfig {
         Self {
             url: url.into(),
             auth_header: None,
-            retry_max: default_retry_max(),
-            timeout_ms: default_timeout_ms(),
+            retry_max: DEFAULT_RETRY_MAX,
+            timeout_ms: DEFAULT_TIMEOUT_MS,
         }
     }
 }
 
 /// HTTP webhook sink. One per configured URL; cheap to clone (the
-/// inner `reqwest::Client` is cloneable).
+/// inner [`RetryingPoster`] holds a reference-counted client).
 #[derive(Debug, Clone)]
 pub struct WebhookSink {
-    client: Client,
-    config: WebhookSinkConfig,
+    poster: RetryingPoster,
 }
 
 impl WebhookSink {
-    /// Build the sink. The `reqwest::Client` is created once per
-    /// sink so connection pooling kicks in across calls.
-    pub fn new(config: WebhookSinkConfig) -> reqwest::Result<Self> {
-        let client = Client::builder()
-            .timeout(Duration::from_millis(config.timeout_ms))
-            .build()?;
-        Ok(Self { client, config })
+    /// Build the sink. The `RetryingPoster` creates its
+    /// `reqwest::Client` once so connection pooling spans calls.
+    pub fn new(config: WebhookSinkConfig) -> Result<Self, BuildError> {
+        let poster = RetryingPoster::new(
+            config.url,
+            config.auth_header,
+            config.retry_max,
+            config.timeout_ms,
+        )?;
+        Ok(Self { poster })
     }
 }
 
 #[async_trait]
 impl CdrSink for WebhookSink {
     async fn emit(&self, record: CdrRecord) {
-        // Run the POST + retry loop on a spawned task so the
-        // per-call cleanup (which calls us) doesn't block on
-        // network I/O. The sink contract (CLAUDE.md §4.7) says
-        // emission is best-effort — losing a record on a daemon
-        // restart is acceptable, blocking call teardown is not.
-        let client = self.client.clone();
-        let config = self.config.clone();
+        // Run the POST + retry loop on a spawned task so the per-call
+        // cleanup (which calls us) doesn't block on network I/O. The
+        // sink contract (CLAUDE.md §4.7) says emission is best-effort
+        // — losing a record on a daemon restart is acceptable,
+        // blocking call teardown is not.
+        let poster = self.poster.clone();
         tokio::spawn(async move {
-            post_with_retry(&client, &config, record).await;
+            poster
+                .post(
+                    &record,
+                    PostLog {
+                        kind: "CDR webhook",
+                        call_id: record.call_id.as_str(),
+                        detail: None,
+                    },
+                )
+                .await;
         });
-    }
-}
-
-async fn post_with_retry(client: &Client, config: &WebhookSinkConfig, record: CdrRecord) {
-    let mut attempt: u32 = 0;
-    loop {
-        let mut req = client.post(&config.url).json(&record);
-        if let Some(auth) = config.auth_header.as_deref() {
-            req = req.header("Authorization", auth);
-        }
-        match req.send().await {
-            Ok(resp) => {
-                let status = resp.status();
-                if status.is_success() {
-                    debug!(
-                        url = %config.url,
-                        call_id = %record.call_id,
-                        status = %status,
-                        "CDR webhook delivered"
-                    );
-                    return;
-                }
-                if !is_transient(status) {
-                    warn!(
-                        url = %config.url,
-                        call_id = %record.call_id,
-                        status = %status,
-                        "CDR webhook rejected (4xx); not retrying"
-                    );
-                    return;
-                }
-                warn!(
-                    url = %config.url,
-                    call_id = %record.call_id,
-                    status = %status,
-                    attempt = attempt + 1,
-                    "CDR webhook transient failure"
-                );
-            }
-            Err(e) => {
-                warn!(
-                    url = %config.url,
-                    call_id = %record.call_id,
-                    error = %e,
-                    attempt = attempt + 1,
-                    "CDR webhook request failed"
-                );
-            }
-        }
-        if attempt >= config.retry_max {
-            warn!(
-                url = %config.url,
-                call_id = %record.call_id,
-                attempts = attempt + 1,
-                "CDR webhook giving up; record dropped"
-            );
-            return;
-        }
-        let backoff = backoff_for(attempt);
-        tokio::time::sleep(backoff).await;
-        attempt += 1;
-    }
-}
-
-fn is_transient(status: StatusCode) -> bool {
-    // Retryable per RFC 7231 §6.6: server errors and the explicit
-    // "try again" set. 4xx other than 408 / 429 means our request
-    // is wrong; retrying just amplifies the bad-request rate.
-    status.is_server_error()
-        || status == StatusCode::REQUEST_TIMEOUT
-        || status == StatusCode::TOO_MANY_REQUESTS
-}
-
-/// Exponential backoff: 100ms, 200ms, 400ms, 800ms, capped at 5s.
-fn backoff_for(attempt: u32) -> Duration {
-    let ms = 100u64.saturating_mul(1u64 << attempt.min(6));
-    Duration::from_millis(ms.min(5000))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::schema::{
-        AudioInfo, CdrRecord, Direction, TerminationCause, TerminationInfo, CDR_VERSION,
-    };
-    use chrono::TimeZone;
-    use http_body_util::BodyExt;
-    use hyper::body::Incoming;
-    use hyper::service::service_fn;
-    use hyper::{Request, Response};
-    use hyper_util::rt::TokioIo;
-    use std::convert::Infallible;
-    use std::net::SocketAddr;
-    use std::sync::atomic::{AtomicU32, Ordering};
-    use std::sync::Arc;
-    use tokio::net::TcpListener;
-    use tokio::sync::Mutex as AsyncMutex;
-
-    fn sample(call_id: &str) -> CdrRecord {
-        CdrRecord {
-            version: CDR_VERSION,
-            call_id: call_id.into(),
-            sip_call_id: format!("{call_id}@pbx"),
-            started_at: chrono::Utc.with_ymd_and_hms(2026, 5, 5, 14, 30, 0).unwrap(),
-            ended_at: chrono::Utc.with_ymd_and_hms(2026, 5, 5, 14, 30, 1).unwrap(),
-            duration_ms: 1000,
-            from: "+1".into(),
-            to: "5000".into(),
-            direction: Direction::Inbound,
-            route: "default".into(),
-            ws_url: "wss://x/y".into(),
-            audio: AudioInfo {
-                codec: "PCMU".into(),
-                payload_type: 0,
-                sample_rate: 8000,
-            },
-            termination: TerminationInfo {
-                cause: TerminationCause::ServerHangup,
-                bridge_disconnect: String::new(),
-                tap_disconnect: String::new(),
-            },
-        }
-    }
-
-    /// Payload + auth-header recorder; each request mutates the
-    /// inner state. Programmable status code per attempt.
-    struct Recorder {
-        payloads: AsyncMutex<Vec<serde_json::Value>>,
-        auth_headers: AsyncMutex<Vec<Option<String>>>,
-        attempt: AtomicU32,
-        status_per_attempt: Vec<u16>,
-    }
-
-    impl Recorder {
-        fn new(status_per_attempt: Vec<u16>) -> Arc<Self> {
-            Arc::new(Self {
-                payloads: AsyncMutex::new(Vec::new()),
-                auth_headers: AsyncMutex::new(Vec::new()),
-                attempt: AtomicU32::new(0),
-                status_per_attempt,
-            })
-        }
-    }
-
-    /// Spin up a tiny hyper server on an ephemeral port. The
-    /// returned URL is what the sink POSTs to.
-    async fn spawn_server(rec: Arc<Recorder>) -> String {
-        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
-        let addr: SocketAddr = listener.local_addr().unwrap();
-        tokio::spawn(async move {
-            loop {
-                let (stream, _) = match listener.accept().await {
-                    Ok(s) => s,
-                    Err(_) => break,
-                };
-                let rec = Arc::clone(&rec);
-                tokio::spawn(async move {
-                    let _ = hyper::server::conn::http1::Builder::new()
-                        .serve_connection(
-                            TokioIo::new(stream),
-                            service_fn(move |req: Request<Incoming>| {
-                                let rec = Arc::clone(&rec);
-                                async move { handle(rec, req).await }
-                            }),
-                        )
-                        .await;
-                });
-            }
-        });
-        format!("http://{addr}/cdr")
-    }
-
-    async fn handle(
-        rec: Arc<Recorder>,
-        req: Request<Incoming>,
-    ) -> Result<Response<String>, Infallible> {
-        let auth = req
-            .headers()
-            .get("authorization")
-            .and_then(|v| v.to_str().ok().map(str::to_string));
-        let body = req.collect().await.expect("collect").to_bytes();
-        let json: serde_json::Value = serde_json::from_slice(&body).expect("body is valid JSON");
-
-        rec.payloads.lock().await.push(json);
-        rec.auth_headers.lock().await.push(auth);
-
-        let attempt_idx = rec.attempt.fetch_add(1, Ordering::Relaxed) as usize;
-        let status_code = rec
-            .status_per_attempt
-            .get(attempt_idx)
-            .copied()
-            .unwrap_or(200);
-        let resp = Response::builder()
-            .status(status_code)
-            .body(String::new())
-            .unwrap();
-        Ok(resp)
-    }
-
-    #[tokio::test]
-    async fn happy_path_posts_record_with_optional_auth_header() {
-        let rec = Recorder::new(vec![200]);
-        let url = spawn_server(Arc::clone(&rec)).await;
-
-        let sink = WebhookSink::new(WebhookSinkConfig {
-            url,
-            auth_header: Some("Bearer test-token".into()),
-            retry_max: 0,
-            timeout_ms: 1000,
-        })
-        .unwrap();
-
-        sink.emit(sample("c-1")).await;
-        // emit() spawns; give the spawned POST time to land.
-        tokio::time::sleep(Duration::from_millis(150)).await;
-
-        let payloads = rec.payloads.lock().await;
-        assert_eq!(payloads.len(), 1);
-        assert_eq!(payloads[0]["call_id"], serde_json::json!("c-1"));
-        assert_eq!(payloads[0]["version"], serde_json::json!(1));
-
-        let auth = rec.auth_headers.lock().await;
-        assert_eq!(auth[0].as_deref(), Some("Bearer test-token"));
-    }
-
-    #[tokio::test]
-    async fn transient_5xx_retries_then_succeeds() {
-        // 503, 503, 200 — sink should hit the third attempt and
-        // give up before that with retry_max=2 succeeded path.
-        let rec = Recorder::new(vec![503, 503, 200]);
-        let url = spawn_server(Arc::clone(&rec)).await;
-
-        let sink = WebhookSink::new(WebhookSinkConfig {
-            url,
-            auth_header: None,
-            retry_max: 3,
-            timeout_ms: 1000,
-        })
-        .unwrap();
-
-        sink.emit(sample("c-retry")).await;
-        // Backoff: 100 + 200 = 300ms before attempt 3; pad
-        // generously for slow runners.
-        tokio::time::sleep(Duration::from_millis(800)).await;
-
-        let payloads = rec.payloads.lock().await;
-        assert_eq!(payloads.len(), 3, "expected 3 attempts");
-    }
-
-    #[tokio::test]
-    async fn permanent_4xx_does_not_retry() {
-        // 401 is non-retryable; sink posts once and gives up.
-        let rec = Recorder::new(vec![401, 200]);
-        let url = spawn_server(Arc::clone(&rec)).await;
-
-        let sink = WebhookSink::new(WebhookSinkConfig {
-            url,
-            auth_header: None,
-            retry_max: 5,
-            timeout_ms: 1000,
-        })
-        .unwrap();
-
-        sink.emit(sample("c-401")).await;
-        tokio::time::sleep(Duration::from_millis(300)).await;
-
-        let payloads = rec.payloads.lock().await;
-        assert_eq!(payloads.len(), 1, "4xx must not retry");
-    }
-
-    #[tokio::test]
-    async fn retry_exhaustion_drops_record_without_panicking() {
-        // Server returns 500 forever; sink should give up after
-        // retry_max attempts and not panic.
-        let rec = Recorder::new(vec![500, 500, 500, 500, 500]);
-        let url = spawn_server(Arc::clone(&rec)).await;
-
-        let sink = WebhookSink::new(WebhookSinkConfig {
-            url,
-            auth_header: None,
-            retry_max: 2,
-            timeout_ms: 500,
-        })
-        .unwrap();
-
-        sink.emit(sample("c-give-up")).await;
-        // Backoff is 100 + 200 = 300ms; total ~ 500ms. Pad.
-        tokio::time::sleep(Duration::from_millis(900)).await;
-
-        let payloads = rec.payloads.lock().await;
-        assert_eq!(payloads.len(), 3, "first attempt + retry_max=2 retries");
     }
 }

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -17,6 +17,9 @@ tracing.workspace    = true
 
 # Internal — config compiles raw TOML into the same types core/routes
 # already use, so consumers (the daemon binary) get ready-to-pass values.
+# `siphon-ai-bridge` is a direct dep for `normalize_auth_header`, the
+# shared `ws_auth_header` normalizer that owns the wire-header behavior.
+siphon-ai-bridge.workspace     = true
 siphon-ai-core.workspace       = true
 siphon-ai-media-glue.workspace = true
 siphon-ai-routes.workspace     = true

--- a/crates/config/src/compile.rs
+++ b/crates/config/src/compile.rs
@@ -27,6 +27,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::time::Duration;
 
+use siphon_ai_bridge::normalize_auth_header;
 use siphon_ai_core::BridgeDefaults;
 use siphon_ai_media_glue::Codec;
 use siphon_ai_routes::{compile as compile_routes, RawRouteFile, RouteSet};
@@ -703,23 +704,6 @@ fn is_ws_compatible(codec: Codec) -> bool {
 
 fn default_codecs() -> Vec<Codec> {
     vec![Codec::Pcmu, Codec::Pcma]
-}
-
-/// Normalize a configured WS auth header into the full
-/// `Authorization` value the bridge emits verbatim. See the
-/// matching helper in `core::acceptor::normalize_auth_header` for
-/// the full rationale — both crates accept input via the same
-/// `ws_auth_header` TOML key and must produce the same wire bytes.
-///
-/// - `"Bearer xxx"`, `"Basic abc"`, `"Digest …"` → returned as-is.
-/// - `"xxx"` (a bare token with no whitespace) → `"Bearer xxx"`.
-fn normalize_auth_header(value: &str) -> String {
-    let trimmed = value.trim();
-    if trimmed.contains(char::is_whitespace) {
-        trimmed.to_string()
-    } else {
-        format!("Bearer {trimmed}")
-    }
 }
 
 fn compile_dialplan(routes: Vec<siphon_ai_routes::RawRoute>) -> Result<RouteSet, CompileError> {

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -63,8 +63,8 @@ use sip_uac::integrated::IntegratedUAC;
 use sip_uas::integrated::{AcceptInviteAsyncOutcome, IntegratedUAS};
 use sip_uas::{NegotiatedSessionTimer, SessionTimerPolicy, UserAgentServer};
 use siphon_ai_bridge::{
-    AudioEncoding, AudioFormat, BridgeConfig, CallId as BridgeCallId, Direction, DisconnectReason,
-    OutgoingEvent, SipMeta, StartMsg, PROTOCOL_VERSION,
+    normalize_auth_header, AudioEncoding, AudioFormat, BridgeConfig, CallId as BridgeCallId,
+    Direction, DisconnectReason, OutgoingEvent, SipMeta, StartMsg, PROTOCOL_VERSION,
 };
 use siphon_ai_cdr::{
     AudioInfo as CdrAudioInfo, CdrRecord, CdrSinkHandle, Direction as CdrDirection, NullSink,
@@ -341,33 +341,6 @@ pub fn build_bridge_config(
         auth_header,
         connect_timeout,
     })
-}
-
-/// Normalize a configured WS auth header into the full
-/// `Authorization` value the bridge emits verbatim.
-///
-/// - `"Bearer xxx"`, `"Basic abc"`, `"Digest …"` → returned as-is
-///   (any RFC 9110 scheme works; the WS conn layer sends what we
-///   hand it without reformatting).
-/// - `"xxx"` (a bare token with no whitespace) → `"Bearer xxx"`.
-///   Preserves the historic UX where operators wrote just the
-///   token for Bearer-auth WS servers.
-///
-/// Previously this function was named `strip_bearer_prefix` and
-/// returned only the token portion of "Bearer xxx", leaving the
-/// caller (`bridge/conn.rs`) to re-prepend "Bearer " unconditionally
-/// when emitting the header. That broke any non-Bearer scheme:
-/// `"Basic abc"` would survive the strip unchanged, then become
-/// `"Bearer Basic abc"` on the wire.
-fn normalize_auth_header(header: &str) -> String {
-    let trimmed = header.trim();
-    // A bare token has no inner whitespace; an "Authorization"
-    // header always has a scheme keyword followed by a space.
-    if trimmed.contains(char::is_whitespace) {
-        trimmed.to_string()
-    } else {
-        format!("Bearer {trimmed}")
-    }
 }
 
 /// Resolve the codec list for a matched route. The route's
@@ -2640,41 +2613,6 @@ a=sendrecv\r\n",
         assert_eq!(outcome.answer_direction, None);
         assert_eq!(outcome.answer_sdp, cached_answer_pcmu());
         assert_eq!(outcome.remote_addr, None);
-    }
-
-    // ─── normalize_auth_header ─────────────────────────────────────
-
-    #[test]
-    fn normalize_auth_header_passes_bearer_through() {
-        assert_eq!(normalize_auth_header("Bearer abc"), "Bearer abc");
-    }
-
-    #[test]
-    fn normalize_auth_header_passes_basic_through() {
-        assert_eq!(
-            normalize_auth_header("Basic dXNlcjpwYXNz"),
-            "Basic dXNlcjpwYXNz"
-        );
-    }
-
-    #[test]
-    fn normalize_auth_header_passes_digest_through() {
-        assert_eq!(
-            normalize_auth_header("Digest username=\"foo\""),
-            "Digest username=\"foo\""
-        );
-    }
-
-    #[test]
-    fn normalize_auth_header_promotes_bare_token_to_bearer() {
-        // Historic UX: operators wrote just the token for Bearer auth.
-        assert_eq!(normalize_auth_header("xyz123"), "Bearer xyz123");
-    }
-
-    #[test]
-    fn normalize_auth_header_trims_outer_whitespace() {
-        assert_eq!(normalize_auth_header("  Bearer abc  "), "Bearer abc");
-        assert_eq!(normalize_auth_header("  xyz123  "), "Bearer xyz123");
     }
 
     // ─── sdp_audio_remote_addr ─────────────────────────────────────

--- a/crates/core/tests/acceptor_cdr.rs
+++ b/crates/core/tests/acceptor_cdr.rs
@@ -3,110 +3,21 @@
 //! Confirms the spawned task emits exactly one CDR record with the
 //! shape consumers will see.
 
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use bytes::Bytes;
 use forge_engine::{MediaBridgeManager, SessionManager, SessionManagerConfig};
 use forge_rtp::PortPoolConfig;
-use futures::{SinkExt, StreamExt};
 use parking_lot::Mutex;
-use serde_json::Value;
-use sip_core::{Headers as SipHeaders, Method, Request, RequestLine, SipUri};
 use siphon_ai_bridge::CallId as BridgeCallId;
 use siphon_ai_cdr::{CdrRecord, CdrSink, Direction as CdrDirection, TerminationCause};
 use siphon_ai_core::{BridgeDefaults, BridgingAcceptor, CallRegistry};
 use siphon_ai_media_glue::MediaSetup;
-use siphon_ai_routes::{load_from_toml, RouteSet};
 use siphon_ai_sip_glue::InviteFacts;
-use tokio::net::TcpListener;
-use tokio_tungstenite::tungstenite::handshake::server::{
-    ErrorResponse as HsErrorResponse, Request as HsRequest, Response as HsResponse,
-};
-use tokio_tungstenite::tungstenite::http::HeaderValue;
-use tokio_tungstenite::tungstenite::Message;
 
-const LINPHONE_PCMU_OFFER: &str = "v=0\r\n\
-o=alice 1234 5678 IN IP4 10.0.0.5\r\n\
-s=Talk\r\n\
-c=IN IP4 10.0.0.5\r\n\
-t=0 0\r\n\
-m=audio 7078 RTP/AVP 0 8 101\r\n\
-a=rtpmap:0 PCMU/8000\r\n\
-a=rtpmap:8 PCMA/8000\r\n\
-a=rtpmap:101 telephone-event/8000\r\n\
-a=fmtp:101 0-15\r\n\
-a=sendrecv\r\n";
-
-#[allow(clippy::result_large_err)]
-fn echo_subprotocol(req: &HsRequest, mut resp: HsResponse) -> Result<HsResponse, HsErrorResponse> {
-    if let Some(offered) = req.headers().get("Sec-WebSocket-Protocol") {
-        resp.headers_mut().insert(
-            "Sec-WebSocket-Protocol",
-            HeaderValue::from_bytes(offered.as_bytes()).unwrap(),
-        );
-    }
-    Ok(resp)
-}
-
-/// WS server that ACKs the controller's `start` then politely
-/// closes when it receives the `stop`. Returns the bound port via
-/// the oneshot.
-async fn server_acks_start_then_idles(port_tx: tokio::sync::oneshot::Sender<u16>) {
-    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
-    let port = listener.local_addr().unwrap().port();
-    let _ = port_tx.send(port);
-    let (stream, _) = listener.accept().await.expect("accept");
-    let mut ws = tokio_tungstenite::accept_hdr_async(stream, echo_subprotocol)
-        .await
-        .expect("ws accept");
-    while let Some(msg) = ws.next().await {
-        match msg {
-            Ok(Message::Text(t)) => {
-                let v: Value = serde_json::from_str(&t).unwrap();
-                if v["type"] == "stop" {
-                    let _ = ws.send(Message::Close(None)).await;
-                    break;
-                }
-            }
-            Ok(Message::Close(_)) | Err(_) => break,
-            _ => {}
-        }
-    }
-}
-
-fn invite(body: &str, request_uri: &str) -> Request {
-    let uri = SipUri::parse(request_uri).expect("uri");
-    let line = RequestLine::new(Method::Invite, uri);
-    let mut h = SipHeaders::new();
-    h.push("Via", "SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bK-cdr")
-        .unwrap();
-    h.push("From", "<sip:+13125551234@carrier.example.net>;tag=abc")
-        .unwrap();
-    h.push("To", "<sip:5000@siphon.example.com>").unwrap();
-    h.push("Call-ID", "abc-cdr@pbx.example.com").unwrap();
-    h.push("CSeq", "1 INVITE").unwrap();
-    h.push("User-Agent", "Cisco-CP8841").unwrap();
-    h.push("Content-Type", "application/sdp").unwrap();
-    h.push("Content-Length", body.len().to_string()).unwrap();
-    Request::new(line, h, Bytes::from(body.as_bytes().to_vec())).unwrap()
-}
-
-fn one_route(ws_url: String) -> RouteSet {
-    load_from_toml(&format!(
-        r#"
-        [[route]]
-        name = "main_reception"
-        [route.match]
-        any = true
-        [route.bridge]
-        ws_url = "{ws_url}"
-        "#,
-    ))
-    .expect("compile routes")
-}
+mod common;
+use common::{invite, one_route, server_acks_start_then_idles, LINPHONE_PCMU_OFFER};
 
 /// Recording sink that holds onto every emitted record.
 #[derive(Default)]
@@ -151,9 +62,13 @@ async fn run_call_emits_cdr_when_controller_exits() {
         .with_call_id_factory(Arc::new(|| BridgeCallId::new("siphon-cdr-test")))
         .with_cdr_sink(Arc::clone(&recorder) as Arc<dyn CdrSink>);
 
-    let routes = one_route(ws_url.clone());
+    let routes = one_route("main_reception", &ws_url);
     let route = routes.iter().next().unwrap();
-    let req = invite(LINPHONE_PCMU_OFFER, "sip:5000@siphon.example.com");
+    let req = invite(
+        LINPHONE_PCMU_OFFER,
+        "sip:5000@siphon.example.com",
+        "abc-cdr@pbx.example.com",
+    );
     let facts = InviteFacts::extract(&req);
 
     let prepared = acceptor
@@ -233,9 +148,13 @@ async fn null_sink_is_the_default_when_no_sink_configured() {
     let acceptor = BridgingAcceptor::new(media, BridgeDefaults::default(), registry.clone())
         .with_call_id_factory(Arc::new(|| BridgeCallId::new("siphon-null-cdr")));
 
-    let routes = one_route(ws_url);
+    let routes = one_route("main_reception", &ws_url);
     let route = routes.iter().next().unwrap();
-    let req = invite(LINPHONE_PCMU_OFFER, "sip:5000@siphon.example.com");
+    let req = invite(
+        LINPHONE_PCMU_OFFER,
+        "sip:5000@siphon.example.com",
+        "abc-cdr@pbx.example.com",
+    );
     let facts = InviteFacts::extract(&req);
     let prepared = acceptor
         .prepare_call(&req, route, &facts)
@@ -252,11 +171,4 @@ async fn null_sink_is_the_default_when_no_sink_configured() {
         .await
         .expect("run_call completes")
         .expect("task does not panic");
-}
-
-/// Helper: silence unused-imports for HashMap in environments where
-/// the chain above doesn't already drag it in.
-#[allow(dead_code)]
-fn _hash_map_in_scope() -> HashMap<String, String> {
-    HashMap::new()
 }

--- a/crates/core/tests/acceptor_metrics.rs
+++ b/crates/core/tests/acceptor_metrics.rs
@@ -9,112 +9,21 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use bytes::Bytes;
 use forge_engine::{MediaBridgeManager, SessionManager, SessionManagerConfig};
 use forge_rtp::PortPoolConfig;
-use futures::{SinkExt, StreamExt};
-use serde_json::Value;
-use sip_core::{Headers as SipHeaders, Method, Request, RequestLine, SipUri};
 use siphon_ai_bridge::CallId as BridgeCallId;
 use siphon_ai_core::{BridgeDefaults, BridgingAcceptor, CallRegistry};
 use siphon_ai_media_glue::MediaSetup;
-use siphon_ai_routes::{load_from_toml, RouteSet};
 use siphon_ai_sip_glue::InviteFacts;
 use siphon_ai_telemetry::{
     prometheus_builder, register_descriptions, CALLS_ACTIVE, CALLS_TOTAL, CALL_DURATION_SECONDS,
     INVITES_TOTAL, ROUTE_MATCH_TOTAL, SDP_NEGOTIATE_SECONDS,
 };
-use tokio::net::TcpListener;
-use tokio_tungstenite::tungstenite::handshake::server::{
-    ErrorResponse as HsErrorResponse, Request as HsRequest, Response as HsResponse,
+
+mod common;
+use common::{
+    invite, one_route, server_acks_start_then_idles, G729_ONLY_OFFER, LINPHONE_PCMU_OFFER,
 };
-use tokio_tungstenite::tungstenite::http::HeaderValue;
-use tokio_tungstenite::tungstenite::Message;
-
-const LINPHONE_PCMU_OFFER: &str = "v=0\r\n\
-o=alice 1234 5678 IN IP4 10.0.0.5\r\n\
-s=Talk\r\n\
-c=IN IP4 10.0.0.5\r\n\
-t=0 0\r\n\
-m=audio 7078 RTP/AVP 0 8 101\r\n\
-a=rtpmap:0 PCMU/8000\r\n\
-a=rtpmap:8 PCMA/8000\r\n\
-a=rtpmap:101 telephone-event/8000\r\n\
-a=fmtp:101 0-15\r\n\
-a=sendrecv\r\n";
-
-const G729_ONLY_OFFER: &str = "v=0\r\n\
-o=- 1 1 IN IP4 10.0.0.5\r\n\
-s=Talk\r\n\
-c=IN IP4 10.0.0.5\r\n\
-t=0 0\r\n\
-m=audio 7000 RTP/AVP 18\r\n\
-a=rtpmap:18 G729/8000\r\n\
-a=sendrecv\r\n";
-
-#[allow(clippy::result_large_err)]
-fn echo_subprotocol(req: &HsRequest, mut resp: HsResponse) -> Result<HsResponse, HsErrorResponse> {
-    if let Some(offered) = req.headers().get("Sec-WebSocket-Protocol") {
-        resp.headers_mut().insert(
-            "Sec-WebSocket-Protocol",
-            HeaderValue::from_bytes(offered.as_bytes()).unwrap(),
-        );
-    }
-    Ok(resp)
-}
-
-async fn server_acks_start_then_idles(port_tx: tokio::sync::oneshot::Sender<u16>) {
-    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
-    let port = listener.local_addr().unwrap().port();
-    let _ = port_tx.send(port);
-    let (stream, _) = listener.accept().await.expect("accept");
-    let mut ws = tokio_tungstenite::accept_hdr_async(stream, echo_subprotocol)
-        .await
-        .expect("ws accept");
-    while let Some(msg) = ws.next().await {
-        match msg {
-            Ok(Message::Text(t)) => {
-                let v: Value = serde_json::from_str(&t).unwrap();
-                if v["type"] == "stop" {
-                    let _ = ws.send(Message::Close(None)).await;
-                    break;
-                }
-            }
-            Ok(Message::Close(_)) | Err(_) => break,
-            _ => {}
-        }
-    }
-}
-
-fn invite(body: &str, request_uri: &str, call_id: &str) -> Request {
-    let uri = SipUri::parse(request_uri).expect("uri");
-    let line = RequestLine::new(Method::Invite, uri);
-    let mut h = SipHeaders::new();
-    h.push("Via", "SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bK-m")
-        .unwrap();
-    h.push("From", "<sip:+13125551234@carrier.example.net>;tag=abc")
-        .unwrap();
-    h.push("To", "<sip:5000@siphon.example.com>").unwrap();
-    h.push("Call-ID", call_id).unwrap();
-    h.push("CSeq", "1 INVITE").unwrap();
-    h.push("Content-Type", "application/sdp").unwrap();
-    h.push("Content-Length", body.len().to_string()).unwrap();
-    Request::new(line, h, Bytes::from(body.as_bytes().to_vec())).unwrap()
-}
-
-fn one_route(ws_url: &str) -> RouteSet {
-    load_from_toml(&format!(
-        r#"
-        [[route]]
-        name = "metrics_route"
-        [route.match]
-        any = true
-        [route.bridge]
-        ws_url = "{ws_url}"
-        "#,
-    ))
-    .expect("compile routes")
-}
 
 fn build_acceptor() -> (BridgingAcceptor, Arc<MediaBridgeManager>, CallRegistry) {
     let session_mgr = SessionManager::new(
@@ -154,7 +63,7 @@ async fn full_call_lifecycle_emits_expected_metrics() {
     let ws_url = format!("ws://127.0.0.1:{port}/");
 
     let (acceptor, _bridge_mgr, registry) = build_acceptor();
-    let routes = one_route(&ws_url);
+    let routes = one_route("metrics_route", &ws_url);
     let route = routes.iter().next().unwrap();
     let req = invite(
         LINPHONE_PCMU_OFFER,
@@ -220,7 +129,7 @@ async fn rejected_invite_increments_rejected_counter() {
     register_descriptions();
 
     let (acceptor, _, _) = build_acceptor();
-    let routes = one_route("wss://x/y");
+    let routes = one_route("metrics_route", "wss://x/y");
     let route = routes.iter().next().unwrap();
     let req = invite(
         G729_ONLY_OFFER,

--- a/crates/core/tests/acceptor_webhooks.rs
+++ b/crates/core/tests/acceptor_webhooks.rs
@@ -8,98 +8,17 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use bytes::Bytes;
 use forge_engine::{MediaBridgeManager, SessionManager, SessionManagerConfig};
 use forge_rtp::PortPoolConfig;
-use futures::{SinkExt, StreamExt};
 use parking_lot::Mutex;
-use serde_json::Value;
-use sip_core::{Headers as SipHeaders, Method, Request, RequestLine, SipUri};
 use siphon_ai_bridge::CallId as BridgeCallId;
 use siphon_ai_core::{BridgeDefaults, BridgingAcceptor, CallRegistry};
 use siphon_ai_media_glue::MediaSetup;
-use siphon_ai_routes::{load_from_toml, RouteSet};
 use siphon_ai_sip_glue::InviteFacts;
 use siphon_ai_webhooks::{WebhookEvent, WebhookSink};
-use tokio::net::TcpListener;
-use tokio_tungstenite::tungstenite::handshake::server::{
-    ErrorResponse as HsErrorResponse, Request as HsRequest, Response as HsResponse,
-};
-use tokio_tungstenite::tungstenite::http::HeaderValue;
-use tokio_tungstenite::tungstenite::Message;
 
-const LINPHONE_PCMU_OFFER: &str = "v=0\r\n\
-o=alice 1234 5678 IN IP4 10.0.0.5\r\n\
-s=Talk\r\n\
-c=IN IP4 10.0.0.5\r\n\
-t=0 0\r\n\
-m=audio 7078 RTP/AVP 0\r\n\
-a=rtpmap:0 PCMU/8000\r\n\
-a=sendrecv\r\n";
-
-#[allow(clippy::result_large_err)]
-fn echo_subprotocol(req: &HsRequest, mut resp: HsResponse) -> Result<HsResponse, HsErrorResponse> {
-    if let Some(offered) = req.headers().get("Sec-WebSocket-Protocol") {
-        resp.headers_mut().insert(
-            "Sec-WebSocket-Protocol",
-            HeaderValue::from_bytes(offered.as_bytes()).unwrap(),
-        );
-    }
-    Ok(resp)
-}
-
-async fn server_acks_start_then_idles(port_tx: tokio::sync::oneshot::Sender<u16>) {
-    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
-    let port = listener.local_addr().unwrap().port();
-    let _ = port_tx.send(port);
-    let (stream, _) = listener.accept().await.expect("accept");
-    let mut ws = tokio_tungstenite::accept_hdr_async(stream, echo_subprotocol)
-        .await
-        .expect("ws accept");
-    while let Some(msg) = ws.next().await {
-        match msg {
-            Ok(Message::Text(t)) => {
-                let v: Value = serde_json::from_str(&t).unwrap();
-                if v["type"] == "stop" {
-                    let _ = ws.send(Message::Close(None)).await;
-                    break;
-                }
-            }
-            Ok(Message::Close(_)) | Err(_) => break,
-            _ => {}
-        }
-    }
-}
-
-fn invite(body: &str, request_uri: &str, call_id: &str) -> Request {
-    let uri = SipUri::parse(request_uri).expect("uri");
-    let line = RequestLine::new(Method::Invite, uri);
-    let mut h = SipHeaders::new();
-    h.push("Via", "SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bK-w")
-        .unwrap();
-    h.push("From", "<sip:+13125551234@carrier.example.net>;tag=abc")
-        .unwrap();
-    h.push("To", "<sip:5000@siphon.example.com>").unwrap();
-    h.push("Call-ID", call_id).unwrap();
-    h.push("CSeq", "1 INVITE").unwrap();
-    h.push("Content-Type", "application/sdp").unwrap();
-    h.push("Content-Length", body.len().to_string()).unwrap();
-    Request::new(line, h, Bytes::from(body.as_bytes().to_vec())).unwrap()
-}
-
-fn one_route(ws_url: &str) -> RouteSet {
-    load_from_toml(&format!(
-        r#"
-        [[route]]
-        name = "webhook_route"
-        [route.match]
-        any = true
-        [route.bridge]
-        ws_url = "{ws_url}"
-        "#,
-    ))
-    .expect("compile routes")
-}
+mod common;
+use common::{invite, one_route, server_acks_start_then_idles, LINPHONE_PCMU_OFFER};
 
 #[derive(Default)]
 struct Recorder {
@@ -141,7 +60,7 @@ async fn run_call_emits_call_start_then_call_end() {
         .with_call_id_factory(Arc::new(|| BridgeCallId::new("siphon-webhook-test")))
         .with_webhook_sink(Arc::clone(&recorder) as Arc<dyn WebhookSink>);
 
-    let routes = one_route(&ws_url);
+    let routes = one_route("webhook_route", &ws_url);
     let route = routes.iter().next().unwrap();
     let req = invite(
         LINPHONE_PCMU_OFFER,
@@ -223,7 +142,7 @@ async fn null_webhook_sink_is_the_default() {
     let acceptor = BridgingAcceptor::new(media, BridgeDefaults::default(), registry.clone())
         .with_call_id_factory(Arc::new(|| BridgeCallId::new("siphon-null-webhook")));
 
-    let routes = one_route(&ws_url);
+    let routes = one_route("webhook_route", &ws_url);
     let route = routes.iter().next().unwrap();
     let req = invite(
         LINPHONE_PCMU_OFFER,

--- a/crates/core/tests/common/mod.rs
+++ b/crates/core/tests/common/mod.rs
@@ -1,0 +1,126 @@
+//! Shared fixtures for the `siphon-ai-core` integration tests.
+//!
+//! Rust compiles every file in `tests/` as its own binary, so these
+//! helpers were historically copy-pasted across `acceptor_metrics`,
+//! `acceptor_webhooks`, `acceptor_cdr`, `hold_resume`, and
+//! `registry_bye`. This module centralizes the ones that genuinely
+//! repeated: the WS subprotocol handshake callback, the "ack start
+//! then idle" WS server, the INVITE builder, the single-route
+//! dialplan, and the SDP offer fixtures.
+//!
+//! Pulled in via `mod common;` per test file. `dead_code` is allowed
+//! because no single test binary exercises every helper.
+#![allow(dead_code)]
+
+use bytes::Bytes;
+use futures::{SinkExt, StreamExt};
+use serde_json::Value;
+use sip_core::{Headers as SipHeaders, Method, Request, RequestLine, SipUri};
+use siphon_ai_routes::{load_from_toml, RouteSet};
+use tokio::net::TcpListener;
+use tokio_tungstenite::tungstenite::handshake::server::{
+    ErrorResponse as HsErrorResponse, Request as HsRequest, Response as HsResponse,
+};
+use tokio_tungstenite::tungstenite::http::HeaderValue;
+use tokio_tungstenite::tungstenite::Message;
+
+/// A Linphone-style PCMU/PCMA offer with `telephone-event` — the
+/// canonical inbound SDP for the acceptor integration tests.
+pub const LINPHONE_PCMU_OFFER: &str = "v=0\r\n\
+o=alice 1234 5678 IN IP4 10.0.0.5\r\n\
+s=Talk\r\n\
+c=IN IP4 10.0.0.5\r\n\
+t=0 0\r\n\
+m=audio 7078 RTP/AVP 0 8 101\r\n\
+a=rtpmap:0 PCMU/8000\r\n\
+a=rtpmap:8 PCMA/8000\r\n\
+a=rtpmap:101 telephone-event/8000\r\n\
+a=fmtp:101 0-15\r\n\
+a=sendrecv\r\n";
+
+/// A G.729-only offer — no codec SiphonAI supports, used to exercise
+/// the 488 reject path.
+pub const G729_ONLY_OFFER: &str = "v=0\r\n\
+o=- 1 1 IN IP4 10.0.0.5\r\n\
+s=Talk\r\n\
+c=IN IP4 10.0.0.5\r\n\
+t=0 0\r\n\
+m=audio 7000 RTP/AVP 18\r\n\
+a=rtpmap:18 G729/8000\r\n\
+a=sendrecv\r\n";
+
+/// Handshake callback that echoes the `siphon-ai.v1` subprotocol so
+/// tungstenite's stricter-than-spec client accepts the upgrade.
+#[allow(clippy::result_large_err)]
+pub fn echo_subprotocol(
+    req: &HsRequest,
+    mut resp: HsResponse,
+) -> Result<HsResponse, HsErrorResponse> {
+    if let Some(offered) = req.headers().get("Sec-WebSocket-Protocol") {
+        resp.headers_mut().insert(
+            "Sec-WebSocket-Protocol",
+            HeaderValue::from_bytes(offered.as_bytes()).unwrap(),
+        );
+    }
+    Ok(resp)
+}
+
+/// WS server that accepts one connection, ACKs the controller's
+/// `start` by idling, and closes politely when it sees the `stop`.
+/// Reports the bound port back over `port_tx`.
+pub async fn server_acks_start_then_idles(port_tx: tokio::sync::oneshot::Sender<u16>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    let _ = port_tx.send(port);
+    let (stream, _) = listener.accept().await.expect("accept");
+    let mut ws = tokio_tungstenite::accept_hdr_async(stream, echo_subprotocol)
+        .await
+        .expect("ws accept");
+    while let Some(msg) = ws.next().await {
+        match msg {
+            Ok(Message::Text(t)) => {
+                let v: Value = serde_json::from_str(&t).unwrap();
+                if v["type"] == "stop" {
+                    let _ = ws.send(Message::Close(None)).await;
+                    break;
+                }
+            }
+            Ok(Message::Close(_)) | Err(_) => break,
+            _ => {}
+        }
+    }
+}
+
+/// Build an inbound INVITE carrying `body` as an `application/sdp`
+/// offer, addressed to `request_uri`, with the given `Call-ID`.
+pub fn invite(body: &str, request_uri: &str, call_id: &str) -> Request {
+    let uri = SipUri::parse(request_uri).expect("uri");
+    let line = RequestLine::new(Method::Invite, uri);
+    let mut h = SipHeaders::new();
+    h.push("Via", "SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bK-test")
+        .unwrap();
+    h.push("From", "<sip:+13125551234@carrier.example.net>;tag=abc")
+        .unwrap();
+    h.push("To", "<sip:5000@siphon.example.com>").unwrap();
+    h.push("Call-ID", call_id).unwrap();
+    h.push("CSeq", "1 INVITE").unwrap();
+    h.push("Content-Type", "application/sdp").unwrap();
+    h.push("Content-Length", body.len().to_string()).unwrap();
+    Request::new(line, h, Bytes::from(body.as_bytes().to_vec())).unwrap()
+}
+
+/// A single-route dialplan matching everything (`any = true`) and
+/// bridging to `ws_url`. `name` is the route name the test asserts on.
+pub fn one_route(name: &str, ws_url: &str) -> RouteSet {
+    load_from_toml(&format!(
+        r#"
+        [[route]]
+        name = "{name}"
+        [route.match]
+        any = true
+        [route.bridge]
+        ws_url = "{ws_url}"
+        "#,
+    ))
+    .expect("compile routes")
+}

--- a/crates/core/tests/hold_resume.rs
+++ b/crates/core/tests/hold_resume.rs
@@ -22,22 +22,10 @@ use siphon_ai_bridge::{
 use siphon_ai_core::{CallController, CallControllerConfig};
 use siphon_ai_media_glue::MediaTap;
 use tokio::net::TcpListener;
-use tokio_tungstenite::tungstenite::handshake::server::{
-    ErrorResponse as HsErrorResponse, Request as HsRequest, Response as HsResponse,
-};
-use tokio_tungstenite::tungstenite::http::HeaderValue;
 use tokio_tungstenite::tungstenite::Message;
 
-#[allow(clippy::result_large_err)]
-fn echo_subprotocol(req: &HsRequest, mut resp: HsResponse) -> Result<HsResponse, HsErrorResponse> {
-    if let Some(offered) = req.headers().get("Sec-WebSocket-Protocol") {
-        resp.headers_mut().insert(
-            "Sec-WebSocket-Protocol",
-            HeaderValue::from_bytes(offered.as_bytes()).unwrap(),
-        );
-    }
-    Ok(resp)
-}
+mod common;
+use common::echo_subprotocol;
 
 /// WS server that captures every text frame's `type` + relevant
 /// payload fields, reports them back over a channel, and closes

--- a/crates/core/tests/registry_bye.rs
+++ b/crates/core/tests/registry_bye.rs
@@ -28,50 +28,10 @@ use siphon_ai_core::{CallController, CallControllerConfig, CallRegistry, CallTer
 use siphon_ai_media_glue::MediaTap;
 use siphon_ai_sip_glue::{dispatch_bye, DialogAction};
 use tokio::net::TcpListener;
-use tokio_tungstenite::tungstenite::handshake::server::{
-    ErrorResponse as HsErrorResponse, Request as HsRequest, Response as HsResponse,
-};
-use tokio_tungstenite::tungstenite::http::HeaderValue;
 use tokio_tungstenite::tungstenite::Message;
 
-/// Handshake callback that echoes the siphon-ai.v1 subprotocol so
-/// tungstenite's stricter-than-spec client accepts the upgrade.
-#[allow(clippy::result_large_err)]
-fn echo_subprotocol(req: &HsRequest, mut resp: HsResponse) -> Result<HsResponse, HsErrorResponse> {
-    if let Some(offered) = req.headers().get("Sec-WebSocket-Protocol") {
-        resp.headers_mut().insert(
-            "Sec-WebSocket-Protocol",
-            HeaderValue::from_bytes(offered.as_bytes()).unwrap(),
-        );
-    }
-    Ok(resp)
-}
-
-async fn server_acks_start_then_idles(port_tx: tokio::sync::oneshot::Sender<u16>) {
-    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
-    let port = listener.local_addr().unwrap().port();
-    let _ = port_tx.send(port);
-    let (stream, _) = listener.accept().await.expect("accept");
-    let mut ws = tokio_tungstenite::accept_hdr_async(stream, echo_subprotocol)
-        .await
-        .expect("ws accept");
-
-    // Drain the start message and wait quietly for the controller's
-    // stop on shutdown.
-    while let Some(msg) = ws.next().await {
-        match msg {
-            Ok(Message::Text(t)) => {
-                let v: Value = serde_json::from_str(&t).unwrap();
-                if v["type"] == "stop" {
-                    let _ = ws.send(Message::Close(None)).await;
-                    break;
-                }
-            }
-            Ok(Message::Close(_)) | Err(_) => break,
-            _ => {}
-        }
-    }
-}
+mod common;
+use common::{echo_subprotocol, server_acks_start_then_idles};
 
 /// Same as [`server_acks_start_then_idles`] but captures the `reason`
 /// field of the controller's `stop` event and reports it back. Used

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name        = "siphon-ai-http"
+description = "Retrying JSON-over-HTTP POST delivery shared by SiphonAI's CDR and lifecycle webhook sinks."
+version.workspace      = true
+edition.workspace      = true
+rust-version.workspace = true
+license.workspace      = true
+authors.workspace      = true
+repository.workspace   = true
+
+[dependencies]
+tokio.workspace     = true
+reqwest.workspace   = true
+serde.workspace     = true
+thiserror.workspace = true
+tracing.workspace   = true
+
+[dev-dependencies]
+serde_json.workspace     = true
+hyper.workspace          = true
+hyper-util.workspace     = true
+http-body-util.workspace = true

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -1,0 +1,312 @@
+//! Retrying JSON-over-HTTP POST delivery.
+//!
+//! [`RetryingPoster`] is the shared transport behind SiphonAI's two
+//! outbound webhook sinks — the CDR webhook sink (`siphon-ai-cdr`)
+//! and the lifecycle webhook sink (`siphon-ai-webhooks`). Both POST a
+//! JSON body to an operator-supplied URL, retry transient failures
+//! with exponential backoff, and never block the per-call task; the
+//! only thing that differs between them is the payload type and the
+//! log labels. Keeping the retry / backoff / transient-classification
+//! / auth logic here means a change to any of it — including future
+//! HMAC request signing — happens once.
+//!
+//! Per CLAUDE.md §4.7 delivery is best-effort: a failure after the
+//! retry budget is exhausted is logged and the payload dropped, and
+//! nothing on this path panics.
+
+use std::time::Duration;
+
+use reqwest::{Client, StatusCode};
+use serde::Serialize;
+use thiserror::Error;
+use tracing::{debug, warn};
+
+/// Default retry budget for transient delivery failures. `0` means
+/// "POST once, don't retry".
+pub const DEFAULT_RETRY_MAX: u32 = 3;
+
+/// Default per-attempt HTTP timeout, in milliseconds.
+pub const DEFAULT_TIMEOUT_MS: u64 = 5000;
+
+/// Building a [`RetryingPoster`] failed: the underlying
+/// `reqwest::Client` could not be constructed (e.g. the TLS backend
+/// failed to initialise). Wraps the `reqwest` error so consumers
+/// don't need a direct dependency on `reqwest`.
+#[derive(Debug, Error)]
+#[error("failed to build HTTP client: {0}")]
+pub struct BuildError(#[from] reqwest::Error);
+
+/// Identity fields stamped onto a delivery's `tracing` lines so an
+/// operator can correlate a webhook log back to the call.
+#[derive(Debug, Clone, Copy)]
+pub struct PostLog<'a> {
+    /// Human label for the sink, e.g. `"CDR webhook"`.
+    pub kind: &'a str,
+    /// `call_id` for correlation; pass `"-"` when there is none.
+    pub call_id: &'a str,
+    /// Optional extra detail, e.g. a webhook event type. Logged as
+    /// `"-"` when `None`.
+    pub detail: Option<&'a str>,
+}
+
+/// A connection-pooling HTTP client that POSTs JSON payloads and
+/// retries transient failures with exponential backoff.
+///
+/// Cheap to clone — the inner `reqwest::Client` is reference-counted,
+/// so a sink can hand a fresh clone to each spawned delivery task.
+#[derive(Debug, Clone)]
+pub struct RetryingPoster {
+    client: Client,
+    url: String,
+    auth_header: Option<String>,
+    retry_max: u32,
+}
+
+impl RetryingPoster {
+    /// Build a poster targeting `url`.
+    ///
+    /// `auth_header`, when set, is sent verbatim as the
+    /// `Authorization` header on every attempt. `retry_max` is the
+    /// number of retries *after* the first attempt; `timeout_ms`
+    /// bounds each individual attempt. The `reqwest::Client` is
+    /// created once here so connection pooling spans deliveries.
+    pub fn new(
+        url: impl Into<String>,
+        auth_header: Option<String>,
+        retry_max: u32,
+        timeout_ms: u64,
+    ) -> Result<Self, BuildError> {
+        let client = Client::builder()
+            .timeout(Duration::from_millis(timeout_ms))
+            .build()?;
+        Ok(Self {
+            client,
+            url: url.into(),
+            auth_header,
+            retry_max,
+        })
+    }
+
+    /// POST `payload` as JSON, retrying transient failures.
+    ///
+    /// Transient failures (connect errors, 5xx, 408, 429) retry up to
+    /// the configured budget with exponential backoff. Other 4xx are
+    /// not retried — they mean the receiver is rejecting our payload
+    /// shape, and retrying would just amplify load. A failure after
+    /// the budget is exhausted is logged and the payload dropped.
+    ///
+    /// `log` only feeds `tracing`; it does not affect delivery.
+    pub async fn post<T: Serialize>(&self, payload: &T, log: PostLog<'_>) {
+        let PostLog {
+            kind,
+            call_id,
+            detail,
+        } = log;
+        let detail = detail.unwrap_or("-");
+        let mut attempt: u32 = 0;
+        loop {
+            let mut req = self.client.post(&self.url).json(payload);
+            if let Some(auth) = self.auth_header.as_deref() {
+                req = req.header("Authorization", auth);
+            }
+            match req.send().await {
+                Ok(resp) => {
+                    let status = resp.status();
+                    if status.is_success() {
+                        debug!(kind, url = %self.url, call_id, detail, status = %status, "webhook delivered");
+                        return;
+                    }
+                    if !is_transient(status) {
+                        warn!(kind, url = %self.url, call_id, detail, status = %status, "webhook rejected (4xx); not retrying");
+                        return;
+                    }
+                    warn!(kind, url = %self.url, call_id, detail, status = %status, attempt = attempt + 1, "webhook transient failure");
+                }
+                Err(e) => {
+                    warn!(kind, url = %self.url, call_id, detail, error = %e, attempt = attempt + 1, "webhook request failed");
+                }
+            }
+            if attempt >= self.retry_max {
+                warn!(kind, url = %self.url, call_id, detail, attempts = attempt + 1, "webhook giving up; payload dropped");
+                return;
+            }
+            tokio::time::sleep(backoff_for(attempt)).await;
+            attempt += 1;
+        }
+    }
+}
+
+/// Retryable per RFC 9110 §15: server errors plus the explicit "try
+/// again" set. Other 4xx mean our request is malformed; retrying
+/// would only amplify the bad-request rate.
+fn is_transient(status: StatusCode) -> bool {
+    status.is_server_error()
+        || status == StatusCode::REQUEST_TIMEOUT
+        || status == StatusCode::TOO_MANY_REQUESTS
+}
+
+/// Exponential backoff: 100ms, 200ms, 400ms, 800ms, …, capped at 5s.
+fn backoff_for(attempt: u32) -> Duration {
+    let ms = 100u64.saturating_mul(1u64 << attempt.min(6));
+    Duration::from_millis(ms.min(5000))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http_body_util::BodyExt;
+    use hyper::body::Incoming;
+    use hyper::service::service_fn;
+    use hyper::{Request, Response};
+    use hyper_util::rt::TokioIo;
+    use std::convert::Infallible;
+    use std::net::SocketAddr;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+    use tokio::net::TcpListener;
+    use tokio::sync::Mutex as AsyncMutex;
+
+    #[derive(Serialize)]
+    struct Sample {
+        id: String,
+        n: u32,
+    }
+
+    fn sample(id: &str) -> Sample {
+        Sample {
+            id: id.into(),
+            n: 42,
+        }
+    }
+
+    fn log(call_id: &str) -> PostLog<'_> {
+        PostLog {
+            kind: "test webhook",
+            call_id,
+            detail: None,
+        }
+    }
+
+    /// Payload + auth-header recorder; programmable status per attempt.
+    struct Recorder {
+        payloads: AsyncMutex<Vec<serde_json::Value>>,
+        auth_headers: AsyncMutex<Vec<Option<String>>>,
+        attempt: AtomicU32,
+        status_per_attempt: Vec<u16>,
+    }
+
+    impl Recorder {
+        fn new(status_per_attempt: Vec<u16>) -> Arc<Self> {
+            Arc::new(Self {
+                payloads: AsyncMutex::new(Vec::new()),
+                auth_headers: AsyncMutex::new(Vec::new()),
+                attempt: AtomicU32::new(0),
+                status_per_attempt,
+            })
+        }
+    }
+
+    /// Spin up a tiny hyper server on an ephemeral port. The returned
+    /// URL is what the poster POSTs to.
+    async fn spawn_server(rec: Arc<Recorder>) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr: SocketAddr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let (stream, _) = match listener.accept().await {
+                    Ok(s) => s,
+                    Err(_) => break,
+                };
+                let rec = Arc::clone(&rec);
+                tokio::spawn(async move {
+                    let _ = hyper::server::conn::http1::Builder::new()
+                        .serve_connection(
+                            TokioIo::new(stream),
+                            service_fn(move |req: Request<Incoming>| {
+                                let rec = Arc::clone(&rec);
+                                async move { handle(rec, req).await }
+                            }),
+                        )
+                        .await;
+                });
+            }
+        });
+        format!("http://{addr}/sink")
+    }
+
+    async fn handle(
+        rec: Arc<Recorder>,
+        req: Request<Incoming>,
+    ) -> Result<Response<String>, Infallible> {
+        let auth = req
+            .headers()
+            .get("authorization")
+            .and_then(|v| v.to_str().ok().map(str::to_string));
+        let body = req.collect().await.expect("collect").to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("body is valid JSON");
+        rec.payloads.lock().await.push(json);
+        rec.auth_headers.lock().await.push(auth);
+        let idx = rec.attempt.fetch_add(1, Ordering::Relaxed) as usize;
+        let status = rec.status_per_attempt.get(idx).copied().unwrap_or(200);
+        Ok(Response::builder()
+            .status(status)
+            .body(String::new())
+            .unwrap())
+    }
+
+    #[tokio::test]
+    async fn happy_path_posts_payload_with_optional_auth_header() {
+        let rec = Recorder::new(vec![200]);
+        let url = spawn_server(Arc::clone(&rec)).await;
+        let poster = RetryingPoster::new(url, Some("Bearer test-token".into()), 0, 1000).unwrap();
+
+        poster.post(&sample("c-1"), log("c-1")).await;
+
+        let payloads = rec.payloads.lock().await;
+        assert_eq!(payloads.len(), 1);
+        assert_eq!(payloads[0]["id"], serde_json::json!("c-1"));
+        assert_eq!(payloads[0]["n"], serde_json::json!(42));
+        let auth = rec.auth_headers.lock().await;
+        assert_eq!(auth[0].as_deref(), Some("Bearer test-token"));
+    }
+
+    #[tokio::test]
+    async fn transient_5xx_retries_then_succeeds() {
+        // 503, 503, 200 — the poster keeps trying through the budget.
+        let rec = Recorder::new(vec![503, 503, 200]);
+        let url = spawn_server(Arc::clone(&rec)).await;
+        let poster = RetryingPoster::new(url, None, 3, 1000).unwrap();
+
+        poster.post(&sample("c-retry"), log("c-retry")).await;
+
+        let payloads = rec.payloads.lock().await;
+        assert_eq!(payloads.len(), 3, "expected 3 attempts");
+    }
+
+    #[tokio::test]
+    async fn permanent_4xx_does_not_retry() {
+        // 401 is non-retryable; the poster sends once and gives up.
+        let rec = Recorder::new(vec![401, 200]);
+        let url = spawn_server(Arc::clone(&rec)).await;
+        let poster = RetryingPoster::new(url, None, 5, 1000).unwrap();
+
+        poster.post(&sample("c-401"), log("c-401")).await;
+
+        let payloads = rec.payloads.lock().await;
+        assert_eq!(payloads.len(), 1, "4xx must not retry");
+    }
+
+    #[tokio::test]
+    async fn retry_exhaustion_drops_payload_without_panicking() {
+        // Server returns 500 forever; the poster gives up after the
+        // budget and must not panic.
+        let rec = Recorder::new(vec![500, 500, 500, 500, 500]);
+        let url = spawn_server(Arc::clone(&rec)).await;
+        let poster = RetryingPoster::new(url, None, 2, 500).unwrap();
+
+        poster.post(&sample("c-give-up"), log("c-give-up")).await;
+
+        let payloads = rec.payloads.lock().await;
+        assert_eq!(payloads.len(), 3, "first attempt + retry_max=2 retries");
+    }
+}

--- a/crates/media-glue/src/tap.rs
+++ b/crates/media-glue/src/tap.rs
@@ -472,9 +472,24 @@ impl MediaTap {
                                     frames_sent_to_forge = 0;
                                     first_audio_pushed_at = None;
                                 }
-                                if events_tx.send(out).await.is_err() {
-                                    debug!("events_tx closed; ending tap");
-                                    return Ok(TapDisconnect::ControllerHungUp);
+                                // Best-effort, mirroring
+                                // `CallHandle::push_bridge_event`: a
+                                // backed-up or closed bridge channel
+                                // must NOT stall the audio arms of
+                                // this `select!` loop, so `try_send`
+                                // rather than `send().await`. Tap
+                                // events (DTMF / speech / mark) are
+                                // informational; a dropped one isn't
+                                // fatal. Genuine controller teardown
+                                // is still caught by the
+                                // `caller_audio_tx` / `playout_audio_rx`
+                                // arms above.
+                                if let Err(e) = events_tx.try_send(out) {
+                                    warn!(
+                                        call_id = %self.call_id,
+                                        error = %e,
+                                        "events_tx full or closed; dropping tap event"
+                                    );
                                 }
                             }
                         }

--- a/crates/media-glue/tests/common/mod.rs
+++ b/crates/media-glue/tests/common/mod.rs
@@ -1,0 +1,34 @@
+//! Shared SDP fixtures for the `siphon-ai-media-glue` integration
+//! tests.
+//!
+//! `LINPHONE_PCMU_OFFER` and `G729_ONLY_OFFER` were duplicated
+//! verbatim between `setup.rs` and `sdp_negotiation.rs`. Centralizing
+//! them keeps the offer→answer negotiation tests and the end-to-end
+//! `MediaSetup` tests exercising byte-identical inputs.
+//!
+//! Pulled in via `mod common;` per test file. `dead_code` is allowed
+//! because not every test binary uses every fixture.
+#![allow(dead_code)]
+
+/// Linphone-style PCMU/PCMA offer with `telephone-event`.
+pub const LINPHONE_PCMU_OFFER: &str = "v=0\r\n\
+o=alice 1234 5678 IN IP4 10.0.0.5\r\n\
+s=Talk\r\n\
+c=IN IP4 10.0.0.5\r\n\
+t=0 0\r\n\
+m=audio 7078 RTP/AVP 0 8 101\r\n\
+a=rtpmap:0 PCMU/8000\r\n\
+a=rtpmap:8 PCMA/8000\r\n\
+a=rtpmap:101 telephone-event/8000\r\n\
+a=fmtp:101 0-15\r\n\
+a=sendrecv\r\n";
+
+/// G.729-only offer — no codec SiphonAI supports.
+pub const G729_ONLY_OFFER: &str = "v=0\r\n\
+o=- 1 1 IN IP4 10.0.0.5\r\n\
+s=Talk\r\n\
+c=IN IP4 10.0.0.5\r\n\
+t=0 0\r\n\
+m=audio 7000 RTP/AVP 18\r\n\
+a=rtpmap:18 G729/8000\r\n\
+a=sendrecv\r\n";

--- a/crates/media-glue/tests/sdp_negotiation.rs
+++ b/crates/media-glue/tests/sdp_negotiation.rs
@@ -26,17 +26,8 @@ fn caps_full(port: u16) -> LocalCapabilities {
     }
 }
 
-const LINPHONE_PCMU_OFFER: &str = "v=0\r\n\
-o=alice 1234 5678 IN IP4 10.0.0.5\r\n\
-s=Talk\r\n\
-c=IN IP4 10.0.0.5\r\n\
-t=0 0\r\n\
-m=audio 7078 RTP/AVP 0 8 101\r\n\
-a=rtpmap:0 PCMU/8000\r\n\
-a=rtpmap:8 PCMA/8000\r\n\
-a=rtpmap:101 telephone-event/8000\r\n\
-a=fmtp:101 0-15\r\n\
-a=sendrecv\r\n";
+mod common;
+use common::{G729_ONLY_OFFER, LINPHONE_PCMU_OFFER};
 
 const ASTERISK_OPUS_PREF_OFFER: &str = "v=0\r\n\
 o=- 1700000000 1 IN IP4 10.0.0.5\r\n\
@@ -59,15 +50,6 @@ c=IN IP4 10.0.0.5\r\n\
 t=0 0\r\n\
 m=video 5004 RTP/AVP 96\r\n\
 a=rtpmap:96 H264/90000\r\n\
-a=sendrecv\r\n";
-
-const G729_ONLY_OFFER: &str = "v=0\r\n\
-o=- 1 1 IN IP4 10.0.0.5\r\n\
-s=Talk\r\n\
-c=IN IP4 10.0.0.5\r\n\
-t=0 0\r\n\
-m=audio 7000 RTP/AVP 18\r\n\
-a=rtpmap:18 G729/8000\r\n\
 a=sendrecv\r\n";
 
 #[test]

--- a/crates/media-glue/tests/setup.rs
+++ b/crates/media-glue/tests/setup.rs
@@ -16,26 +16,8 @@ use siphon_ai_bridge::{pack_pcm16_le, unpack_pcm16_le};
 use siphon_ai_media_glue::{Codec, InboundCall, MediaSetup, SdpError, SetupError};
 use tokio::sync::mpsc;
 
-const LINPHONE_PCMU_OFFER: &str = "v=0\r\n\
-o=alice 1234 5678 IN IP4 10.0.0.5\r\n\
-s=Talk\r\n\
-c=IN IP4 10.0.0.5\r\n\
-t=0 0\r\n\
-m=audio 7078 RTP/AVP 0 8 101\r\n\
-a=rtpmap:0 PCMU/8000\r\n\
-a=rtpmap:8 PCMA/8000\r\n\
-a=rtpmap:101 telephone-event/8000\r\n\
-a=fmtp:101 0-15\r\n\
-a=sendrecv\r\n";
-
-const G729_ONLY_OFFER: &str = "v=0\r\n\
-o=- 1 1 IN IP4 10.0.0.5\r\n\
-s=Talk\r\n\
-c=IN IP4 10.0.0.5\r\n\
-t=0 0\r\n\
-m=audio 7000 RTP/AVP 18\r\n\
-a=rtpmap:18 G729/8000\r\n\
-a=sendrecv\r\n";
+mod common;
+use common::{G729_ONLY_OFFER, LINPHONE_PCMU_OFFER};
 
 fn small_session_manager(min: u16, max: u16) -> Arc<SessionManager> {
     let config = SessionManagerConfig {

--- a/crates/telemetry/src/hep.rs
+++ b/crates/telemetry/src/hep.rs
@@ -9,9 +9,12 @@
 //! - `HepProtocol::Log` (0x64): one short text line per call lifecycle
 //!   event (start, end, register state change). Carries the call_id
 //!   as the correlation chunk so Homer threads it through the same
-//!   SIP / RTCP view.
-//! - `HepProtocol::Cdr` (0x65): the full CDR JSON when a call ends,
-//!   same correlation key.
+//!   SIP / RTCP view. See [`HepTelemetry::emit_log`].
+//!
+//! `HepProtocol::Cdr` (0x65) chunks — the full CDR JSON emitted when a
+//! call ends — are composed by `siphon-ai-cdr`'s `HepCdrSink`, which
+//! shares this module's `HepSink` via [`HepTelemetry::sink`] rather
+//! than duplicating the packet-composition here.
 //!
 //! Per CLAUDE.md §4.7 emission is best-effort, never blocking. The
 //! underlying `UdpHepSink` drops on full and the drop counter is
@@ -152,24 +155,6 @@ impl HepTelemetry {
             timestamp: SystemTime::now(),
             correlation_id: correlation_id.map(|s| s.to_string()),
             payload: message.as_bytes().to_vec(),
-        });
-    }
-
-    /// Emit a CDR JSON blob as chunk-type 101 (`Cdr`). Caller is
-    /// responsible for serializing the CDR before invocation —
-    /// telemetry doesn't pull the CDR schema in to avoid a dep on
-    /// `siphon-ai-cdr`.
-    pub fn emit_cdr_json(&self, json: &[u8], correlation_id: Option<&str>) {
-        self.sink.send(HepPacket {
-            capture_id: self.capture_id,
-            capture_password: self.capture_password.clone(),
-            protocol: HepProtocol::Cdr,
-            transport: IpProto::Udp,
-            src: unspecified_addr(),
-            dst: unspecified_addr(),
-            timestamp: SystemTime::now(),
-            correlation_id: correlation_id.map(|s| s.to_string()),
-            payload: json.to_vec(),
         });
     }
 

--- a/crates/webhooks/Cargo.toml
+++ b/crates/webhooks/Cargo.toml
@@ -12,18 +12,15 @@ repository.workspace   = true
 tokio.workspace       = true
 async-trait.workspace = true
 serde.workspace       = true
-serde_json.workspace  = true
-reqwest.workspace     = true
 chrono.workspace      = true
 thiserror.workspace   = true
 tracing.workspace     = true
+# Internal — shared retrying JSON-POST transport behind the HTTP sink.
+siphon-ai-http.workspace = true
 
 # v1 doesn't ship HMAC signing — left as a follow-up per docs/DEV_PLAN.md
 # §11.6 ("Lifecycle Webhooks"). Re-enable hmac/sha2/base64 when that lands.
 
 [dev-dependencies]
-hyper.workspace          = true
-hyper-util.workspace     = true
-http-body-util.workspace = true
-bytes.workspace          = true
-parking_lot.workspace    = true
+serde_json.workspace  = true
+parking_lot.workspace = true

--- a/crates/webhooks/src/http.rs
+++ b/crates/webhooks/src/http.rs
@@ -1,26 +1,15 @@
-//! HTTP POST sink with retry + exponential backoff.
+//! Lifecycle webhook sink — a thin [`WebhookSink`] adapter over
+//! [`siphon_ai_http::RetryingPoster`].
 //!
-//! Mirrors `siphon-ai-cdr`'s `WebhookSink` shape: each `emit`
-//! spawns the POST so the per-call task never blocks on network
-//! I/O. Transient failures (5xx, 408, 429) retry; 4xx never
-//! retries; failures after `retry_max` are logged and dropped.
-//!
-//! ## Why a separate impl from `siphon-ai-cdr`'s webhook?
-//!
-//! The shape is similar but the lifetimes are different — CDR
-//! webhooks fire one record per call, lifecycle webhooks fire two
-//! (or more, when ws_failure / etc. land). Keeping them apart
-//! avoids an awkward "is this a CDR or an event?" generic. If the
-//! shared logic ever grows, factoring out an internal
-//! `http-retry-post` helper crate would be the right move; v1
-//! stays simple.
-
-use std::time::Duration;
+//! Each `emit` spawns the retrying POST so the per-call task never
+//! blocks on network I/O. The retry budget, exponential backoff,
+//! transient-status classification, and `Authorization` header live
+//! in `siphon-ai-http`, shared with the CDR webhook sink — so a
+//! change to delivery behavior (or future HMAC signing) happens once.
 
 use async_trait::async_trait;
-use reqwest::{Client, StatusCode};
 use serde::{Deserialize, Serialize};
-use tracing::{debug, warn};
+use siphon_ai_http::{BuildError, PostLog, RetryingPoster, DEFAULT_RETRY_MAX, DEFAULT_TIMEOUT_MS};
 
 use crate::event::WebhookEvent;
 use crate::sink::WebhookSink;
@@ -42,10 +31,10 @@ pub struct HttpSinkConfig {
 }
 
 fn default_retry_max() -> u32 {
-    3
+    DEFAULT_RETRY_MAX
 }
 fn default_timeout_ms() -> u64 {
-    5000
+    DEFAULT_TIMEOUT_MS
 }
 
 impl HttpSinkConfig {
@@ -53,24 +42,28 @@ impl HttpSinkConfig {
         Self {
             url: url.into(),
             auth_header: None,
-            retry_max: default_retry_max(),
-            timeout_ms: default_timeout_ms(),
+            retry_max: DEFAULT_RETRY_MAX,
+            timeout_ms: DEFAULT_TIMEOUT_MS,
         }
     }
 }
 
+/// HTTP lifecycle-webhook sink. Cheap to clone (the inner
+/// [`RetryingPoster`] holds a reference-counted client).
 #[derive(Debug, Clone)]
 pub struct HttpSink {
-    client: Client,
-    config: HttpSinkConfig,
+    poster: RetryingPoster,
 }
 
 impl HttpSink {
-    pub fn new(config: HttpSinkConfig) -> reqwest::Result<Self> {
-        let client = Client::builder()
-            .timeout(Duration::from_millis(config.timeout_ms))
-            .build()?;
-        Ok(Self { client, config })
+    pub fn new(config: HttpSinkConfig) -> Result<Self, BuildError> {
+        let poster = RetryingPoster::new(
+            config.url,
+            config.auth_header,
+            config.retry_max,
+            config.timeout_ms,
+        )?;
+        Ok(Self { poster })
     }
 }
 
@@ -78,286 +71,18 @@ impl HttpSink {
 impl WebhookSink for HttpSink {
     async fn emit(&self, event: WebhookEvent) {
         // Spawn so the per-call task never blocks on network I/O.
-        let client = self.client.clone();
-        let config = self.config.clone();
+        let poster = self.poster.clone();
         tokio::spawn(async move {
-            post_with_retry(&client, &config, event).await;
+            poster
+                .post(
+                    &event,
+                    PostLog {
+                        kind: "lifecycle webhook",
+                        call_id: event.call_id().unwrap_or("-"),
+                        detail: Some(event.type_str()),
+                    },
+                )
+                .await;
         });
-    }
-}
-
-async fn post_with_retry(client: &Client, config: &HttpSinkConfig, event: WebhookEvent) {
-    let mut attempt: u32 = 0;
-    loop {
-        let mut req = client.post(&config.url).json(&event);
-        if let Some(auth) = config.auth_header.as_deref() {
-            req = req.header("Authorization", auth);
-        }
-        match req.send().await {
-            Ok(resp) => {
-                let status = resp.status();
-                if status.is_success() {
-                    debug!(
-                        url = %config.url,
-                        call_id = event.call_id().unwrap_or("-"),
-                        event_type = event.type_str(),
-                        status = %status,
-                        "lifecycle webhook delivered"
-                    );
-                    return;
-                }
-                if !is_transient(status) {
-                    warn!(
-                        url = %config.url,
-                        call_id = event.call_id().unwrap_or("-"),
-                        event_type = event.type_str(),
-                        status = %status,
-                        "lifecycle webhook rejected (4xx); not retrying"
-                    );
-                    return;
-                }
-                warn!(
-                    url = %config.url,
-                    call_id = event.call_id().unwrap_or("-"),
-                    event_type = event.type_str(),
-                    status = %status,
-                    attempt = attempt + 1,
-                    "lifecycle webhook transient failure"
-                );
-            }
-            Err(e) => {
-                warn!(
-                    url = %config.url,
-                    call_id = event.call_id().unwrap_or("-"),
-                    event_type = event.type_str(),
-                    error = %e,
-                    attempt = attempt + 1,
-                    "lifecycle webhook request failed"
-                );
-            }
-        }
-        if attempt >= config.retry_max {
-            warn!(
-                url = %config.url,
-                call_id = event.call_id().unwrap_or("-"),
-                event_type = event.type_str(),
-                attempts = attempt + 1,
-                "lifecycle webhook giving up; event dropped"
-            );
-            return;
-        }
-        tokio::time::sleep(backoff_for(attempt)).await;
-        attempt += 1;
-    }
-}
-
-fn is_transient(status: StatusCode) -> bool {
-    status.is_server_error()
-        || status == StatusCode::REQUEST_TIMEOUT
-        || status == StatusCode::TOO_MANY_REQUESTS
-}
-
-/// Exponential backoff: 100ms, 200ms, 400ms, 800ms, capped at 5s.
-/// Same shape as the CDR webhook for predictable operator behaviour.
-fn backoff_for(attempt: u32) -> Duration {
-    let ms = 100u64.saturating_mul(1u64 << attempt.min(6));
-    Duration::from_millis(ms.min(5000))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::event::{CallEndEvent, CallStartEvent, WEBHOOK_VERSION};
-    use chrono::TimeZone;
-    use http_body_util::BodyExt;
-    use hyper::body::Incoming;
-    use hyper::service::service_fn;
-    use hyper::{Request, Response};
-    use hyper_util::rt::TokioIo;
-    use std::convert::Infallible;
-    use std::net::SocketAddr;
-    use std::sync::atomic::{AtomicU32, Ordering};
-    use std::sync::Arc;
-    use tokio::net::TcpListener;
-    use tokio::sync::Mutex as AsyncMutex;
-
-    fn start_event(call_id: &str) -> WebhookEvent {
-        WebhookEvent::CallStart(CallStartEvent {
-            version: WEBHOOK_VERSION,
-            call_id: call_id.into(),
-            sip_call_id: format!("{call_id}@pbx"),
-            timestamp: chrono::Utc.with_ymd_and_hms(2026, 5, 5, 14, 30, 0).unwrap(),
-            from: "+1".into(),
-            to: "5000".into(),
-            route: "default".into(),
-            ws_url: "wss://x/y".into(),
-        })
-    }
-
-    fn end_event(call_id: &str) -> WebhookEvent {
-        WebhookEvent::CallEnd(CallEndEvent {
-            version: WEBHOOK_VERSION,
-            call_id: call_id.into(),
-            sip_call_id: format!("{call_id}@pbx"),
-            timestamp: chrono::Utc.with_ymd_and_hms(2026, 5, 5, 14, 30, 1).unwrap(),
-            from: "+1".into(),
-            to: "5000".into(),
-            route: "default".into(),
-            ws_url: "wss://x/y".into(),
-            duration_ms: 1000,
-            termination_cause: "server_hangup".into(),
-        })
-    }
-
-    struct Recorder {
-        payloads: AsyncMutex<Vec<serde_json::Value>>,
-        auth_headers: AsyncMutex<Vec<Option<String>>>,
-        attempt: AtomicU32,
-        status_per_attempt: Vec<u16>,
-    }
-
-    impl Recorder {
-        fn new(status_per_attempt: Vec<u16>) -> Arc<Self> {
-            Arc::new(Self {
-                payloads: AsyncMutex::new(Vec::new()),
-                auth_headers: AsyncMutex::new(Vec::new()),
-                attempt: AtomicU32::new(0),
-                status_per_attempt,
-            })
-        }
-    }
-
-    async fn spawn_server(rec: Arc<Recorder>) -> String {
-        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
-        let addr: SocketAddr = listener.local_addr().unwrap();
-        tokio::spawn(async move {
-            loop {
-                let (stream, _) = match listener.accept().await {
-                    Ok(s) => s,
-                    Err(_) => break,
-                };
-                let rec = Arc::clone(&rec);
-                tokio::spawn(async move {
-                    let _ = hyper::server::conn::http1::Builder::new()
-                        .serve_connection(
-                            TokioIo::new(stream),
-                            service_fn(move |req: Request<Incoming>| {
-                                let rec = Arc::clone(&rec);
-                                async move { handle(rec, req).await }
-                            }),
-                        )
-                        .await;
-                });
-            }
-        });
-        format!("http://{addr}/webhooks")
-    }
-
-    async fn handle(
-        rec: Arc<Recorder>,
-        req: Request<Incoming>,
-    ) -> Result<Response<String>, Infallible> {
-        let auth = req
-            .headers()
-            .get("authorization")
-            .and_then(|v| v.to_str().ok().map(str::to_string));
-        let body = req.collect().await.expect("collect").to_bytes();
-        let json: serde_json::Value = serde_json::from_slice(&body).expect("body is valid JSON");
-        rec.payloads.lock().await.push(json);
-        rec.auth_headers.lock().await.push(auth);
-        let attempt_idx = rec.attempt.fetch_add(1, Ordering::Relaxed) as usize;
-        let status_code = rec
-            .status_per_attempt
-            .get(attempt_idx)
-            .copied()
-            .unwrap_or(200);
-        Ok(Response::builder()
-            .status(status_code)
-            .body(String::new())
-            .unwrap())
-    }
-
-    #[tokio::test]
-    async fn happy_path_posts_event_with_auth_header() {
-        let rec = Recorder::new(vec![200]);
-        let url = spawn_server(Arc::clone(&rec)).await;
-        let sink = HttpSink::new(HttpSinkConfig {
-            url,
-            auth_header: Some("Bearer slack-token".into()),
-            retry_max: 0,
-            timeout_ms: 1000,
-        })
-        .unwrap();
-
-        sink.emit(start_event("c-1")).await;
-        tokio::time::sleep(Duration::from_millis(150)).await;
-
-        let payloads = rec.payloads.lock().await;
-        assert_eq!(payloads.len(), 1);
-        assert_eq!(payloads[0]["type"], serde_json::json!("call_start"));
-        assert_eq!(payloads[0]["call_id"], serde_json::json!("c-1"));
-
-        let auth = rec.auth_headers.lock().await;
-        assert_eq!(auth[0].as_deref(), Some("Bearer slack-token"));
-    }
-
-    #[tokio::test]
-    async fn transient_5xx_retries_then_succeeds() {
-        let rec = Recorder::new(vec![503, 503, 200]);
-        let url = spawn_server(Arc::clone(&rec)).await;
-        let sink = HttpSink::new(HttpSinkConfig {
-            url,
-            auth_header: None,
-            retry_max: 3,
-            timeout_ms: 1000,
-        })
-        .unwrap();
-
-        sink.emit(end_event("c-retry")).await;
-        // Backoff: 100 + 200 = 300ms before attempt 3; pad.
-        tokio::time::sleep(Duration::from_millis(800)).await;
-
-        let payloads = rec.payloads.lock().await;
-        assert_eq!(payloads.len(), 3);
-        assert_eq!(payloads[2]["type"], serde_json::json!("call_end"));
-    }
-
-    #[tokio::test]
-    async fn permanent_4xx_does_not_retry() {
-        let rec = Recorder::new(vec![401, 200]);
-        let url = spawn_server(Arc::clone(&rec)).await;
-        let sink = HttpSink::new(HttpSinkConfig {
-            url,
-            auth_header: None,
-            retry_max: 5,
-            timeout_ms: 1000,
-        })
-        .unwrap();
-
-        sink.emit(start_event("c-401")).await;
-        tokio::time::sleep(Duration::from_millis(300)).await;
-
-        let payloads = rec.payloads.lock().await;
-        assert_eq!(payloads.len(), 1);
-    }
-
-    #[tokio::test]
-    async fn retry_exhaustion_drops_event_without_panicking() {
-        let rec = Recorder::new(vec![500, 500, 500, 500, 500]);
-        let url = spawn_server(Arc::clone(&rec)).await;
-        let sink = HttpSink::new(HttpSinkConfig {
-            url,
-            auth_header: None,
-            retry_max: 2,
-            timeout_ms: 500,
-        })
-        .unwrap();
-
-        sink.emit(start_event("c-give-up")).await;
-        tokio::time::sleep(Duration::from_millis(900)).await;
-
-        let payloads = rec.payloads.lock().await;
-        // initial attempt + retry_max=2 retries
-        assert_eq!(payloads.len(), 3);
     }
 }


### PR DESCRIPTION
Addresses five code-quality findings ahead of the 0.1.0 release. Each finding is a separate commit, so they can be reviewed (and reverted) independently.

## 1. Shared retrying JSON POST sink (`e5c0643`)

`siphon-ai-cdr`'s CDR webhook sink and `siphon-ai-webhooks`' lifecycle webhook sink each carried a near-identical copy of the same retry stack: config defaults, `reqwest::Client` setup, `post_with_retry`, transient-status classification, exponential backoff, and the test scaffolding.

New `siphon-ai-http` crate exposes `RetryingPoster`; both sinks become thin adapters. Neither references `reqwest` directly anymore — `BuildError` keeps the surface clean. `webhooks` also moves `serde_json` to dev-dependencies (test-only).

## 2. Non-blocking tap events (`c2ca455`)

`MediaTap::run` awaited `events_tx.send().await` inside the `select!` loop, which could stall the audio path. Switched to `try_send` + warn/drop.

## 3. Single `normalize_auth_header` (`dc56db6`)

Was duplicated in `config` and `core` with "keep in sync" comments. Moved to `siphon-ai-bridge`.

## 4. Single CD owner (`d2314d3`)

Deleted the dead `emit_cdr_json`; `HepCdrSink` is the single owner.

## 5. Shared test fixtures (`64a80d5`)

`tests/common/mod.rs` per crate for duplicated fixtures.

---

Verified: `cargo test --workspace` ✓ · `cargo clippy` ✓ · `cargo fmt` ✓.
