### PR TITLE
chore: prepare 0.1.0 release (version, license, changelog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,79 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-05-22
+
+First public release. SiphonAI is a provider-neutral SIP-to-WebSocket
+media bridge: it terminates SIP calls, streams the call audio over a
+WebSocket to a developer-supplied server, and plays audio received back
+over that WebSocket into the call. It contains no AI code — the AI is
+the WebSocket server's job.
+
+### Added
+
+#### SIP signaling
+
+- Inbound trunk mode (UAS): accept calls from a SIP trunk or PBX, gated
+  by an optional per-trunk source-IP / From-host allowlist.
+- Registered-phone mode (UAC + REGISTER): register to a PBX (e.g. Cisco
+  CUCM, Asterisk, FreeSWITCH) as a phone, with periodic re-REGISTER,
+  retry/backoff, and digest authentication.
+- Call lifecycle: INVITE / ACK / BYE / CANCEL, 100 Trying, provisional
+  and final responses, re-INVITE for hold / resume.
+- Blind transfer initiated from the WebSocket server (REFER).
+- RFC 3261 / RFC 3581 response compliance: Via `received=` / `rport=`,
+  rich Contact, and an honest `Allow` header on 405 / OPTIONS.
+
+#### Media
+
+- RTP / RTCP bridging via forge-media, with jitter buffering.
+- Codecs: G.711 PCMU / PCMA (8 kHz) and G.722 (16 kHz).
+- DTMF via RFC 2833 (telephone-event), surfaced to the WebSocket server.
+- Barge-in: VAD-driven `speech_started` events for interruption handling.
+
+#### WebSocket bridge protocol v1
+
+- Bidirectional audio as 20 ms PCM16 little-endian mono frames
+  (160 samples @ 8 kHz, 320 @ 16 kHz).
+- Control and event messages with monotonic per-call `seq` numbering.
+- Canonical protocol specification in `docs/PROTOCOL.md`.
+
+#### Routing
+
+- TOML dialplan: ordered, first-match-wins routes matched on the inbound
+  INVITE (request URI, To, From, Call-ID, custom headers).
+- Optional per-route regex matching and per-route overrides of global
+  media / bridge settings.
+
+#### Configuration
+
+- Single TOML configuration file with load-time validation (invalid
+  regex, dangling references, unset env vars fail loud at startup).
+- Environment-variable expansion in config values.
+
+#### Observability
+
+- Structured `tracing` logs with `call_id` correlation.
+- Prometheus metrics with bounded-cardinality labels.
+- Distributed tracing spans for long-running per-call operations.
+- HEP/EEP emission to Homer for SIP, RTCP, and application events.
+- Call Detail Records (CDR) as JSON, to a file sink and/or webhook sink.
+- Out-of-band lifecycle webhooks (call start / end, registration state).
+- `/health` and `/ready` endpoints with k8s-correct semantics.
+- Runtime per-target log-level adjustment via the admin API.
+
+#### Packaging
+
+- Multi-stage Docker image and `docker compose` quickstart stack.
+- Idempotent Debian 13 install scripts with systemd units.
+- Reference WebSocket servers in `examples/`: echo (Python / Node),
+  an OpenAI Realtime bridge, and a Deepgram + LLM voice bot.
+
+[Unreleased]: https://github.com/thevoiceguy/siphon-ai/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/thevoiceguy/siphon-ai/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "base64",
  "bytes",
@@ -2784,7 +2784,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2805,7 +2805,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "regex",
  "serde",
@@ -2819,7 +2819,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2855,7 +2855,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2875,7 +2875,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "regex",
  "serde",
@@ -2886,7 +2886,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2909,7 +2909,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.0"
+version = "0.1.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2025 siphon-rs contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 James Ferris <ferrous.communications@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/SPIKE_MEDIA_TAP.md
+++ b/docs/SPIKE_MEDIA_TAP.md
@@ -82,7 +82,7 @@ the codec packetization (typically `ptime=20` in SDP). Our bridge crate
 must *re-frame* outbound chunks to exactly 20 ms before they hit the WS,
 and accept inbound chunks of any size from the WS and re-frame them to
 whatever forge expects on the way back in. That re-framing lives in
-`crates/media-glue` (or `crates/bridge` — TBD; see Week 2).
+`crates/media-glue`.
 
 ## Out-of-band events
 


### PR DESCRIPTION
Release housekeeping for the first tagged release — the administrative blockers identified in the 0.1.0 readiness review.

## Changes

- **Version** — workspace `version` bumped `0.0.0` → `0.1.0`. All crates inherit it via `version.workspace = true`; `Cargo.lock` resynced.
- **License files** — added `LICENSE-MIT` and `LICENSE-APACHE`. The workspace manifest has always declared `MIT OR Apache-2.0`, but the files were missing. Copyright: James Ferris <ferrous.communications@gmail.com>. `LICENSE-APACHE` is the verbatim Apache-2.0 text.
- **Changelog** — added `CHANGELOG.md` (Keep a Changelog format) with a `[0.1.0]` section summarising the v1 feature set.
- **Docs** — dropped a stale `TBD` in `SPIKE_MEDIA_TAP.md` (the re-framing crate location was settled long ago).

## Not included

- README still reads `v0.1.0-rc — pre-release`; flip to `v0.1.0` at tag time.
- No CI workflow yet (`.github/workflows/`) — recommended but not blocking.

Verified: `cargo check --workspace` clean.
