### PR TITLE
chore: sync Cargo.lock for siphon-ai-http after 0.1.0 bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "http-body-util",
  "hyper",


### PR DESCRIPTION
Three-way-merge follow-up. `#65` introduced `siphon-ai-http` at workspace version 0.0.0 (its branch base); `#66` bumped the workspace version to 0.1.0 but couldn't touch a crate that didn't exist on its branch yet. After both merged, the lock had every other siphon-ai-* crate at 0.1.0 and `siphon-ai-http` at 0.0.0. `cargo build` regenerated it — one line.