### PR TITLE
chore: bump siphon-rs for PRACK tag fix; resolve 0.2.0 §9.1 (call progress)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2518,7 +2518,7 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 [[package]]
 name = "sip-auth"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ef59180819a3#ef59180819a3945506985c85009700fbe9fac659"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=c03fa985b00a#c03fa985b00ad5bf5592e6561664e8a123e636e2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2541,7 +2541,7 @@ dependencies = [
 [[package]]
 name = "sip-core"
 version = "0.7.6"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ef59180819a3#ef59180819a3945506985c85009700fbe9fac659"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=c03fa985b00a#c03fa985b00ad5bf5592e6561664e8a123e636e2"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2554,7 +2554,7 @@ dependencies = [
 [[package]]
 name = "sip-dialog"
 version = "0.3.3"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ef59180819a3#ef59180819a3945506985c85009700fbe9fac659"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=c03fa985b00a#c03fa985b00ad5bf5592e6561664e8a123e636e2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2572,7 +2572,7 @@ dependencies = [
 [[package]]
 name = "sip-dns"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ef59180819a3#ef59180819a3945506985c85009700fbe9fac659"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=c03fa985b00a#c03fa985b00ad5bf5592e6561664e8a123e636e2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2586,7 +2586,7 @@ dependencies = [
 [[package]]
 name = "sip-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ef59180819a3#ef59180819a3945506985c85009700fbe9fac659"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=c03fa985b00a#c03fa985b00ad5bf5592e6561664e8a123e636e2"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -2597,7 +2597,7 @@ dependencies = [
 [[package]]
 name = "sip-observe"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ef59180819a3#ef59180819a3945506985c85009700fbe9fac659"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=c03fa985b00a#c03fa985b00ad5bf5592e6561664e8a123e636e2"
 dependencies = [
  "once_cell",
  "tracing",
@@ -2606,7 +2606,7 @@ dependencies = [
 [[package]]
 name = "sip-parse"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ef59180819a3#ef59180819a3945506985c85009700fbe9fac659"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=c03fa985b00a#c03fa985b00ad5bf5592e6561664e8a123e636e2"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2620,7 +2620,7 @@ dependencies = [
 [[package]]
 name = "sip-ratelimit"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ef59180819a3#ef59180819a3945506985c85009700fbe9fac659"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=c03fa985b00a#c03fa985b00ad5bf5592e6561664e8a123e636e2"
 dependencies = [
  "dashmap 5.5.3",
  "parking_lot",
@@ -2640,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ef59180819a3#ef59180819a3945506985c85009700fbe9fac659"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=c03fa985b00a#c03fa985b00ad5bf5592e6561664e8a123e636e2"
 dependencies = [
  "nom",
  "smol_str",
@@ -2649,7 +2649,7 @@ dependencies = [
 [[package]]
 name = "sip-transaction"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ef59180819a3#ef59180819a3945506985c85009700fbe9fac659"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=c03fa985b00a#c03fa985b00ad5bf5592e6561664e8a123e636e2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2668,7 +2668,7 @@ dependencies = [
 [[package]]
 name = "sip-transport"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ef59180819a3#ef59180819a3945506985c85009700fbe9fac659"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=c03fa985b00a#c03fa985b00ad5bf5592e6561664e8a123e636e2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2687,7 +2687,7 @@ dependencies = [
 [[package]]
 name = "sip-uac"
 version = "0.4.2"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ef59180819a3#ef59180819a3945506985c85009700fbe9fac659"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=c03fa985b00a#c03fa985b00ad5bf5592e6561664e8a123e636e2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2700,7 +2700,7 @@ dependencies = [
  "sip-dialog",
  "sip-dns",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=ef59180819a3)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=c03fa985b00a)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -2712,7 +2712,7 @@ dependencies = [
 [[package]]
 name = "sip-uas"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ef59180819a3#ef59180819a3945506985c85009700fbe9fac659"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=c03fa985b00a#c03fa985b00ad5bf5592e6561664e8a123e636e2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2722,7 +2722,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=ef59180819a3)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=c03fa985b00a)",
  "sip-transaction",
  "sip-transport",
  "smol_str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,16 +102,16 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 # main branch and replace the rev hashes here (see CLAUDE.md §7.5).
 
 # siphon-rs — RFC 3261 SIP stack
-sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ef59180819a3" }
-sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ef59180819a3" }
-sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ef59180819a3", features = ["tls"] }
-sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ef59180819a3" }
-sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ef59180819a3" }
-sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ef59180819a3" }
-sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ef59180819a3" }
-sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ef59180819a3" }
-sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ef59180819a3" }
-sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ef59180819a3" }
+sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "c03fa985b00a" }
+sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "c03fa985b00a" }
+sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "c03fa985b00a", features = ["tls"] }
+sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "c03fa985b00a" }
+sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "c03fa985b00a" }
+sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "c03fa985b00a" }
+sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "c03fa985b00a" }
+sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "c03fa985b00a" }
+sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "c03fa985b00a" }
+sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "c03fa985b00a" }
 
 # forge-media — RTP / codecs / SDP / DTMF / engine.
 #

--- a/docs/DEV_PLAN_0.2.0.md
+++ b/docs/DEV_PLAN_0.2.0.md
@@ -1,6 +1,6 @@
 # SiphonAI 0.2.0 Development Plan
 
-**Status:** working draft. Pending the decisions in §9 before Sprint 1.
+**Status:** working draft. 1 / 6 decisions in §9 resolved (call-progress / early-media — see §9.1); the remaining five gate Sprint 1.
 
 This is the incremental plan from `v0.1.0` (see `docs/DEV_PLAN.md` for the original product definition and locked decisions). It picks up the 0.2.0 roadmap brief and re-organises it around what actually fits siphon-ai's "thin orchestration bridge" mission per `CLAUDE.md` §4.1.
 
@@ -129,7 +129,10 @@ Therefore: **protocol stays at `version: "1"` for 0.2.0.** A v2 bump would only 
 
 These are the gates worth resolving before any code lands. The recommendations are opinions, not facts:
 
-1. **Early media in `session_progress` mode** — does forge support sending RTP before 200 OK? If not, that mode degrades to "send 183 then 200 OK with no real early media." Either limit scope or open a forge PR.
+1. ✅ **Early media in `session_progress` mode** — **resolved**.
+   - **Forge**: investigated — supports it today, no changes needed. The acceptor already calls `start_session()` *before* `accept_invite` (see `crates/core/src/acceptor.rs:1331`, with an explicit "Start forge's RTP forwarding loop BEFORE the 200 OK" comment), and `send_rtp_to` has no "answered" gate, only requiring the remote address (already seeded from the offer).
+   - **siphon-rs**: was missing one RFC 3262 correctness fix — `create_reliable_provisional` ignored the dialog's local tag and stamped a random one, so PRACK matching would never work end-to-end. Fixed upstream in [siphon-rs#47](https://github.com/thevoiceguy/siphon-rs/pull/47); siphon-ai bumped to that rev.
+   - **Decision**: 0.2.0 ships **Flavour B (best-effort 183 with negotiated SDP)**. Peers that include `Require: 100rel` in the INVITE are detected at INVITE time and the call falls through to `instant_answer` with a `warn!` log (so they still get bridged, just without reliable provisionals). The reliable / 100rel-honouring variant — and the "AI plays a prompt during the 183 phase" *Flavour C* — are deferred to **0.2.1 / 0.3.0**, when `on_prack` wiring in `RoutingHandler` and a `BridgeIn::Answer` control message are tackled together.
 2. **`silence_detected` / `dead_air_detected` default thresholds** — proposal: `silence_threshold_ms = 1500`, `dead_air_threshold_ms = 5000`. Survey against actual call traffic before locking.
 3. **RTP stats cadence** — default emit interval? Proposal: `5000 ms`. Configurable per-call via a control message?
 4. **Twilio example scope** — inbound-trunk config + pointer to echo-ws-server, or a fuller "Twilio sends webhook, siphon-ai handles the SIP" loop? The former is much smaller.


### PR DESCRIPTION
Two-part 0.2.0 prep:

1. **Bump siphon-rs `ef59180` → `c03fa98`** — picks up [siphon-rs#47](https://github.com/thevoiceguy/siphon-rs/pull/47) (`create_reliable_provisional` honours the dialog's local tag). The previous behaviour ignored the dialog tag and stamped a random one, so reliable 1xx + PRACK could never match end-to-end. The fix is a 0.2.0 prerequisite for the reliable / 100rel-honouring variant of `session_progress` mode.

2. **Resolve `docs/DEV_PLAN_0.2.0.md` §9.1** — call-progress / early-media decision now reads:

   > 0.2.0 ships **Flavour B** (best-effort 183 with negotiated SDP). Peers that include `Require: 100rel` are detected at INVITE time and fall through to `instant_answer` with a `warn!` log. Reliable variant + Flavour C ("AI plays during 183 phase") are deferred to 0.2.1 / 0.3.0 alongside `on_prack` wiring + a new `BridgeIn::Answer` control message.

   Forge needs no changes; the existing flow already calls `session_manager.start_session()` before `accept_invite` (`crates/core/src/acceptor.rs:1331`).

Status header bumped to '1 / 6 §9 decisions resolved'. `cargo check --workspace` clean against the new rev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)