### PR TITLE
feat(sip): configurable call progress (180 / 183) mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Configurable SIP call progress** (`[sip.call_progress]`). New `mode` field selects what — if any — provisional response the UAS sends before the `200 OK`:
+  - `instant_answer` (default; v0.1.0 behaviour): skip extra provisionals.
+  - `ringing`: send `180 Ringing` (no body) before the 2xx.
+  - `session_progress`: send `183 Session Progress` with the negotiated answer SDP before the 2xx (Flavour B per `docs/DEV_PLAN_0.2.0.md` §9.1 — best-effort, no `100rel`). Peers that include `Require: 100rel` in the INVITE fall back to `instant_answer` with a `warn!` log; reliable provisionals are deferred to 0.2.1 / 0.3.0.
+
+  Backwards-compatible: existing configs without the `[sip.call_progress]` block keep v0.1.0 behaviour.
+
 ## [0.1.0] - 2026-05-22
 
 First public release. SiphonAI is a provider-neutral SIP-to-WebSocket

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -219,7 +219,8 @@ impl Runtime {
             BridgingAcceptor::new(media_setup, bridge_defaults, registry.clone())
                 .with_cdr_sink(cdr_sink)
                 .with_webhook_sink(webhook_sink)
-                .with_session_timer_policy(session_timer_policy),
+                .with_session_timer_policy(session_timer_policy)
+                .with_call_progress(sip.call_progress),
         );
 
         // ─── Registration manager ──────────────────────────────────

--- a/crates/config/src/compile.rs
+++ b/crates/config/src/compile.rs
@@ -276,6 +276,10 @@ pub struct SipConfig {
     pub transports: Vec<SipTransport>,
     pub user_agent: Option<String>,
     pub contact: Option<String>,
+    /// What — if any — provisional response the UAS layers on top of
+    /// `100 Trying` before the 2xx. From `[sip.call_progress].mode`;
+    /// default is `InstantAnswer` (v0.1.0 behaviour).
+    pub call_progress: siphon_ai_core::CallProgressMode,
     /// `Some` when `[sip.tls]` is supplied AND `tls` is in the
     /// transports list. `None` when TLS isn't enabled. Daemon
     /// loads cert/key from these paths at startup.
@@ -351,6 +355,12 @@ pub enum CompileError {
 
     #[error("[media].dtmf is {0:?}; expected \"rfc2833\" or \"off\"")]
     UnknownDtmfMode(String),
+
+    #[error(
+        "[sip.call_progress].mode is {0:?}; expected \"instant_answer\", \"ringing\", \
+         or \"session_progress\""
+    )]
+    UnknownCallProgressMode(String),
 
     #[error("[bridge.barge_in].mode is {0:?}; expected \"auto_clear\" or \"notify_only\"")]
     UnknownBargeInMode(String),
@@ -509,6 +519,8 @@ fn compile_sip(raw: RawSip) -> Result<SipConfig, CompileError> {
     let tls_enabled = transports.contains(&SipTransport::Tls);
     let tls = compile_sip_tls(raw.tls, tls_enabled, &listen_addr)?;
 
+    let call_progress = compile_call_progress(raw.call_progress)?;
+
     // RFC 4028: 90 s is the floor (Min-SE). An operator setting
     // something smaller is asking for trouble; reject at load.
     let min_session_expires = match raw.min_session_expires_secs {
@@ -526,9 +538,21 @@ fn compile_sip(raw: RawSip) -> Result<SipConfig, CompileError> {
         user_agent: raw.user_agent,
         contact: raw.contact,
         tls,
+        call_progress,
         min_session_expires,
         preferred_session_expires,
     })
+}
+
+fn compile_call_progress(
+    raw: crate::raw::RawCallProgress,
+) -> Result<siphon_ai_core::CallProgressMode, CompileError> {
+    match raw.mode.as_deref() {
+        None | Some("instant_answer") => Ok(siphon_ai_core::CallProgressMode::InstantAnswer),
+        Some("ringing") => Ok(siphon_ai_core::CallProgressMode::Ringing),
+        Some("session_progress") => Ok(siphon_ai_core::CallProgressMode::SessionProgress),
+        Some(other) => Err(CompileError::UnknownCallProgressMode(other.to_string())),
+    }
 }
 
 fn compile_sip_tls(
@@ -1063,6 +1087,52 @@ fn compile_cdr(raw: RawCdr) -> Result<CdrConfig, CompileError> {
         file,
         webhook,
     })
+}
+
+#[cfg(test)]
+mod call_progress_tests {
+    use super::{compile_call_progress, CompileError};
+    use crate::raw::RawCallProgress;
+    use siphon_ai_core::CallProgressMode;
+
+    fn raw(mode: Option<&str>) -> RawCallProgress {
+        RawCallProgress {
+            mode: mode.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn missing_block_defaults_to_instant_answer() {
+        assert_eq!(
+            compile_call_progress(raw(None)).unwrap(),
+            CallProgressMode::InstantAnswer
+        );
+    }
+
+    #[test]
+    fn explicit_modes_parse() {
+        assert_eq!(
+            compile_call_progress(raw(Some("instant_answer"))).unwrap(),
+            CallProgressMode::InstantAnswer
+        );
+        assert_eq!(
+            compile_call_progress(raw(Some("ringing"))).unwrap(),
+            CallProgressMode::Ringing
+        );
+        assert_eq!(
+            compile_call_progress(raw(Some("session_progress"))).unwrap(),
+            CallProgressMode::SessionProgress
+        );
+    }
+
+    #[test]
+    fn unknown_mode_errors() {
+        let err = compile_call_progress(raw(Some("instant-answer"))).unwrap_err();
+        match err {
+            CompileError::UnknownCallProgressMode(s) => assert_eq!(s, "instant-answer"),
+            other => panic!("expected UnknownCallProgressMode, got {other:?}"),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/config/src/raw.rs
+++ b/crates/config/src/raw.rs
@@ -104,6 +104,11 @@ pub struct RawSip {
     /// for UDP-only deployments.
     #[serde(default)]
     pub tls: RawSipTls,
+    /// Call-progress sub-block — how the UAS responds to inbound
+    /// INVITEs before the 2xx. Unset = `mode = "instant_answer"`
+    /// (v0.1.0 behaviour).
+    #[serde(default)]
+    pub call_progress: RawCallProgress,
     /// RFC 4028 Min-SE we'll enforce on inbound INVITEs. Defaults
     /// to 90 (RFC minimum). Smaller values are rejected with 422.
     #[serde(default)]
@@ -113,6 +118,22 @@ pub struct RawSip {
     /// here. Unset = honour the peer's value uncapped.
     #[serde(default)]
     pub preferred_session_expires_secs: Option<u32>,
+}
+
+/// `[sip.call_progress]` — what — if any — provisional response
+/// `siphon-ai` layers on top of `IntegratedUAS`'s `100 Trying`
+/// before the 2xx. See `docs/DEV_PLAN_0.2.0.md` §4.1.
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawCallProgress {
+    /// `"instant_answer"` (default) | `"ringing"` | `"session_progress"`.
+    /// `instant_answer` matches v0.1.0 behaviour (skip extra
+    /// provisional). `ringing` sends `180 Ringing`. `session_progress`
+    /// sends `183 Session Progress` with the negotiated answer SDP
+    /// (best-effort; peers requiring `100rel` fall back to
+    /// `instant_answer` per the §9.1 decision).
+    #[serde(default)]
+    pub mode: Option<String>,
 }
 
 /// `[sip.tls]` — TLS server configuration. Required when

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -56,7 +56,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use parking_lot::RwLock;
-use sip_core::Request;
+use sip_core::{Request, Response};
 use sip_dialog::session_timer_manager::{SessionTimerEvent, SessionTimerManager};
 use sip_dialog::{DialogId, DialogManager};
 use sip_uac::integrated::IntegratedUAC;
@@ -163,6 +163,33 @@ impl Default for BargeInConfig {
             mode: BargeInMode::AutoClear,
         }
     }
+}
+
+/// How the UAS responds to inbound INVITEs before the 200 OK
+/// (per `docs/DEV_PLAN_0.2.0.md` §4.1). All three modes still emit
+/// `100 Trying` from `IntegratedUAS`; this enum picks what — if
+/// anything — siphon-ai layers on top before the 2xx.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CallProgressMode {
+    /// Skip any extra provisional and let `IntegratedUAS` go
+    /// straight from 100 Trying to the 2xx. Default; matches v0.1.0
+    /// behaviour.
+    #[default]
+    InstantAnswer,
+    /// Send `180 Ringing` (no body) before the 2xx. Useful when an
+    /// upstream PBX wants a ringback-style progress signal.
+    Ringing,
+    /// Send `183 Session Progress` carrying the negotiated answer
+    /// SDP before the 2xx, so a peer that needs the answer for
+    /// carrier-style early-media routing / billing has it before
+    /// the call is technically answered.
+    ///
+    /// "Flavour B" per the §9.1 decision: the provisional is
+    /// best-effort (no `100rel`). Peers that include `Require:
+    /// 100rel` in the INVITE fall back to `InstantAnswer` with a
+    /// `warn!` — the reliable / Flavour-C path is deferred until
+    /// `on_prack` wiring lands.
+    SessionProgress,
 }
 
 impl Default for BridgeDefaults {
@@ -437,6 +464,42 @@ pub fn resolve_inactivity_timeout(
 /// `BargeInConfig.enabled = false` flip — which today degrades
 /// `AutoClear` to `Notify` — can grow knobs without leaking into
 /// every call site.
+/// True when the INVITE's `Require` header lists `100rel`
+/// (case-insensitive per RFC 3261 §27.1). siphon-ai 0.2.0 ships
+/// best-effort provisionals only — peers that *require* reliable
+/// provisionals fall back to `InstantAnswer` mode rather than risk
+/// sending a non-compliant unreliable 1xx.
+fn requires_100rel(request: &Request) -> bool {
+    request
+        .headers()
+        .get("Require")
+        .map(|v| {
+            v.split(',')
+                .any(|tok| tok.trim().eq_ignore_ascii_case("100rel"))
+        })
+        .unwrap_or(false)
+}
+
+/// Attach an SDP body to a `Response` (typically a freshly-built
+/// `183 Session Progress`), updating `Content-Type` and
+/// `Content-Length` to match. Returns a new `Response` — the
+/// underlying type sets the body at construction, not by mutation.
+fn attach_sdp_body(response: Response, sdp: &str) -> Response {
+    let bytes = sdp.as_bytes().to_vec();
+    let content_length = bytes.len().to_string();
+    let mut response = response;
+    response
+        .headers_mut()
+        .set_or_push("Content-Type", "application/sdp")
+        .expect("content-type header valid");
+    response
+        .headers_mut()
+        .set_or_push("Content-Length", &content_length)
+        .expect("content-length header valid");
+    let (start, headers, _) = response.into_parts();
+    Response::new(start, headers, bytes.into()).expect("valid response with SDP body")
+}
+
 fn barge_in_to_tap_action(cfg: &BargeInConfig) -> siphon_ai_media_glue::BargeInAction {
     if !cfg.enabled {
         return siphon_ai_media_glue::BargeInAction::Notify;
@@ -567,6 +630,11 @@ pub struct BridgingAcceptor {
     /// with timers and drained when it ends. Read by the fan-out
     /// task; written by `on_matched` and `run_call`'s cleanup arm.
     dialog_handles: Arc<RwLock<HashMap<DialogId, crate::call::CallHandle>>>,
+    /// What — if any — provisional response `on_matched` sends
+    /// before the 2xx. Defaults to [`CallProgressMode::InstantAnswer`]
+    /// (v0.1.0 behaviour); operators opt in to `Ringing` or
+    /// `SessionProgress` via `[sip.call_progress]`.
+    call_progress: CallProgressMode,
 }
 
 /// Daemon-wide REFER plumbing (shared across every accepted call).
@@ -703,7 +771,16 @@ impl BridgingAcceptor {
             session_timer_policy: SessionTimerPolicy::default(),
             session_timer_manager,
             dialog_handles,
+            call_progress: CallProgressMode::default(),
         }
+    }
+
+    /// Override the call-progress mode used by [`Self::on_matched`]
+    /// when responding to inbound INVITEs. Defaults to
+    /// [`CallProgressMode::InstantAnswer`] (the v0.1.0 behaviour).
+    pub fn with_call_progress(mut self, mode: CallProgressMode) -> Self {
+        self.call_progress = mode;
+        self
     }
 
     /// Install the [`IntegratedUAS`] handle the acceptor uses to send
@@ -1363,6 +1440,50 @@ impl CallAcceptor for BridgingAcceptor {
                     call.handle.send_final(response).await;
                     metrics::counter!(INVITES_TOTAL, "result" => "rejected").increment(1);
                     return Ok(());
+                }
+
+                // ─── Configurable call progress (§4 / §9.1) ──────
+                // Send the operator-selected provisional response —
+                // 180 Ringing or 183 Session Progress with the
+                // negotiated answer SDP — between the forge-active
+                // step above and the 2xx below. `InstantAnswer`
+                // (default, v0.1.0 behaviour) skips this entirely
+                // and lets `accept_invite_with_session_timer` send
+                // the 2xx straight after `100 Trying`.
+                match self.call_progress {
+                    CallProgressMode::InstantAnswer => {}
+                    CallProgressMode::Ringing => {
+                        let r180 = UserAgentServer::create_response(call.request, 180, "Ringing");
+                        call.handle.send_provisional(r180).await;
+                    }
+                    CallProgressMode::SessionProgress => {
+                        // Flavour B (§9.1): best-effort 183 with the
+                        // negotiated answer SDP. A peer that requires
+                        // 100rel needs reliable provisionals, which
+                        // siphon-ai 0.2.0 does not ship — sending an
+                        // unreliable 183 to such a peer is
+                        // non-compliant. Fall through to InstantAnswer
+                        // with a warn so the call still completes.
+                        if requires_100rel(call.request) {
+                            warn!(
+                                call_id = %prepared.bridge_call_id,
+                                "INVITE has `Require: 100rel` but reliable \
+                                 provisionals are not supported yet \
+                                 (deferred to 0.2.1 / 0.3.0); falling back \
+                                 to instant_answer for this call"
+                            );
+                        } else {
+                            let r183 = attach_sdp_body(
+                                UserAgentServer::create_response(
+                                    call.request,
+                                    183,
+                                    "Session Progress",
+                                ),
+                                &prepared.answer.answer_text,
+                            );
+                            call.handle.send_provisional(r183).await;
+                        }
+                    }
                 }
 
                 // 200 OK with the negotiated SDP via the canonical
@@ -2613,6 +2734,45 @@ a=sendrecv\r\n",
         assert_eq!(outcome.answer_direction, None);
         assert_eq!(outcome.answer_sdp, cached_answer_pcmu());
         assert_eq!(outcome.remote_addr, None);
+    }
+
+    // ─── requires_100rel ───────────────────────────────────────────
+
+    #[test]
+    fn requires_100rel_false_when_no_require_header() {
+        let req = invite_with(Some("application/sdp"), "v=0\r\n");
+        assert!(!super::requires_100rel(&req));
+    }
+
+    #[test]
+    fn requires_100rel_true_when_present_alone() {
+        let req = invite_with_require("100rel");
+        assert!(super::requires_100rel(&req));
+    }
+
+    #[test]
+    fn requires_100rel_true_when_in_token_list() {
+        // RFC 3261 §27.1 — `Require` is a comma-separated option-tag list.
+        let req = invite_with_require("timer, 100rel, replaces");
+        assert!(super::requires_100rel(&req));
+    }
+
+    #[test]
+    fn requires_100rel_is_case_insensitive() {
+        let req = invite_with_require("100REL");
+        assert!(super::requires_100rel(&req));
+    }
+
+    #[test]
+    fn requires_100rel_false_for_unrelated_tokens() {
+        let req = invite_with_require("timer, replaces");
+        assert!(!super::requires_100rel(&req));
+    }
+
+    fn invite_with_require(value: &str) -> Request {
+        let mut req = invite_with(Some("application/sdp"), "v=0\r\n");
+        req.headers_mut().push("Require", value).unwrap();
+        req
     }
 
     // ─── sdp_audio_remote_addr ─────────────────────────────────────

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -13,7 +13,7 @@ pub mod transfer;
 pub use acceptor::{
     build_bridge_config, build_start_msg, extract_offer_sdp, extract_sip_call_id, resolve_barge_in,
     resolve_codecs, resolve_dtmf_pt, AcceptError, BargeInConfig, BargeInMode, BridgeBuildError,
-    BridgeDefaults, BridgingAcceptor, CallIdFactory, OfferError, PreparedCall,
+    BridgeDefaults, BridgingAcceptor, CallIdFactory, CallProgressMode, OfferError, PreparedCall,
 };
 pub use call::{
     CallController, CallControllerConfig, CallError, CallHandle, CallOutcome, CallState,

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -55,6 +55,35 @@ before TOML parsing. Unset variables without a default fail the load.
 > (UAC mode) is not supported and will return a clear error to the
 > transaction manager rather than silently downgrading to UDP.
 
+### `[sip.call_progress]`
+
+What — if any — provisional response the UAS layers on top of
+`IntegratedUAS`'s `100 Trying` before the 2xx. Defaults to
+`instant_answer` (v0.1.0 behaviour).
+
+| Field  | Type   | Default          | Notes |
+|--------|--------|------------------|-------|
+| `mode` | string | `instant_answer` | One of `"instant_answer"`, `"ringing"`, `"session_progress"`. Anything else is rejected at load. |
+
+```toml
+[sip.call_progress]
+mode = "session_progress"
+```
+
+| Mode                | Wire behaviour                                                                     | Use case                                                            |
+|---------------------|------------------------------------------------------------------------------------|---------------------------------------------------------------------|
+| `instant_answer`    | No extra provisional; `100 Trying` then straight to `200 OK`.                       | AI receptionists, voice bots, demos.                                |
+| `ringing`           | `180 Ringing` (no body) before `200 OK`.                                            | PBX-style call flows that expect ringback signalling.               |
+| `session_progress`  | `183 Session Progress` carrying the negotiated answer SDP, then `200 OK`.           | Carrier-style integrations that route or bill on early-media SDP.   |
+
+> **`session_progress` and `100rel`.** SiphonAI 0.2.0 sends 183
+> best-effort (no `Require: 100rel`). When the inbound INVITE
+> *requires* `100rel`, the call falls back to `instant_answer` for
+> that call with a `warn!` log, rather than sending a non-compliant
+> unreliable 183 to a peer that demanded reliable provisionals. The
+> reliable-provisional path is targeted at 0.2.1 / 0.3.0 alongside
+> `BridgeIn::Answer` (the "AI plays during 183 phase" flow).
+
 ## `[media]`
 
 | Field                       | Type             | Default                | Notes |

--- a/test-harness/sipp-scenarios/session_progress_then_answer.xml
+++ b/test-harness/sipp-scenarios/session_progress_then_answer.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  session_progress_then_answer — Verifies `[sip.call_progress] mode =
+  "session_progress"`. SIPp acts as the caller (UAC); SiphonAI is the
+  UAS. We expect a `183 Session Progress` carrying the negotiated
+  answer SDP BEFORE the `200 OK`, then normal ACK / BYE.
+
+  The 183 recv is required (not optional) — that's the point of the
+  scenario. The 100 and 180 recv lines are optional because the
+  transaction layer may or may not retransmit a 100, and 180 is
+  exclusive to `mode = "ringing"`.
+
+  Run this scenario against a daemon configured with:
+      [sip.call_progress]
+      mode = "session_progress"
+-->
+<scenario name="session_progress_then_answer">
+  <send>
+<![CDATA[
+INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+Max-Forwards: 70
+From: <sip:sipp@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:sipp@[local_ip]:[local_port]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=user1 53655765 2353687637 IN IP4 [local_ip]
+s=-
+c=IN IP4 [local_ip]
+t=0 0
+m=audio 9000 RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+]]>
+  </send>
+
+  <recv response="100" optional="true"/>
+  <recv response="180" optional="true"/>
+
+  <!-- The 183 is mandatory. Required-by-default; rtd captures the
+       round-trip time so a slow path shows up in the SIPp report. -->
+  <recv response="183" rtd="true">
+    <action>
+      <!-- Assert the 183 carries an SDP body — the whole point of
+           session_progress mode. The scenario fails if Content-Type
+           is anything other than application/sdp. -->
+      <ereg regexp="application/sdp"
+            search_in="hdr"
+            header="Content-Type:"
+            check_it="true"
+            assign_to="183_sdp_present"/>
+    </action>
+  </recv>
+
+  <recv response="200" rtd="true"/>
+
+  <send>
+<![CDATA[
+ACK sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]-ack
+Max-Forwards: 70
+From: <sip:sipp@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="300"/>
+
+  <send>
+<![CDATA[
+BYE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]-bye
+Max-Forwards: 70
+From: <sip:sipp@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 BYE
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="200" rtd="true"/>
+</scenario>


### PR DESCRIPTION
Sprint 1 deliverable #1 from `docs/DEV_PLAN_0.2.0.md`. New `[sip.call_progress]` config block:

| Mode               | Behaviour                                                                          |
|--------------------|------------------------------------------------------------------------------------|
| `instant_answer` (default) | Skip extra provisional — v0.1.0 behaviour.                                |
| `ringing`          | Send `180 Ringing` (no body) before the 2xx.                                       |
| `session_progress` | Send `183 Session Progress` with the negotiated answer SDP before the 2xx (best-effort Flavour B). |

`session_progress` peers that include `Require: 100rel` fall back to `instant_answer` with a `warn!` — the reliable / Flavour-C path is deferred to 0.2.1 / 0.3.0 alongside `on_prack` wiring.

**Implementation:**
- New `CallProgressMode` enum in `siphon-ai-core`; `BridgingAcceptor::with_call_progress()` builder.
- Provisional sent between `start_session` and `accept_invite_with_session_timer` — after forge is hot, before the 2xx — so a media-side failure doesn't leave a spurious 183 on the wire.
- `requires_100rel()` + 5 unit tests covering option-tag list parsing (RFC 3261 §27.1).
- Compile-side tests for all three modes plus unknown-mode error path.

**Docs:**
- `docs/CONFIG.md` — new `[sip.call_progress]` section.
- `CHANGELOG.md` — entry under `[Unreleased]`.
- `test-harness/sipp-scenarios/session_progress_then_answer.xml` — asserts `Content-Type: application/sdp` on the 183 before the 200 OK.

**Verification:** `cargo test --workspace` — 40 test binaries pass; clippy and fmt clean. Backwards-compatible (configs without the new block keep v0.1.0 behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)