### PR TITLE
feat(bridge): BridgeIn::Mute / BridgeIn::Unmute (sustained AI-side mute)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`BridgeIn::Mute` / `BridgeIn::Unmute`** (WS protocol §4.6). Sustained AI-side mute primitive — distinct from `clear` (one-shot flush). On `mute`: subsequent audio bytes from the WS server are dropped (channel still drained so the WS server isn't back-pressured) and forge's playout queue is flushed for immediate silence. `unmute` releases the gate. Protocol-version unchanged; existing servers ignore the new variants.
+
 - **Configurable SIP call progress** (`[sip.call_progress]`). New `mode` field selects what — if any — provisional response the UAS sends before the `200 OK`:
   - `instant_answer` (default; v0.1.0 behaviour): skip extra provisionals.
   - `ringing`: send `180 Ringing` (no body) before the 2xx.

--- a/crates/bridge/src/conn.rs
+++ b/crates/bridge/src/conn.rs
@@ -490,6 +490,8 @@ fn bridge_in_call_id(msg: &BridgeIn) -> &str {
         BridgeIn::Hangup { call_id, .. } => call_id.as_str(),
         BridgeIn::Transfer { call_id, .. } => call_id.as_str(),
         BridgeIn::SendDtmf { call_id, .. } => call_id.as_str(),
+        BridgeIn::Mute { call_id } => call_id.as_str(),
+        BridgeIn::Unmute { call_id } => call_id.as_str(),
     }
 }
 
@@ -545,6 +547,12 @@ mod tests {
                 call_id: CallId::new("e"),
                 digit: '1',
                 duration_ms: 80,
+            },
+            BridgeIn::Mute {
+                call_id: CallId::new("f"),
+            },
+            BridgeIn::Unmute {
+                call_id: CallId::new("g"),
             },
         ] {
             assert!(!bridge_in_call_id(&msg).is_empty());

--- a/crates/bridge/src/protocol.rs
+++ b/crates/bridge/src/protocol.rs
@@ -261,6 +261,21 @@ pub enum BridgeIn {
         /// Clamped to `[40, 2000]` ms by SiphonAI.
         duration_ms: u32,
     },
+
+    /// Suspend AI-side playout to the caller until a matching
+    /// [`BridgeIn::Unmute`] arrives. SiphonAI drops audio bytes the
+    /// WS server keeps streaming during the mute, AND flushes audio
+    /// already queued into the media engine — so the caller hears
+    /// silence immediately, not after the queued tail plays out.
+    ///
+    /// Distinct from [`BridgeIn::Clear`], which is a one-shot
+    /// barge-in flush. `Mute` is sustained and `Unmute` is required
+    /// to resume.
+    Mute { call_id: CallId },
+
+    /// Resume AI-side playout after a [`BridgeIn::Mute`]. A no-op
+    /// if the call is not muted.
+    Unmute { call_id: CallId },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -549,6 +564,20 @@ mod tests {
         };
         assert_eq!(digit, '1');
         assert_eq!(duration_ms, 200);
+    }
+
+    #[test]
+    fn bridge_in_mute() {
+        let raw = r#"{ "type": "mute", "call_id": "c" }"#;
+        let msg: BridgeIn = assert_round_trip(raw);
+        assert!(matches!(msg, BridgeIn::Mute { ref call_id } if call_id.as_str() == "c"));
+    }
+
+    #[test]
+    fn bridge_in_unmute() {
+        let raw = r#"{ "type": "unmute", "call_id": "c" }"#;
+        let msg: BridgeIn = assert_round_trip(raw);
+        assert!(matches!(msg, BridgeIn::Unmute { ref call_id } if call_id.as_str() == "c"));
     }
 
     // ─── Negative cases ─────────────────────────────────────────────────

--- a/crates/core/src/call.rs
+++ b/crates/core/src/call.rs
@@ -433,6 +433,23 @@ impl CallController {
                                 warn!(error = %e, "tap command channel full or closed; dropping Clear");
                             }
                         }
+                        Some(BridgeIn::Mute { call_id: cid }) => {
+                            debug!(ws_call_id = %cid, "forwarding Mute to tap");
+                            // Same try_send policy: a dropped Mute is
+                            // recoverable — the WS server can re-send.
+                            // The alternative (await on a full channel)
+                            // would back-pressure the WS receive loop
+                            // and stall every other control message.
+                            if let Err(e) = tap_cmd_tx.try_send(TapCommand::Mute) {
+                                warn!(error = %e, "tap command channel full or closed; dropping Mute");
+                            }
+                        }
+                        Some(BridgeIn::Unmute { call_id: cid }) => {
+                            debug!(ws_call_id = %cid, "forwarding Unmute to tap");
+                            if let Err(e) = tap_cmd_tx.try_send(TapCommand::Unmute) {
+                                warn!(error = %e, "tap command channel full or closed; dropping Unmute");
+                            }
+                        }
                         Some(BridgeIn::Mark { call_id: cid, name }) => {
                             debug!(ws_call_id = %cid, %name, "forwarding Mark to tap");
                             // Mark is a notification request — the

--- a/crates/media-glue/src/tap.rs
+++ b/crates/media-glue/src/tap.rs
@@ -152,6 +152,17 @@ pub enum TapCommand {
     /// signalling; tighter sync needs a forge upstream PR exposing a
     /// per-frame playout-completion hook.
     Mark { name: String },
+
+    /// Suspend AI-side playout. Backed by a sustained `muted` flag
+    /// on the tap: incoming bytes from the controller→tap channel
+    /// are drained and dropped, and forge's queue is flushed so the
+    /// caller hears silence immediately rather than after the
+    /// already-queued tail. Pairs with [`TapCommand::Unmute`].
+    Mute,
+
+    /// Resume AI-side playout after [`TapCommand::Mute`]. A no-op
+    /// if the tap is not currently muted.
+    Unmute,
 }
 
 /// How the tap reacts to forge-vad `SpeechStarted` events. Mirrors
@@ -223,6 +234,12 @@ pub struct MediaTap {
     /// fully-built tap via [`Self::with_inactivity_timeout`] so the
     /// 4-arg `attach()` form in tests stays terse.
     inactivity_timeout: Option<Duration>,
+    /// AI-side playout gate. Set by [`TapCommand::Mute`], cleared by
+    /// [`TapCommand::Unmute`]. While `true`, the playout arm drains
+    /// the controller→tap audio channel but drops the bytes instead
+    /// of pushing them into forge — the caller hears silence and
+    /// the WS server isn't back-pressured.
+    muted: bool,
 }
 
 impl std::fmt::Debug for MediaTap {
@@ -284,6 +301,7 @@ impl MediaTap {
             events_keepalive: None,
             barge_in_action,
             inactivity_timeout: None,
+            muted: false,
         })
     }
 
@@ -375,6 +393,16 @@ impl MediaTap {
                         debug!("playout_audio_rx closed; ending tap");
                         return Ok(TapDisconnect::ControllerHungUp);
                     };
+                    // `TapCommand::Mute` gates AI-side playout. We
+                    // still recv (draining the channel keeps WS
+                    // backpressure away) but skip unpack + forge so
+                    // the caller hears silence. Mark bookkeeping
+                    // intentionally untouched — frames we drop never
+                    // play, so they don't move the "audio queued so
+                    // far" clock.
+                    if self.muted {
+                        continue;
+                    }
                     let samples = unpack_pcm16_le(&bytes)?;
                     let frame = OutboundMediaFrame {
                         target: MediaTarget::A,
@@ -530,6 +558,50 @@ impl MediaTap {
                         continue;
                     };
                     match cmd {
+                        TapCommand::Mute => {
+                            // Sustained AI-side gate. Same drain +
+                            // forge-flush combo as Clear so the
+                            // caller hears silence immediately; the
+                            // `muted` flag then drops all subsequent
+                            // bytes in the playout arm until Unmute.
+                            self.muted = true;
+                            let mut drained = 0usize;
+                            while let Ok(_bytes) = playout_audio_rx.try_recv() {
+                                drained += 1;
+                            }
+                            if let Err(e) = self
+                                .handle
+                                .flush(Some(MediaTarget::A), None)
+                                .await
+                            {
+                                warn!(
+                                    call_id = %self.call_id,
+                                    error = %e,
+                                    "forge flush failed during Mute",
+                                );
+                            } else {
+                                debug!(
+                                    call_id = %self.call_id,
+                                    drained,
+                                    "muted; flushed pending outbound playout",
+                                );
+                            }
+                            // Mark bookkeeping reset — anything queued
+                            // before the mute is gone and cannot
+                            // satisfy a pending Mark estimate.
+                            frames_sent_to_forge = 0;
+                            first_audio_pushed_at = None;
+                        }
+                        TapCommand::Unmute => {
+                            // Just lift the gate. No flush — there's
+                            // nothing queued because the playout arm
+                            // has been dropping bytes since Mute.
+                            self.muted = false;
+                            debug!(
+                                call_id = %self.call_id,
+                                "unmuted; AI playout resumes",
+                            );
+                        }
                         TapCommand::Clear => {
                             // Drain any bytes queued in the
                             // controller→tap audio channel before

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -299,6 +299,31 @@ and the call continues.
 `digit` is one of `0-9 * # A B C D`. SiphonAI generates an RFC 2833
 event of `duration_ms` (clamped to `[40, 2000]`).
 
+### 4.6 `mute` / `unmute` — sustained AI-side mute
+
+```json
+{ "type": "mute",   "call_id": "..." }
+{ "type": "unmute", "call_id": "..." }
+```
+
+`mute` suspends AI-side playout to the caller until `unmute` arrives.
+On receipt of `mute`, SiphonAI:
+
+1. Sets a per-call gate that drops audio bytes the WS server continues
+   to stream (the channel is still drained — the WS server is *not*
+   back-pressured — so other control messages keep flowing).
+2. Flushes audio already queued into the media engine so the caller
+   hears silence immediately, not after the queued tail plays out.
+
+`unmute` clears the gate; subsequent audio frames flow into the call.
+`unmute` while not muted is a no-op.
+
+**Distinct from `clear`.** `clear` is a one-shot flush — typically
+fired in response to caller barge-in — that drains pending playout
+once and then accepts new audio. `mute` is sustained, requires an
+explicit `unmute` to release, and is the right primitive for "put
+this call on hold from the AI side."
+
 ---
 
 ## 5. Protocol rules


### PR DESCRIPTION
Sprint 1 deliverable #2 from `docs/DEV_PLAN_0.2.0.md`. Adds the sustained-mute primitive distinct from `clear` (one-shot flush).

**Protocol** — two new `BridgeIn` variants, additive to v1:

```json
{ "type": "mute",   "call_id": "..." }
{ "type": "unmute", "call_id": "..." }
```

On `mute`, SiphonAI:
1. Sets a per-call gate that drops audio bytes the WS server keeps streaming (channel still drained — WS server is NOT back-pressured).
2. Flushes forge's queue so the caller hears silence immediately, not after the queued tail.

`unmute` clears the gate. `unmute` while not muted is a no-op.

**Implementation:**
- New `BridgeIn::Mute` / `BridgeIn::Unmute` variants; `bridge_in_call_id` covers them.
- New `TapCommand::Mute` / `TapCommand::Unmute`; `MediaTap.muted: bool` field.
- Controller dispatch via `try_send` (drop-rather-than-block, like Clear / SendDtmf).
- Playout arm `continue`s on muted; Mute cmd handler mirrors Clear's drain + flush plus resets Mark bookkeeping.

**Docs:** `docs/PROTOCOL.md` §4.6, `CHANGELOG.md` under `[Unreleased]`.

**Tests:** `bridge_in_mute` / `bridge_in_unmute` JSON round-trip; `bridge_in_call_id_extracts_from_each_variant` extended.

`cargo test --workspace` green (40 test binaries); clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)