### PR TITLE
feat(media): silence_detected / dead_air_detected events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`silence_detected` / `dead_air_detected` WS events** (PROTOCOL §3.6 / §3.7). Timer-derived primitives the WS server can use for "are you still there?" prompts and hung-call teardown. `silence_detected` is one-sided (caller has been VAD-silent past `[bridge].silence_threshold_ms`, default 3 s); fires once per silence stretch. `dead_air_detected` is two-sided (neither caller speech nor outbound WS audio past `[bridge].dead_air_threshold_ms`, default 10 s); re-fires on every elapsed threshold. Both thresholds are per-route overridable; `0` disables. Detection cadence is 500 ms. Underlying state machine factored into `IdleDetector` (8 unit tests). Counters: `siphon_ai_silence_events_total`, `siphon_ai_dead_air_events_total`.
+
 - **`BridgeIn::Mute` / `BridgeIn::Unmute`** (WS protocol §4.6). Sustained AI-side mute primitive — distinct from `clear` (one-shot flush). On `mute`: subsequent audio bytes from the WS server are dropped (channel still drained so the WS server isn't back-pressured) and forge's playout queue is flushed for immediate silence. `unmute` releases the gate. Protocol-version unchanged; existing servers ignore the new variants.
 
 - **Configurable SIP call progress** (`[sip.call_progress]`). New `mode` field selects what — if any — provisional response the UAS sends before the `200 OK`:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2878,6 +2878,7 @@ dependencies = [
  "forge-engine",
  "forge-rtp",
  "forge-sdp",
+ "metrics 0.23.1",
  "siphon-ai-bridge",
  "thiserror 1.0.69",
  "tokio",

--- a/crates/bridge/src/conn.rs
+++ b/crates/bridge/src/conn.rs
@@ -135,6 +135,22 @@ pub enum OutgoingEvent {
     },
     /// Direction returned to `sendrecv` after a [`Self::Hold`].
     Resume,
+    /// Caller has been silent (no VAD speech) for at least
+    /// `duration_ms`. Configurable via `[bridge].silence_threshold_ms`;
+    /// `0` disables. Fires once per silence stretch — the next event
+    /// only after a speech-then-silence cycle.
+    SilenceDetected {
+        duration_ms: u64,
+    },
+    /// No audio in EITHER direction (no caller VAD speech AND no
+    /// outbound playout from the WS server) for at least
+    /// `duration_ms`. Suspect connectivity / hung call. Configurable
+    /// via `[bridge].dead_air_threshold_ms`; `0` disables. Fires
+    /// every time the threshold is crossed without either side
+    /// producing audio.
+    DeadAirDetected {
+        duration_ms: u64,
+    },
     Stop {
         reason: StopReason,
     },
@@ -469,6 +485,16 @@ fn build_bridge_out(event: OutgoingEvent, call_id: CallId, seq: Seq) -> BridgeOu
             direction,
         },
         OutgoingEvent::Resume => BridgeOut::Resume { call_id, seq },
+        OutgoingEvent::SilenceDetected { duration_ms } => BridgeOut::SilenceDetected {
+            call_id,
+            seq,
+            duration_ms,
+        },
+        OutgoingEvent::DeadAirDetected { duration_ms } => BridgeOut::DeadAirDetected {
+            call_id,
+            seq,
+            duration_ms,
+        },
         OutgoingEvent::Stop { reason } => BridgeOut::Stop {
             call_id,
             seq,

--- a/crates/bridge/src/protocol.rs
+++ b/crates/bridge/src/protocol.rs
@@ -98,6 +98,29 @@ pub enum BridgeOut {
     /// The server may resume sending audio.
     Resume { call_id: CallId, seq: Seq },
 
+    /// Caller has been silent (no VAD speech) for at least
+    /// `duration_ms`. Configurable via `[bridge].silence_threshold_ms`;
+    /// `0` disables emission. Fires once per silence stretch (the
+    /// next event only after a speech → silence cycle); a long
+    /// silence does not generate a stream of these.
+    SilenceDetected {
+        call_id: CallId,
+        seq: Seq,
+        duration_ms: u64,
+    },
+
+    /// No audio observed in EITHER direction (no caller VAD speech
+    /// AND no outbound playout from the WS server) for at least
+    /// `duration_ms`. Suspect connectivity or a hung call.
+    /// Configurable via `[bridge].dead_air_threshold_ms`; `0`
+    /// disables emission. Fires every time the threshold elapses
+    /// without either side producing audio.
+    DeadAirDetected {
+        call_id: CallId,
+        seq: Seq,
+        duration_ms: u64,
+    },
+
     /// The caller pressed a DTMF key.
     Dtmf {
         call_id: CallId,
@@ -410,6 +433,36 @@ mod tests {
                 seq: 67,
                 ts_ms: 1890,
                 duration_ms: 656,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn bridge_out_silence_detected() {
+        let raw =
+            r#"{ "type": "silence_detected", "call_id": "c", "seq": 12, "duration_ms": 3000 }"#;
+        let msg: BridgeOut = assert_round_trip(raw);
+        assert!(matches!(
+            msg,
+            BridgeOut::SilenceDetected {
+                seq: 12,
+                duration_ms: 3000,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn bridge_out_dead_air_detected() {
+        let raw =
+            r#"{ "type": "dead_air_detected", "call_id": "c", "seq": 13, "duration_ms": 10000 }"#;
+        let msg: BridgeOut = assert_round_trip(raw);
+        assert!(matches!(
+            msg,
+            BridgeOut::DeadAirDetected {
+                seq: 13,
+                duration_ms: 10000,
                 ..
             }
         ));

--- a/crates/config/src/compile.rs
+++ b/crates/config/src/compile.rs
@@ -661,6 +661,20 @@ fn compile_bridge(raw: RawBridge, media: &RawMedia) -> Result<BridgeDefaults, Co
         Some(n) => Some(Duration::from_secs(n)),
     };
 
+    // Silence / dead-air primitives — §9.2 defaults. Same shape as
+    // inactivity_timeout: `None` = use default, `Some(0)` = disable,
+    // `Some(n)` = `n` ms.
+    let silence_threshold = match raw.silence_threshold_ms {
+        None => Some(Duration::from_millis(3000)),
+        Some(0) => None,
+        Some(ms) => Some(Duration::from_millis(ms)),
+    };
+    let dead_air_threshold = match raw.dead_air_threshold_ms {
+        None => Some(Duration::from_millis(10000)),
+        Some(0) => None,
+        Some(ms) => Some(Duration::from_millis(ms)),
+    };
+
     Ok(BridgeDefaults {
         ws_url: raw.ws_url.filter(|s| !s.is_empty()),
         auth_header,
@@ -670,6 +684,8 @@ fn compile_bridge(raw: RawBridge, media: &RawMedia) -> Result<BridgeDefaults, Co
         forward_headers: raw.forward_headers.unwrap_or_default(),
         barge_in,
         inactivity_timeout,
+        silence_threshold,
+        dead_air_threshold,
     })
 }
 

--- a/crates/config/src/raw.rs
+++ b/crates/config/src/raw.rs
@@ -395,6 +395,18 @@ pub struct RawBridge {
     /// (`enabled = true`, `mode = "auto_clear"`).
     #[serde(default)]
     pub barge_in: RawBargeIn,
+    /// One-sided silence threshold: fire `silence_detected` when the
+    /// caller has been silent (no forge-vad speech) for this many
+    /// milliseconds. `None` (unset) = use the 3000 ms default; `0` =
+    /// disable the event entirely.
+    #[serde(default)]
+    pub silence_threshold_ms: Option<u64>,
+    /// Two-sided dead-air threshold: fire `dead_air_detected` when
+    /// NEITHER side has produced audio (no caller speech AND no
+    /// outbound playout from the WS server) for this many ms.
+    /// `None` (unset) = use the 10000 ms default; `0` = disable.
+    #[serde(default)]
+    pub dead_air_threshold_ms: Option<u64>,
 }
 
 /// `[bridge.barge_in]` — global default barge-in policy.

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -130,6 +130,16 @@ pub struct BridgeDefaults {
     /// enough to weather a flap, short enough that an abandoned call
     /// after PBX network failure releases its forge session quickly.
     pub inactivity_timeout: Option<Duration>,
+    /// Default one-sided silence threshold: emit `silence_detected`
+    /// when the caller has been silent for this long (forge-vad
+    /// drives the underlying "speech" signal). `None` disables.
+    /// Default `Some(3000ms)` per `docs/DEV_PLAN_0.2.0.md` §9.2.
+    pub silence_threshold: Option<Duration>,
+    /// Default two-sided dead-air threshold: emit `dead_air_detected`
+    /// when neither caller speech nor outbound WS audio has been
+    /// observed for this long. `None` disables. Default
+    /// `Some(10000ms)` per `docs/DEV_PLAN_0.2.0.md` §9.2.
+    pub dead_air_threshold: Option<Duration>,
 }
 
 /// What the daemon does when forge-vad reports speech-started.
@@ -203,6 +213,8 @@ impl Default for BridgeDefaults {
             forward_headers: Vec::new(),
             barge_in: BargeInConfig::default(),
             inactivity_timeout: Some(Duration::from_secs(60)),
+            silence_threshold: Some(Duration::from_millis(3000)),
+            dead_air_threshold: Some(Duration::from_millis(10000)),
         }
     }
 }
@@ -456,6 +468,33 @@ pub fn resolve_inactivity_timeout(
         None => defaults.inactivity_timeout,
         Some(0) => None,
         Some(n) => Some(Duration::from_secs(n)),
+    }
+}
+
+/// Resolve the per-call silence threshold by merging the daemon
+/// default with the per-route override (`[route.bridge].silence_threshold_ms`).
+/// `None` returned = the event is disabled for this call.
+pub fn resolve_silence_threshold(
+    defaults: &BridgeDefaults,
+    route: &CompiledRoute,
+) -> Option<Duration> {
+    match route.bridge.silence_threshold_ms {
+        None => defaults.silence_threshold,
+        Some(0) => None,
+        Some(ms) => Some(Duration::from_millis(ms)),
+    }
+}
+
+/// Resolve the per-call dead-air threshold (same shape as
+/// [`resolve_silence_threshold`]).
+pub fn resolve_dead_air_threshold(
+    defaults: &BridgeDefaults,
+    route: &CompiledRoute,
+) -> Option<Duration> {
+    match route.bridge.dead_air_threshold_ms {
+        None => defaults.dead_air_threshold,
+        Some(0) => None,
+        Some(ms) => Some(Duration::from_millis(ms)),
     }
 }
 
@@ -1885,6 +1924,8 @@ impl BridgingAcceptor {
                 to_tag: None,
                 barge_in_action: barge_in_to_tap_action(&resolve_barge_in(&self.defaults, route)),
                 inactivity_timeout: resolve_inactivity_timeout(&self.defaults, route),
+                silence_threshold: resolve_silence_threshold(&self.defaults, route),
+                dead_air_threshold: resolve_dead_air_threshold(&self.defaults, route),
             })
             .await?;
 

--- a/crates/media-glue/Cargo.toml
+++ b/crates/media-glue/Cargo.toml
@@ -15,6 +15,7 @@ async-trait.workspace = true
 thiserror.workspace   = true
 tracing.workspace     = true
 uuid.workspace        = true
+metrics.workspace     = true
 
 # Sibling SiphonAI crates
 siphon-ai-bridge.workspace = true

--- a/crates/media-glue/src/idle.rs
+++ b/crates/media-glue/src/idle.rs
@@ -1,0 +1,229 @@
+//! `IdleDetector` — derives `silence_detected` / `dead_air_detected`
+//! events from VAD / playout activity timing.
+//!
+//! Pulled out of [`crate::tap::MediaTap`] so the detection logic is
+//! testable without spinning up a forge session.
+//!
+//! ## Definitions
+//!
+//! - **Silence** is *one-sided*: the caller has not produced VAD
+//!   speech for at least `silence_threshold`. Fires once per stretch
+//!   of silence; the next event only after a speech → silence cycle.
+//! - **Dead-air** is *two-sided*: neither caller VAD speech nor any
+//!   outbound playout from the WS server has been observed for at
+//!   least `dead_air_threshold`. Fires every time the threshold
+//!   elapses without either side producing audio (re-anchors on each
+//!   fire), so a hung call generates a steady drumbeat of events.
+//!
+//! Both thresholds are optional. `None` = disable that event entirely.
+
+use std::time::{Duration, Instant};
+
+/// What a [`IdleDetector::poll`] call wants the caller to emit on
+/// the WS bridge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IdleEvent {
+    /// Caller silent (no VAD speech) for `duration_ms`. Suppresses
+    /// re-firing until the next `note_speech_started`.
+    SilenceDetected { duration_ms: u64 },
+    /// Neither side has produced audio for `duration_ms`. Re-anchors
+    /// the timer on every fire — a still-dead call will see another
+    /// event every `dead_air_threshold` until something happens.
+    DeadAirDetected { duration_ms: u64 },
+}
+
+/// Timing-only detector. Owns no I/O; the caller (typically the
+/// media tap) feeds it event timestamps and polls it for derived
+/// events on a regular cadence.
+#[derive(Debug)]
+pub struct IdleDetector {
+    silence_threshold: Option<Duration>,
+    dead_air_threshold: Option<Duration>,
+    last_speech_started: Instant,
+    last_any_audio: Instant,
+    /// True once we've emitted `SilenceDetected` for the current
+    /// silence stretch; cleared on the next `note_speech_started`.
+    silence_fired: bool,
+}
+
+impl IdleDetector {
+    /// `now` anchors both timers — pass [`Instant::now`] at tap
+    /// construction time.
+    pub fn new(
+        silence_threshold: Option<Duration>,
+        dead_air_threshold: Option<Duration>,
+        now: Instant,
+    ) -> Self {
+        Self {
+            silence_threshold,
+            dead_air_threshold,
+            last_speech_started: now,
+            last_any_audio: now,
+            silence_fired: false,
+        }
+    }
+
+    /// True when at least one threshold is configured. The caller
+    /// uses this to gate the poll-tick arm in its `select!` loop.
+    pub fn is_active(&self) -> bool {
+        self.silence_threshold.is_some() || self.dead_air_threshold.is_some()
+    }
+
+    /// VAD reported the caller started speaking. Resets both
+    /// timers — caller is no longer silent and there's audio
+    /// activity on the call.
+    pub fn note_speech_started(&mut self, now: Instant) {
+        self.last_speech_started = now;
+        self.last_any_audio = now;
+        self.silence_fired = false;
+    }
+
+    /// The WS server pushed audio toward the caller. Resets ONLY
+    /// the dead-air timer — the caller may still be silent.
+    pub fn note_ws_audio(&mut self, now: Instant) {
+        self.last_any_audio = now;
+    }
+
+    /// Check the timers and return any events that should fire.
+    /// Updates internal state (the silence-suppression flag and the
+    /// dead-air anchor) so calling repeatedly is safe.
+    pub fn poll(&mut self, now: Instant) -> Vec<IdleEvent> {
+        let mut out = Vec::new();
+
+        if let Some(threshold) = self.silence_threshold {
+            if !self.silence_fired {
+                let elapsed = now.saturating_duration_since(self.last_speech_started);
+                if elapsed >= threshold {
+                    out.push(IdleEvent::SilenceDetected {
+                        duration_ms: elapsed.as_millis() as u64,
+                    });
+                    self.silence_fired = true;
+                }
+            }
+        }
+
+        if let Some(threshold) = self.dead_air_threshold {
+            let elapsed = now.saturating_duration_since(self.last_any_audio);
+            if elapsed >= threshold {
+                out.push(IdleEvent::DeadAirDetected {
+                    duration_ms: elapsed.as_millis() as u64,
+                });
+                // Re-anchor: the next dead-air event fires after
+                // another full threshold elapses, not continuously.
+                self.last_any_audio = now;
+            }
+        }
+
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ms(n: u64) -> Duration {
+        Duration::from_millis(n)
+    }
+
+    #[test]
+    fn fresh_detector_fires_nothing() {
+        let now = Instant::now();
+        let mut d = IdleDetector::new(Some(ms(3000)), Some(ms(10000)), now);
+        assert!(d.poll(now).is_empty());
+        assert!(d.poll(now + ms(100)).is_empty());
+    }
+
+    #[test]
+    fn both_thresholds_disabled_means_inactive() {
+        let now = Instant::now();
+        let d = IdleDetector::new(None, None, now);
+        assert!(!d.is_active());
+    }
+
+    #[test]
+    fn silence_fires_at_threshold_then_suppressed() {
+        let now = Instant::now();
+        let mut d = IdleDetector::new(Some(ms(3000)), None, now);
+        assert!(d.poll(now + ms(2999)).is_empty());
+        // At the threshold the silence event fires…
+        let events = d.poll(now + ms(3001));
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            IdleEvent::SilenceDetected { duration_ms } if duration_ms >= 3000
+        ));
+        // …and is suppressed for the rest of the same stretch.
+        assert!(d.poll(now + ms(8000)).is_empty());
+        assert!(d.poll(now + ms(15000)).is_empty());
+    }
+
+    #[test]
+    fn silence_re_arms_after_speech() {
+        let now = Instant::now();
+        let mut d = IdleDetector::new(Some(ms(3000)), None, now);
+        let _ = d.poll(now + ms(3100));
+        // Speech resets the suppression flag.
+        d.note_speech_started(now + ms(5000));
+        assert!(d.poll(now + ms(6000)).is_empty());
+        let events = d.poll(now + ms(8500));
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], IdleEvent::SilenceDetected { .. }));
+    }
+
+    #[test]
+    fn dead_air_fires_repeatedly_at_each_threshold() {
+        let now = Instant::now();
+        let mut d = IdleDetector::new(None, Some(ms(10000)), now);
+        assert!(d.poll(now + ms(9999)).is_empty());
+        let events = d.poll(now + ms(10001));
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], IdleEvent::DeadAirDetected { .. }));
+        // After firing the anchor re-bases at `now + 10001`, so the
+        // next fire is at `+20001`, not still pending at `+10500`.
+        assert!(d.poll(now + ms(10500)).is_empty());
+        assert!(d.poll(now + ms(20002)).len() == 1);
+    }
+
+    #[test]
+    fn ws_audio_resets_dead_air_but_not_silence() {
+        let now = Instant::now();
+        let mut d = IdleDetector::new(Some(ms(3000)), Some(ms(10000)), now);
+        // WS server pushes audio every 2s. Caller stays silent.
+        for tick in 1..=6 {
+            d.note_ws_audio(now + ms(2000 * tick));
+        }
+        let events = d.poll(now + ms(12001));
+        // Silence should fire (caller silent > 3s), but dead-air
+        // must NOT (WS audio kept the anchor fresh).
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, IdleEvent::SilenceDetected { .. })));
+        assert!(!events
+            .iter()
+            .any(|e| matches!(e, IdleEvent::DeadAirDetected { .. })));
+    }
+
+    #[test]
+    fn speech_resets_both() {
+        let now = Instant::now();
+        let mut d = IdleDetector::new(Some(ms(3000)), Some(ms(10000)), now);
+        d.note_speech_started(now + ms(8000));
+        // After speech, neither event should fire until thresholds
+        // elapse from the new anchor.
+        assert!(d.poll(now + ms(10000)).is_empty());
+        let events = d.poll(now + ms(11001));
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], IdleEvent::SilenceDetected { .. }));
+    }
+
+    #[test]
+    fn poll_at_anchor_time_is_a_no_op() {
+        // saturating_duration_since against a future `now` is 0,
+        // which must NOT count as past-threshold.
+        let now = Instant::now();
+        let mut d = IdleDetector::new(Some(ms(1)), Some(ms(1)), now);
+        // Polling at exactly `now` — elapsed = 0, below threshold of 1ms.
+        assert!(d.poll(now).is_empty());
+    }
+}

--- a/crates/media-glue/src/lib.rs
+++ b/crates/media-glue/src/lib.rs
@@ -7,6 +7,7 @@
 //! the steady-state frame loop beyond what the codec/wire format
 //! mandate, no `unwrap`/`panic`, no `std::sync::Mutex`, no blocking I/O.
 
+pub(crate) mod idle;
 pub mod sdp;
 pub mod setup;
 pub mod tap;

--- a/crates/media-glue/src/setup.rs
+++ b/crates/media-glue/src/setup.rs
@@ -100,6 +100,16 @@ pub struct InboundCall<'a> {
     /// `None` disables the watchdog. Resolved by the acceptor from
     /// `[media].inactivity_timeout_secs` and the route's override.
     pub inactivity_timeout: Option<std::time::Duration>,
+    /// One-sided silence threshold for the idle detector — emit
+    /// `silence_detected` when the caller has been VAD-silent for
+    /// this long. `None` disables the event. Resolved by the
+    /// acceptor from `[bridge].silence_threshold_ms` plus any
+    /// per-route override.
+    pub silence_threshold: Option<std::time::Duration>,
+    /// Two-sided dead-air threshold — emit `dead_air_detected` when
+    /// neither caller speech nor outbound WS audio has been
+    /// observed for this long. `None` disables.
+    pub dead_air_threshold: Option<std::time::Duration>,
 }
 
 /// What [`MediaSetup::accept_inbound`] hands back on success.
@@ -268,7 +278,8 @@ impl MediaSetup {
             answer.negotiated_audio_sample_rate,
             call.barge_in_action,
         )?
-        .with_inactivity_timeout(call.inactivity_timeout);
+        .with_inactivity_timeout(call.inactivity_timeout)
+        .with_idle_thresholds(call.silence_threshold, call.dead_air_threshold);
 
         guard.disarm();
 
@@ -390,6 +401,8 @@ mod tests {
                 to_tag: None,
                 barge_in_action: BargeInAction::Notify,
                 inactivity_timeout: None,
+                silence_threshold: None,
+                dead_air_threshold: None,
             })
             .await;
 

--- a/crates/media-glue/src/tap.rs
+++ b/crates/media-glue/src/tap.rs
@@ -58,6 +58,8 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use crate::idle::{IdleDetector, IdleEvent};
+
 use forge_core::{CallId, DtmfDetectionMethod, DtmfEventKind, EventBus, ForgeError, ForgeEvent};
 use forge_dtmf::DtmfDigit;
 use forge_engine::{
@@ -240,6 +242,15 @@ pub struct MediaTap {
     /// of pushing them into forge — the caller hears silence and
     /// the WS server isn't back-pressured.
     muted: bool,
+    /// Timer-based derivation of `silence_detected` / `dead_air_detected`
+    /// events. Polled on a 500 ms tick in `run()` when at least one
+    /// threshold is configured; receives `note_speech_started` on
+    /// every forge-vad speech-started, and `note_ws_audio` on every
+    /// playout byte arriving from the WS server. Initialized with
+    /// both thresholds `None` (disabled); the acceptor calls
+    /// [`Self::with_idle_thresholds`] before `run()` to install the
+    /// resolved per-call values.
+    idle_detector: IdleDetector,
 }
 
 impl std::fmt::Debug for MediaTap {
@@ -302,6 +313,7 @@ impl MediaTap {
             barge_in_action,
             inactivity_timeout: None,
             muted: false,
+            idle_detector: IdleDetector::new(None, None, Instant::now()),
         })
     }
 
@@ -310,6 +322,20 @@ impl MediaTap {
     /// `inactivity_timeout_secs` lands on the tap before `run` starts.
     pub fn with_inactivity_timeout(mut self, timeout: Option<Duration>) -> Self {
         self.inactivity_timeout = timeout;
+        self
+    }
+
+    /// Install the silence / dead-air thresholds resolved from
+    /// `[bridge].silence_threshold_ms` + `[bridge].dead_air_threshold_ms`
+    /// (and any per-route override). `None` disables that event for
+    /// this call. Acceptor calls this after `attach_with_barge_in`
+    /// before `run()`.
+    pub fn with_idle_thresholds(
+        mut self,
+        silence: Option<Duration>,
+        dead_air: Option<Duration>,
+    ) -> Self {
+        self.idle_detector = IdleDetector::new(silence, dead_air, Instant::now());
         self
     }
 
@@ -361,6 +387,17 @@ impl MediaTap {
         let watchdog = tokio::time::sleep(watchdog_initial);
         tokio::pin!(watchdog);
 
+        // Silence / dead-air poll tick. 500 ms cadence gives ±500 ms
+        // detection accuracy against thresholds of 3 s / 10 s — fine
+        // for the WS-server "are you still there?" use case. The
+        // first tick fires after the period (not immediately) so we
+        // don't spam events on a freshly-connected call.
+        let mut idle_check = tokio::time::interval(Duration::from_millis(500));
+        idle_check.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        // Consume the immediate first tick that `interval` emits, so
+        // the arm doesn't fire at t=0 against a fresh detector.
+        idle_check.tick().await;
+
         loop {
             tokio::select! {
                 biased;
@@ -393,6 +430,12 @@ impl MediaTap {
                         debug!("playout_audio_rx closed; ending tap");
                         return Ok(TapDisconnect::ControllerHungUp);
                     };
+                    // Idle-detector: any WS-side push counts as
+                    // "audio activity" for dead-air detection,
+                    // regardless of mute state — a muted call where
+                    // the WS server keeps streaming is NOT dead air,
+                    // it's intentional silence.
+                    self.idle_detector.note_ws_audio(Instant::now());
                     // `TapCommand::Mute` gates AI-side playout. We
                     // still recv (draining the channel keeps WS
                     // backpressure away) but skip unpack + forge so
@@ -463,6 +506,16 @@ impl MediaTap {
                     match event {
                         Ok(ev) => {
                             if let Some(out) = derive_outgoing_event(&self.call_id, ev) {
+                                // Hook the idle detector on every
+                                // SpeechStarted — regardless of
+                                // barge-in policy. Resets silence +
+                                // dead-air timers and clears the
+                                // silence-fired suppression flag so
+                                // the next silence stretch can fire
+                                // a fresh event.
+                                if matches!(out, OutgoingEvent::SpeechStarted { .. }) {
+                                    self.idle_detector.note_speech_started(Instant::now());
+                                }
                                 // Barge-in `auto_clear`: when forge-vad
                                 // reports speech-started AND this call's
                                 // policy is AutoClear, drop pending
@@ -641,6 +694,34 @@ impl MediaTap {
                                 name,
                                 frames_sent_to_forge,
                                 first_audio_pushed_at,
+                            );
+                        }
+                    }
+                }
+
+                // Idle-detector poll. Fires every 500 ms when at
+                // least one threshold is configured; emits derived
+                // `SilenceDetected` / `DeadAirDetected` events as
+                // best-effort (same try_send policy as DTMF and
+                // Mark).
+                _ = idle_check.tick(), if self.idle_detector.is_active() => {
+                    let now = Instant::now();
+                    for ev in self.idle_detector.poll(now) {
+                        let out = match ev {
+                            IdleEvent::SilenceDetected { duration_ms } => {
+                                metrics::counter!("siphon_ai_silence_events_total").increment(1);
+                                OutgoingEvent::SilenceDetected { duration_ms }
+                            }
+                            IdleEvent::DeadAirDetected { duration_ms } => {
+                                metrics::counter!("siphon_ai_dead_air_events_total").increment(1);
+                                OutgoingEvent::DeadAirDetected { duration_ms }
+                            }
+                        };
+                        if let Err(e) = events_tx.try_send(out) {
+                            warn!(
+                                call_id = %self.call_id,
+                                error = %e,
+                                "events_tx full or closed; dropping idle event"
                             );
                         }
                     }

--- a/crates/media-glue/tests/setup.rs
+++ b/crates/media-glue/tests/setup.rs
@@ -54,6 +54,8 @@ fn pcmu_call(call_id: &str, offer: &'static str) -> InboundCall<'static> {
         to_tag: Some("to-tag-1".to_string()),
         barge_in_action: ::siphon_ai_media_glue::BargeInAction::Notify,
         inactivity_timeout: None,
+        silence_threshold: None,
+        dead_air_threshold: None,
     }
 }
 
@@ -220,6 +222,8 @@ async fn no_common_codec_rolls_back_session() {
             to_tag: None,
             barge_in_action: ::siphon_ai_media_glue::BargeInAction::Notify,
             inactivity_timeout: None,
+            silence_threshold: None,
+            dead_air_threshold: None,
         })
         .await;
     assert!(matches!(
@@ -256,6 +260,8 @@ async fn malformed_offer_does_not_allocate_ports() {
             to_tag: None,
             barge_in_action: ::siphon_ai_media_glue::BargeInAction::Notify,
             inactivity_timeout: None,
+            silence_threshold: None,
+            dead_air_threshold: None,
         })
         .await
         .unwrap_err();

--- a/crates/routes/src/raw.rs
+++ b/crates/routes/src/raw.rs
@@ -89,6 +89,14 @@ pub struct BridgeOverride {
 
     #[serde(default)]
     pub barge_in: BargeInOverride,
+
+    /// Per-route override of `[bridge].silence_threshold_ms`. Same
+    /// shape as the global: `None` = inherit, `Some(0)` = disable,
+    /// `Some(n)` = `n` ms.
+    pub silence_threshold_ms: Option<u64>,
+    /// Per-route override of `[bridge].dead_air_threshold_ms`. Same
+    /// shape as `silence_threshold_ms`.
+    pub dead_air_threshold_ms: Option<u64>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, PartialEq)]

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -95,12 +95,20 @@ mode = "session_progress"
 
 ## `[bridge]`
 
-| Field                    | Type      | Default | Notes |
-|--------------------------|-----------|---------|-------|
-| `ws_url`                 | URL       | unset   | If unset, every route MUST set its own `ws_url` or the call rejects with 503. |
-| `ws_auth_header`         | string    | unset   | Sent verbatim as the `Authorization` header. `${VAR}` expansion works. |
-| `ws_connect_timeout_ms`  | integer   | `5000`  | WS handshake budget. |
-| `forward_headers`        | string[]  | `[]`    | SIP header names (case-insensitive) to copy onto `start.sip.headers`. |
+| Field                      | Type      | Default  | Notes |
+|----------------------------|-----------|----------|-------|
+| `ws_url`                   | URL       | unset    | If unset, every route MUST set its own `ws_url` or the call rejects with 503. |
+| `ws_auth_header`           | string    | unset    | Sent verbatim as the `Authorization` header. `${VAR}` expansion works. |
+| `ws_connect_timeout_ms`    | integer   | `5000`   | WS handshake budget. |
+| `forward_headers`          | string[]  | `[]`     | SIP header names (case-insensitive) to copy onto `start.sip.headers`. |
+| `silence_threshold_ms`     | integer   | `3000`   | One-sided: emit `silence_detected` (PROTOCOL §3.6) when the caller has been VAD-silent for this long. `0` disables. Per-route override via `[route.bridge].silence_threshold_ms`. |
+| `dead_air_threshold_ms`    | integer   | `10000`  | Two-sided: emit `dead_air_detected` (PROTOCOL §3.7) when neither caller speech nor outbound WS audio has been observed for this long. `0` disables. Per-route override via `[route.bridge].dead_air_threshold_ms`. |
+
+> **Detection cadence.** Both events are polled every 500 ms, so the
+> `duration_ms` on the wire may overshoot the configured threshold by
+> up to that amount. Acceptable for the "are you still there?" /
+> "hang up the dead call" use cases these primitives target;
+> sub-second accuracy needs a different design.
 
 ### `[bridge.barge_in]`
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -200,6 +200,8 @@ on the metrics crate's defaults (CLAUDE.md §7.4).
 | `siphon_ai_ws_connect_seconds`          | histogram | —                                     | WS handshake time. |
 | `siphon_ai_register_state{name,state}`  | gauge     | `name`, `state=pending\|registered\|auth_failed\|rejected\|failed\|disabled` | Current row per `[[register]]`. Exactly one state per `name` is `1` at any time. |
 | `siphon_ai_register_attempts_total`     | counter   | `name`, `outcome=registered\|auth_failed\|rejected\|transport_error` | One tick per REGISTER attempt. |
+| `siphon_ai_silence_events_total`        | counter   | —                                     | Times `silence_detected` fired on the WS bridge. Configurable via `[bridge].silence_threshold_ms`. |
+| `siphon_ai_dead_air_events_total`       | counter   | —                                     | Times `dead_air_detected` fired on the WS bridge. Configurable via `[bridge].dead_air_threshold_ms`. |
 | `forge_rtcp_*`                          | various   | per-call (forge-side)                 | RTP/RTCP quality. See forge-media's own metric inventory. |
 | `heplify_*`                             | various   | from the HEP collector                | Only visible if you scrape heplify too. |
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -187,7 +187,40 @@ been fully played out into the call.
 { "type": "mark", "call_id": "...", "seq": 91, "name": "greeting_done" }
 ```
 
-### 3.6 `stop` — call ended
+### 3.6 `silence_detected` — caller has been silent
+
+```json
+{ "type": "silence_detected", "call_id": "...", "seq": 102, "duration_ms": 3000 }
+```
+
+Fired when the caller has produced no VAD speech for at least
+`[bridge].silence_threshold_ms` (default 3 s; configurable, per-route
+override; `0` disables the event). The `duration_ms` reports actual
+elapsed time at fire, which may exceed the threshold by up to one
+poll cadence (500 ms). The event fires **once per silence stretch** —
+the next `silence_detected` only after a speech → silence cycle.
+
+Typical use: prompt the caller ("are you still there?") or escalate
+to a human after a configurable wait.
+
+### 3.7 `dead_air_detected` — no audio in either direction
+
+```json
+{ "type": "dead_air_detected", "call_id": "...", "seq": 103, "duration_ms": 10000 }
+```
+
+Fired when **neither** caller VAD speech **nor** outbound playout from
+the WS server has been observed for at least
+`[bridge].dead_air_threshold_ms` (default 10 s; configurable,
+per-route override; `0` disables). Re-fires every time the threshold
+elapses without either side producing audio — a still-dead call
+generates a steady drumbeat of these events.
+
+Distinct from `silence_detected`, which is one-sided (caller silent
+but the AI may still be talking). `dead_air_detected` suggests a
+hung call or connectivity issue; typical reaction is to hang up.
+
+### 3.8 `stop` — call ended
 
 ```json
 { "type": "stop", "call_id": "...", "seq": 200, "reason": "caller_hangup" }
@@ -206,7 +239,7 @@ been fully played out into the call.
 `stop` is the last message SiphonAI sends on the connection. SiphonAI
 then closes the WebSocket cleanly (close code 1000).
 
-### 3.7 `error` — fatal error
+### 3.9 `error` — fatal error
 
 ```json
 { "type": "error", "call_id": "...", "seq": 201, "code": "rtp_timeout", "message": "no RTP for 30s on leg A" }


### PR DESCRIPTION
Sprint 1 Week 2 deliverable from `docs/DEV_PLAN_0.2.0.md`. Adds timer-derived idle primitives the WS server uses for "are you still there?" prompts and hung-call teardown.

**Protocol** — two new `BridgeOut` events (additive, v1 unchanged):

```json
{ "type": "silence_detected", "call_id": "...", "seq": N, "duration_ms": 3000 }
{ "type": "dead_air_detected", "call_id": "...", "seq": N, "duration_ms": 10000 }
```

| Event | Side | Default | Re-fire? |
|---|---|---|---|
| `silence_detected` | One-sided (caller VAD-silent) | 3 s | Once per stretch (re-arms on speech) |
| `dead_air_detected` | Two-sided (neither caller speech nor WS audio) | 10 s | Every threshold elapsed |

Per-route override via `[route.bridge].silence_threshold_ms` / `.dead_air_threshold_ms`; `0` disables.

**Implementation:**
- New `IdleDetector` helper (`crates/media-glue/src/idle.rs`) — pure state machine, 8 unit tests.
- 500 ms-tick `select!` arm in `MediaTap::run` polls + emits.
- Detector hooks: `note_speech_started` on every VAD SpeechStarted; `note_ws_audio` on every WS-side push (before mute gate — a muted call with WS streaming is NOT dead air).
- Counters: `siphon_ai_silence_events_total`, `siphon_ai_dead_air_events_total`.

**Docs:** PROTOCOL §3.6/3.7 (renumbered `stop`/`error` to §3.8/3.9), CONFIG `[bridge]` table extended, DEPLOY metrics table, CHANGELOG.

`cargo test --workspace` green (40 binaries; +8 IdleDetector tests + 2 BridgeOut round-trip tests); clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)