### PR TITLE
chore: pin rust-toolchain.toml to 1.95.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,10 @@
+# Pinned to a specific patch version (not "stable") so the toolchain
+# clippy / rustfmt run against is identical on every dev box, every
+# branch, and every CI runner — eliminating the cross-version drift
+# that produced PR #78 (CI's clippy was 1.95.0 and tripped
+# `result_large_err`; my local clippy was older and didn't). Bump
+# this explicitly when a newer stable is desired.
 [toolchain]
-channel    = "stable"
+channel    = "1.95.0"
 components = ["rustfmt", "clippy"]
 profile    = "minimal"


### PR DESCRIPTION
## Why

`channel = "stable"` lets every dev box and every CI runner resolve to whatever stable happens to be installed, and clippy lints are not stable across patch versions. PR #78 was the first time it actually bit us — CI ran clippy 1.95.0 (the current stable) and tripped `result_large_err`; my local clippy was older and silent on the same code, so the lint only surfaced after push. Same risk applies to any future-stable's new lints.

Pinning to `1.95.0` makes the toolchain bit-identical everywhere. Newer stables become explicit bumps — touch this file, run the suite locally, push.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — to be confirmed by CI gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)