### PR TITLE
chore(release): v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,14 @@ These are documented because they're DoD adjacent and worth setting expectation 
 - **Reliable provisionals (RFC 3262 `100rel`) for `session_progress` mode** are not implemented. INVITEs that include `Require: 100rel` fall back to `instant_answer` for that call with a `warn!` log rather than sending a non-compliant unreliable 183. The reliable path is paired with `BridgeIn::Answer` (the "AI plays during the 183 phase" flow) for 0.2.1 / 0.3.0.
 - **Hot reload of the SIP/TLS cert is not implemented.** Cert rotation requires a daemon restart; pair with an L4 load balancer if your traffic pattern can't tolerate that. The renewal recipe in `docs/DEPLOY.md` § TLS deployment uses a Let's Encrypt deploy-hook + `systemctl restart`.
 
+### Deferred to 0.2.1 (Sprint 1 §5 stretch slip)
+
+`docs/DEV_PLAN_0.2.0.md` §5 listed three stretch items that slip to 0.2.1 per the plan's own policy ("Stretch items slot into spare time, in §5 order. If stretch eats more than Week 5, bump them to 0.2.1."). For clarity:
+
+- **mTLS for the bridge WebSocket connection** and wire-format validation against the WS server's cert. The 0.2.0 TLS recipe in `docs/DEPLOY.md` covers SIP/TLS + server-auth WSS + cert rotation; client-cert auth on the WS leg would need a `[bridge.tls.client_cert]` / `[bridge.tls.client_key]` config surface and the matching rustls connector wiring — not in 0.2.0.
+- **Attended transfer (REFER with Replaces)** — depends on siphon-rs UAC capability that wasn't ready in time.
+- **`examples/provider-toolkit-py/`** — a pluggable Deepgram/Whisper STT + OpenAI/Anthropic/Groq LLM + ElevenLabs/Cartesia TTS reference example. The 0.2.0 reference servers (`echo-ws-server-python`, `openai-realtime-bridge-py`, `transcription-server-py`) cover the canonical shapes; the multi-provider toolkit is a 0.2.1 cleanup item.
+
 ## [0.1.0] - 2026-05-22
 
 First public release. SiphonAI is a provider-neutral SIP-to-WebSocket

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-05-25
+
+Second release. Theme: **operator primitives** — the WS server can
+now react to silence and dead-air with built-in events instead of
+running its own VAD timers, observe RTP quality without scraping
+RTCP, mute the AI's playout independently of `clear`, and pick
+between three call-progress modes per deployment. Plus an
+end-to-end Twilio recipe, a Deepgram transcription reference
+server, a CI gate on every PR, and the operator-facing TLS
+deployment recipe.
+
+Protocol stays at `version: "1"` — every new variant is additive,
+so v1 WS servers built against 0.1.0 keep working unchanged.
+
 ### Added
 
 - **Transcription reference WS server** (`examples/transcription-server-py/`). Streaming Python WS server that pipes every call's audio to Deepgram and emits one JSON-line transcript per result on stdout. Demonstrates the non-agent (observer) use case — real-time transcription, compliance recording, supervisor assist. README documents the swap pattern for AssemblyAI / Whisper / OpenAI; points at `openai-realtime-bridge-py` for the multi-provider abstraction. Single dep (`websockets>=13`); ~390 LoC including comments.
@@ -27,6 +41,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `session_progress`: send `183 Session Progress` with the negotiated answer SDP before the 2xx (Flavour B per `docs/DEV_PLAN_0.2.0.md` §9.1 — best-effort, no `100rel`). Peers that include `Require: 100rel` in the INVITE fall back to `instant_answer` with a `warn!` log; reliable provisionals are deferred to 0.2.1 / 0.3.0.
 
   Backwards-compatible: existing configs without the `[sip.call_progress]` block keep v0.1.0 behaviour.
+
+- **TLS deployment recipe** (`docs/DEPLOY.md` § TLS deployment). End-to-end walkthrough for a TLS-secured deployment using the SIP/TLS + WSS mechanics that already shipped in 0.1.0: cert provisioning options, `[sip.tls]` configuration, the file-permission pattern for cert/key under the systemd `siphon` user, Let's Encrypt deploy-hook for renewal, and an `openssl s_client` + SIPp `-t l1` smoke test. WSS works out-of-the-box against any publicly-signed cert because the WS client is built with `rustls-tls-webpki-roots` — no host-CA-store dependency.
+
+### Changed
+
+- **Rust toolchain pinned to `1.95.0`** (`rust-toolchain.toml`). Previously `channel = "stable"`, which let local dev clippy drift from CI clippy — a drift PR #78 surfaced when CI's clippy 1.95.0 caught a `result_large_err` lint that the older local clippy was silent on. Future-stable bumps are now an explicit edit to this file.
+
+- **CI failure diagnostics for SIPp** (`.github/workflows/test.yml`). The SIPp regression job now cats every `*_errors.log` (in the scenarios dir; `run-all.sh` pins its CWD there so paths are predictable) and every daemon log on failure. The first real failure under the new pipeline — a `session_timer_echo` SIPp scenario using `[auto_media_port]` (added in SIPp 3.7; CI's ubuntu-latest apt sip-tester is 3.6.0) — was diagnosed and fixed in the same hour the dump was added.
+
+### Known limitations
+
+These are documented because they're DoD adjacent and worth setting expectation around.
+
+- **`rtp_stats.rtcp_rtt_ms` is not populated.** The `rtp_stats` event has the field reserved in PROTOCOL §3.8, but jitter and packet-loss are the only quality dimensions the daemon currently exposes (forge-media doesn't surface RTT in the `QualityDegraded` / `QualityRestored` events the snapshot is derived from). RTT exposure is targeted at 0.2.1 / 0.3.0 alongside the forge-media work.
+- **Reliable provisionals (RFC 3262 `100rel`) for `session_progress` mode** are not implemented. INVITEs that include `Require: 100rel` fall back to `instant_answer` for that call with a `warn!` log rather than sending a non-compliant unreliable 183. The reliable path is paired with `BridgeIn::Answer` (the "AI plays during the 183 phase" flow) for 0.2.1 / 0.3.0.
+- **Hot reload of the SIP/TLS cert is not implemented.** Cert rotation requires a daemon restart; pair with an L4 load balancer if your traffic pattern can't tolerate that. The renewal recipe in `docs/DEPLOY.md` § TLS deployment uses a Let's Encrypt deploy-hook + `systemctl restart`.
 
 ## [0.1.0] - 2026-05-22
 
@@ -96,5 +126,6 @@ the WebSocket server's job.
 - Reference WebSocket servers in `examples/`: echo (Python / Node),
   an OpenAI Realtime bridge, and a Deepgram + LLM voice bot.
 
-[Unreleased]: https://github.com/thevoiceguy/siphon-ai/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/thevoiceguy/siphon-ai/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/thevoiceguy/siphon-ai/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/thevoiceguy/siphon-ai/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64",
  "bytes",
@@ -2784,7 +2784,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2801,7 +2801,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "regex",
  "serde",
@@ -2816,7 +2816,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -2867,7 +2867,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2888,7 +2888,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "regex",
  "serde",
@@ -2899,7 +2899,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2922,7 +2922,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
+**v0.2.0** — second release. Adds the operator-primitive event surface
+(`silence_detected`, `dead_air_detected`, `rtp_stats`), sustained-mute
+control (`BridgeIn::Mute` / `Unmute` — distinct from one-shot `clear`),
+three configurable call-progress modes (`instant_answer` / `ringing` /
+`session_progress`), an end-to-end Twilio Elastic SIP Trunk recipe, a
+Deepgram transcription reference WS server, a CI gate on every PR
+(fmt + clippy + cargo test + SIPp regression), and the operator-facing
+TLS deployment recipe. Protocol stays at `version: "1"` — every new
+variant is additive, so v1 WS servers built against 0.1.0 keep working
+unchanged. Full notes: [`CHANGELOG.md`](CHANGELOG.md).
+
 **v0.1.0** — first public release. The audio path, WS protocol, SIP signaling,
 HEP capture, CDR/webhook sinks, and trunk-allowlist gate are in. Real-world
 FreeSWITCH-bridged calls work with sub-second user-to-audio latency on a

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -39,6 +39,130 @@ operator's network, and the daemon container.
 | Outbound 9060     | UDP    | `[hep].collector` | outbound | HEP3 to Homer. UDP only in v1. |
 | Outbound 5060/5061 | UDP/TCP | `[[register]].server` | bidirectional | Per `[[register]]` block. |
 
+## TLS deployment (SIP/TLS + WSS)
+
+A production deployment encrypts both legs: SIP/TLS for signaling
+to the carrier or PBX, and WSS for the bridge to the WS server.
+The mechanics already ship in v0.1.0; this is the recipe.
+
+### 1. Obtain a certificate
+
+`siphon-ai` reads a PEM cert chain + PEM private key from disk —
+any provisioning path works. Common options:
+
+| Source | When to use | Notes |
+|--------|-------------|-------|
+| **Let's Encrypt (DNS-01)** | Public SIP-on-Internet, the carrier accepts a public CA. | Use DNS-01 so the daemon doesn't need port 80; renewals are unattended via certbot's deploy-hook. |
+| **Carrier-issued / pinned** | The carrier signs your cert or expects a specific intermediate. | Drop the carrier's chain in as `cert`. The private-CA bundle goes in your OS trust store if you also need to *verify* the carrier's leaf. |
+| **Internal PKI** | Site-to-site to your own PBX (e.g. Asterisk, CUCM). | Both sides trust an internal root. Put the root in `/etc/ssl/certs/` so rustls picks it up via the system store path you've configured. |
+
+The cert's CommonName / SubjectAltName must include the hostname
+the carrier or PBX resolves for your trunk — usually the same name
+you put in `[node].public_address`.
+
+### 2. Configure `[sip.tls]`
+
+```toml
+[sip]
+listen     = "0.0.0.0:5060"
+transports = ["udp", "tcp", "tls"]   # `"tls"` requires the block below
+
+[sip.tls]
+listen = "0.0.0.0:5061"              # standard SIP/TLS port
+cert   = "/etc/siphon-ai/tls/fullchain.pem"
+key    = "/etc/siphon-ai/tls/privkey.pem"
+```
+
+Both `cert` and `key` are paths on disk; the daemon loads them at
+startup via `sip_transport::load_rustls_server_config` and binds
+the listener before answering `/ready`. A missing or unreadable
+file fails fast at startup with a clear error — no silent fallback
+to UDP.
+
+> **Inbound UAS only in v0.1.0/0.2.0.** Outbound TLS connections
+> (UAC originating a new TLS dialog) are not implemented and
+> return a clear error rather than silently downgrading. Inbound
+> `INVITE sips:…` from the carrier works.
+
+### 3. WSS to the WebSocket server
+
+Just set `wss://` in `[bridge].ws_url` (or `[route.bridge].ws_url`):
+
+```toml
+[bridge]
+ws_url = "wss://reception.example.com/sip-bridge"
+```
+
+No client cert or extra config is needed. The daemon's
+`tokio-tungstenite` client is built with `rustls-tls-webpki-roots`
+— the Mozilla CA bundle is baked into the binary, so trust works
+out-of-the-box for any publicly-signed cert without depending on
+the host's CA store. For an internal CA, the simpler path is to
+terminate WSS at a reverse proxy with a publicly-trusted cert in
+front of your WS server.
+
+`[bridge].ws_auth_header` works identically over WSS — use it for
+the bearer token your WS server expects:
+
+```toml
+ws_auth_header = "Bearer ${BRIDGE_TOKEN}"
+```
+
+### 4. File permissions for cert/key
+
+The systemd unit runs as the unprivileged `siphon` user; that user
+must be able to *read* the cert and key but should not own them.
+
+```sh
+sudo install -d -m 0750 -o root -g siphon /etc/siphon-ai/tls
+sudo install -m 0640 -o root -g siphon fullchain.pem /etc/siphon-ai/tls/
+sudo install -m 0640 -o root -g siphon privkey.pem   /etc/siphon-ai/tls/
+```
+
+`ProtectSystem=strict` in the unit blocks writes outside
+`/etc/siphon-ai/`, which is fine because renewal tools write to
+the cert directory directly.
+
+### 5. Renewal
+
+`siphon-ai` re-reads cert + key on startup, not at runtime. The
+simplest reliable pattern is to restart on renewal:
+
+```sh
+# Let's Encrypt deploy-hook (drop into /etc/letsencrypt/renewal-hooks/deploy/)
+#!/bin/sh
+set -e
+install -m 0640 -o root -g siphon \
+    "$RENEWED_LINEAGE/fullchain.pem" /etc/siphon-ai/tls/
+install -m 0640 -o root -g siphon \
+    "$RENEWED_LINEAGE/privkey.pem"   /etc/siphon-ai/tls/
+systemctl restart siphon-ai
+```
+
+A restart drops in-flight calls. If your traffic pattern can't
+tolerate that, run two instances behind an L4 load balancer and
+restart them one at a time. Hot cert reload is on the roadmap for
+a later release.
+
+### 6. Smoke test
+
+```sh
+# From outside the daemon: confirm the TLS listener answers and
+# presents the expected cert.
+openssl s_client -connect siphon.example.com:5061 -servername siphon.example.com \
+    -showcerts < /dev/null 2>&1 | head -20
+
+# Verify your trunk peer can route a SIPS INVITE end-to-end.
+# SIPp's `-t l1` enables TLS:
+sipp -sn uac -t l1 -tls_cert client.pem -tls_key client.pem \
+     siphon.example.com:5061 -m 1 -s 1000
+```
+
+If the listener answers but the carrier sees handshake failures,
+the usual cause is a missing intermediate in `fullchain.pem` —
+verify with `openssl s_client -showcerts` that the full chain is
+present, not just the leaf.
+
 ## systemd unit (sketch)
 
 A minimal unit file. Put the config under `/etc/siphon-ai/`, the binary

--- a/test-harness/sipp-scenarios/run-all.sh
+++ b/test-harness/sipp-scenarios/run-all.sh
@@ -116,7 +116,56 @@ for s in "${scenarios[@]}"; do
     run_scenario "$s" || failures=$((failures + 1))
 done
 
-# ─── Optional second phase: blind_transfer ────────────────────────
+# ─── Always-on auxiliary phase: session_progress ─────────────────
+# Verifies `[sip.call_progress] mode = "session_progress"` produces a
+# 183 with the negotiated answer SDP before the 200 OK (the §4.1
+# deliverable from the 0.2.0 plan). The main scenarios run against
+# the default config (`instant_answer` in `configs/local-dev.toml`),
+# so this phase stops that daemon and brings up a fresh one with a
+# session_progress config on the same port.
+echo
+echo "─── auxiliary phase: session_progress ────────────────"
+cleanup
+trap - EXIT
+
+SP_DAEMON_LOG=$(mktemp -t siphon-ai-sp.XXXXXX.log)
+SP_CONFIG=$(mktemp -t siphon-ai-sp.XXXXXX.toml)
+cat >"$SP_CONFIG" <<EOF
+[node]
+id = "siphon-ai-sipp-sp"
+[sip]
+listen = "127.0.0.1:$DAEMON_PORT"
+[sip.call_progress]
+mode = "session_progress"
+[media]
+codecs = ["pcmu"]
+[bridge]
+ws_url = "ws://127.0.0.1:8765/"
+[[route]]
+name = "default"
+[route.match]
+any = true
+EOF
+
+RUST_LOG=siphon_ai=info "$DAEMON_BIN" --config "$SP_CONFIG" \
+    >"$SP_DAEMON_LOG" 2>&1 &
+SP_DAEMON_PID=$!
+sp_cleanup() {
+    if kill -0 "$SP_DAEMON_PID" 2>/dev/null; then
+        kill "$SP_DAEMON_PID" 2>/dev/null || true
+        wait "$SP_DAEMON_PID" 2>/dev/null || true
+    fi
+}
+trap sp_cleanup EXIT
+sleep 1.2
+
+total=$((total + 1))
+run_scenario session_progress_then_answer.xml || failures=$((failures + 1))
+
+sp_cleanup
+trap - EXIT
+
+# ─── Optional third phase: blind_transfer ─────────────────────────
 # Needs a WS server that proactively emits BridgeIn::Transfer. The
 # runner stops the daemon, brings up an echo-ws that auto-emits
 # transfer pointing back at the SIPp port, then restarts the daemon

--- a/test-harness/sipp-scenarios/session_progress_then_answer.xml
+++ b/test-harness/sipp-scenarios/session_progress_then_answer.xml
@@ -47,12 +47,19 @@ a=rtpmap:0 PCMU/8000
     <action>
       <!-- Assert the 183 carries an SDP body — the whole point of
            session_progress mode. The scenario fails if Content-Type
-           is anything other than application/sdp. -->
+           is anything other than application/sdp.
+           The `<log>` line below isn't decorative: SIPp's
+           `-trace_err` flags `assign_to` variables that are captured
+           but never referenced ("is referenced 1 times"), and the
+           bash runner treats any errors.log content as a scenario
+           failure. Naming the variable starts-with-a-letter avoids
+           the `[$183_…]` substitution-parse ambiguity. -->
       <ereg regexp="application/sdp"
             search_in="hdr"
             header="Content-Type:"
             check_it="true"
-            assign_to="183_sdp_present"/>
+            assign_to="sdp_content_type"/>
+      <log message="183 Content-Type=[$sdp_content_type]"/>
     </action>
   </recv>
 


### PR DESCRIPTION
## What ships

Workspace 0.1.0 → 0.2.0. CHANGELOG cut. README status updated. Plus the missing-but-promised **TLS deployment recipe** in `docs/DEPLOY.md` to close DoD §10 #8 (the mechanics already shipped in 0.1.0; the recipe didn't).

### Features (already merged across Sprint 1 PRs #71 – #77)

| Area | Surface |
|---|---|
| Media-primitive events | `BridgeOut::SilenceDetected` / `DeadAirDetected` (PROTOCOL §3.6/§3.7) — configurable thresholds, `0` disables |
| RTP quality observability | `BridgeOut::RtpStats` (§3.8) — periodic snapshot + Prometheus histograms |
| Sustained mute | `BridgeIn::Mute` / `Unmute` (§4.6) — distinct from one-shot `Clear` |
| Call progress | `[sip.call_progress]` — `instant_answer` / `ringing` / `session_progress` (Flavour B, falls back on `Require: 100rel`) |
| Twilio recipe | `docs/INTEGRATIONS_TWILIO.md` + `examples/twilio-trunk/` |
| Transcription reference | `examples/transcription-server-py/` — Deepgram streaming WS server |
| CI gate | `.github/workflows/test.yml` — fmt + clippy `-D warnings` + cargo test + SIPp regression on every PR |
| Toolchain pin | `rust-toolchain.toml` → `1.95.0` (closes the PR #78 drift class) |

### This release commit adds

* `docs/DEPLOY.md` § TLS deployment — SIP/TLS + WSS end-to-end recipe (cert provisioning options, `[sip.tls]`, systemd file perms, Let's Encrypt deploy-hook, openssl + SIPp `-t l1` smoke test).
* CHANGELOG `[Unreleased]` → `[0.2.0]` with a "Known limitations" subsection covering the three deferred items (RTCP RTT, 100rel, cert hot-reload).
* `Cargo.toml` workspace version 0.1.0 → 0.2.0; `Cargo.lock` regenerated.
* README status block re-flagged for 0.2.0 (0.1.0 paragraph kept for historical context).

### Known limitations (documented)

* `rtp_stats.rtcp_rtt_ms` not yet populated — forge upstream gap.
* Reliable provisionals (RFC 3262 100rel) for `session_progress` deferred to 0.2.1 / 0.3.0 alongside `BridgeIn::Answer`.
* Hot reload of SIP/TLS cert not implemented — recipe uses restart-on-renewal.

## Protocol versioning

Stays at `version: "1"` — every 0.2.0 addition is additive (new `BridgeIn` / `BridgeOut` variants + new event types). WS servers built against 0.1.0 keep working unchanged.

## Verification

| Check | Result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo test --workspace --locked` | 175 tests, 0 failures |
| `bash test-harness/sipp-scenarios/run-all.sh` | 6/6 pass |

All under the pinned 1.95.0 toolchain. CI gate validates the same.

## DoD §10 status

7/8 ✅. The one ⚠️ is #3 (RTT) — jitter + packet-loss exposed, RTT deferred upstream and documented in CHANGELOG. #8 closed by this commit's DEPLOY.md addition.

## Post-merge

After CI green: tag `v0.2.0` on the merge commit, push tag, create GitHub release with the `[0.2.0]` CHANGELOG section as the body. **Tagging will be confirmed before push — irreversible.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)