### PR TITLE
docs(twilio): point TLS deep-dive at the 0.2.0 DEPLOY.md recipe

### DIFF
--- a/docs/INTEGRATIONS_TWILIO.md
+++ b/docs/INTEGRATIONS_TWILIO.md
@@ -141,8 +141,11 @@ Twilio terminates TLS at the trunk — they validate your certificate
 against the public CA chain. Use Let's Encrypt or your existing
 internal PKI.
 
-The deeper "rotate certs, mTLS, cert pinning" story is in
-[`docs/DEPLOY.md`](DEPLOY.md) (forthcoming for 0.3.0).
+The deeper "cert provisioning, file permissions under the systemd
+`siphon` user, Let's Encrypt deploy-hook for renewal, openssl + SIPp
+smoke test" recipe is in [`docs/DEPLOY.md`](DEPLOY.md) § TLS
+deployment (landed in 0.2.0). mTLS for the bridge WS leg and SRTP
+for the media leg are still 0.2.1 / 0.3.0 — see CHANGELOG.
 
 ---
 


### PR DESCRIPTION
0.2.0 shipped the TLS deployment recipe in `docs/DEPLOY.md` § TLS deployment (provisioning, systemd file perms, Let's Encrypt deploy-hook, openssl + SIPp smoke test), but `docs/INTEGRATIONS_TWILIO.md` still pointed at it as "forthcoming for 0.3.0".

Updates the link target to reflect reality and adds an honest "what's still missing in 0.2.0" pointer — **mTLS for the bridge WS leg** and **SRTP for the media leg** are both 0.2.1 / 0.3.0 per CHANGELOG `[0.2.0]` § Deferred to 0.2.1 + § Known limitations.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)