### PR TITLE
feat(media-glue,bridge): wire RtcpReportReceived → BridgeOut.rtp_stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,7 +669,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 [[package]]
 name = "forge-codecs"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=8f54cd32190e#8f54cd32190e94bc218352e0f14275cc2c1f9f90"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=5f04df57a39b#5f04df57a39bafbb9b6541d90732cd37d2f84a0c"
 dependencies = [
  "ezk-g722",
  "lazy_static",
@@ -671,7 +680,7 @@ dependencies = [
 [[package]]
 name = "forge-core"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=8f54cd32190e#8f54cd32190e94bc218352e0f14275cc2c1f9f90"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=5f04df57a39b#5f04df57a39bafbb9b6541d90732cd37d2f84a0c"
 dependencies = [
  "chrono",
  "serde",
@@ -686,7 +695,7 @@ dependencies = [
 [[package]]
 name = "forge-dtmf"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=8f54cd32190e#8f54cd32190e94bc218352e0f14275cc2c1f9f90"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=5f04df57a39b#5f04df57a39bafbb9b6541d90732cd37d2f84a0c"
 dependencies = [
  "chrono",
  "forge-core",
@@ -698,7 +707,7 @@ dependencies = [
 [[package]]
 name = "forge-engine"
 version = "0.4.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=8f54cd32190e#8f54cd32190e94bc218352e0f14275cc2c1f9f90"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=5f04df57a39b#5f04df57a39bafbb9b6541d90732cd37d2f84a0c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -728,7 +737,7 @@ dependencies = [
 [[package]]
 name = "forge-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=8f54cd32190e#8f54cd32190e94bc218352e0f14275cc2c1f9f90"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=5f04df57a39b#5f04df57a39bafbb9b6541d90732cd37d2f84a0c"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -741,7 +750,7 @@ dependencies = [
 [[package]]
 name = "forge-injection"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=8f54cd32190e#8f54cd32190e94bc218352e0f14275cc2c1f9f90"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=5f04df57a39b#5f04df57a39bafbb9b6541d90732cd37d2f84a0c"
 dependencies = [
  "forge-core",
  "rubato",
@@ -754,7 +763,7 @@ dependencies = [
 [[package]]
 name = "forge-recorder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=8f54cd32190e#8f54cd32190e94bc218352e0f14275cc2c1f9f90"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=5f04df57a39b#5f04df57a39bafbb9b6541d90732cd37d2f84a0c"
 dependencies = [
  "bytes",
  "forge-core",
@@ -768,7 +777,7 @@ dependencies = [
 [[package]]
 name = "forge-resampler"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=8f54cd32190e#8f54cd32190e94bc218352e0f14275cc2c1f9f90"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=5f04df57a39b#5f04df57a39bafbb9b6541d90732cd37d2f84a0c"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -777,7 +786,7 @@ dependencies = [
 [[package]]
 name = "forge-rtp"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=8f54cd32190e#8f54cd32190e94bc218352e0f14275cc2c1f9f90"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=5f04df57a39b#5f04df57a39bafbb9b6541d90732cd37d2f84a0c"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -799,11 +808,14 @@ dependencies = [
 [[package]]
 name = "forge-sdp"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=8f54cd32190e#8f54cd32190e94bc218352e0f14275cc2c1f9f90"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=5f04df57a39b#5f04df57a39bafbb9b6541d90732cd37d2f84a0c"
 dependencies = [
+ "base64",
  "chrono",
  "forge-core",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=8f54cd32190e)",
+ "forge-rtp",
+ "rand 0.9.4",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=5f04df57a39b)",
  "smol_str",
  "thiserror 2.0.18",
 ]
@@ -811,7 +823,7 @@ dependencies = [
 [[package]]
 name = "forge-transcoder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=8f54cd32190e#8f54cd32190e94bc218352e0f14275cc2c1f9f90"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=5f04df57a39b#5f04df57a39bafbb9b6541d90732cd37d2f84a0c"
 dependencies = [
  "bytes",
  "forge-codecs",
@@ -824,7 +836,7 @@ dependencies = [
 [[package]]
 name = "forge-vad"
 version = "0.1.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=8f54cd32190e#8f54cd32190e94bc218352e0f14275cc2c1f9f90"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=5f04df57a39b#5f04df57a39bafbb9b6541d90732cd37d2f84a0c"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -2518,7 +2530,7 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 [[package]]
 name = "sip-auth"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=c03fa985b00a#c03fa985b00ad5bf5592e6561664e8a123e636e2"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=d0d3691244de#d0d3691244de5c0769853a62111f56ac3a0f7f83"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2541,7 +2553,7 @@ dependencies = [
 [[package]]
 name = "sip-core"
 version = "0.7.6"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=c03fa985b00a#c03fa985b00ad5bf5592e6561664e8a123e636e2"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=d0d3691244de#d0d3691244de5c0769853a62111f56ac3a0f7f83"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2554,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "sip-dialog"
 version = "0.3.3"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=c03fa985b00a#c03fa985b00ad5bf5592e6561664e8a123e636e2"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=d0d3691244de#d0d3691244de5c0769853a62111f56ac3a0f7f83"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2572,7 +2584,7 @@ dependencies = [
 [[package]]
 name = "sip-dns"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=c03fa985b00a#c03fa985b00ad5bf5592e6561664e8a123e636e2"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=d0d3691244de#d0d3691244de5c0769853a62111f56ac3a0f7f83"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2586,7 +2598,7 @@ dependencies = [
 [[package]]
 name = "sip-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=c03fa985b00a#c03fa985b00ad5bf5592e6561664e8a123e636e2"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=d0d3691244de#d0d3691244de5c0769853a62111f56ac3a0f7f83"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -2597,7 +2609,7 @@ dependencies = [
 [[package]]
 name = "sip-observe"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=c03fa985b00a#c03fa985b00ad5bf5592e6561664e8a123e636e2"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=d0d3691244de#d0d3691244de5c0769853a62111f56ac3a0f7f83"
 dependencies = [
  "once_cell",
  "tracing",
@@ -2606,7 +2618,7 @@ dependencies = [
 [[package]]
 name = "sip-parse"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=c03fa985b00a#c03fa985b00ad5bf5592e6561664e8a123e636e2"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=d0d3691244de#d0d3691244de5c0769853a62111f56ac3a0f7f83"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2620,7 +2632,7 @@ dependencies = [
 [[package]]
 name = "sip-ratelimit"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=c03fa985b00a#c03fa985b00ad5bf5592e6561664e8a123e636e2"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=d0d3691244de#d0d3691244de5c0769853a62111f56ac3a0f7f83"
 dependencies = [
  "dashmap 5.5.3",
  "parking_lot",
@@ -2631,7 +2643,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=8f54cd32190e#8f54cd32190e94bc218352e0f14275cc2c1f9f90"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=5f04df57a39b#5f04df57a39bafbb9b6541d90732cd37d2f84a0c"
 dependencies = [
  "nom",
  "smol_str",
@@ -2640,7 +2652,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=c03fa985b00a#c03fa985b00ad5bf5592e6561664e8a123e636e2"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=d0d3691244de#d0d3691244de5c0769853a62111f56ac3a0f7f83"
 dependencies = [
  "nom",
  "smol_str",
@@ -2649,7 +2661,7 @@ dependencies = [
 [[package]]
 name = "sip-transaction"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=c03fa985b00a#c03fa985b00ad5bf5592e6561664e8a123e636e2"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=d0d3691244de#d0d3691244de5c0769853a62111f56ac3a0f7f83"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2668,9 +2680,10 @@ dependencies = [
 [[package]]
 name = "sip-transport"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=c03fa985b00a#c03fa985b00ad5bf5592e6561664e8a123e636e2"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=d0d3691244de#d0d3691244de5c0769853a62111f56ac3a0f7f83"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "bytes",
  "dashmap 5.5.3",
  "memchr",
@@ -2687,7 +2700,7 @@ dependencies = [
 [[package]]
 name = "sip-uac"
 version = "0.4.2"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=c03fa985b00a#c03fa985b00ad5bf5592e6561664e8a123e636e2"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=d0d3691244de#d0d3691244de5c0769853a62111f56ac3a0f7f83"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2700,7 +2713,7 @@ dependencies = [
  "sip-dialog",
  "sip-dns",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=c03fa985b00a)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=d0d3691244de)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -2712,7 +2725,7 @@ dependencies = [
 [[package]]
 name = "sip-uas"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=c03fa985b00a#c03fa985b00ad5bf5592e6561664e8a123e636e2"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=d0d3691244de#d0d3691244de5c0769853a62111f56ac3a0f7f83"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2722,7 +2735,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=c03fa985b00a)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=d0d3691244de)",
  "sip-transaction",
  "sip-transport",
  "smol_str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,16 +102,16 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 # main branch and replace the rev hashes here (see CLAUDE.md §7.5).
 
 # siphon-rs — RFC 3261 SIP stack
-sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "c03fa985b00a" }
-sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "c03fa985b00a" }
-sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "c03fa985b00a", features = ["tls"] }
-sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "c03fa985b00a" }
-sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "c03fa985b00a" }
-sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "c03fa985b00a" }
-sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "c03fa985b00a" }
-sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "c03fa985b00a" }
-sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "c03fa985b00a" }
-sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "c03fa985b00a" }
+sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "d0d3691244de" }
+sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "d0d3691244de" }
+sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "d0d3691244de", features = ["tls"] }
+sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "d0d3691244de" }
+sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "d0d3691244de" }
+sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "d0d3691244de" }
+sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "d0d3691244de" }
+sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "d0d3691244de" }
+sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "d0d3691244de" }
+sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "d0d3691244de" }
 
 # forge-media — RTP / codecs / SDP / DTMF / engine.
 #
@@ -127,14 +127,14 @@ sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "c03
 # forge-ice, Cow/lifetime in forge-recorder), but the subset SiphonAI
 # pulls — forge-core, forge-rtp, forge-engine (g722 only), forge-codecs,
 # forge-sdp, forge-dtmf, forge-vad, forge-hep — all build cleanly.
-forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "8f54cd32190e" }
-forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "8f54cd32190e" }
-forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "8f54cd32190e", default-features = false, features = ["g722"] }
-forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "8f54cd32190e" }
-forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "8f54cd32190e" }
-forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "8f54cd32190e" }
-forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "8f54cd32190e" }
-forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "8f54cd32190e" }
+forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "5f04df57a39b" }
+forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "5f04df57a39b" }
+forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "5f04df57a39b", default-features = false, features = ["g722"] }
+forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "5f04df57a39b" }
+forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "5f04df57a39b" }
+forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "5f04df57a39b" }
+forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "5f04df57a39b" }
+forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "5f04df57a39b" }
 
 # hep-rs — HEP3 codec, transport, HepSink trait. Owned by the same
 # author as siphon-rs and forge-media; lives in its own repo.

--- a/crates/bridge/src/conn.rs
+++ b/crates/bridge/src/conn.rs
@@ -162,6 +162,9 @@ pub enum OutgoingEvent {
         /// Packet loss as a ratio in `[0.0, 1.0]`. `None` until
         /// forge has reported its first quality assessment.
         packet_loss_ratio: Option<f32>,
+        /// Mean RTT in milliseconds. `None` until forge originates
+        /// its own SRs (0.3.1 follow-up).
+        rtcp_rtt_ms: Option<f32>,
     },
     Stop {
         reason: StopReason,
@@ -510,11 +513,13 @@ fn build_bridge_out(event: OutgoingEvent, call_id: CallId, seq: Seq) -> BridgeOu
         OutgoingEvent::RtpStats {
             jitter_ms,
             packet_loss_ratio,
+            rtcp_rtt_ms,
         } => BridgeOut::RtpStats {
             call_id,
             seq,
             jitter_ms,
             packet_loss_ratio,
+            rtcp_rtt_ms,
         },
         OutgoingEvent::Stop { reason } => BridgeOut::Stop {
             call_id,

--- a/crates/bridge/src/protocol.rs
+++ b/crates/bridge/src/protocol.rs
@@ -136,6 +136,11 @@ pub enum BridgeOut {
         /// Packet loss as a ratio in `[0.0, 1.0]`, or `null`.
         #[serde(skip_serializing_if = "Option::is_none", default)]
         packet_loss_ratio: Option<f32>,
+        /// Mean round-trip time over the reporting window in milliseconds,
+        /// or `null` until forge-engine originates its own RTCP SRs
+        /// (deferred to 0.3.1 per DEV_PLAN_0.3.0.md §9 decision 10).
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        rtcp_rtt_ms: Option<f32>,
     },
 
     /// The caller pressed a DTMF key.
@@ -521,11 +526,12 @@ mod tests {
 
     #[test]
     fn bridge_out_rtp_stats_with_values() {
-        let raw = r#"{ "type": "rtp_stats", "call_id": "c", "seq": 50, "jitter_ms": 12.5, "packet_loss_ratio": 0.004 }"#;
+        let raw = r#"{ "type": "rtp_stats", "call_id": "c", "seq": 50, "jitter_ms": 12.5, "packet_loss_ratio": 0.004, "rtcp_rtt_ms": 42.0 }"#;
         let msg: BridgeOut = assert_round_trip(raw);
         let BridgeOut::RtpStats {
             jitter_ms,
             packet_loss_ratio,
+            rtcp_rtt_ms,
             ..
         } = msg
         else {
@@ -533,11 +539,12 @@ mod tests {
         };
         assert_eq!(jitter_ms, Some(12.5));
         assert_eq!(packet_loss_ratio, Some(0.004));
+        assert_eq!(rtcp_rtt_ms, Some(42.0));
     }
 
     #[test]
     fn bridge_out_rtp_stats_with_nulls() {
-        // First snapshot before any RTCP report has arrived: both
+        // First snapshot before any RTCP report has arrived: all three
         // fields are absent / null. Test deserialize-only because
         // skip_serializing_if drops them on the way back out.
         let raw = r#"{ "type": "rtp_stats", "call_id": "c", "seq": 1 }"#;
@@ -545,6 +552,7 @@ mod tests {
         let BridgeOut::RtpStats {
             jitter_ms,
             packet_loss_ratio,
+            rtcp_rtt_ms,
             ..
         } = msg
         else {
@@ -552,6 +560,31 @@ mod tests {
         };
         assert!(jitter_ms.is_none());
         assert!(packet_loss_ratio.is_none());
+        assert!(rtcp_rtt_ms.is_none());
+    }
+
+    #[test]
+    fn bridge_out_rtp_stats_jitter_loss_without_rtt() {
+        // Common shape pre-0.3.1: jitter and loss populate from
+        // RtcpReportReceived, but rtt_ms stays None until forge
+        // originates its own SRs. Verify the field is *omitted*
+        // (not present as JSON null) to match skip_serializing_if.
+        let msg = BridgeOut::RtpStats {
+            call_id: CallId("c".to_string()),
+            seq: 7,
+            jitter_ms: Some(11.2),
+            packet_loss_ratio: Some(0.012),
+            rtcp_rtt_ms: None,
+        };
+        let v: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&msg).unwrap()).unwrap();
+        let obj = v.as_object().unwrap();
+        assert!(obj.contains_key("jitter_ms"));
+        assert!(obj.contains_key("packet_loss_ratio"));
+        assert!(
+            !obj.contains_key("rtcp_rtt_ms"),
+            "rtcp_rtt_ms must be absent (not null) when None"
+        );
     }
 
     #[test]

--- a/crates/media-glue/src/rtp_stats.rs
+++ b/crates/media-glue/src/rtp_stats.rs
@@ -2,24 +2,28 @@
 //! reported by forge and exposes it as a snapshot for periodic
 //! emission of `rtp_stats` WS events.
 //!
-//! ## Why a tracker, not a poller
+//! ## Wiring
 //!
-//! forge-engine does not (in 0.2.0) expose a session-level
-//! `rtp_stats_snapshot()` API. What it does emit is the
-//! [`forge_core::ForgeEvent::QualityDegraded`] / `QualityRestored`
-//! events whenever its quality assessment changes. We subscribe to
-//! those, cache the last-known values, and emit periodic snapshots
-//! at `[bridge].rtp_stats_interval_ms` cadence using the cache.
+//! forge-engine emits a [`forge_core::ForgeEvent::RtcpReportReceived`]
+//! event on every incoming RTCP RR block, carrying `jitter_ms`,
+//! `packet_loss_ratio`, and (when forge is also originating its own
+//! SRs) `rtt_ms`. The tap subscribes, caches the last-known values
+//! via [`RtpStatsTracker::note_rtcp_report`], and emits periodic
+//! snapshots at `[bridge].rtp_stats_interval_ms` cadence using the
+//! cache.
 //!
-//! This means the emitted values reflect forge's most-recent state,
-//! not the literal current measurement. For a healthy call that
-//! never degraded, both fields are `None` (no data yet). After a
-//! `QualityDegraded` arrives, both are `Some(value)`. After a
-//! `QualityRestored`, both are `Some(0.0)` — explicitly "back to
-//! healthy" rather than ambiguous `None`. A future forge upstream
-//! PR exposing a snapshot accessor would let us replace the tracker
-//! with a poller and get true periodic measurements; the WS event
-//! shape stays the same either way.
+//! The legacy [`forge_core::ForgeEvent::QualityDegraded`] /
+//! `QualityRestored` events were the 0.2.0 plan but never had a
+//! producer in forge — see siphon-ai DEV_PLAN_0.3.0.md §9 decision
+//! 8 for the resolution. The threshold-based `QualityDegraded` arm
+//! is kept for forward-compatibility but is currently a no-op in
+//! production because nothing emits it.
+//!
+//! For a healthy call that never received an RR (e.g., short call),
+//! all snapshot fields are `None` (no data yet). Once at least one
+//! RR has arrived, they are `Some(value)`. `rtt_ms` may stay `None`
+//! even when jitter/loss are populated — RTT requires forge to
+//! originate its own SRs (deferred to 0.3.1 per §9 decision 10).
 
 use std::time::Duration;
 
@@ -29,6 +33,11 @@ use std::time::Duration;
 pub struct RtpStatsSnapshot {
     pub jitter_ms: Option<f32>,
     pub packet_loss_ratio: Option<f32>,
+    /// Mean round-trip time over the reporting window in milliseconds.
+    /// `None` until forge-engine originates its own RTCP SRs (deferred
+    /// to 0.3.1 per DEV_PLAN_0.3.0.md §9 decision 10) — distinct from
+    /// `Some(0.0)`, which is degenerate.
+    pub rtt_ms: Option<f32>,
 }
 
 /// Per-call RTP-stats state. Owned by the tap; updated from forge
@@ -38,6 +47,7 @@ pub struct RtpStatsTracker {
     interval: Option<Duration>,
     last_jitter_ms: Option<f32>,
     last_packet_loss_ratio: Option<f32>,
+    last_rtt_ms: Option<f32>,
 }
 
 impl RtpStatsTracker {
@@ -47,6 +57,7 @@ impl RtpStatsTracker {
             interval,
             last_jitter_ms: None,
             last_packet_loss_ratio: None,
+            last_rtt_ms: None,
         }
     }
 
@@ -60,17 +71,40 @@ impl RtpStatsTracker {
         self.interval
     }
 
+    /// forge reported a `RtcpReportReceived` — cache the three RR-derived
+    /// fields. `rtt_ms = None` is preserved as-is (we don't want the
+    /// snapshot's `rtt_ms` to flip to `Some(0.0)` when forge can't yet
+    /// compute RTT).
+    pub fn note_rtcp_report(
+        &mut self,
+        jitter_ms: f32,
+        packet_loss_ratio: f32,
+        rtt_ms: Option<f32>,
+    ) {
+        self.last_jitter_ms = Some(jitter_ms);
+        self.last_packet_loss_ratio = Some(packet_loss_ratio);
+        if rtt_ms.is_some() {
+            self.last_rtt_ms = rtt_ms;
+        }
+    }
+
     /// forge reported a `QualityDegraded` — cache the values.
     /// `packet_loss_percent` is in [0.0, 100.0] (forge's convention);
     /// we convert to ratio [0.0, 1.0] for the wire event.
+    ///
+    /// Kept for backwards compatibility with the threshold-based event.
+    /// `RtcpReportReceived` is the per-RR cadence event the
+    /// 0.3.0 producer emits; this method handles the (currently unused)
+    /// threshold path.
     pub fn note_quality_degraded(&mut self, packet_loss_percent: f32, jitter_ms: f32) {
         self.last_jitter_ms = Some(jitter_ms);
         self.last_packet_loss_ratio = Some(packet_loss_percent / 100.0);
     }
 
-    /// forge reported a `QualityRestored` — mark both fields as
-    /// "explicitly healthy" (`Some(0.0)`), not `None`. Consumers
-    /// distinguish "no data yet" (`None`) from "healthy" (`0.0`).
+    /// forge reported a `QualityRestored` — mark jitter and loss as
+    /// "explicitly healthy" (`Some(0.0)`), not `None`. `rtt_ms` is
+    /// left untouched: it's an absolute measurement, not a threshold,
+    /// so "healthy" doesn't imply zero RTT.
     pub fn note_quality_restored(&mut self) {
         self.last_jitter_ms = Some(0.0);
         self.last_packet_loss_ratio = Some(0.0);
@@ -81,6 +115,7 @@ impl RtpStatsTracker {
         RtpStatsSnapshot {
             jitter_ms: self.last_jitter_ms,
             packet_loss_ratio: self.last_packet_loss_ratio,
+            rtt_ms: self.last_rtt_ms,
         }
     }
 }
@@ -95,6 +130,48 @@ mod tests {
         let snap = t.snapshot();
         assert!(snap.jitter_ms.is_none());
         assert!(snap.packet_loss_ratio.is_none());
+        assert!(snap.rtt_ms.is_none());
+    }
+
+    #[test]
+    fn rtcp_report_populates_all_three_fields() {
+        let mut t = RtpStatsTracker::new(Some(Duration::from_secs(5)));
+        t.note_rtcp_report(
+            17.2,  /* jitter ms */
+            0.025, /* 2.5% loss */
+            Some(42.0),
+        );
+        let snap = t.snapshot();
+        assert_eq!(snap.jitter_ms, Some(17.2));
+        assert!((snap.packet_loss_ratio.unwrap() - 0.025).abs() < 1e-6);
+        assert_eq!(snap.rtt_ms, Some(42.0));
+    }
+
+    #[test]
+    fn rtcp_report_with_none_rtt_keeps_prior_rtt() {
+        // Once a real RTT measurement lands, later RRs with rtt=None
+        // (e.g., a window with no matching SR) shouldn't wipe it.
+        // This matches the §A.7 reality: RTT is sparse.
+        let mut t = RtpStatsTracker::new(Some(Duration::from_secs(5)));
+        t.note_rtcp_report(10.0, 0.01, Some(35.0));
+        t.note_rtcp_report(11.0, 0.02, None);
+        let snap = t.snapshot();
+        assert_eq!(snap.rtt_ms, Some(35.0));
+        // …but jitter and loss DO update on every RR.
+        assert_eq!(snap.jitter_ms, Some(11.0));
+    }
+
+    #[test]
+    fn restored_does_not_clear_rtt() {
+        // QualityRestored is a threshold event for jitter/loss only.
+        // rtt_ms is an absolute measurement and shouldn't be reset.
+        let mut t = RtpStatsTracker::new(Some(Duration::from_secs(5)));
+        t.note_rtcp_report(50.0, 0.1, Some(80.0));
+        t.note_quality_restored();
+        let snap = t.snapshot();
+        assert_eq!(snap.jitter_ms, Some(0.0));
+        assert_eq!(snap.packet_loss_ratio, Some(0.0));
+        assert_eq!(snap.rtt_ms, Some(80.0));
     }
 
     #[test]

--- a/crates/media-glue/src/tap.rs
+++ b/crates/media-glue/src/tap.rs
@@ -539,6 +539,19 @@ impl MediaTap {
                             // forward Quality events to the WS — they
                             // surface via the periodic rtp_stats arm).
                             match &ev {
+                                ForgeEvent::RtcpReportReceived {
+                                    call_id: cid,
+                                    jitter_ms,
+                                    packet_loss_ratio,
+                                    rtt_ms,
+                                    ..
+                                } if cid == &self.call_id => {
+                                    self.rtp_stats.note_rtcp_report(
+                                        *jitter_ms,
+                                        *packet_loss_ratio,
+                                        *rtt_ms,
+                                    );
+                                }
                                 ForgeEvent::QualityDegraded {
                                     call_id: cid,
                                     packet_loss_percent,
@@ -794,9 +807,13 @@ impl MediaTap {
                     if let Some(l) = snap.packet_loss_ratio {
                         metrics::histogram!("siphon_ai_rtp_packet_loss_ratio").record(l as f64);
                     }
+                    if let Some(r) = snap.rtt_ms {
+                        metrics::histogram!("siphon_ai_rtp_rtt_ms").record(r as f64);
+                    }
                     let out = OutgoingEvent::RtpStats {
                         jitter_ms: snap.jitter_ms,
                         packet_loss_ratio: snap.packet_loss_ratio,
+                        rtcp_rtt_ms: snap.rtt_ms,
                     };
                     if let Err(e) = events_tx.try_send(out) {
                         warn!(

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -328,6 +328,7 @@ on the metrics crate's defaults (CLAUDE.md §7.4).
 | `siphon_ai_dead_air_events_total`       | counter   | —                                     | Times `dead_air_detected` fired on the WS bridge. Configurable via `[bridge].dead_air_threshold_ms`. |
 | `siphon_ai_rtp_jitter_ms`               | histogram | —                                     | RTP jitter snapshot recorded on every `rtp_stats` emission (when forge has reported a value). |
 | `siphon_ai_rtp_packet_loss_ratio`       | histogram | —                                     | Packet-loss ratio (0.0-1.0) recorded on every `rtp_stats` emission. |
+| `siphon_ai_rtp_rtt_ms`                  | histogram | —                                     | Mean RTCP round-trip time recorded on every `rtp_stats` emission. Stays empty until forge originates its own SRs (0.3.1 follow-up). |
 | `forge_rtcp_*`                          | various   | per-call (forge-side)                 | RTP/RTCP quality. See forge-media's own metric inventory. |
 | `heplify_*`                             | various   | from the HEP collector                | Only visible if you scrape heplify too. |
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -247,16 +247,13 @@ quality assessment for the call:
 
 | Field                | Type            | Notes |
 |----------------------|-----------------|-------|
-| `jitter_ms`          | float \| null   | Estimated inter-arrival jitter. `null` if forge hasn't reported. After a `QualityRestored` event in forge, this resets to `0.0` — distinct from `null`. |
+| `jitter_ms`          | float \| null   | Estimated inter-arrival jitter. `null` if no RTCP RR has arrived yet. After a `QualityRestored` event in forge, this resets to `0.0` — distinct from `null`. |
 | `packet_loss_ratio`  | float \| null   | Loss as a ratio in `[0.0, 1.0]` (NOT a percent). Same `null` / `0.0` distinction. |
+| `rtcp_rtt_ms`        | float \| null   | Mean round-trip time over the reporting window. `null` until forge originates its own RTCP SRs (deferred to 0.3.1). Distinct from `0.0`, which is degenerate; once populated, the field is sticky — a window with no fresh RTT sample preserves the last measurement rather than reverting to `null`. |
 
 Codec and sample-rate are constant for a call — consumers should
 correlate to the `start` message (§3.1) rather than expecting them
 on every snapshot.
-
-`rtcp_rtt_ms` is not yet available in 0.2.0 (forge upstream gap).
-Planned for 0.2.1 / 0.3.0 once forge exposes a session-level
-snapshot accessor.
 
 ### 3.9 `stop` — call ended
 


### PR DESCRIPTION
W3 of the 0.3.0 sprint. Consumes the new \`ForgeEvent::RtcpReportReceived\` event added in [forge-media#57](https://github.com/thevoiceguy/forge-media/pull/57) + emitted in [forge-media#60](https://github.com/thevoiceguy/forge-media/pull/60). Closes a pre-existing 0.2.0 gap where \`rtp_stats.jitter_ms\` and \`rtp_stats.packet_loss_ratio\` had no producer and were always emitted as \`null\`.

## Wiring

- Bump forge-media rev \`8f54cd3\` → \`5f04df5\` (adds RtcpReportReceived variant + RttTracker primitive + forge-engine emitter + Code Coverage tarpaulin fix).
- Bump siphon-rs rev \`c03fa98\` → \`d0d3691\` (swappable TLS + CI on PRs).

## What this changes

### \`media-glue/src/rtp_stats.rs\`

- \`RtpStatsSnapshot\` gains \`rtt_ms: Option<f32>\`.
- \`RtpStatsTracker\` gains \`last_rtt_ms\` cache + new \`note_rtcp_report(jitter_ms, packet_loss_ratio, rtt_ms)\` method.
- \`rtt_ms\` is **sticky** — a later RR with \`rtt_ms = None\` doesn't wipe a previous measurement (matches RFC 3550 §A.7 reality: RTT is sparse).
- \`note_quality_restored\` no longer clears \`rtt_ms\` — RTT is absolute, not a threshold.
- Legacy \`note_quality_degraded\` kept for forward-compat (no production producer today).

### \`media-glue/src/tap.rs\`

- New match arm on \`ForgeEvent::RtcpReportReceived\` → \`note_rtcp_report\`.
- Periodic-emit arm records \`siphon_ai_rtp_rtt_ms\` Prometheus histogram when the snapshot has an RTT value.
- Existing \`QualityDegraded\`/\`Restored\` arms preserved.

### \`bridge/src/protocol.rs\` + \`conn.rs\`

- \`BridgeOut::RtpStats\` + \`OutgoingEvent::RtpStats\` gain \`rtcp_rtt_ms: Option<f32>\` with \`#[serde(skip_serializing_if = \"Option::is_none\")]\` — wire shape stays backwards-compatible.
- Three new protocol tests: round-trip with all three fields populated; all-null deserialize; absent-not-null when \`rtcp_rtt_ms\` is None.

### Docs

- \`PROTOCOL.md\` §3.8: documents \`rtcp_rtt_ms\` with stickiness semantics; removes the "not yet available in 0.2.0" note.
- \`DEPLOY.md\`: adds \`siphon_ai_rtp_rtt_ms\` to the metrics table.

## Verification

| Gate | Result |
|---|---|
| \`cargo build --workspace\` | ✅ |
| \`cargo test --workspace\` | ✅ 429 passed, 0 failed |
| \`cargo fmt --all -- --check\` | ✅ |
| \`cargo clippy --workspace --all-targets -- -D warnings\` | ✅ |

## Out of scope (0.3.1 follow-up)

Outbound SR origination in forge-engine. \`rtcp_rtt_ms\` stays \`null\` end-to-end in 0.3.0 because forge doesn't yet send SRs that the remote can echo back in RR \`last_sr\` fields. The primitive is ready (\`forge_rtp::RttTracker\`); only the producer wiring is missing — matches DEV_PLAN_0.3.0.md §9 decision 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)