### PR TITLE
docs: TLS REGISTER recipe + remove stale UAS-only disclaimer (W4 Part B)

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -49,11 +49,12 @@ before TOML parsing. Unset variables without a default fail the load.
 | `cert`   | path        | required when TLS on | PEM cert chain on disk. |
 | `key`    | path        | required when TLS on | PEM private key on disk. |
 
-> **Inbound UAS only.** SiphonAI v0.1.0 is a UAS — it terminates
-> inbound TLS connections and writes responses back over the
-> established socket. Originating a new outbound TLS connection
-> (UAC mode) is not supported and will return a clear error to the
-> transaction manager rather than silently downgrading to UDP.
+> **Inbound UAS + outbound UAC for REGISTER.** SiphonAI terminates
+> inbound TLS for SIP signaling at this listener (v0.1.0). Outbound
+> TLS is supported for the UAC's `[[register]]` path as of 0.3.0 —
+> registrations with `transport = "tls"` actually go out over TLS
+> (see [`docs/REGISTRATION.md`](REGISTRATION.md)). Outbound TLS for
+> originated INVITEs is post-v1 per CLAUDE.md §8.
 
 ### `[sip.call_progress]`
 

--- a/docs/REGISTRATION.md
+++ b/docs/REGISTRATION.md
@@ -57,17 +57,64 @@ drive task. Names must be unique.
 - Lifecycle webhook (`registration_state_changed`) on every transition.
 - Prometheus metrics (`siphon_ai_register_state`, `siphon_ai_register_attempts_total`).
 
-## What v1 does NOT support (yet)
+## TLS registration (0.3.0+)
 
-- DNS-resolved registrar hostnames. v1 accepts literal IPv4 addresses only;
-  hostnames produce a clear error at config-load time. SRV/NAPTR-driven
-  failover lives in v1.1.
-- SIGHUP reload of registrations. The set is static for the daemon's
+To register over `sips:` (RFC 3261 §26.2.1), set `transport = "tls"`:
+
+```toml
+[[register]]
+name      = "carrier-secure"
+server    = "203.0.113.42"   # literal IP (hostnames are 0.3.1, see below)
+port      = 5061              # default for TLS
+transport = "tls"
+username  = "siphon"
+password  = "${REGISTRAR_PASSWORD}"
+```
+
+What this gets you:
+
+- The daemon's `IntegratedUAC` builds a `sips:` URI from `server`/`port`
+  and dispatches the REGISTER over the TLS transport that siphon-rs's
+  `sip-transport` (W1 PR siphon-rs#49) negotiates. **No fallback to UDP.**
+- Trust uses the daemon-wide TLS client roots — currently the
+  `webpki-roots` Mozilla CA bundle baked into the binary. Same trust
+  store the bridge WS leg uses by default (see
+  [`docs/DEPLOY.md`](DEPLOY.md) §3a).
+- mTLS: if your carrier requires a client cert for SIP-side TLS, the
+  daemon presents the same `[sip.tls]` cert it uses for inbound — there
+  is no separate `[[register]].tls` client cert in 0.3.0.
+
+### Twilio Elastic SIP Trunk example
+
+Twilio's secure SIP runs on `:5061` over TLS; bind via the regional
+edge IP returned by their portal (the public hostname uses anycast,
+so picking one IP at config time keeps the registrar stable):
+
+```toml
+[[register]]
+name      = "twilio-secure"
+server    = "54.172.60.0"
+port      = 5061
+transport = "tls"
+username  = "your-trunk-username"
+password  = "${TWILIO_TRUNK_PASSWORD}"
+```
+
+## What 0.3.0 still does NOT support
+
+- **DNS-resolved registrar hostnames.** Configs still accept literal
+  IPv4 / IPv6 addresses only; hostnames produce a clear error at
+  config-load time. The runtime resolver in `sip-dns` exists but the
+  static IP requirement keeps config validation simple and
+  startup-deterministic. SRV/NAPTR-driven failover (RFC 3263
+  `_sips._tcp`) and hostname registrars are 0.3.1+.
+- **SIGHUP reload of registrations.** The set is static for the daemon's
   lifetime; restart to add/remove/edit a `[[register]]` block.
-- Per-registration TLS client roots. The daemon's webpki trust store applies
-  to all TLS registrations.
-- Outbound TCP/TLS connect from the UAC for registrations on those
-  transports. v1 sends REGISTER over UDP regardless of `transport = "tcp"|"tls"`.
+- **Per-registration cert pinning.** All TLS registrations share the
+  daemon-wide webpki trust store. SPKI pinning on a per-`[[register]]`
+  basis (the `[[register]].tls.pinned_sha256` shape the dev plan
+  sketches) needs an siphon-rs API to install a per-target
+  `ClientConfig` and isn't done. 0.3.1+ follow-up.
 
 ## Observability
 


### PR DESCRIPTION
DEV_PLAN_0.3.0.md §4.5. The wire-level TLS REGISTER path was already wired via [siphon-rs#49 (swappable TLS)](https://github.com/thevoiceguy/siphon-rs/pull/49) + the existing \`registration.rs\` \`sips:\` URI construction. This PR closes the docs gap and surfaces what's still deferred.

## What this updates

### \`docs/REGISTRATION.md\`

- New **"TLS registration (0.3.0+)"** section with a Twilio Elastic SIP Trunk example. Documents the \`transport = "tls"\` shape and what trust store the daemon uses (webpki-roots + the same \`[sip.tls]\` client cert from inbound).
- Replaces the stale **"v1 sends REGISTER over UDP regardless of transport"** claim — TLS REGISTER actually goes out over TLS now; no UDP fallback. Confirmed by reading \`bins/siphon-ai/src/registration.rs::registrar_target\` which builds a \`sips:\` URI for \`SipTransport::Tls\`, and sip-uac's \`register()\` which routes through \`resolve_target\` → \`send_non_invite_request\` honouring the resolved transport.
- Documents the 0.3.0 limitations honestly: literal IPs only for \`server\`, no per-registration cert pinning, no SIGHUP reload — all 0.3.1+ follow-ups.

### \`docs/CONFIG.md\` \`[sip.tls]\` callout

The old **"Inbound UAS only … originating a new outbound TLS connection (UAC mode) is not supported"** warning was stale (predates siphon-rs swappable-TLS). Replaced with a precise statement: inbound UAS still terminates TLS here; outbound TLS is supported for \`[[register]]\` (UAC) as of 0.3.0; outbound TLS for originated INVITEs is post-v1 per CLAUDE.md §8.

## What's still NOT supported in 0.3.0

Documented in REGISTRATION.md so operators have an honest picture:

- **DNS-resolved registrar hostnames** (the \`_sips._tcp\` SRV form the plan calls for). The static-IP requirement in \`compile.rs::compile_registers\` is still in force — lifting it needs touching \`RegisterConfig.server_addr: SocketAddr\` which fans out across sip-glue. 0.3.1.
- **Per-registration cert pinning** (\`[[register]].tls.pinned_sha256\`). siphon-rs's UAC takes a daemon-wide TLS client config and doesn't yet expose a per-target \`ClientConfig\` API. 0.3.1.

## Verification

- \`cargo build --workspace\` clean.
- \`cargo test --workspace\`: **463 passed, 0 failed** (no code changes — same tally as W4 Part A).

## Coordinates with

- W4 Part A ([siphon-ai#90](https://github.com/thevoiceguy/siphon-ai/pull/90)) — mTLS for the WS bridge leg.
- [siphon-rs#49](https://github.com/thevoiceguy/siphon-rs/pull/49) — swappable TLS, the wire-level enabler.
- [siphon-ai DEV_PLAN_0.3.0.md §4.5](https://github.com/thevoiceguy/siphon-ai/blob/main/docs/DEV_PLAN_0.3.0.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)