### PR TITLE
chore: 0.3.0 release prep (CHANGELOG + version bump + SIGHUP fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,207 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-26
+
+Third release. Theme: **trust and encryption** — every transport
+the daemon touches can now run encrypted. SIP/TLS gets hot cert
+reload (no in-flight call drops on renewal). The WebSocket bridge
+gets mTLS with optional SPKI cert pinning. Inbound calls offering
+DTLS-SRTP get a SAVPF answer end-to-end (forge handles the
+handshake, derives SRTP keys, decrypts media). RTP-quality events
+(`jitter_ms`, `packet_loss_ratio`, and an `rtcp_rtt_ms` field
+reserved for 0.3.1) now actually populate.
+
+Protocol stays at `version: "1"` — every new variant is additive,
+so v1 WS servers built against 0.1.0 / 0.2.0 keep working
+unchanged. The wire-shape additions land *behind* the new config
+defaults: out of the box, 0.3.0 behaves like 0.2.0.
+
+### Added
+
+#### Encryption
+
+- **DTLS-SRTP for inbound calls** (PROTOCOL §3.1 `start.srtp`,
+  DEV_PLAN_0.3.0.md §4.1). When the offer's audio m-line is
+  `UDP/TLS/RTP/SAVPF` and `[media].srtp` is `"preferred"` or
+  `"required"`, the daemon:
+  1. extracts the remote `a=fingerprint:` + `a=setup:` from the
+     offer,
+  2. answers `UDP/TLS/RTP/SAVPF` with our own SHA-256 fingerprint
+     and `a=setup:passive` (RFC 5763 §5),
+  3. provisions the DTLS leg on the per-call `MediaSession`,
+     forge-engine's recv loop demuxes the inbound DTLS handshake
+     (RFC 5764 §5.1.2 first-byte demux),
+  4. on handshake completion, the derived SRTP master keys
+     install into the existing `SrtpContext` and subsequent SRTP
+     packets decode through the ordinary unprotect path.
+
+  `start.srtp` is populated with `{exchange: "dtls", profile:
+  "AES_CM_128_HMAC_SHA1_80"}` — the profile is best-guess
+  pre-handshake (RFC 5764 mandates that suite as baseline; the
+  actual negotiation may select a stronger AES-GCM suite).
+
+  Long-lived per-process DTLS cert generated at daemon startup
+  (rcgen). Same cert presented to every DTLS handshake; rotation
+  is via daemon restart (or `systemctl reload` on the SIP/TLS
+  side — DTLS-SRTP cert rotation is intentionally NOT exposed,
+  since rotating it mid-call would invalidate in-flight handshakes).
+
+  SDES (`RTP/SAVP` / `RTP/SAVPF`) offers are rejected with 488 —
+  forge-sdp ships the `a=crypto:` parser but the forge-engine
+  producer wiring isn't done. 0.3.1.
+
+- **`[media].srtp` config + policy gate**. New
+  `[media].srtp = "off" | "preferred" | "required"` (default
+  `"off"`, matches 0.2.0). Per-route override via
+  `[route.media].srtp`. The policy matrix is enforced before any
+  media bring-up — incompatible offers fail fast with 488:
+
+  | Mode | Plaintext (`RTP/AVP`) | DTLS-SRTP | SDES |
+  |---|---|---|---|
+  | `off` | ✓ | 488 | 488 |
+  | `preferred` | ✓ | ✓ | 488 |
+  | `required` | 488 | ✓ | 488 |
+
+  Resolution via `resolve_srtp_mode(defaults, route)` mirrors the
+  other `resolve_*` helpers; unknown route-level values warn and
+  fall back to defaults.
+
+- **mTLS for the bridge WebSocket leg** (`[bridge.tls]` block,
+  DEV_PLAN_0.3.0.md §4.2 Part A, `docs/DEPLOY.md` §3a). New
+  config:
+
+  ```toml
+  [bridge.tls]
+  client_cert    = "/etc/siphon-ai/bridge/client.pem"
+  client_key     = "/etc/siphon-ai/bridge/client.key"
+  pinned_sha256  = "..."   # optional 64-hex-char SPKI SHA-256
+  ```
+
+  Builds a custom `rustls::ClientConfig` and hands it to
+  `tokio-tungstenite`'s `Connector::Rustls`. The optional SPKI
+  pin (SHA-256 of the server's `SubjectPublicKeyInfo` per
+  RFC 7469 §3) replaces default CA verification with exact-match,
+  appropriate for carrier-pinned PBX deployments. Cert / key /
+  pin validation happens at config compile so issues surface at
+  daemon startup, not at first call.
+
+- **Outbound TLS UAC for REGISTER** (DEV_PLAN_0.3.0.md §4.5,
+  `docs/REGISTRATION.md` "TLS registration"). `transport = "tls"`
+  on a `[[register]]` block now actually goes out over TLS — no
+  silent fallback to UDP. Uses the daemon-wide webpki trust
+  store (Mozilla CA bundle). Twilio Elastic SIP Trunk recipe in
+  `REGISTRATION.md`. The stale "Inbound UAS only" disclaimer in
+  `CONFIG.md` is removed.
+
+- **SIGHUP hot cert reload for SIP/TLS** (DEV_PLAN_0.3.0.md
+  §4.3). `systemctl reload siphon-ai` rotates `[sip.tls].cert` +
+  `.key` without dropping in-flight TLS sessions. In-flight
+  dialogs keep using the cert they handshook with
+  (RFC 5746-compliant); new connections pick up the fresh cert.
+  Broken PEM on reload doesn't kill the daemon — `error!`
+  logged, previous cert keeps serving. New metric
+  `siphon_ai_sip_tls_reload_attempts_total{outcome}`. systemd
+  `ExecReload=/bin/kill -HUP $MAINPID`. Builds on siphon-rs's
+  `run_tls_with_swappable_config` (#49).
+
+#### Observability
+
+- **`rtp_stats` event fields populate** (PROTOCOL §3.8,
+  DEV_PLAN_0.3.0.md §4.4). `jitter_ms` and `packet_loss_ratio`
+  are now driven by a new `ForgeEvent::RtcpReportReceived` event
+  forge-engine emits on every received RR (forge-media#57 +
+  #60). Closes the pre-existing 0.2.0 gap where both fields were
+  always `null`. New `siphon_ai_rtp_rtt_ms` histogram alongside
+  the existing jitter / loss histograms.
+
+- **`rtcp_rtt_ms` field reserved + sticky semantics** in
+  PROTOCOL §3.8. The field is documented and the wire shape is
+  pinned, but stays `null` in 0.3.0 — populating it needs
+  forge-engine to originate its own RTCP SRs (the
+  `forge_rtp::RttTracker` primitive is ready and tested in
+  forge-media#57). When a real value does arrive in a future
+  release, it'll be "sticky": once populated, a later window
+  with no fresh RR doesn't wipe it.
+
+### Changed
+
+- **`forge-media` rev pinned to `f7cd7f0`**, picking up DTLS-SRTP
+  scaffolding (#61), recv-loop demux (#62), RtcpReportReceived
+  event + emitter (#57 + #60), SDES primitives (#56), tarpaulin
+  coverage fix (#59).
+
+- **`siphon-rs` rev pinned to `d0d3691`**, picking up swappable
+  TLS `ServerConfig` (#49) and CI-on-PR gating (#50).
+
+- **`[sip.tls]` callout in `docs/CONFIG.md`** — old "Inbound UAS
+  only" warning replaced with a precise statement: inbound UAS
+  still terminates TLS here; outbound TLS works for
+  `[[register]]` as of 0.3.0; originated INVITEs are still
+  post-v1.
+
+### Fixed
+
+- **forge-rtp DTLS verify-callback** (forge-media#61). The
+  existing `DtlsContext::new` installed OpenSSL's default
+  chain-verify mode, which fails closed on self-signed certs —
+  which is what every DTLS-SRTP peer presents (RFC 5763 §5).
+  Replaced with a `set_verify_callback` that accepts any chain;
+  fingerprint verification runs post-handshake as before. Makes
+  the entire DTLS path actually usable for the first time.
+
+- **forge-media Code Coverage** (forge-media#59). Tarpaulin
+  failures on every PR since 2026-05-11 fixed: one missing
+  feature gate (`test_codec_config_stored` needed
+  `#[cfg(feature = "opus")]`) + one timing-tight assertion in
+  `test_jitter_buffer_timing` that fell over under ptrace
+  instrumentation. Three pre-existing dead-code `opus` tests in
+  `forge-api` now actually run thanks to a new
+  `forge-api/opus` feature.
+
+### Known limitations (0.3.1 carry-forwards)
+
+These are documented in `DEV_PLAN_0.3.0.md` §11 slip-mitigation,
+`PROTOCOL.md`, and `REGISTRATION.md`:
+
+- **`rtcp_rtt_ms` not populated end-to-end.** The field is
+  reserved and the consumer wiring works, but forge-engine
+  doesn't yet originate its own RTCP SRs. The `RttTracker`
+  primitive is ready upstream; what's missing is the periodic
+  SR send loop with RFC 3550 §6.2 bandwidth budget tracking.
+
+- **SDES (`RTP/SAVP`) not produced.** forge-sdp ships the
+  `a=crypto:` parser (forge-media#56); forge-engine doesn't
+  consume it yet. SAVP / non-DTLS SAVPF offers are 488'd under
+  any `srtp_mode`.
+
+- **Per-route `[route.bridge.tls]` override.** mTLS for the
+  bridge is global only in 0.3.0; every accepted call shares
+  the same client cert.
+
+- **Hostname `[[register]].server`.** Static-IP validation in
+  `compile_registers` still rejects hostnames; lifting it needs
+  a `RegisterConfig.server_addr: SocketAddr` refactor.
+
+- **Per-registration cert pinning** (`[[register]].tls.pinned_sha256`).
+  siphon-rs's UAC takes a daemon-wide TLS client config and
+  doesn't yet expose a per-target `ClientConfig` API.
+
+- **Attended transfer (REFER with Replaces)** carried over from
+  0.2.0 — depends on a siphon-rs UAC capability that's still
+  pending.
+
+### Stats
+
+- 8 PRs merged on siphon-ai for 0.3.0: #83, #85, #86, #87, #88,
+  #89, #90, #91, #92.
+- 6 upstream PRs merged on forge-media: #56, #57, #59, #60, #61,
+  #62.
+- 2 upstream PRs merged on siphon-rs: #49, #50.
+- Workspace test count: 429 → 466 (+37 new tests across the
+  sprint; every PR landed with `fmt --check` + `clippy
+  --workspace --all-targets -- -D warnings` clean).
+
 ## [0.2.0] - 2026-05-25
 
 Second release. Theme: **operator primitives** — the WS server can

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2862,7 +2862,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64",
  "bytes",
@@ -2882,7 +2882,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2899,7 +2899,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "regex",
  "serde",
@@ -2914,7 +2914,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2950,7 +2950,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -2965,7 +2965,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2986,7 +2986,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "regex",
  "serde",
@@ -2997,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3020,7 +3020,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3041,7 +3041,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -306,9 +306,14 @@ impl Runtime {
         // semantics match: same cert/key paths, same key-pair
         // validation, just performed on every SIGHUP rather than only
         // at startup.
-        if let (Some(swap), Some(tls)) = (tls_server_config.as_ref(), sip.tls.as_ref()) {
-            spawn_sighup_reloader(tls.clone(), Arc::clone(swap));
-        }
+        // Always install a SIGHUP handler at startup. The default
+        // Unix disposition for SIGHUP is *terminate the process* —
+        // if we don't claim the signal, `systemctl reload
+        // siphon-ai` on a non-TLS deployment would kill the daemon.
+        // When TLS is configured the handler does the cert reload;
+        // when it isn't, the handler is a no-op (just consumes the
+        // signal so it doesn't fire the default action).
+        spawn_sighup_handler(sip.tls.clone(), tls_server_config.clone());
 
         // ─── Integrated UAS ────────────────────────────────────────
         let local_uri = sip_local_uri(&node, &sip);
@@ -738,6 +743,56 @@ fn load_sip_tls_server_config(
         "TLS server config loaded"
     );
     Ok(cfg)
+}
+
+/// Install the daemon's SIGHUP handler. Always installed —
+/// claiming the signal prevents the default Unix disposition
+/// (process termination) from firing when an operator runs
+/// `systemctl reload siphon-ai` against a deployment that doesn't
+/// enable TLS.
+///
+/// `tls` + `swappable` are `Some` together (both required for hot
+/// reload to do anything) or `None` together (handler is a no-op
+/// signal consumer). Mixed states fall back to no-op with a `warn!`
+/// — they shouldn't happen, but the daemon doesn't crash if they do.
+fn spawn_sighup_handler(
+    tls: Option<SipTlsConfig>,
+    swappable: Option<Arc<arc_swap::ArcSwap<tokio_rustls::rustls::ServerConfig>>>,
+) {
+    match (tls, swappable) {
+        (Some(tls), Some(swap)) => spawn_sighup_reloader(tls, swap),
+        (None, None) => spawn_sighup_noop(),
+        _ => {
+            warn!(
+                "inconsistent SIGHUP wiring (one of tls/swappable is set, the other isn't); \
+                 falling back to no-op handler"
+            );
+            spawn_sighup_noop();
+        }
+    }
+}
+
+/// No-op SIGHUP consumer for deployments without TLS. Just claims
+/// the signal so the default "terminate" disposition doesn't fire.
+fn spawn_sighup_noop() {
+    use tokio::signal::unix::{signal, SignalKind};
+    tokio::spawn(async move {
+        let mut stream = match signal(SignalKind::hangup()) {
+            Ok(s) => s,
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    "failed to install no-op SIGHUP handler; daemon may terminate on \
+                     `systemctl reload` until TLS is configured",
+                );
+                return;
+            }
+        };
+        info!("SIGHUP handler installed (no TLS configured; signal is a no-op)");
+        while stream.recv().await.is_some() {
+            info!("SIGHUP received but no TLS configured; ignoring");
+        }
+    });
 }
 
 /// Install a SIGHUP handler that hot-reloads the SIP/TLS cert.


### PR DESCRIPTION
W6 of the 0.3.0 sprint. **Do not merge until deep testing is complete** — this PR is the release-prep payload; the actual \`v0.3.0\` tag + GitHub release follow after the verification pass.

## What this ships

### \`CHANGELOG.md\` 0.3.0 entry
Grouped by feature area — **Encryption** (DTLS-SRTP E2E + \`[bridge.tls]\` mTLS + TLS REGISTER + SIGHUP cert reload), **Observability** (\`rtp_stats\` actually populates), **Changed** (forge-media \`f7cd7f0\` + siphon-rs \`d0d3691\`), **Fixed** (forge-rtp DTLS verify-callback, tarpaulin Code Coverage), **Known limitations** (0.3.1 carry-forwards), and stats (8 siphon-ai + 6 forge-media + 2 siphon-rs PRs; tests 429 → 466).

### Workspace version 0.2.0 → 0.3.0
Single \`workspace.package.version\` edit; all 11 crates inherit.

### Bug fix: no-op SIGHUP handler when TLS is off
Surfaced by the smoke test in this PR. Pre-fix: a no-TLS daemon gets killed by \`systemctl reload\` because the default Unix SIGHUP disposition is \"terminate\", and W5's reloader only installs when \`[sip.tls]\` is configured. Fix: \`spawn_sighup_handler\` always installs a signal consumer at startup. When TLS is set, it's the reload task; when not, it's a no-op consumer that logs \`INFO\` and ignores the signal.

## Verification (CI-equivalent)

| Gate | Result |
|---|---|
| \`cargo build --workspace\` | ✅ |
| \`cargo test --workspace\` | ✅ 466 passed |
| \`cargo fmt --all -- --check\` | ✅ |
| \`cargo clippy --workspace --all-targets -- -D warnings\` | ✅ |
| **Smoke test** (start, SIGHUP, SIGTERM with no-TLS config) | ✅ daemon survives SIGHUP |
| **SIPp suite** (\`run-all.sh\` with echo WS on 127.0.0.1:8765) | ✅ **all 7 scenarios passed** |

## Before tagging — operator's deep testing pass

The testing plan picks up from here. Suggested coverage:

- Place a real call through a DTLS-SRTP-offering peer (e.g., WebRTC bridge). Confirm \`start.srtp = {exchange: \"dtls\", ...}\` lands and audio decodes both directions.
- Configure \`[bridge.tls]\` with a real WS server's client cert, with and without \`pinned_sha256\`. Confirm WS handshake.
- \`transport = \"tls\"\` on a \`[[register]]\` against a live TLS registrar (Twilio Elastic Secure SIP Trunk works per REGISTRATION.md). Confirm registration completes over TLS, not UDP.
- Mid-call \`systemctl reload siphon-ai\` against a SIP/TLS deployment. Confirm: in-flight call stays up; new calls present the renewed cert.
- \`rtp_stats\` events on a longer-running call. Confirm \`jitter_ms\` + \`packet_loss_ratio\` populate; \`rtcp_rtt_ms\` stays \`null\` (expected for 0.3.0).

## Not in this PR

- \`v0.3.0\` git tag.
- GitHub release.
- README.md status flip (0.2.0 → 0.3.0).

These land after testing passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)