### PR TITLE
chore(deps): bump siphon-rs to pick up Record-Route fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`200 OK` to INVITE now carries the request's `Record-Route` headers** — picked up via a siphon-rs bump (`d0d3691244de` → `47cd5d39c7d6`, [thevoiceguy/siphon-rs#51](https://github.com/thevoiceguy/siphon-rs/pull/51)). The UAS response builder previously dropped every `Record-Route` from the INVITE, in violation of RFC 3261 §12.1.1. Subsequent in-dialog requests (ACK / BYE / re-INVITE / REFER) routed straight to the UAS's `Contact` instead of traversing the proxy chain — silent under carriers like Twilio (whose edge tolerates direct-to-Contact in-dialog routing), but a latent dialog-killer behind stricter SBCs or multi-proxy topologies. No SiphonAI-side code change; the fix is entirely in the upstream UAS builder.
+
 ## [0.3.0] - 2026-05-26
 
 Third release. Theme: **trust and encryption** — every transport

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2610,7 +2610,7 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 [[package]]
 name = "sip-auth"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=d0d3691244de#d0d3691244de5c0769853a62111f56ac3a0f7f83"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=47cd5d39c7d6#47cd5d39c7d6e9334612c03281a86d884e233ed9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2633,7 +2633,7 @@ dependencies = [
 [[package]]
 name = "sip-core"
 version = "0.7.6"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=d0d3691244de#d0d3691244de5c0769853a62111f56ac3a0f7f83"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=47cd5d39c7d6#47cd5d39c7d6e9334612c03281a86d884e233ed9"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2646,7 +2646,7 @@ dependencies = [
 [[package]]
 name = "sip-dialog"
 version = "0.3.3"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=d0d3691244de#d0d3691244de5c0769853a62111f56ac3a0f7f83"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=47cd5d39c7d6#47cd5d39c7d6e9334612c03281a86d884e233ed9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2664,7 +2664,7 @@ dependencies = [
 [[package]]
 name = "sip-dns"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=d0d3691244de#d0d3691244de5c0769853a62111f56ac3a0f7f83"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=47cd5d39c7d6#47cd5d39c7d6e9334612c03281a86d884e233ed9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2678,7 +2678,7 @@ dependencies = [
 [[package]]
 name = "sip-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=d0d3691244de#d0d3691244de5c0769853a62111f56ac3a0f7f83"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=47cd5d39c7d6#47cd5d39c7d6e9334612c03281a86d884e233ed9"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -2689,7 +2689,7 @@ dependencies = [
 [[package]]
 name = "sip-observe"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=d0d3691244de#d0d3691244de5c0769853a62111f56ac3a0f7f83"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=47cd5d39c7d6#47cd5d39c7d6e9334612c03281a86d884e233ed9"
 dependencies = [
  "once_cell",
  "tracing",
@@ -2698,7 +2698,7 @@ dependencies = [
 [[package]]
 name = "sip-parse"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=d0d3691244de#d0d3691244de5c0769853a62111f56ac3a0f7f83"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=47cd5d39c7d6#47cd5d39c7d6e9334612c03281a86d884e233ed9"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2712,7 +2712,7 @@ dependencies = [
 [[package]]
 name = "sip-ratelimit"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=d0d3691244de#d0d3691244de5c0769853a62111f56ac3a0f7f83"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=47cd5d39c7d6#47cd5d39c7d6e9334612c03281a86d884e233ed9"
 dependencies = [
  "dashmap 5.5.3",
  "parking_lot",
@@ -2723,7 +2723,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=d0d3691244de#d0d3691244de5c0769853a62111f56ac3a0f7f83"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=47cd5d39c7d6#47cd5d39c7d6e9334612c03281a86d884e233ed9"
 dependencies = [
  "nom",
  "smol_str",
@@ -2741,7 +2741,7 @@ dependencies = [
 [[package]]
 name = "sip-transaction"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=d0d3691244de#d0d3691244de5c0769853a62111f56ac3a0f7f83"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=47cd5d39c7d6#47cd5d39c7d6e9334612c03281a86d884e233ed9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2760,7 +2760,7 @@ dependencies = [
 [[package]]
 name = "sip-transport"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=d0d3691244de#d0d3691244de5c0769853a62111f56ac3a0f7f83"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=47cd5d39c7d6#47cd5d39c7d6e9334612c03281a86d884e233ed9"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2780,7 +2780,7 @@ dependencies = [
 [[package]]
 name = "sip-uac"
 version = "0.4.2"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=d0d3691244de#d0d3691244de5c0769853a62111f56ac3a0f7f83"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=47cd5d39c7d6#47cd5d39c7d6e9334612c03281a86d884e233ed9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2793,7 +2793,7 @@ dependencies = [
  "sip-dialog",
  "sip-dns",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=d0d3691244de)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=47cd5d39c7d6)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -2805,7 +2805,7 @@ dependencies = [
 [[package]]
 name = "sip-uas"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=d0d3691244de#d0d3691244de5c0769853a62111f56ac3a0f7f83"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=47cd5d39c7d6#47cd5d39c7d6e9334612c03281a86d884e233ed9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2815,7 +2815,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=d0d3691244de)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=47cd5d39c7d6)",
  "sip-transaction",
  "sip-transport",
  "smol_str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,16 +102,16 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 # main branch and replace the rev hashes here (see CLAUDE.md §7.5).
 
 # siphon-rs — RFC 3261 SIP stack
-sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "d0d3691244de" }
-sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "d0d3691244de" }
-sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "d0d3691244de", features = ["tls"] }
-sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "d0d3691244de" }
-sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "d0d3691244de" }
-sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "d0d3691244de" }
-sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "d0d3691244de" }
-sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "d0d3691244de" }
-sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "d0d3691244de" }
-sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "d0d3691244de" }
+sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "47cd5d39c7d6" }
+sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "47cd5d39c7d6" }
+sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "47cd5d39c7d6", features = ["tls"] }
+sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "47cd5d39c7d6" }
+sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "47cd5d39c7d6" }
+sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "47cd5d39c7d6" }
+sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "47cd5d39c7d6" }
+sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "47cd5d39c7d6" }
+sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "47cd5d39c7d6" }
+sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "47cd5d39c7d6" }
 
 # forge-media — RTP / codecs / SDP / DTMF / engine.
 #


### PR DESCRIPTION
## Summary

- Bumps the 10 `siphon-*` workspace deps from `d0d3691244de` → `47cd5d39c7d6`.
- Pulls in [thevoiceguy/siphon-rs#51](https://github.com/thevoiceguy/siphon-rs/pull/51), which fixes a RFC 3261 §12.1.1 violation: the UAS response builder was dropping every `Record-Route` header from request → response.
- `CHANGELOG.md` entry added under `[Unreleased] → Fixed`.

## Why

Spotted while inspecting a real Twilio inbound. Every Twilio PSTN INVITE carries `Record-Route: <sip:<edge>;lr>`, but our 200 OK had none — so subsequent in-dialog requests (ACK / BYE / re-INVITE / REFER) routed directly to our `Contact`, bypassing Twilio's edge. Calls survived because Twilio tolerates that, but the same setup behind any stricter SBC or multi-proxy carrier topology would silently drop dialogs mid-call.

No SiphonAI-side code change needed; the fix is entirely in the upstream UAS builder.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace` — all green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] (Optional, reviewer) sngrep a Twilio inbound after deploy and confirm `Record-Route: <sip:54.244.51.1;lr>` appears in the outgoing 200 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)