### PR TITLE
chore(deps): bump siphon-rs to pick up §13/§20 response polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Responses now emit `Server:` instead of `User-Agent:`, advertise `Allow:` on 2xx to INVITE, and omit empty `Supported:` on OPTIONS 200 OK** — picked up via a siphon-rs bump (`47cd5d39c7d6` → `a4f8521561d6`, [thevoiceguy/siphon-rs#52](https://github.com/thevoiceguy/siphon-rs/pull/52)). Three independent RFC 3261 §13/§20 polish items: (1) §20.41 / §20.50 — responses identify the UAS via `Server:`, requests use `User-Agent:` (we were emitting the latter on responses; carriers tolerated it but it confused header-name-strict SIP analysers); (2) §13.2.1 — 2xx to INVITE SHOULD advertise the methods the UAS supports so the peer learns what mid-dialog requests (re-INVITE / UPDATE / REFER / INFO) are legal without an OPTIONS probe; (3) §20.37 — an empty `Supported:` value implies nothing useful and some peers treat the blank as a parse oddity. No SiphonAI-side code change.
+
 - **`200 OK` to INVITE now carries the request's `Record-Route` headers** — picked up via a siphon-rs bump (`d0d3691244de` → `47cd5d39c7d6`, [thevoiceguy/siphon-rs#51](https://github.com/thevoiceguy/siphon-rs/pull/51)). The UAS response builder previously dropped every `Record-Route` from the INVITE, in violation of RFC 3261 §12.1.1. Subsequent in-dialog requests (ACK / BYE / re-INVITE / REFER) routed straight to the UAS's `Contact` instead of traversing the proxy chain — silent under carriers like Twilio (whose edge tolerates direct-to-Contact in-dialog routing), but a latent dialog-killer behind stricter SBCs or multi-proxy topologies. No SiphonAI-side code change; the fix is entirely in the upstream UAS builder.
 
 ## [0.3.0] - 2026-05-26

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2610,7 +2610,7 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 [[package]]
 name = "sip-auth"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=47cd5d39c7d6#47cd5d39c7d6e9334612c03281a86d884e233ed9"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a4f8521561d6#a4f8521561d60db31103c1cf41d1c4ed14cde114"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2633,7 +2633,7 @@ dependencies = [
 [[package]]
 name = "sip-core"
 version = "0.7.6"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=47cd5d39c7d6#47cd5d39c7d6e9334612c03281a86d884e233ed9"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a4f8521561d6#a4f8521561d60db31103c1cf41d1c4ed14cde114"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2646,7 +2646,7 @@ dependencies = [
 [[package]]
 name = "sip-dialog"
 version = "0.3.3"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=47cd5d39c7d6#47cd5d39c7d6e9334612c03281a86d884e233ed9"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a4f8521561d6#a4f8521561d60db31103c1cf41d1c4ed14cde114"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2664,7 +2664,7 @@ dependencies = [
 [[package]]
 name = "sip-dns"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=47cd5d39c7d6#47cd5d39c7d6e9334612c03281a86d884e233ed9"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a4f8521561d6#a4f8521561d60db31103c1cf41d1c4ed14cde114"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2678,7 +2678,7 @@ dependencies = [
 [[package]]
 name = "sip-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=47cd5d39c7d6#47cd5d39c7d6e9334612c03281a86d884e233ed9"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a4f8521561d6#a4f8521561d60db31103c1cf41d1c4ed14cde114"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -2689,7 +2689,7 @@ dependencies = [
 [[package]]
 name = "sip-observe"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=47cd5d39c7d6#47cd5d39c7d6e9334612c03281a86d884e233ed9"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a4f8521561d6#a4f8521561d60db31103c1cf41d1c4ed14cde114"
 dependencies = [
  "once_cell",
  "tracing",
@@ -2698,7 +2698,7 @@ dependencies = [
 [[package]]
 name = "sip-parse"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=47cd5d39c7d6#47cd5d39c7d6e9334612c03281a86d884e233ed9"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a4f8521561d6#a4f8521561d60db31103c1cf41d1c4ed14cde114"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2712,7 +2712,7 @@ dependencies = [
 [[package]]
 name = "sip-ratelimit"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=47cd5d39c7d6#47cd5d39c7d6e9334612c03281a86d884e233ed9"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a4f8521561d6#a4f8521561d60db31103c1cf41d1c4ed14cde114"
 dependencies = [
  "dashmap 5.5.3",
  "parking_lot",
@@ -2723,7 +2723,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=47cd5d39c7d6#47cd5d39c7d6e9334612c03281a86d884e233ed9"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a4f8521561d6#a4f8521561d60db31103c1cf41d1c4ed14cde114"
 dependencies = [
  "nom",
  "smol_str",
@@ -2741,7 +2741,7 @@ dependencies = [
 [[package]]
 name = "sip-transaction"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=47cd5d39c7d6#47cd5d39c7d6e9334612c03281a86d884e233ed9"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a4f8521561d6#a4f8521561d60db31103c1cf41d1c4ed14cde114"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2760,7 +2760,7 @@ dependencies = [
 [[package]]
 name = "sip-transport"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=47cd5d39c7d6#47cd5d39c7d6e9334612c03281a86d884e233ed9"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a4f8521561d6#a4f8521561d60db31103c1cf41d1c4ed14cde114"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2780,7 +2780,7 @@ dependencies = [
 [[package]]
 name = "sip-uac"
 version = "0.4.2"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=47cd5d39c7d6#47cd5d39c7d6e9334612c03281a86d884e233ed9"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a4f8521561d6#a4f8521561d60db31103c1cf41d1c4ed14cde114"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2793,7 +2793,7 @@ dependencies = [
  "sip-dialog",
  "sip-dns",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=47cd5d39c7d6)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=a4f8521561d6)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -2805,7 +2805,7 @@ dependencies = [
 [[package]]
 name = "sip-uas"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=47cd5d39c7d6#47cd5d39c7d6e9334612c03281a86d884e233ed9"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a4f8521561d6#a4f8521561d60db31103c1cf41d1c4ed14cde114"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2815,7 +2815,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=47cd5d39c7d6)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=a4f8521561d6)",
  "sip-transaction",
  "sip-transport",
  "smol_str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,16 +102,16 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 # main branch and replace the rev hashes here (see CLAUDE.md §7.5).
 
 # siphon-rs — RFC 3261 SIP stack
-sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "47cd5d39c7d6" }
-sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "47cd5d39c7d6" }
-sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "47cd5d39c7d6", features = ["tls"] }
-sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "47cd5d39c7d6" }
-sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "47cd5d39c7d6" }
-sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "47cd5d39c7d6" }
-sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "47cd5d39c7d6" }
-sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "47cd5d39c7d6" }
-sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "47cd5d39c7d6" }
-sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "47cd5d39c7d6" }
+sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a4f8521561d6" }
+sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a4f8521561d6" }
+sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a4f8521561d6", features = ["tls"] }
+sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a4f8521561d6" }
+sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a4f8521561d6" }
+sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a4f8521561d6" }
+sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a4f8521561d6" }
+sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a4f8521561d6" }
+sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a4f8521561d6" }
+sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a4f8521561d6" }
 
 # forge-media — RTP / codecs / SDP / DTMF / engine.
 #


### PR DESCRIPTION
## Summary

- Bumps the 10 `siphon-*` workspace deps from `47cd5d39c7d6` → `a4f8521561d6`.
- Pulls in [thevoiceguy/siphon-rs#52](https://github.com/thevoiceguy/siphon-rs/pull/52): three RFC 3261 §13/§20 response-side polish items.
- `CHANGELOG.md` entry added under `[Unreleased] → Fixed`.

## What the upstream PR fixes

1. **`Server:` instead of `User-Agent:` on responses** (§20.41 / §20.50) — responses identify the UAS via `Server:`; `User-Agent:` is request-only.
2. **`Allow:` advertised on 2xx to INVITE** (§13.2.1) — backfilled from the installed handler's `allow_header()` so peers know what mid-dialog methods (re-INVITE / UPDATE / REFER / INFO) are legal without an OPTIONS probe.
3. **No empty `Supported:` on OPTIONS 200 OK** (§20.37) — absence is the correct default for a UAS with no extensions to advertise.

None of these were interop-breaking; carriers tolerated the old behaviour. But the wire is now spec-correct end-to-end and strict SIP analysers (sngrep, Wireshark `sip.Server` filters) will see the right header names.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace` — all green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] (Optional, reviewer) sngrep a Twilio inbound after deploy — confirm `Server: siphon-rs/0.1.0` and `Allow: INVITE, ACK, BYE, CANCEL, OPTIONS` on the 200 OK, and no `User-Agent:` or empty `Supported:`

🤖 Generated with [Claude Code](https://claude.com/claude-code)