### PR TITLE
chore(install): enable CDR file sink by default + ship logrotate

### DIFF
--- a/scripts/install-debian13.sh
+++ b/scripts/install-debian13.sh
@@ -2,9 +2,10 @@
 #
 # install-debian13.sh — automated walk-through of docs/INSTALL_DEBIAN13.md
 #
-# Runs sections 1-6 of the install guide on a fresh Debian 13 host and
-# leaves you with a running siphon-ai systemd service. Mirrors the
-# guide step-for-step so any divergence is easy to spot.
+# Runs sections 1-8 of the install guide on a fresh Debian 13 host and
+# leaves you with a running siphon-ai systemd service (with CDR file
+# sink enabled and daily log rotation). Mirrors the guide step-for-step
+# so any divergence is easy to spot.
 #
 #   Required (script will prompt if missing):
 #     TRUNK_PEER_IP   The peer (FreeSWITCH, ITSP) allowed to send INVITEs.
@@ -259,6 +260,16 @@ ws_connect_timeout_ms = 3000
 enabled     = true
 http_listen = "$OBS_LISTEN"
 
+# Call Detail Records — one JSON object per completed call appended
+# to cdr.jsonl. Directory + permissions are set up below; rotation
+# is handled by /etc/logrotate.d/siphon-ai-cdr.
+[cdr]
+enabled = true
+
+[cdr.file]
+enabled = true
+path    = "/var/log/siphon-ai/cdr.jsonl"
+
 # Trunk allowlist — INVITEs from any other peer get 403.
 [[trunk]]
 name       = "freeswitch-main"
@@ -329,6 +340,41 @@ ok "siphon-ai.service enabled and started"
 # Give the daemon a beat to bind its sockets before we probe it.
 sleep 2
 
+# ─── 7. Log rotation ──────────────────────────────────────────────────────
+
+step "Section 7: Log rotation for CDR JSONL"
+
+# `copytruncate` is the correct choice for our append-only CDR file:
+# the daemon keeps the file open, so we want logrotate to copy then
+# truncate in place rather than rename-and-signal. Worst-case loss
+# window is one write between the copy and the truncate — acceptable
+# for CDRs.
+backup_if_exists /etc/logrotate.d/siphon-ai-cdr
+sudo tee /etc/logrotate.d/siphon-ai-cdr >/dev/null <<EOF
+/var/log/siphon-ai/cdr.jsonl {
+    daily
+    rotate 30
+    compress
+    delaycompress
+    missingok
+    notifempty
+    copytruncate
+    su $SERVICE_USER $SERVICE_USER
+    create 0640 $SERVICE_USER $SERVICE_USER
+}
+EOF
+sudo chown root:root /etc/logrotate.d/siphon-ai-cdr
+sudo chmod 0644 /etc/logrotate.d/siphon-ai-cdr
+
+# Validate the rules file — logrotate's parser is permissive but a
+# bad directive here would silently skip rotation forever. `--debug`
+# parses without acting and exits non-zero on real errors.
+if sudo logrotate --debug /etc/logrotate.d/siphon-ai-cdr >/dev/null 2>&1; then
+  ok "/etc/logrotate.d/siphon-ai-cdr installed and parses cleanly"
+else
+  warn "/etc/logrotate.d/siphon-ai-cdr installed but logrotate --debug reports issues; check manually"
+fi
+
 # ─── 8. Verify ────────────────────────────────────────────────────────────
 
 step "Section 8: Verify"
@@ -369,6 +415,8 @@ $RTP_PORT_MIN-$RTP_PORT_MAX, and Prometheus + admin on $OBS_LISTEN.
 Tail logs:        sudo journalctl -u siphon-ai -f
 Active calls:     curl -s http://$obs_host_port/admin/calls | jq
 Metrics:          curl -s http://$obs_host_port/metrics | grep siphon_ai_
+Recent CDRs:      sudo tail -n 5 /var/log/siphon-ai/cdr.jsonl | jq
+CDR rotation:     /etc/logrotate.d/siphon-ai-cdr (daily, 30 keeps)
 
 Next:
   1. Edit /etc/siphon-ai/env to set real secrets (if you reference


### PR DESCRIPTION
## Summary

A fresh `install-debian13.sh` run now leaves the operator with durable per-call records out of the box — no second TOML edit, no surprise full disk in three months.

- **TOML template** (Section 5) now includes a `[cdr]` + `[cdr.file]` block pointing at `/var/log/siphon-ai/cdr.jsonl`.
- **New Section 7** installs `/etc/logrotate.d/siphon-ai-cdr` and validates it with `logrotate --debug` so typos surface at install time.
- **Trailing cheat-sheet** now lists the CDR tail / rotation paths.

Header comment updated to reflect Sections 1–8 (was 1–6).

## Why now

Observed in production this morning: with no CDR sink enabled, the only record of past calls was `journalctl`, which makes ops queries like "calls today by route" or "duration sum for billing" awkward. The TOML schema, sink crate, directory setup, and systemd `ReadWritePaths` grant were all already in place — the config block was the missing piece.

## Logrotate design

```
/var/log/siphon-ai/cdr.jsonl {
    daily
    rotate 30
    compress
    delaycompress
    missingok
    notifempty
    copytruncate
    su <SERVICE_USER> <SERVICE_USER>
    create 0640 <SERVICE_USER> <SERVICE_USER>
}
```

- **`copytruncate`** — the daemon keeps the JSONL file open with an `append` writer; rename-and-signal would need a SIGHUP-reopen hook the CDR writer doesn't have. Tiny race window (one write between copy and truncate), acceptable for CDRs.
- **`delaycompress`** — yesterday's file stays uncompressed so `tail` / `jq` work without `zcat`.
- **`su` + `create`** — honours the non-root service user; without them Debian 13's logrotate refuses to rotate files in non-root-owned dirs.
- **`logrotate --debug` at install time** — parses the rules file without acting, exits non-zero on real errors. Catches typos now rather than three months later when the disk fills.

## Idempotency

Re-running the script backs up an existing `/etc/logrotate.d/siphon-ai-cdr` to `.bak.<timestamp>`, same pattern as the TOML and unit file. The existing `/var/log/siphon-ai` directory + ownership setup in Section 4 was already in place, so nothing changes there.

## What's NOT changed

- `/var/log/siphon-ai` directory creation, ownership (`<SERVICE_USER>:<SERVICE_USER> 0750`), and systemd `ReadWritePaths=/var/log/siphon-ai` — already correct in `install-debian13.sh` from before this PR.
- The CDR schema, sink crate, or runtime wiring — none of those needed touching.

## Test plan

- [x] `bash -n scripts/install-debian13.sh` — shell syntax clean
- [ ] (Reviewer) fresh-VM run of the script, place a call, confirm `sudo tail /var/log/siphon-ai/cdr.jsonl | jq` shows a record and `sudo logrotate -d /etc/logrotate.d/siphon-ai-cdr` parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)