### PR TITLE
chore(deps): bump forge-media to 5c30c03e17f4 for RTP marker-bit fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,7 +581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -684,7 +684,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "forge-codecs"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=33443589ce2e#33443589ce2ef2eef34e4413b17ba5ac401b5767"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=5c30c03e17f4#5c30c03e17f4f674c761c5de19bfd57bb920158c"
 dependencies = [
  "ezk-g722",
  "lazy_static",
@@ -695,7 +695,7 @@ dependencies = [
 [[package]]
 name = "forge-core"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=33443589ce2e#33443589ce2ef2eef34e4413b17ba5ac401b5767"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=5c30c03e17f4#5c30c03e17f4f674c761c5de19bfd57bb920158c"
 dependencies = [
  "chrono",
  "serde",
@@ -710,7 +710,7 @@ dependencies = [
 [[package]]
 name = "forge-dtmf"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=33443589ce2e#33443589ce2ef2eef34e4413b17ba5ac401b5767"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=5c30c03e17f4#5c30c03e17f4f674c761c5de19bfd57bb920158c"
 dependencies = [
  "chrono",
  "forge-core",
@@ -722,7 +722,7 @@ dependencies = [
 [[package]]
 name = "forge-engine"
 version = "0.4.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=33443589ce2e#33443589ce2ef2eef34e4413b17ba5ac401b5767"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=5c30c03e17f4#5c30c03e17f4f674c761c5de19bfd57bb920158c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -752,7 +752,7 @@ dependencies = [
 [[package]]
 name = "forge-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=33443589ce2e#33443589ce2ef2eef34e4413b17ba5ac401b5767"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=5c30c03e17f4#5c30c03e17f4f674c761c5de19bfd57bb920158c"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -765,7 +765,7 @@ dependencies = [
 [[package]]
 name = "forge-injection"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=33443589ce2e#33443589ce2ef2eef34e4413b17ba5ac401b5767"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=5c30c03e17f4#5c30c03e17f4f674c761c5de19bfd57bb920158c"
 dependencies = [
  "forge-core",
  "rubato",
@@ -778,7 +778,7 @@ dependencies = [
 [[package]]
 name = "forge-recorder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=33443589ce2e#33443589ce2ef2eef34e4413b17ba5ac401b5767"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=5c30c03e17f4#5c30c03e17f4f674c761c5de19bfd57bb920158c"
 dependencies = [
  "bytes",
  "forge-core",
@@ -792,7 +792,7 @@ dependencies = [
 [[package]]
 name = "forge-resampler"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=33443589ce2e#33443589ce2ef2eef34e4413b17ba5ac401b5767"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=5c30c03e17f4#5c30c03e17f4f674c761c5de19bfd57bb920158c"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "forge-rtp"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=33443589ce2e#33443589ce2ef2eef34e4413b17ba5ac401b5767"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=5c30c03e17f4#5c30c03e17f4f674c761c5de19bfd57bb920158c"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -826,14 +826,14 @@ dependencies = [
 [[package]]
 name = "forge-sdp"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=33443589ce2e#33443589ce2ef2eef34e4413b17ba5ac401b5767"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=5c30c03e17f4#5c30c03e17f4f674c761c5de19bfd57bb920158c"
 dependencies = [
  "base64",
  "chrono",
  "forge-core",
  "forge-rtp",
  "rand 0.9.4",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=33443589ce2e)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=5c30c03e17f4)",
  "smol_str",
  "thiserror 2.0.18",
 ]
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "forge-transcoder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=33443589ce2e#33443589ce2ef2eef34e4413b17ba5ac401b5767"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=5c30c03e17f4#5c30c03e17f4f674c761c5de19bfd57bb920158c"
 dependencies = [
  "bytes",
  "forge-codecs",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "forge-vad"
 version = "0.1.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=33443589ce2e#33443589ce2ef2eef34e4413b17ba5ac401b5767"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=5c30c03e17f4#5c30c03e17f4f674c761c5de19bfd57bb920158c"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -2353,7 +2353,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2723,7 +2723,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=33443589ce2e#33443589ce2ef2eef34e4413b17ba5ac401b5767"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=5c30c03e17f4#5c30c03e17f4f674c761c5de19bfd57bb920158c"
 dependencies = [
  "nom",
  "smol_str",
@@ -3398,7 +3398,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4055,7 +4055,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,14 +127,14 @@ sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a4f
 # forge-ice, Cow/lifetime in forge-recorder), but the subset SiphonAI
 # pulls — forge-core, forge-rtp, forge-engine (g722 only), forge-codecs,
 # forge-sdp, forge-dtmf, forge-vad, forge-hep — all build cleanly.
-forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "33443589ce2e" }
-forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "33443589ce2e" }
-forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "33443589ce2e", default-features = false, features = ["g722", "dtls"] }
-forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "33443589ce2e" }
-forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "33443589ce2e" }
-forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "33443589ce2e" }
-forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "33443589ce2e" }
-forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "33443589ce2e" }
+forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "5c30c03e17f4" }
+forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "5c30c03e17f4" }
+forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "5c30c03e17f4", default-features = false, features = ["g722", "dtls"] }
+forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "5c30c03e17f4" }
+forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "5c30c03e17f4" }
+forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "5c30c03e17f4" }
+forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "5c30c03e17f4" }
+forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "5c30c03e17f4" }
 
 # hep-rs — HEP3 codec, transport, HepSink trait. Owned by the same
 # author as siphon-rs and forge-media; lives in its own repo.


### PR DESCRIPTION
## Summary

Bumps all 8 `forge-*` pins from `33443589ce2e` → `5c30c03e17f4`, pulling **forge-media [#68](https://github.com/thevoiceguy/forge-media/pull/68)**: the RTP marker bit is now set only on the **first packet of a talkspurt** (RFC 3551 §4.1), not on every outbound packet.

### Why

SiphonAI streams one 20 ms frame per playout call. forge's previous logic set the marker on the first chunk of each append, so with frame-at-a-time delivery **every** outbound RTP packet got M=1. Confirmed in a live Twilio Secure Trunking capture — 264/264 outbound packets had the marker set, while Twilio's inbound stream correctly had M=0. Not audible (the static was a separate, already-resolved stale-binary issue), but a real RFC violation that can make stricter jitter buffers repeatedly treat each packet as a new talkspurt.

The fix lives entirely upstream — **no SiphonAI code change**, just the rev bump.

## Validation

- `cargo build --workspace` — clean
- `cargo test --workspace` — all green (media-glue tap 21, sdp_negotiation 14, acceptor/controller/routes/sip-glue/telemetry/webhooks suites, etc.)
- No stale `33443589` refs remain in `Cargo.toml` / `Cargo.lock`

> Note: SIPp / HEP-collector-stub harnesses (CLAUDE.md §7.5) not run here — this is a pure upstream rev bump with no protocol/SIP-path change and the workspace suite is green. Worth a smoke call after deploy.

## Deploy reminder

After merge, on prod: `git pull && cargo build --release && sudo install -m755 target/release/siphon-ai /usr/local/bin/siphon-ai && sudo systemctl restart siphon-ai` — **rebuild the binary**, don't just restart (that's what caused the earlier "fix didn't take" static).

🤖 Generated with [Claude Code](https://claude.com/claude-code)