### PR TITLE
chore: release 0.3.2 — forge-media bump for rtcp_rtt_ms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-06-05
+
+Closes the last open 0.3.0 Definition-of-Done item: `rtcp_rtt_ms` now
+populates on live calls.
+
+### Fixed
+
+- **`rtp_stats.rtcp_rtt_ms` is now populated instead of always `null`** — picked up via a forge-media bump (`5c30c03e17f4` → `e95a31a959a6`, [thevoiceguy/forge-media#69](https://github.com/thevoiceguy/forge-media/pull/69)). The `rtcp_rtt_ms` field has shipped since 0.3.0 but always emitted `null`: forge-engine's terminator mode generates an RTP stream toward the carrier (its own SSRC) yet never originated RTCP **Sender Reports** for it, so the carrier's Receiver Reports came back with `last_sr = 0` and the `RttTracker` (RFC 3550 §A.7) had nothing to match against. 0.3.0 plan §9 decision 10 deferred the SR emitter as a follow-up; this is it. forge-engine now sends an SR per generated stream every 5 s (RFC 3550 §6.2 minimum), SRTCP-protected, and resolves the echoed `last_sr`/`delay_since_last_sr` from incoming RRs into the RTT sample carried on `RtcpReportReceived`. SiphonAI already consumed the field (`media-glue` populates `rtcp_rtt_ms` on the `rtp_stats` WS event and records the `siphon_ai_rtp_rtt_ms` histogram), so no SiphonAI-side code change — the value simply starts flowing. Expect a sample on each RR (~every 5 s) once both directions of RTCP are live.
+
 ## [0.3.1] - 2026-06-05
 
 Carrier-interop hardening for the 0.3.0 encryption stack. 0.3.0 shipped
@@ -393,7 +402,8 @@ the WebSocket server's job.
 - Reference WebSocket servers in `examples/`: echo (Python / Node),
   an OpenAI Realtime bridge, and a Deepgram + LLM voice bot.
 
-[Unreleased]: https://github.com/thevoiceguy/siphon-ai/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/thevoiceguy/siphon-ai/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/thevoiceguy/siphon-ai/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/thevoiceguy/siphon-ai/compare/v0.2.0...v0.3.1
 [0.2.0]: https://github.com/thevoiceguy/siphon-ai/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/thevoiceguy/siphon-ai/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,7 +581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -684,7 +684,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "forge-codecs"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=5c30c03e17f4#5c30c03e17f4f674c761c5de19bfd57bb920158c"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=e95a31a959a6#e95a31a959a6c9d515c7fb59c6141818ef071369"
 dependencies = [
  "ezk-g722",
  "lazy_static",
@@ -695,7 +695,7 @@ dependencies = [
 [[package]]
 name = "forge-core"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=5c30c03e17f4#5c30c03e17f4f674c761c5de19bfd57bb920158c"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=e95a31a959a6#e95a31a959a6c9d515c7fb59c6141818ef071369"
 dependencies = [
  "chrono",
  "serde",
@@ -710,7 +710,7 @@ dependencies = [
 [[package]]
 name = "forge-dtmf"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=5c30c03e17f4#5c30c03e17f4f674c761c5de19bfd57bb920158c"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=e95a31a959a6#e95a31a959a6c9d515c7fb59c6141818ef071369"
 dependencies = [
  "chrono",
  "forge-core",
@@ -722,7 +722,7 @@ dependencies = [
 [[package]]
 name = "forge-engine"
 version = "0.4.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=5c30c03e17f4#5c30c03e17f4f674c761c5de19bfd57bb920158c"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=e95a31a959a6#e95a31a959a6c9d515c7fb59c6141818ef071369"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -752,7 +752,7 @@ dependencies = [
 [[package]]
 name = "forge-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=5c30c03e17f4#5c30c03e17f4f674c761c5de19bfd57bb920158c"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=e95a31a959a6#e95a31a959a6c9d515c7fb59c6141818ef071369"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -765,7 +765,7 @@ dependencies = [
 [[package]]
 name = "forge-injection"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=5c30c03e17f4#5c30c03e17f4f674c761c5de19bfd57bb920158c"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=e95a31a959a6#e95a31a959a6c9d515c7fb59c6141818ef071369"
 dependencies = [
  "forge-core",
  "rubato",
@@ -778,7 +778,7 @@ dependencies = [
 [[package]]
 name = "forge-recorder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=5c30c03e17f4#5c30c03e17f4f674c761c5de19bfd57bb920158c"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=e95a31a959a6#e95a31a959a6c9d515c7fb59c6141818ef071369"
 dependencies = [
  "bytes",
  "forge-core",
@@ -792,7 +792,7 @@ dependencies = [
 [[package]]
 name = "forge-resampler"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=5c30c03e17f4#5c30c03e17f4f674c761c5de19bfd57bb920158c"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=e95a31a959a6#e95a31a959a6c9d515c7fb59c6141818ef071369"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "forge-rtp"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=5c30c03e17f4#5c30c03e17f4f674c761c5de19bfd57bb920158c"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=e95a31a959a6#e95a31a959a6c9d515c7fb59c6141818ef071369"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -826,14 +826,14 @@ dependencies = [
 [[package]]
 name = "forge-sdp"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=5c30c03e17f4#5c30c03e17f4f674c761c5de19bfd57bb920158c"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=e95a31a959a6#e95a31a959a6c9d515c7fb59c6141818ef071369"
 dependencies = [
  "base64",
  "chrono",
  "forge-core",
  "forge-rtp",
  "rand 0.9.4",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=5c30c03e17f4)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=e95a31a959a6)",
  "smol_str",
  "thiserror 2.0.18",
 ]
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "forge-transcoder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=5c30c03e17f4#5c30c03e17f4f674c761c5de19bfd57bb920158c"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=e95a31a959a6#e95a31a959a6c9d515c7fb59c6141818ef071369"
 dependencies = [
  "bytes",
  "forge-codecs",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "forge-vad"
 version = "0.1.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=5c30c03e17f4#5c30c03e17f4f674c761c5de19bfd57bb920158c"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=e95a31a959a6#e95a31a959a6c9d515c7fb59c6141818ef071369"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -2353,7 +2353,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2723,7 +2723,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=5c30c03e17f4#5c30c03e17f4f674c761c5de19bfd57bb920158c"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a4f8521561d6#a4f8521561d60db31103c1cf41d1c4ed14cde114"
 dependencies = [
  "nom",
  "smol_str",
@@ -2732,7 +2732,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a4f8521561d6#a4f8521561d60db31103c1cf41d1c4ed14cde114"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=e95a31a959a6#e95a31a959a6c9d515c7fb59c6141818ef071369"
 dependencies = [
  "nom",
  "smol_str",
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2862,7 +2862,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "base64",
  "bytes",
@@ -2882,7 +2882,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2899,7 +2899,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "regex",
  "serde",
@@ -2914,7 +2914,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2950,7 +2950,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -2965,7 +2965,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2986,7 +2986,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "regex",
  "serde",
@@ -2997,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3020,7 +3020,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3041,7 +3041,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3398,7 +3398,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4055,7 +4055,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"
@@ -127,14 +127,14 @@ sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a4f
 # forge-ice, Cow/lifetime in forge-recorder), but the subset SiphonAI
 # pulls — forge-core, forge-rtp, forge-engine (g722 only), forge-codecs,
 # forge-sdp, forge-dtmf, forge-vad, forge-hep — all build cleanly.
-forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "5c30c03e17f4" }
-forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "5c30c03e17f4" }
-forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "5c30c03e17f4", default-features = false, features = ["g722", "dtls"] }
-forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "5c30c03e17f4" }
-forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "5c30c03e17f4" }
-forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "5c30c03e17f4" }
-forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "5c30c03e17f4" }
-forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "5c30c03e17f4" }
+forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "e95a31a959a6" }
+forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "e95a31a959a6" }
+forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "e95a31a959a6", default-features = false, features = ["g722", "dtls"] }
+forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "e95a31a959a6" }
+forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "e95a31a959a6" }
+forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "e95a31a959a6" }
+forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "e95a31a959a6" }
+forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "e95a31a959a6" }
 
 # hep-rs — HEP3 codec, transport, HepSink trait. Owned by the same
 # author as siphon-rs and forge-media; lives in its own repo.


### PR DESCRIPTION
## Summary

Bumps all 8 `forge-*` pins `5c30c03e17f4` → `e95a31a959a6` (forge-media [#69](https://github.com/thevoiceguy/forge-media/pull/69)) and cuts **v0.3.2**. This makes `rtcp_rtt_ms` populate on live calls — **closing the last open 0.3.0 Definition-of-Done item** (§9 decision 10).

## Why

`rtp_stats.rtcp_rtt_ms` has shipped since 0.3.0 but always emitted `null`: forge-engine's terminator mode generates an RTP stream toward the carrier (its own SSRC) but never originated RTCP **Sender Reports** for it, so the carrier's Receiver Reports came back with `last_sr = 0` and the `RttTracker` (RFC 3550 §A.7) had nothing to match against.

forge-media #69 adds the SR emitter: forge-engine now sends an SRTCP-protected SR per generated stream every 5 s (RFC 3550 §6.2), records it, and resolves the echoed `last_sr`/`delay_since_last_sr` from incoming RRs into the RTT sample on `RtcpReportReceived`.

**No SiphonAI-side code change** — `media-glue` already populates `rtcp_rtt_ms` on the `rtp_stats` WS event and records the `siphon_ai_rtp_rtt_ms` histogram. The value simply starts flowing (a sample on each RR, ~every 5 s, once both directions of RTCP are live).

## Validation

- `cargo build --workspace` clean at the new rev; everything compiles at `0.3.2`
- `cargo test --workspace` — all green (40 test-result groups, 0 failures)
- No stale `5c30c03` refs in `Cargo.toml` / `Cargo.lock`

## After merge

Tag `v0.3.2`, then redeploy prod (**rebuild** the binary) and confirm `rtcp_rtt_ms` is non-null on a live call / in the `siphon_ai_rtp_rtt_ms` histogram.

> Note: the README status flip (PR #109) is still open and independent; it'll want a tiny follow-up to say 0.3.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)