### PR TITLE
feat(telemetry): explicit histogram buckets for siphon_ai_rtp_rtt_ms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`siphon_ai_rtp_rtt_ms` now renders as a bucketed Prometheus histogram instead of a summary.** The metric had no explicit buckets registered, so `metrics-exporter-prometheus` fell back to a summary (quantiles) — inconsistent with the other `_seconds` histograms and awkward to aggregate across instances. It now has explicit ms buckets (10 ms–1 s) via `set_buckets_for_metric`, matching the 0.3.0 housekeeping rule ("histograms get sensible buckets defined explicitly"). `/metrics` now emits `siphon_ai_rtp_rtt_ms_bucket{le="…"}` lines; anything scraping the old `{quantile="…"}` series should switch to `histogram_quantile()` over the buckets.
+
 ## [0.3.2] - 2026-06-05
 
 Closes the last open 0.3.0 Definition-of-Done item: `rtcp_rtt_ms` now

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -15,7 +15,7 @@
 //!
 //! ## Buckets
 //!
-//! Three histograms get explicit buckets per the CLAUDE.md guidance
+//! Four histograms get explicit buckets per the CLAUDE.md guidance
 //! ("histograms get sensible buckets defined explicitly; don't rely
 //! on defaults"). Buckets target the latencies operators care about:
 //!
@@ -91,6 +91,13 @@ pub const SDP_NEGOTIATE_SECONDS: &str = "siphon_ai_sdp_negotiate_seconds";
 /// End-to-end call duration (started_at → ended_at on the CDR).
 pub const CALL_DURATION_SECONDS: &str = "siphon_ai_call_duration_seconds";
 
+/// RTCP-derived round-trip time, in **milliseconds** (the `_ms` suffix
+/// carries the unit — unlike the `_seconds` histograms above). Recorded
+/// per received Receiver Report from `media-glue` (RFC 3550 §A.7). The
+/// literal name must match the `histogram!` call site in
+/// `siphon-ai-media-glue`; the bucket matcher keys on this string.
+pub const RTP_RTT_MS: &str = "siphon_ai_rtp_rtt_ms";
+
 #[derive(Debug, Error)]
 pub enum InitError {
     #[error("metrics recorder install failed: {0}")]
@@ -117,6 +124,9 @@ pub fn prometheus_builder() -> Result<PrometheusBuilder, InitError> {
                 Matcher::Full(CALL_DURATION_SECONDS.to_string()),
                 &CALL_DURATION_BUCKETS,
             )
+        })
+        .and_then(|b| {
+            b.set_buckets_for_metric(Matcher::Full(RTP_RTT_MS.to_string()), &RTP_RTT_MS_BUCKETS)
         })
         .map_err(|e| InitError::Install(e.to_string()))
 }
@@ -193,6 +203,11 @@ pub fn register_descriptions() {
         Unit::Seconds,
         "End-to-end call duration."
     );
+    describe_histogram!(
+        RTP_RTT_MS,
+        Unit::Milliseconds,
+        "RTCP-derived round-trip time (ms) per received Receiver Report (RFC 3550 §A.7)."
+    );
 }
 
 /// Buckets for `ws_connect_seconds`. The first bucket (25ms) catches
@@ -211,6 +226,14 @@ pub const SDP_NEGOTIATE_BUCKETS: [f64; 8] = [0.0001, 0.0005, 0.001, 0.005, 0.01,
 /// stuck-call long-tail that operators want page-able.
 pub const CALL_DURATION_BUCKETS: [f64; 10] = [
     1.0, 5.0, 15.0, 30.0, 60.0, 180.0, 600.0, 1800.0, 3600.0, 14400.0,
+];
+
+/// Buckets for `rtp_rtt_ms`, in **milliseconds**. Span healthy regional
+/// VoIP (10–100 ms — a Twilio leg measured ~67 ms), elevated
+/// transcontinental / congested paths (100–300 ms), and the pathological
+/// tail (≥500 ms) operators page on.
+pub const RTP_RTT_MS_BUCKETS: [f64; 11] = [
+    10.0, 20.0, 30.0, 50.0, 75.0, 100.0, 150.0, 200.0, 300.0, 500.0, 1000.0,
 ];
 
 #[cfg(test)]
@@ -275,6 +298,23 @@ mod tests {
         assert!(
             !out.contains(&format!("{WS_CONNECT_SECONDS}{{quantile")),
             "histogram unexpectedly rendered as summary"
+        );
+    }
+
+    #[test]
+    fn rtp_rtt_ms_renders_with_explicit_buckets_not_summary() {
+        // Regression for the cosmetic 0.3.2 follow-up: rtcp_rtt_ms was
+        // rendering as a summary (quantiles) because no buckets were set.
+        let out = with_recorder(|| {
+            histogram!(RTP_RTT_MS).record(67.1);
+        });
+        assert!(
+            out.contains(&format!("{RTP_RTT_MS}_bucket")),
+            "expected buckets in:\n{out}"
+        );
+        assert!(
+            !out.contains(&format!("{RTP_RTT_MS}{{quantile")),
+            "rtt histogram unexpectedly rendered as summary"
         );
     }
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -404,7 +404,7 @@ on the metrics crate's defaults (CLAUDE.md §7.4).
 | `siphon_ai_dead_air_events_total`       | counter   | —                                     | Times `dead_air_detected` fired on the WS bridge. Configurable via `[bridge].dead_air_threshold_ms`. |
 | `siphon_ai_rtp_jitter_ms`               | histogram | —                                     | RTP jitter snapshot recorded on every `rtp_stats` emission (when forge has reported a value). |
 | `siphon_ai_rtp_packet_loss_ratio`       | histogram | —                                     | Packet-loss ratio (0.0-1.0) recorded on every `rtp_stats` emission. |
-| `siphon_ai_rtp_rtt_ms`                  | histogram | —                                     | Mean RTCP round-trip time recorded on every `rtp_stats` emission. Stays empty until forge originates its own SRs (0.3.1 follow-up). |
+| `siphon_ai_rtp_rtt_ms`                  | histogram | —                                     | RTCP-derived round-trip time (ms) per received Receiver Report (RFC 3550 §A.7). Populated since 0.3.2 (forge originates SRs); explicit buckets 10ms–1s. Records a sample roughly every RTCP cycle (~5s) once bidirectional RTCP is flowing. |
 | `siphon_ai_sip_tls_reload_attempts_total` | counter | `outcome=ok\|failed`                  | One tick per SIGHUP cert-reload attempt. `failed` means a broken cert/key on disk; the listener keeps serving the previous cert. |
 | `forge_rtcp_*`                          | various   | per-call (forge-side)                 | RTP/RTCP quality. See forge-media's own metric inventory. |
 | `heplify_*`                             | various   | from the HEP collector                | Only visible if you scrape heplify too. |


### PR DESCRIPTION
## Summary

`siphon_ai_rtp_rtt_ms` was rendering as a Prometheus **summary** (quantiles) because no buckets were registered — `metrics-exporter-prometheus` falls back to a summary in that case. Observed on prod after the 0.3.2 deploy:

```
# TYPE siphon_ai_rtp_rtt_ms summary
siphon_ai_rtp_rtt_ms{quantile="0.5"} 67.15
...
```

This registers explicit **millisecond** buckets (10 ms – 1 s) so it renders as a real bucketed histogram (`siphon_ai_rtp_rtt_ms_bucket{le="…"}`), consistent with the other `_seconds` histograms and aggregatable across instances via `histogram_quantile()`.

## Changes

- `RTP_RTT_MS` const + `RTP_RTT_MS_BUCKETS` (`10,20,30,50,75,100,150,200,300,500,1000` ms) wired into `prometheus_builder()` via `set_buckets_for_metric`
- `describe_histogram!` HELP text (RFC 3550 §A.7)
- Regression test: renders as `_bucket`, not `{quantile`
- DEPLOY.md metric inventory updated (the old entry still said the field "stays empty until forge originates its own SRs" — shipped in 0.3.2)
- CHANGELOG `[Unreleased]` note (the `{quantile=…}` series goes away; scrapers switch to `histogram_quantile()` over buckets)

Telemetry tests green, fmt + clippy clean.

> Heads-up: this changes the `/metrics` shape for this one series (summary → histogram). Logged under `[Unreleased]`; happy to cut it as **0.3.3** or let it ride to the next release — your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)