### PR TITLE
feat(security): siphon-ai-security crate — verstat types + attestation policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2996,6 +2996,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphon-ai-security"
+version = "0.3.2"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "siphon-ai-sip-glue"
 version = "0.3.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/http",
     "crates/media-glue",
     "crates/routes",
+    "crates/security",
     "crates/sip-glue",
     "crates/telemetry",
     "crates/webhooks",
@@ -32,6 +33,7 @@ siphon-ai-core        = { path = "crates/core" }
 siphon-ai-http        = { path = "crates/http" }
 siphon-ai-media-glue  = { path = "crates/media-glue" }
 siphon-ai-routes      = { path = "crates/routes" }
+siphon-ai-security    = { path = "crates/security" }
 siphon-ai-sip-glue    = { path = "crates/sip-glue" }
 siphon-ai-telemetry   = { path = "crates/telemetry" }
 siphon-ai-webhooks    = { path = "crates/webhooks" }

--- a/crates/security/Cargo.toml
+++ b/crates/security/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name        = "siphon-ai-security"
+description = "Call-authentication types: STIR/SHAKEN verstat, attestation policy, trust-anchor config."
+version.workspace      = true
+edition.workspace      = true
+rust-version.workspace = true
+license.workspace      = true
+authors.workspace      = true
+repository.workspace   = true
+
+[dependencies]
+serde      = { workspace = true, features = ["derive"] }
+thiserror.workspace  = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/crates/security/src/attestation.rs
+++ b/crates/security/src/attestation.rs
@@ -1,0 +1,81 @@
+//! SHAKEN attestation level (ATIS-1000074 §5.2.3).
+
+use serde::{Deserialize, Serialize};
+
+/// How strongly the originating provider vouches for the calling number.
+///
+/// Ordered by trust strength: `A` (full) is the strongest, `C` (gateway)
+/// the weakest. Use [`AttestationLevel::rank`] for policy comparisons
+/// rather than relying on a derived ordering — the wire characters (`A`
+/// highest) run opposite to alphabetical intuition, so the rank is made
+/// explicit on purpose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AttestationLevel {
+    /// Full attestation — provider authenticated the customer and confirmed
+    /// their right to use the calling number.
+    #[serde(rename = "A")]
+    A,
+    /// Partial attestation — origin authenticated, number authorization not
+    /// confirmed.
+    #[serde(rename = "B")]
+    B,
+    /// Gateway attestation — only the ingress point is authenticated.
+    #[serde(rename = "C")]
+    C,
+}
+
+impl AttestationLevel {
+    /// Trust strength: `A`=3 (strongest) … `C`=1 (weakest). A call satisfies
+    /// a minimum-attestation policy when its rank is `>=` the policy's rank.
+    pub fn rank(self) -> u8 {
+        match self {
+            Self::A => 3,
+            Self::B => 2,
+            Self::C => 1,
+        }
+    }
+
+    /// Parse the single-character claim value (`"A"` / `"B"` / `"C"`).
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "A" => Some(Self::A),
+            "B" => Some(Self::B),
+            "C" => Some(Self::C),
+            _ => None,
+        }
+    }
+
+    /// The wire character.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::A => "A",
+            Self::B => "B",
+            Self::C => "C",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rank_orders_a_strongest() {
+        assert!(AttestationLevel::A.rank() > AttestationLevel::B.rank());
+        assert!(AttestationLevel::B.rank() > AttestationLevel::C.rank());
+    }
+
+    #[test]
+    fn parse_roundtrips() {
+        for s in ["A", "B", "C"] {
+            assert_eq!(AttestationLevel::parse(s).unwrap().as_str(), s);
+        }
+        assert_eq!(AttestationLevel::parse("D"), None);
+    }
+
+    #[test]
+    fn serde_uses_wire_chars() {
+        let json = serde_json::to_string(&AttestationLevel::A).unwrap();
+        assert_eq!(json, "\"A\"");
+    }
+}

--- a/crates/security/src/config.rs
+++ b/crates/security/src/config.rs
@@ -1,0 +1,115 @@
+//! Compiled STIR/SHAKEN configuration and trust-anchor plumbing.
+//!
+//! These are the *typed* forms the config crate compiles `[security]` /
+//! `[security.stir_shaken]` into. Verification itself (cert fetch, ES256,
+//! chain validation) is not wired here — this revision only validates that
+//! the trust-anchor file is present and PEM-shaped so misconfiguration
+//! fails loud at startup rather than on the first signed call.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use thiserror::Error;
+
+/// Default verification-certificate cache TTL (1 hour) — matches HTTP cache
+/// semantics on the `x5u`/`info` cert responses (plan §9 decision 2).
+pub const DEFAULT_CERT_CACHE_TTL: Duration = Duration::from_secs(3600);
+
+/// Compiled `[security.stir_shaken]` block.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StirShakenConfig {
+    /// Master switch. When `false` (default) no Identity parsing or
+    /// verification runs and no `verstat` is surfaced — a 0.3.x deployment
+    /// upgrades with zero behaviour change.
+    pub enabled: bool,
+    /// Path to the PEM bundle of STI-PA trust anchors (the iconectiv root,
+    /// shipped in `contrib/sti-pa-roots.pem` per plan §9 decision 1).
+    pub trust_anchors: PathBuf,
+    /// How long a fetched signing certificate is cached before re-fetch.
+    pub cert_cache_ttl: Duration,
+    /// Reject inbound INVITEs that carry no `Identity` header with 428
+    /// ("Use Identity Header", RFC 8224 §6.2.2) instead of admitting them
+    /// as unsigned.
+    pub require_identity: bool,
+}
+
+impl Default for StirShakenConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            trust_anchors: PathBuf::new(),
+            cert_cache_ttl: DEFAULT_CERT_CACHE_TTL,
+            require_identity: false,
+        }
+    }
+}
+
+/// Failure loading / validating the trust-anchor file.
+#[derive(Debug, Error)]
+pub enum TrustAnchorError {
+    /// The file could not be read (missing, permissions, …).
+    #[error("trust anchor file {path:?} could not be read: {source}")]
+    Io {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    /// The file was read but contains no PEM `CERTIFICATE` blocks.
+    #[error("trust anchor file {path:?} contains no PEM certificates")]
+    NoCertificates { path: PathBuf },
+}
+
+/// Count `-----BEGIN CERTIFICATE-----` blocks in a PEM bundle. Pure so the
+/// counting rule is unit-testable without touching the filesystem.
+fn count_pem_certificates(pem: &str) -> usize {
+    pem.matches("-----BEGIN CERTIFICATE-----").count()
+}
+
+/// Validate that a trust-anchor file exists and holds at least one PEM
+/// certificate. Returns the certificate count. Used at config-load time so
+/// a missing/empty anchor file is a loud startup failure, not a silent
+/// "every call fails verification" at runtime.
+///
+/// This intentionally does **not** parse the certificates — DER decoding
+/// and chain construction belong to the verifier, which lands with the
+/// crypto dependencies.
+pub fn validate_trust_anchors(path: &Path) -> Result<usize, TrustAnchorError> {
+    let contents = std::fs::read_to_string(path).map_err(|source| TrustAnchorError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let count = count_pem_certificates(&contents);
+    if count == 0 {
+        return Err(TrustAnchorError::NoCertificates {
+            path: path.to_path_buf(),
+        });
+    }
+    Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_disabled_with_1h_ttl() {
+        let c = StirShakenConfig::default();
+        assert!(!c.enabled);
+        assert!(!c.require_identity);
+        assert_eq!(c.cert_cache_ttl, DEFAULT_CERT_CACHE_TTL);
+    }
+
+    #[test]
+    fn counts_pem_blocks() {
+        assert_eq!(count_pem_certificates(""), 0);
+        assert_eq!(count_pem_certificates("not a cert"), 0);
+        let one = "-----BEGIN CERTIFICATE-----\nMII...\n-----END CERTIFICATE-----\n";
+        assert_eq!(count_pem_certificates(one), 1);
+        assert_eq!(count_pem_certificates(&one.repeat(3)), 3);
+    }
+
+    #[test]
+    fn missing_file_is_io_error() {
+        let err = validate_trust_anchors(Path::new("/nonexistent/sti-pa-roots.pem")).unwrap_err();
+        assert!(matches!(err, TrustAnchorError::Io { .. }));
+    }
+}

--- a/crates/security/src/lib.rs
+++ b/crates/security/src/lib.rs
@@ -1,0 +1,43 @@
+//! Call-authentication types for SiphonAI (STIR/SHAKEN).
+//!
+//! This crate owns the **typed vocabulary** of the 0.4.0 call-authentication
+//! theme — the verstat verdict, attestation levels, the minimum-attestation
+//! policy gate, and the compiled `[security.stir_shaken]` config — without
+//! any of the verification machinery. It's deliberately small and
+//! dependency-light so every other layer (config, core accept path,
+//! bridge protocol, CDR, HEP) can depend on it cheaply.
+//!
+//! ## What lives here
+//!
+//! - [`AttestationLevel`] — SHAKEN A/B/C, with an explicit trust [`rank`].
+//! - [`VerificationResult`] — the per-call verstat verdict surfaced on
+//!   `BridgeOut::Start`, the CDR, and HEP. Use
+//!   [`trusted_attestation`] for policy, never the raw `attest` claim.
+//! - [`MinAttestation`] — the policy gate: parse, strict per-route
+//!   [`resolve`], and [`permits`] implementing the §4 matrix.
+//! - [`StirShakenConfig`] + [`validate_trust_anchors`] — compiled config and
+//!   load-time trust-anchor plumbing.
+//!
+//! ## What does NOT live here (yet)
+//!
+//! The verifier: Identity-header parsing (that's siphon-rs `sip-identity`),
+//! ES256 signature checking, `x5u` cert fetch, and chain validation against
+//! the trust anchors. Those wire a [`VerificationResult`] *in*; this crate
+//! only defines its shape and what policy does with it.
+//!
+//! [`rank`]: AttestationLevel::rank
+//! [`trusted_attestation`]: VerificationResult::trusted_attestation
+//! [`resolve`]: MinAttestation::resolve
+//! [`permits`]: MinAttestation::permits
+
+mod attestation;
+mod config;
+mod policy;
+mod verstat;
+
+pub use attestation::AttestationLevel;
+pub use config::{
+    validate_trust_anchors, StirShakenConfig, TrustAnchorError, DEFAULT_CERT_CACHE_TTL,
+};
+pub use policy::MinAttestation;
+pub use verstat::VerificationResult;

--- a/crates/security/src/policy.rs
+++ b/crates/security/src/policy.rs
@@ -1,0 +1,154 @@
+//! Minimum-attestation policy: the gate that decides whether a verified
+//! call is allowed through, and how global/per-route policies combine.
+
+use crate::attestation::AttestationLevel;
+use crate::verstat::VerificationResult;
+
+/// The minimum attestation a call must carry to be accepted.
+///
+/// `None` admits everything (the default — zero behaviour change for
+/// deployments that don't opt in). `A`/`B`/`C` require a *trusted*
+/// attestation at or above that level.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MinAttestation {
+    /// No attestation requirement — every call passes the gate.
+    #[default]
+    None,
+    /// Require trusted attestation `C` or better.
+    C,
+    /// Require trusted attestation `B` or better.
+    B,
+    /// Require trusted attestation `A`.
+    A,
+}
+
+impl MinAttestation {
+    /// Parse the config value. `"none"` (or unset) → [`MinAttestation::None`].
+    /// Case-insensitive on the level letters. Returns `None` for an
+    /// unrecognised value so the caller can surface a precise config error.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "none" => Some(Self::None),
+            "a" => Some(Self::A),
+            "b" => Some(Self::B),
+            "c" => Some(Self::C),
+            _ => None,
+        }
+    }
+
+    /// The required rank, or `None` when there is no requirement. Mirrors
+    /// [`AttestationLevel::rank`] so the two compare directly.
+    fn required_rank(self) -> Option<u8> {
+        match self {
+            Self::None => None,
+            Self::C => Some(AttestationLevel::C.rank()),
+            Self::B => Some(AttestationLevel::B.rank()),
+            Self::A => Some(AttestationLevel::A.rank()),
+        }
+    }
+
+    /// Resolve the effective policy for a route. **Strict override**: a
+    /// route value fully replaces the global, even if more permissive
+    /// (matching `[route.bridge.tls]` semantics from 0.3.0). A route with
+    /// no override inherits the global.
+    pub fn resolve(
+        global: MinAttestation,
+        route_override: Option<MinAttestation>,
+    ) -> MinAttestation {
+        route_override.unwrap_or(global)
+    }
+
+    /// Decide whether a call's verification verdict satisfies this policy.
+    ///
+    /// Implements the §4 policy matrix: `None` always admits; otherwise the
+    /// call needs a *trusted* attestation (verification fully passed) at or
+    /// above the required rank. An unsigned call, an invalid signature, or a
+    /// header below the threshold is rejected.
+    pub fn permits(self, result: &VerificationResult) -> bool {
+        match self.required_rank() {
+            None => true,
+            Some(required) => result
+                .trusted_attestation()
+                .is_some_and(|level| level.rank() >= required),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn verdict(attest: Option<AttestationLevel>, passed: bool) -> VerificationResult {
+        VerificationResult {
+            attest,
+            orig_tn: None,
+            orig_passed: passed,
+            dest_passed: passed,
+            cert_chain_valid: passed,
+            signature_valid: passed,
+            error: None,
+        }
+    }
+
+    #[test]
+    fn parse_accepts_none_and_levels_case_insensitively() {
+        assert_eq!(MinAttestation::parse("none"), Some(MinAttestation::None));
+        assert_eq!(MinAttestation::parse("A"), Some(MinAttestation::A));
+        assert_eq!(MinAttestation::parse("b"), Some(MinAttestation::B));
+        assert_eq!(MinAttestation::parse(" C "), Some(MinAttestation::C));
+        assert_eq!(MinAttestation::parse("strong"), None);
+    }
+
+    #[test]
+    fn default_is_none() {
+        assert_eq!(MinAttestation::default(), MinAttestation::None);
+    }
+
+    #[test]
+    fn strict_override_can_loosen_or_tighten() {
+        // Route override fully replaces global, even when more permissive.
+        assert_eq!(
+            MinAttestation::resolve(MinAttestation::B, Some(MinAttestation::C)),
+            MinAttestation::C
+        );
+        assert_eq!(
+            MinAttestation::resolve(MinAttestation::B, Some(MinAttestation::A)),
+            MinAttestation::A
+        );
+        // No override → inherit global.
+        assert_eq!(
+            MinAttestation::resolve(MinAttestation::B, None),
+            MinAttestation::B
+        );
+    }
+
+    /// The full §4 policy matrix.
+    #[test]
+    fn policy_matrix() {
+        let a = verdict(Some(AttestationLevel::A), true);
+        let b = verdict(Some(AttestationLevel::B), true);
+        let c = verdict(Some(AttestationLevel::C), true);
+        let absent = verdict(None, false);
+        let bad_sig = verdict(Some(AttestationLevel::A), false); // claims A, failed verify
+
+        // none: everything passes.
+        for v in [&a, &b, &c, &absent, &bad_sig] {
+            assert!(MinAttestation::None.permits(v));
+        }
+        // C: A,B,C pass; absent + invalid reject.
+        assert!(MinAttestation::C.permits(&a));
+        assert!(MinAttestation::C.permits(&b));
+        assert!(MinAttestation::C.permits(&c));
+        assert!(!MinAttestation::C.permits(&absent));
+        assert!(!MinAttestation::C.permits(&bad_sig));
+        // B: A,B pass; C,absent,invalid reject.
+        assert!(MinAttestation::B.permits(&a));
+        assert!(MinAttestation::B.permits(&b));
+        assert!(!MinAttestation::B.permits(&c));
+        assert!(!MinAttestation::B.permits(&absent));
+        // A: only A passes.
+        assert!(MinAttestation::A.permits(&a));
+        assert!(!MinAttestation::A.permits(&b));
+        assert!(!MinAttestation::A.permits(&c));
+    }
+}

--- a/crates/security/src/verstat.rs
+++ b/crates/security/src/verstat.rs
@@ -1,0 +1,126 @@
+//! The verification verdict (`verstat`) produced for an inbound call.
+
+use serde::{Deserialize, Serialize};
+
+use crate::attestation::AttestationLevel;
+
+/// Outcome of STIR/SHAKEN verification for one inbound INVITE.
+///
+/// The five booleans plus the optional error let a downstream consumer
+/// reconstruct the precise failure mode without re-parsing the Identity
+/// header. This is the shape surfaced on `BridgeOut::Start.verstat`, the
+/// CDR, and the HEP verstat chunk.
+///
+/// **Trust:** `attest` is the level *claimed* in the PASSporT. It is only
+/// trustworthy when the verification passed — use
+/// [`VerificationResult::trusted_attestation`] for any policy decision, not
+/// `attest` directly.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VerificationResult {
+    /// Attestation level claimed in the PASSporT, if a valid one was present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attest: Option<AttestationLevel>,
+    /// Originating TN from the PASSporT `orig.tn` claim.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub orig_tn: Option<String>,
+    /// `orig.tn` matched the SIP `From` user.
+    pub orig_passed: bool,
+    /// A `dest.tn` matched the SIP `To`/R-URI user.
+    pub dest_passed: bool,
+    /// The signing certificate chained to a configured STI-PA trust anchor.
+    pub cert_chain_valid: bool,
+    /// The ES256 signature over the PASSporT verified against that cert.
+    pub signature_valid: bool,
+    /// Human-readable failure reason when verification did not fully pass.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl VerificationResult {
+    /// A verdict for a call with no `Identity` header at all — nothing
+    /// verified, no attestation. Distinct from a present-but-invalid header
+    /// (which carries an `error`).
+    pub fn unsigned() -> Self {
+        Self {
+            attest: None,
+            orig_tn: None,
+            orig_passed: false,
+            dest_passed: false,
+            cert_chain_valid: false,
+            signature_valid: false,
+            error: None,
+        }
+    }
+
+    /// Composite pass: every check succeeded. This is the `verstat_passed`
+    /// CDR field and the precondition for trusting `attest`.
+    pub fn passed(&self) -> bool {
+        self.signature_valid && self.cert_chain_valid && self.orig_passed && self.dest_passed
+    }
+
+    /// The attestation level we are willing to *trust* — the claimed level
+    /// only when [`passed`](Self::passed) holds, else `None`. Policy gates
+    /// must use this, never the raw `attest` claim, so an unsigned or
+    /// invalid call can never satisfy an attestation requirement.
+    pub fn trusted_attestation(&self) -> Option<AttestationLevel> {
+        if self.passed() {
+            self.attest
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn good(attest: AttestationLevel) -> VerificationResult {
+        VerificationResult {
+            attest: Some(attest),
+            orig_tn: Some("+12155551212".into()),
+            orig_passed: true,
+            dest_passed: true,
+            cert_chain_valid: true,
+            signature_valid: true,
+            error: None,
+        }
+    }
+
+    #[test]
+    fn passed_requires_all_checks() {
+        assert!(good(AttestationLevel::A).passed());
+        let mut r = good(AttestationLevel::A);
+        r.signature_valid = false;
+        assert!(!r.passed());
+    }
+
+    #[test]
+    fn trusted_attestation_gated_on_pass() {
+        assert_eq!(
+            good(AttestationLevel::B).trusted_attestation(),
+            Some(AttestationLevel::B)
+        );
+        // Claimed A but signature failed → not trusted.
+        let mut r = good(AttestationLevel::A);
+        r.signature_valid = false;
+        assert_eq!(r.trusted_attestation(), None);
+    }
+
+    #[test]
+    fn unsigned_has_no_trust() {
+        let u = VerificationResult::unsigned();
+        assert!(!u.passed());
+        assert_eq!(u.trusted_attestation(), None);
+        assert_eq!(u.error, None);
+    }
+
+    #[test]
+    fn serializes_without_null_optionals() {
+        let json = serde_json::to_string(&VerificationResult::unsigned()).unwrap();
+        // attest/orig_tn/error skipped when None; booleans always present.
+        assert!(!json.contains("attest"));
+        assert!(!json.contains("error"));
+        assert!(json.contains("\"signature_valid\":false"));
+    }
+}


### PR DESCRIPTION
## Summary

First chunk of the **0.4.0 call-authentication** scaffolding (siphon-ai side). Adds `crates/security/` — the typed vocabulary every other layer will bind to — with **no verification machinery yet** (deliberately small; deps are just `serde` + `thiserror`). Mirrors how the upstream `sip-identity` parsing crate was chunked: foundation first, wiring next.

## What's here

- **`AttestationLevel`** (SHAKEN A/B/C) with an explicit `rank()` — A strongest. The rank is explicit on purpose: the wire letters run opposite to alphabetical intuition.
- **`VerificationResult`** — the per-call verstat verdict (`attest`, `orig_tn`, `orig_passed`, `dest_passed`, `cert_chain_valid`, `signature_valid`, `error`) that will surface on `BridgeOut::Start` / CDR / HEP. Key safety method: `trusted_attestation()` returns the claimed level **only when verification fully passed**, so policy can never trust an unsigned or invalid call.
- **`MinAttestation`** (None/A/B/C) — the policy gate: `parse`, strict per-route `resolve` (route fully overrides global, matching `[route.bridge.tls]` from 0.3.0 per the locked §9 decision), and `permits` implementing the §4 policy matrix.
- **`StirShakenConfig`** (compiled config; default **disabled**, 1h cert cache) + `validate_trust_anchors` — load-time plumbing (file exists + ≥1 PEM block) so a missing/empty trust-anchor file is a loud startup failure, not a silent runtime one.

## Deliberately NOT here

Verification: Identity-header parsing (that's siphon-rs [#53](https://github.com/thevoiceguy/siphon-rs/pull/53)), ES256 signature checking, `x5u` cert fetch, chain validation. Those wire a `VerificationResult` *in*; this crate defines its shape and the policy over it. **Consumer-less by design in this chunk** — the `[security]` TOML config surface, per-route override, and accept-path wiring are the follow-on chunks.

## Locked decisions reflected here

Strict per-route override; 1h TTL cert cache; default-off (zero behaviour change for 0.3.x deployments). 403 reject code and trust-anchor shipping land with the config/accept-path chunks.

## Tests

14 unit tests including the full §4 policy matrix (A/B/C/absent/invalid-sig × none/C/B/A), `trusted_attestation` gating, serde wire shape, and trust-anchor validation. `cargo fmt` + `clippy --all-targets -D warnings` clean; `cargo build/test --workspace` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)