### PR TITLE
feat(config): [security] STIR/SHAKEN config surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2907,6 +2907,7 @@ dependencies = [
  "siphon-ai-core",
  "siphon-ai-media-glue",
  "siphon-ai-routes",
+ "siphon-ai-security",
  "thiserror 1.0.69",
  "toml",
  "tracing",

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -140,6 +140,9 @@ impl Runtime {
             routes,
             registrations,
             trunks,
+            // Parsed + validated at config load; the accept-path / verifier
+            // wiring that consumes it lands in a later 0.4.0 chunk.
+            security: _security,
             cdr,
             observability,
             webhooks,

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -23,3 +23,4 @@ siphon-ai-bridge.workspace     = true
 siphon-ai-core.workspace       = true
 siphon-ai-media-glue.workspace = true
 siphon-ai-routes.workspace     = true
+siphon-ai-security.workspace   = true

--- a/crates/config/src/compile.rs
+++ b/crates/config/src/compile.rs
@@ -35,8 +35,8 @@ use thiserror::Error;
 use tracing::warn;
 
 use crate::raw::{
-    RawBridge, RawCdr, RawConfig, RawHep, RawMedia, RawNode, RawObservability, RawRegister, RawSip,
-    RawSipTls, RawWebhooks,
+    RawBridge, RawCdr, RawConfig, RawHep, RawMedia, RawNode, RawObservability, RawRegister,
+    RawSecurity, RawSip, RawSipTls, RawWebhooks,
 };
 
 /// Compiled, ready-to-pass daemon config.
@@ -61,10 +61,34 @@ pub struct Config {
     /// only). Non-empty enables strict-allowlist mode: every
     /// inbound INVITE must match a trunk or it's 403'd.
     pub trunks: Vec<TrunkConfig>,
+    pub security: SecurityConfig,
     pub cdr: CdrConfig,
     pub observability: ObservabilityConfig,
     pub webhooks: WebhooksConfig,
     pub hep: HepConfig,
+}
+
+/// Compiled `[security]` — the call-authentication policy (STIR/SHAKEN).
+/// Default is fully inert: no minimum attestation and verification
+/// disabled, so a 0.3.x config upgrades with zero behaviour change.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SecurityConfig {
+    /// Global minimum-attestation gate. `None` admits every call.
+    pub min_attestation: siphon_ai_security::MinAttestation,
+    /// SIP status to return when the gate rejects a call (403 / 488 / 606).
+    pub min_attestation_response: u16,
+    /// Compiled STIR/SHAKEN verification settings.
+    pub stir_shaken: siphon_ai_security::StirShakenConfig,
+}
+
+impl Default for SecurityConfig {
+    fn default() -> Self {
+        Self {
+            min_attestation: siphon_ai_security::MinAttestation::None,
+            min_attestation_response: 403,
+            stir_shaken: siphon_ai_security::StirShakenConfig::default(),
+        }
+    }
 }
 
 /// One compiled `[[register]]` block. The daemon's
@@ -377,6 +401,25 @@ pub enum CompileError {
     #[error("[bridge.tls] is malformed: {0}")]
     BadBridgeTls(#[from] siphon_ai_bridge::tls::TlsConfigError),
 
+    #[error("[security].min_attestation is {0:?}; expected \"none\", \"A\", \"B\", or \"C\"")]
+    UnknownMinAttestation(String),
+
+    #[error("[security].min_attestation_response is {0}; expected 403, 488, or 606")]
+    InvalidMinAttestationResponse(u16),
+
+    #[error(
+        "[security].min_attestation is {0:?} but [security.stir_shaken].enabled is false — \
+         without verification no call can produce an attestation, so every call would be \
+         rejected. Enable stir_shaken or set min_attestation = \"none\"."
+    )]
+    MinAttestationWithoutStirShaken(String),
+
+    #[error("[security.stir_shaken].trust_anchors is required when enabled = true")]
+    StirShakenTrustAnchorsRequired,
+
+    #[error("[security.stir_shaken].trust_anchors {path:?} is invalid: {err}")]
+    StirShakenTrustAnchorsInvalid { path: String, err: String },
+
     #[error("[media].rtp_port_range {min}-{max} is invalid (min must be < max and even)")]
     BadRtpPortRange { min: u16, max: u16 },
 
@@ -481,6 +524,7 @@ pub fn compile(raw: RawConfig) -> Result<Config, CompileError> {
     let routes = compile_dialplan(raw.routes)?;
     let registrations = compile_registrations(raw.registrations)?;
     let trunks = compile_trunks(raw.trunks)?;
+    let security = compile_security(raw.security)?;
     let cdr = compile_cdr(raw.cdr)?;
     let observability = compile_observability(raw.observability)?;
     let webhooks = compile_webhooks(raw.webhooks)?;
@@ -529,6 +573,7 @@ pub fn compile(raw: RawConfig) -> Result<Config, CompileError> {
         routes,
         registrations,
         trunks,
+        security,
         cdr,
         observability,
         webhooks,
@@ -686,6 +731,81 @@ pub(crate) fn compile_srtp_mode(
         Some("preferred") => Ok(siphon_ai_core::SrtpMode::Preferred),
         Some("required") => Ok(siphon_ai_core::SrtpMode::Required),
         Some(other) => Err(CompileError::UnknownSrtpMode(other.to_string())),
+    }
+}
+
+/// Compile and validate `[security]`. Fails loud on contradictory config
+/// (unknown attestation level / response code, a `min_attestation` set with
+/// verification disabled, or a missing/empty trust-anchor file when
+/// verification is enabled).
+fn compile_security(raw: RawSecurity) -> Result<SecurityConfig, CompileError> {
+    use siphon_ai_security::{
+        validate_trust_anchors, MinAttestation, StirShakenConfig, DEFAULT_CERT_CACHE_TTL,
+    };
+
+    let min_attestation = match raw.min_attestation.as_deref() {
+        None | Some("") => MinAttestation::None,
+        Some(s) => MinAttestation::parse(s)
+            .ok_or_else(|| CompileError::UnknownMinAttestation(s.to_string()))?,
+    };
+
+    let min_attestation_response = match raw.min_attestation_response {
+        None => 403,
+        Some(code @ (403 | 488 | 606)) => code,
+        Some(other) => return Err(CompileError::InvalidMinAttestationResponse(other)),
+    };
+
+    let stir = raw.stir_shaken;
+    let enabled = stir.enabled.unwrap_or(false);
+    let trust_anchors = stir.trust_anchors.map(PathBuf::from).unwrap_or_default();
+    let cert_cache_ttl = stir
+        .cert_cache_ttl_secs
+        .map(Duration::from_secs)
+        .unwrap_or(DEFAULT_CERT_CACHE_TTL);
+    let require_identity = stir.require_identity.unwrap_or(false);
+
+    // A minimum-attestation gate is meaningless without verification: with
+    // stir_shaken off, no call yields a trusted attestation, so the gate
+    // would 4xx every call. Fail loud rather than black-hole all traffic.
+    if min_attestation != MinAttestation::None && !enabled {
+        return Err(CompileError::MinAttestationWithoutStirShaken(
+            min_attestation_label(min_attestation).to_string(),
+        ));
+    }
+
+    // Validate the trust-anchor file at load time when verification is on,
+    // so a missing/empty bundle is a startup failure, not a per-call one.
+    if enabled {
+        if trust_anchors.as_os_str().is_empty() {
+            return Err(CompileError::StirShakenTrustAnchorsRequired);
+        }
+        validate_trust_anchors(&trust_anchors).map_err(|err| {
+            CompileError::StirShakenTrustAnchorsInvalid {
+                path: trust_anchors.display().to_string(),
+                err: err.to_string(),
+            }
+        })?;
+    }
+
+    Ok(SecurityConfig {
+        min_attestation,
+        min_attestation_response,
+        stir_shaken: StirShakenConfig {
+            enabled,
+            trust_anchors,
+            cert_cache_ttl,
+            require_identity,
+        },
+    })
+}
+
+fn min_attestation_label(m: siphon_ai_security::MinAttestation) -> &'static str {
+    use siphon_ai_security::MinAttestation::*;
+    match m {
+        None => "none",
+        A => "A",
+        B => "B",
+        C => "C",
     }
 }
 
@@ -1286,6 +1406,126 @@ mod srtp_mode_tests {
             compile_srtp_mode(Some("PREFERRED")),
             Err(CompileError::UnknownSrtpMode(_))
         ));
+    }
+}
+
+#[cfg(test)]
+mod security_tests {
+    use super::{compile_security, CompileError, SecurityConfig};
+    use crate::raw::{RawSecurity, RawStirShaken};
+    use siphon_ai_security::{MinAttestation, DEFAULT_CERT_CACHE_TTL};
+
+    #[test]
+    fn default_is_inert() {
+        let c = compile_security(RawSecurity::default()).unwrap();
+        assert_eq!(c.min_attestation, MinAttestation::None);
+        assert_eq!(c.min_attestation_response, 403);
+        assert!(!c.stir_shaken.enabled);
+        assert_eq!(c.stir_shaken.cert_cache_ttl, DEFAULT_CERT_CACHE_TTL);
+        assert_eq!(c, SecurityConfig::default());
+    }
+
+    #[test]
+    fn unknown_min_attestation_fails_loud() {
+        let raw = RawSecurity {
+            min_attestation: Some("strong".into()),
+            ..Default::default()
+        };
+        assert!(matches!(
+            compile_security(raw),
+            Err(CompileError::UnknownMinAttestation(s)) if s == "strong"
+        ));
+    }
+
+    #[test]
+    fn invalid_response_code_rejected() {
+        let raw = RawSecurity {
+            min_attestation_response: Some(500),
+            ..Default::default()
+        };
+        assert!(matches!(
+            compile_security(raw),
+            Err(CompileError::InvalidMinAttestationResponse(500))
+        ));
+    }
+
+    #[test]
+    fn min_attestation_without_stir_shaken_rejected() {
+        // A gate with verification off would 4xx every call — fail loud.
+        let raw = RawSecurity {
+            min_attestation: Some("B".into()),
+            ..Default::default()
+        };
+        assert!(matches!(
+            compile_security(raw),
+            Err(CompileError::MinAttestationWithoutStirShaken(s)) if s == "B"
+        ));
+    }
+
+    #[test]
+    fn enabled_requires_trust_anchors() {
+        let raw = RawSecurity {
+            stir_shaken: RawStirShaken {
+                enabled: Some(true),
+                trust_anchors: None,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(matches!(
+            compile_security(raw),
+            Err(CompileError::StirShakenTrustAnchorsRequired)
+        ));
+    }
+
+    #[test]
+    fn enabled_with_missing_anchor_file_rejected() {
+        let raw = RawSecurity {
+            stir_shaken: RawStirShaken {
+                enabled: Some(true),
+                trust_anchors: Some("/nonexistent/sti-pa-roots.pem".into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(matches!(
+            compile_security(raw),
+            Err(CompileError::StirShakenTrustAnchorsInvalid { .. })
+        ));
+    }
+
+    #[test]
+    fn valid_enabled_config_compiles() {
+        // Write a throwaway PEM bundle so the load-time anchor check passes.
+        let path = std::env::temp_dir().join("siphon_security_test_anchors.pem");
+        std::fs::write(
+            &path,
+            "-----BEGIN CERTIFICATE-----\nMIIB...\n-----END CERTIFICATE-----\n",
+        )
+        .unwrap();
+
+        let raw = RawSecurity {
+            min_attestation: Some("B".into()),
+            min_attestation_response: Some(606),
+            stir_shaken: RawStirShaken {
+                enabled: Some(true),
+                trust_anchors: Some(path.to_string_lossy().into_owned()),
+                cert_cache_ttl_secs: Some(1800),
+                require_identity: Some(true),
+            },
+        };
+        let c = compile_security(raw).unwrap();
+        assert_eq!(c.min_attestation, MinAttestation::B);
+        assert_eq!(c.min_attestation_response, 606);
+        assert!(c.stir_shaken.enabled);
+        assert!(c.stir_shaken.require_identity);
+        assert_eq!(
+            c.stir_shaken.cert_cache_ttl,
+            std::time::Duration::from_secs(1800)
+        );
+        assert_eq!(c.stir_shaken.trust_anchors, path);
+
+        let _ = std::fs::remove_file(&path);
     }
 }
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -35,8 +35,8 @@ use thiserror::Error;
 
 pub use compile::{
     compile, CdrConfig, CdrFileConfig, CdrWebhookConfig, CompileError, Config, HepConfig,
-    MediaConfig, NodeConfig, ObservabilityConfig, RegisterConfig, SipConfig, SipTlsConfig,
-    SipTransport, TrunkCidr, TrunkCidrParseError, TrunkConfig, WebhooksConfig,
+    MediaConfig, NodeConfig, ObservabilityConfig, RegisterConfig, SecurityConfig, SipConfig,
+    SipTlsConfig, SipTransport, TrunkCidr, TrunkCidrParseError, TrunkConfig, WebhooksConfig,
 };
 pub use env::{expand, expand_cow, EnvError, EnvSource, ProcessEnv};
 pub use raw::{

--- a/crates/config/src/raw.rs
+++ b/crates/config/src/raw.rs
@@ -50,6 +50,9 @@ pub struct RawConfig {
     pub trunks: Vec<RawTrunk>,
 
     #[serde(default)]
+    pub security: RawSecurity,
+
+    #[serde(default)]
     pub cdr: RawCdr,
 
     #[serde(default)]
@@ -198,6 +201,54 @@ pub struct RawMedia {
     /// fail-loud error per CLAUDE.md §4.6.
     #[serde(default)]
     pub srtp: Option<String>,
+}
+
+/// `[security]` — call-authentication policy (STIR/SHAKEN, 0.4.0).
+/// Entirely optional; the feature is inert unless
+/// `[security.stir_shaken].enabled = true`. Compiled and validated via
+/// [`compile::compile_security`].
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawSecurity {
+    /// Minimum attestation a call must carry to be accepted:
+    /// `"none"` (default) | `"A"` | `"B"` | `"C"`. Requires
+    /// `[security.stir_shaken].enabled = true` to have any effect — a
+    /// non-`none` value without verification rejects every call, which is
+    /// a fail-loud config error.
+    #[serde(default)]
+    pub min_attestation: Option<String>,
+    /// SIP status returned when the attestation gate rejects a call:
+    /// `403` (default) | `488` | `606`.
+    #[serde(default)]
+    pub min_attestation_response: Option<u16>,
+    /// `[security.stir_shaken]` verification sub-block.
+    #[serde(default)]
+    pub stir_shaken: RawStirShaken,
+}
+
+/// `[security.stir_shaken]` — STIR/SHAKEN verification settings.
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawStirShaken {
+    /// Master switch. `false` (default) → no Identity parsing/verification
+    /// and no `verstat` surfaced (0.3.x behaviour preserved).
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    /// Path to the PEM bundle of STI-PA trust anchors (ship
+    /// `contrib/sti-pa-roots.pem`). Required when `enabled = true`;
+    /// validated at load time (must exist and hold ≥1 PEM certificate).
+    #[serde(default)]
+    pub trust_anchors: Option<String>,
+    /// How long a fetched signing certificate is cached, in seconds.
+    /// `None` → 3600 (1 hour). (Seconds, for consistency with the other
+    /// duration fields in this config; the plan's `"1h"` string form is a
+    /// possible later ergonomics pass.)
+    #[serde(default)]
+    pub cert_cache_ttl_secs: Option<u64>,
+    /// Reject INVITEs with no `Identity` header (428 "Use Identity Header")
+    /// instead of admitting them as unsigned. Default `false`.
+    #[serde(default)]
+    pub require_identity: Option<bool>,
 }
 
 /// `[cdr]` — call detail record sinks. v1 supports a JSONL file

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -19,6 +19,8 @@ before TOML parsing. Unset variables without a default fail the load.
 [bridge.barge_in] # speech-detection policy
 [[route]]         # one per dialplan rule, ORDERED (first match wins)
 [[register]]      # zero or more outbound REGISTERs ("registered phone" mode)
+[security]        # STIR/SHAKEN call-authentication policy (0.4.0)
+[security.stir_shaken]  # verification settings
 [cdr]             # call detail records: file + webhook sinks
 [observability]   # /metrics, /health, /ready, /admin
 [webhooks]        # lifecycle events (call_start, call_end, …)
@@ -265,6 +267,58 @@ request_uri_user = "9000"
   with the carrier's cert pinned by the OS trust store).
 - Digest auth on inbound INVITEs (RFC 3261 §22) is the proper
   "no trust in network" answer; it's a post-v1 feature.
+
+## `[security]` — STIR/SHAKEN call authentication
+
+> **Status (0.4.0, in progress):** the configuration surface is wired and
+> validated at load time. The verifier that produces the verdict (Identity-
+> header parsing, ES256 signature check, certificate-chain validation) lands
+> in subsequent chunks. With `[security.stir_shaken].enabled = false` (the
+> default) the feature is entirely inert — a 0.3.x config upgrades with no
+> behaviour change.
+
+Verifies the RFC 8224 `Identity` header (RFC 8225 PASSporT, SHAKEN profile)
+on inbound INVITEs and, optionally, rejects calls whose attestation is below
+a configured minimum.
+
+```toml
+[security]
+min_attestation          = "none"   # "none" | "A" | "B" | "C"
+min_attestation_response = 403       # 403 | 488 | 606
+
+[security.stir_shaken]
+enabled            = false           # master switch
+trust_anchors      = "/etc/siphon-ai/sti-pa-roots.pem"
+cert_cache_ttl_secs = 3600           # signing-cert cache TTL (seconds)
+require_identity   = false           # reject unsigned INVITEs with 428
+```
+
+### `[security]`
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `min_attestation` | string | `"none"` | Minimum **trusted** attestation to admit a call: `A` (full) > `B` (partial) > `C` (gateway). `"none"` admits everything. A non-`none` value **requires** `stir_shaken.enabled = true` (else every call would be rejected — fail-loud config error). |
+| `min_attestation_response` | int | `403` | SIP status when the gate rejects: `403` (Forbidden, recommended), `488`, or `606`. |
+
+The gate admits a call only when verification **fully passed** and the claimed attestation meets the minimum. An unsigned call, a failed signature, or an attestation below the threshold is rejected — see the policy matrix:
+
+| `min_attestation` | A | B | C | unsigned / header absent | invalid signature |
+|---|---|---|---|---|---|
+| `"none"` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `"C"` | ✓ | ✓ | ✓ | reject | reject |
+| `"B"` | ✓ | ✓ | reject | reject | reject |
+| `"A"` | ✓ | reject | reject | reject | reject |
+
+A per-route override (`[route.security].min_attestation`, strict override of the global) is a follow-on chunk.
+
+### `[security.stir_shaken]`
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `enabled` | bool | `false` | Master switch. When off, no Identity parsing/verification runs and no `verstat` is surfaced. |
+| `trust_anchors` | string | — | Path to the PEM bundle of STI-PA trust anchors (ship `contrib/sti-pa-roots.pem`). **Required when `enabled = true`**; validated at load time (must exist and contain ≥1 PEM certificate). |
+| `cert_cache_ttl_secs` | int | `3600` | How long a fetched signing certificate is cached before re-fetch. (Seconds, matching the other duration fields in this config.) |
+| `require_identity` | bool | `false` | Reject inbound INVITEs that carry no `Identity` header with `428 Use Identity Header` (RFC 8224 §6.2.2) instead of admitting them as unsigned. |
 
 ## `[cdr]`
 

--- a/docs/DEV_PLAN_0.4.0.md
+++ b/docs/DEV_PLAN_0.4.0.md
@@ -64,7 +64,9 @@ the parsing primitive lands.
      [security.stir_shaken]
      enabled         = true
      trust_anchors   = "/etc/siphon-ai/sti-pa-roots.pem"
-     cert_cache_ttl  = "1h"
+     cert_cache_ttl_secs = 3600   # seconds, for consistency with the other
+                                  # duration fields; "1h" string form is a
+                                  # possible later ergonomics pass
      # When the Identity header is absent on an inbound INVITE,
      # the resulting verdict is `attest: null, signature_valid: false`.
      # `require_identity = true` rejects unsigned calls with 428


### PR DESCRIPTION
## Summary

Wires the global **`[security]` / `[security.stir_shaken]`** TOML block onto the `siphon-ai-security` types from #113. This makes the verstat policy + verification settings reachable from a config file and validated at load time. Builds on the merged security crate; depends on nothing else.

## What's wired

- **Raw structs** (`RawSecurity` / `RawStirShaken`) in `crates/config/raw.rs`, with `deny_unknown_fields`.
- **`compile_security`** → `SecurityConfig` on the compiled `Config`, validated **fail-loud** (CLAUDE.md §4.6):
  - unknown `min_attestation` (expect `none`/`A`/`B`/`C`) or `min_attestation_response` (expect `403`/`488`/`606`);
  - `min_attestation` set with `stir_shaken` **disabled** — no call could produce an attestation, so the gate would 4xx everything (caught at load, not in prod);
  - `stir_shaken.enabled` without `trust_anchors`, or with a **missing/empty** trust-anchor PEM file (`validate_trust_anchors` at load time).
- **Default is fully inert** (`min_attestation = none`, verification off) → a 0.3.x config upgrades with zero behaviour change.

## Not yet (later chunks)

- **No accept-path wiring** — the daemon binds `security: _security` pending the verifier. This PR is config surface + validation only.
- **Per-route `[route.security].min_attestation`** override — the strict-override `MinAttestation::resolve` helper already exists in `siphon-ai-security`; the routes-crate plumbing is a focused follow-on.

## Docs

- `CONFIG.md` gains a `[security]` section with the field tables + the full policy matrix.
- `DEV_PLAN_0.4.0.md` example aligned to `cert_cache_ttl_secs` (seconds — matching the codebase's other duration fields rather than the plan's earlier `"1h"` sketch; the string form is noted as a possible later ergonomics pass).

## Tests

7 new `compile_security` tests (defaults inert, each fail-loud path, and a valid enabled config via a throwaway PEM file). `cargo build/test --workspace` green (42 groups, 0 failures); fmt + clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)