### PR TITLE
feat(security,routes): STIR/SHAKEN attestation policy gate + per-route override

### DIFF
--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -235,13 +235,23 @@ impl Runtime {
             None
         };
 
+        // Attestation gate (config already cross-validated: a non-`none`
+        // floor requires stir_shaken enabled). Inert by default — only bites
+        // when a verifier is installed and a floor / require_identity is set.
+        let security_policy = siphon_ai_core::AcceptSecurityPolicy {
+            min_attestation: security.min_attestation,
+            min_attestation_response: security.min_attestation_response,
+            require_identity: security.stir_shaken.require_identity,
+        };
+
         let acceptor = Arc::new(
             BridgingAcceptor::new(media_setup, bridge_defaults, registry.clone())
                 .with_cdr_sink(cdr_sink)
                 .with_webhook_sink(webhook_sink)
                 .with_session_timer_policy(session_timer_policy)
                 .with_call_progress(sip.call_progress)
-                .with_verifier(verifier),
+                .with_verifier(verifier)
+                .with_security_policy(security_policy),
         );
 
         // ─── Registration manager ──────────────────────────────────

--- a/crates/config/src/compile.rs
+++ b/crates/config/src/compile.rs
@@ -414,6 +414,19 @@ pub enum CompileError {
     )]
     MinAttestationWithoutStirShaken(String),
 
+    #[error(
+        "route {route:?} sets [route.security].min_attestation = {value:?}; \
+         expected \"none\", \"A\", \"B\", or \"C\""
+    )]
+    UnknownRouteMinAttestation { route: String, value: String },
+
+    #[error(
+        "route {route:?} sets [route.security].min_attestation but \
+         [security.stir_shaken].enabled is false — without verification the gate would \
+         reject every call this route matches. Enable stir_shaken or drop the override."
+    )]
+    RouteMinAttestationWithoutStirShaken { route: String },
+
     #[error("[security.stir_shaken].trust_anchors is required when enabled = true")]
     StirShakenTrustAnchorsRequired,
 
@@ -535,6 +548,27 @@ pub fn compile(raw: RawConfig) -> Result<Config, CompileError> {
             route_count = routes.len(),
             "no default `any = true` route configured — non-matching INVITEs will be 404'd"
         );
+    }
+
+    // A per-route attestation gate, like the global one, is meaningless
+    // without verification: with stir_shaken off no call produces a trusted
+    // attestation, so the route would reject everything it matches. Fail
+    // loud rather than black-hole that route's traffic. (`min_attestation =
+    // "none"` is a no-op override and allowed either way.)
+    if !security.stir_shaken.enabled {
+        for route in routes.iter() {
+            let overrides_gate = route
+                .security
+                .min_attestation
+                .as_deref()
+                .and_then(siphon_ai_security::MinAttestation::parse)
+                .is_some_and(|m| m != siphon_ai_security::MinAttestation::None);
+            if overrides_gate {
+                return Err(CompileError::RouteMinAttestationWithoutStirShaken {
+                    route: route.name.clone(),
+                });
+            }
+        }
     }
 
     // SRTP-without-SIP/TLS footgun warning (DEV_PLAN_0.3.0.md §11).
@@ -964,6 +998,18 @@ fn compile_dialplan(routes: Vec<siphon_ai_routes::RawRoute>) -> Result<RouteSet,
                 return Err(CompileError::UnknownOnWsFailure {
                     route: route.name.clone(),
                     value: mode.to_string(),
+                });
+            }
+        }
+        // Validate the per-route attestation override at load time so a typo
+        // is a startup failure, not a silent runtime fall-back. The
+        // cross-check against stir_shaken.enabled happens in `compile`,
+        // which has the global security config in scope.
+        if let Some(value) = route.security.min_attestation.as_deref() {
+            if siphon_ai_security::MinAttestation::parse(value).is_none() {
+                return Err(CompileError::UnknownRouteMinAttestation {
+                    route: route.name.clone(),
+                    value: value.to_string(),
                 });
             }
         }

--- a/crates/config/tests/load.rs
+++ b/crates/config/tests/load.rs
@@ -216,6 +216,82 @@ ws_url = "wss://x/y"
 }
 
 #[test]
+fn invalid_per_route_min_attestation_rejected_at_load() {
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[bridge]
+ws_url = "wss://x/y"
+
+[[route]]
+name = "vip"
+[route.match]
+any = true
+[route.security]
+min_attestation = "platinum"
+"#;
+    let err = load_from_str_with_env(toml, &env).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("platinum") && msg.contains("vip"),
+        "got: {msg}"
+    );
+}
+
+#[test]
+fn per_route_min_attestation_without_stir_shaken_rejected() {
+    // A valid level, but verification is off — the gate would 4xx every
+    // call this route matches, so config load must fail loud.
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[bridge]
+ws_url = "wss://x/y"
+
+[[route]]
+name = "vip"
+[route.match]
+any = true
+[route.security]
+min_attestation = "A"
+"#;
+    let err = load_from_str_with_env(toml, &env).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("vip") && msg.contains("stir_shaken"),
+        "got: {msg}"
+    );
+}
+
+#[test]
+fn per_route_min_attestation_none_is_inert_without_stir_shaken() {
+    // `min_attestation = "none"` is a no-op override — allowed even with
+    // verification off (it can't reject anything).
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[bridge]
+ws_url = "wss://x/y"
+
+[[route]]
+name = "open"
+[route.match]
+any = true
+[route.security]
+min_attestation = "none"
+"#;
+    let cfg = load_from_str_with_env(toml, &env).expect("none override compiles");
+    let route = cfg.routes.iter().next().expect("one route");
+    assert_eq!(route.security.min_attestation.as_deref(), Some("none"));
+}
+
+#[test]
 fn session_timer_defaults_to_90s_floor() {
     let env = MapEnv::new([]);
     let toml = r#"

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -75,6 +75,7 @@ use siphon_ai_media_glue::{
     SetupError, TapDisconnect,
 };
 use siphon_ai_routes::CompiledRoute;
+use siphon_ai_security::MinAttestation;
 use siphon_ai_sip_glue::{CallAcceptor, InviteFacts, MatchedCall};
 use siphon_ai_stir_shaken::Verifier;
 use siphon_ai_telemetry::{
@@ -324,6 +325,24 @@ pub enum AcceptError {
         /// Effective mode after resolving the route override.
         mode: SrtpMode,
     },
+
+    /// `[security.stir_shaken].require_identity` is set and the INVITE
+    /// carried no `Identity` header. Maps to **428 Use Identity Header**
+    /// (RFC 8224 §6.2.2).
+    #[error("INVITE carried no Identity header but require_identity is set")]
+    IdentityRequired,
+
+    /// The call's *trusted* attestation was below the effective
+    /// `min_attestation` policy (global, or the per-route override). Maps to
+    /// the configured `min_attestation_response` (403 / 488 / 606) with a
+    /// Q.850 `Reason` header (plan §9 decision 4).
+    #[error("call attestation below policy minimum {required:?}")]
+    AttestationRejected {
+        /// The effective minimum the call failed to meet.
+        required: MinAttestation,
+        /// Configured SIP status to return (403 / 488 / 606).
+        code: u16,
+    },
 }
 
 impl AcceptError {
@@ -352,8 +371,120 @@ impl AcceptError {
             | AcceptError::Setup(SetupError::Tap(_))
             | AcceptError::Controller(_) => (500, "Server Internal Error"),
             AcceptError::SrtpModeMismatch { .. } => (488, "Not Acceptable Here"),
+            AcceptError::IdentityRequired => (428, "Use Identity Header"),
+            AcceptError::AttestationRejected { code, .. } => (*code, reason_phrase(*code)),
         }
     }
+
+    /// The `result` label this rejection contributes to
+    /// `siphon_ai_invites_total`. STIR/SHAKEN policy rejections get their
+    /// own `rejected_attestation` bucket so they're separately alertable
+    /// from ordinary routing/media rejections.
+    pub fn reject_metric_label(&self) -> &'static str {
+        match self {
+            AcceptError::IdentityRequired | AcceptError::AttestationRejected { .. } => {
+                "rejected_attestation"
+            }
+            _ => "rejected",
+        }
+    }
+
+    /// The `Reason` header value to attach to the final response, if any.
+    /// Attestation rejections carry `Q.850;cause=21` ("call rejected") so a
+    /// downstream/Homer can see *why* the call was screened, not just the
+    /// bare status (plan §9 decision 4).
+    pub fn reason_header(&self) -> Option<&'static str> {
+        match self {
+            AcceptError::AttestationRejected { .. } => {
+                Some("Q.850;cause=21;text=\"STIR/SHAKEN attestation below policy\"")
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Reason phrase for the configurable attestation-rejection status codes.
+fn reason_phrase(code: u16) -> &'static str {
+    match code {
+        403 => "Forbidden",
+        488 => "Not Acceptable Here",
+        606 => "Not Acceptable",
+        // `min_attestation_response` is validated to one of the above at
+        // config load; this arm is just a total-match safety net.
+        _ => "Forbidden",
+    }
+}
+
+/// The daemon's compiled STIR/SHAKEN *policy* knobs — the gate the accept
+/// path applies to a verification verdict. Separate from the [`Verifier`]
+/// (which produces the verdict): verification can be on while the gate is
+/// fully permissive (`min_attestation = none`, `require_identity = false`),
+/// which is the default and a complete no-op.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AcceptSecurityPolicy {
+    /// Global minimum trusted attestation. `None` admits every call.
+    pub min_attestation: MinAttestation,
+    /// SIP status returned when the gate rejects (403 / 488 / 606).
+    pub min_attestation_response: u16,
+    /// Reject inbound INVITEs with no `Identity` header (428).
+    pub require_identity: bool,
+}
+
+impl Default for AcceptSecurityPolicy {
+    /// Fully permissive: no attestation floor, no identity requirement. A
+    /// 403 response code is carried but never used until a floor is set.
+    fn default() -> Self {
+        Self {
+            min_attestation: MinAttestation::None,
+            min_attestation_response: 403,
+            require_identity: false,
+        }
+    }
+}
+
+/// Resolve the effective minimum-attestation policy for a matched route:
+/// the per-route `[route.security].min_attestation` override (strict —
+/// fully replaces the global, matching `[route.media].srtp` semantics) or
+/// the global when the route sets none. An unparseable override can't reach
+/// here — the config crate validates it at load.
+fn resolve_min_attestation(global: MinAttestation, route: &CompiledRoute) -> MinAttestation {
+    let route_override = route
+        .security
+        .min_attestation
+        .as_deref()
+        .and_then(MinAttestation::parse);
+    MinAttestation::resolve(global, route_override)
+}
+
+/// Apply the attestation gate to a verification verdict. Free function (not
+/// a method) so the policy decision is unit-testable without standing up an
+/// acceptor. `effective_min` is the already-resolved floor (global + route
+/// override); `had_identity` distinguishes an unsigned call (no `Identity`
+/// header) from a present-but-failed one, which only `require_identity`
+/// cares about.
+fn apply_attestation_gate(
+    policy: &AcceptSecurityPolicy,
+    effective_min: MinAttestation,
+    verdict: &siphon_ai_security::VerificationResult,
+    had_identity: bool,
+) -> Result<(), AcceptError> {
+    // Gate 1: require_identity rejects a call with no Identity header
+    // outright (428), independent of any attestation floor.
+    if policy.require_identity && !had_identity {
+        return Err(AcceptError::IdentityRequired);
+    }
+
+    // Gate 2: the effective minimum-attestation floor. `permits` trusts the
+    // attestation only when verification fully passed, so an unsigned/failed
+    // call can never satisfy a non-`none` floor.
+    if !effective_min.permits(verdict) {
+        return Err(AcceptError::AttestationRejected {
+            required: effective_min,
+            code: policy.min_attestation_response,
+        });
+    }
+
+    Ok(())
 }
 
 // ─── Pure helpers (unit-tested below) ───────────────────────────────
@@ -1271,6 +1402,10 @@ pub struct BridgingAcceptor {
     /// deployment upgrades with zero behaviour change. Shared across calls
     /// (it owns a process-wide cert cache); cheap to clone.
     verifier: Option<Arc<Verifier>>,
+    /// Attestation-gate policy applied to the verdict. Default is fully
+    /// permissive; only consulted when `verifier` is `Some` (a verdict
+    /// exists to gate on).
+    security: AcceptSecurityPolicy,
 }
 
 /// Daemon-wide REFER plumbing (shared across every accepted call).
@@ -1419,6 +1554,7 @@ impl BridgingAcceptor {
             call_progress: CallProgressMode::default(),
             dtls_cert,
             verifier: None,
+            security: AcceptSecurityPolicy::default(),
         }
     }
 
@@ -1499,6 +1635,14 @@ impl BridgingAcceptor {
     /// nothing.
     pub fn with_verifier(mut self, verifier: Option<Arc<Verifier>>) -> Self {
         self.verifier = verifier;
+        self
+    }
+
+    /// Install the attestation-gate policy (`[security].min_attestation`,
+    /// its response code, and `require_identity`). Defaults to fully
+    /// permissive; the gate is only consulted when a verifier is installed.
+    pub fn with_security_policy(mut self, policy: AcceptSecurityPolicy) -> Self {
+        self.security = policy;
         self
     }
 
@@ -2237,8 +2381,13 @@ impl CallAcceptor for BridgingAcceptor {
             Err(e) => {
                 let (code, reason) = e.sip_status();
                 warn!(error = %e, code, reason, "rejecting INVITE");
-                metrics::counter!(INVITES_TOTAL, "result" => "rejected").increment(1);
-                let response = UserAgentServer::create_response(call.request, code, reason);
+                metrics::counter!(INVITES_TOTAL, "result" => e.reject_metric_label()).increment(1);
+                let mut response = UserAgentServer::create_response(call.request, code, reason);
+                // Attestation rejections carry a Q.850 Reason so the caller /
+                // Homer sees why the call was screened (plan §9 decision 4).
+                if let Some(reason_value) = e.reason_header() {
+                    let _ = response.headers_mut().set_or_push("Reason", reason_value);
+                }
                 call.handle.send_final(response).await;
                 // The acceptor's contract with the routing layer is
                 // "MUST send a final response" — we did, so this is
@@ -2499,38 +2648,51 @@ impl std::fmt::Debug for PreparedCall {
 }
 
 impl BridgingAcceptor {
-    /// Verify the inbound INVITE's `Identity` header, when STIR/SHAKEN is
-    /// enabled. Returns the verdict to surface on `start` (and the CDR), or
-    /// `None` when verification is disabled — in which case no `verstat` is
-    /// emitted at all.
+    /// Verify the inbound INVITE's `Identity` header and apply the
+    /// attestation gate, when STIR/SHAKEN is enabled.
+    ///
+    /// Returns:
+    /// - `Ok(Some(verdict))` — verification ran and the call passed the gate;
+    ///   the verdict is surfaced on `start` and the CDR.
+    /// - `Ok(None)` — verification is disabled; no `verstat` is emitted.
+    /// - `Err(_)` — the gate rejected the call (`require_identity` with no
+    ///   `Identity` header → 428, or attestation below `min_attestation` →
+    ///   the configured 4xx). The caller turns this into the final response.
     ///
     /// A missing `Identity` header yields [`VerificationResult::unsigned`]
     /// (attestation `null`, nothing verified) rather than `None`: with
     /// verification on, the absence of a signature is itself a reportable
-    /// outcome. Policy enforcement (reject-on-`require_identity`,
-    /// `min_attestation` gate) is a separate chunk — this only produces and
-    /// records the verdict.
-    async fn verify_identity(
+    /// outcome — and one `require_identity` may reject.
+    async fn run_security(
         &self,
         facts: &InviteFacts,
+        route: &CompiledRoute,
         bridge_call_id: &str,
-    ) -> Option<Box<siphon_ai_security::VerificationResult>> {
-        let (verdict, had_identity) =
-            run_identity_verification(self.verifier.as_deref(), facts).await?;
+    ) -> Result<Option<Box<siphon_ai_security::VerificationResult>>, AcceptError> {
+        let Some((verdict, had_identity)) =
+            run_identity_verification(self.verifier.as_deref(), facts).await
+        else {
+            // Verification disabled — no verdict, no gate.
+            return Ok(None);
+        };
 
         let result = verstat_metric_result(&verdict, had_identity);
         metrics::counter!(VERSTAT_TOTAL, "result" => result).increment(1);
+
+        let effective_min = resolve_min_attestation(self.security.min_attestation, route);
         info!(
             call_id = %bridge_call_id,
             verstat_result = result,
             verstat_attest = verdict.attest.map(|a| a.as_str()).unwrap_or("none"),
             verstat_passed = verdict.passed(),
             orig_tn = verdict.orig_tn.as_deref().unwrap_or(""),
+            min_attestation = effective_min.as_str(),
             error = verdict.error.as_deref().unwrap_or(""),
             "STIR/SHAKEN verification complete"
         );
 
-        Some(Box::new(verdict))
+        apply_attestation_gate(&self.security, effective_min, &verdict, had_identity)?;
+        Ok(Some(Box::new(verdict)))
     }
 
     /// Run every step from "matched route" up to "ready-to-run
@@ -2600,6 +2762,14 @@ impl BridgingAcceptor {
 
         let bridge_call_id = (self.call_id_factory)();
         let forge_call_id = forge_core::CallId::new(bridge_call_id.as_str());
+
+        // STIR/SHAKEN verification + attestation gate. Runs before media
+        // bring-up so a policy-rejected call never allocates a forge session
+        // or RTP port. Returns the verdict to ride `start` → CDR; an `Err`
+        // here is a gate rejection the async wrapper turns into a 4xx/428.
+        let verstat = self
+            .run_security(facts, route, bridge_call_id.as_str())
+            .await?;
 
         debug!(
             ws_url = %bridge_config.ws_url,
@@ -2678,12 +2848,8 @@ impl BridgingAcceptor {
             None
         };
 
-        // STIR/SHAKEN verification, when enabled. Runs here — after media
-        // bring-up, before the controller is built — so the verdict can ride
-        // the `start` message (and from there the CDR). `None` when
-        // verification is disabled, so the field is omitted from `start`.
-        let verstat = self.verify_identity(facts, bridge_call_id.as_str()).await;
-
+        // `verstat` was produced by `run_security` above (before media
+        // bring-up); thread it onto `start` so it flows to the CDR too.
         let start = build_start_msg(
             bridge_call_id.clone(),
             facts,
@@ -4171,5 +4337,160 @@ a=sendrecv\r\n",
         v.dest_passed = true;
         assert!(v.passed());
         assert_eq!(verstat_metric_result(&v, true), "passed");
+    }
+
+    // ─── Attestation gate ─────────────────────────────────────────
+
+    use siphon_ai_security::{AttestationLevel, VerificationResult};
+
+    /// A fully-passing verdict claiming `attest`.
+    fn passing(attest: AttestationLevel) -> VerificationResult {
+        VerificationResult {
+            attest: Some(attest),
+            orig_tn: Some("+12155551212".into()),
+            orig_passed: true,
+            dest_passed: true,
+            cert_chain_valid: true,
+            signature_valid: true,
+            error: None,
+        }
+    }
+
+    fn policy(min: MinAttestation, require_identity: bool) -> AcceptSecurityPolicy {
+        AcceptSecurityPolicy {
+            min_attestation: min,
+            min_attestation_response: 403,
+            require_identity,
+        }
+    }
+
+    #[test]
+    fn gate_admits_when_no_floor_and_no_identity_requirement() {
+        let p = policy(MinAttestation::None, false);
+        // Unsigned call, no identity → still admitted (default-open).
+        let u = VerificationResult::unsigned();
+        assert!(apply_attestation_gate(&p, MinAttestation::None, &u, false).is_ok());
+    }
+
+    #[test]
+    fn gate_rejects_missing_identity_when_required() {
+        let p = policy(MinAttestation::None, true);
+        let u = VerificationResult::unsigned();
+        // require_identity bites only when the header was absent.
+        assert!(matches!(
+            apply_attestation_gate(&p, MinAttestation::None, &u, false),
+            Err(AcceptError::IdentityRequired)
+        ));
+        // Present (even if failed) header satisfies require_identity; with no
+        // floor it then passes.
+        assert!(apply_attestation_gate(&p, MinAttestation::None, &u, true).is_ok());
+    }
+
+    #[test]
+    fn gate_enforces_attestation_floor() {
+        let p = policy(MinAttestation::B, false);
+        // A and B clear a B floor; C does not.
+        assert!(
+            apply_attestation_gate(&p, MinAttestation::B, &passing(AttestationLevel::A), true)
+                .is_ok()
+        );
+        assert!(
+            apply_attestation_gate(&p, MinAttestation::B, &passing(AttestationLevel::B), true)
+                .is_ok()
+        );
+        assert!(matches!(
+            apply_attestation_gate(&p, MinAttestation::B, &passing(AttestationLevel::C), true),
+            Err(AcceptError::AttestationRejected {
+                required: MinAttestation::B,
+                code: 403
+            })
+        ));
+    }
+
+    #[test]
+    fn gate_distrusts_unverified_attestation() {
+        let p = policy(MinAttestation::C, false);
+        // Claims A but verification failed → not trusted → rejected even at
+        // the lowest floor.
+        let mut claimed_a_failed = passing(AttestationLevel::A);
+        claimed_a_failed.signature_valid = false;
+        assert!(matches!(
+            apply_attestation_gate(&p, MinAttestation::C, &claimed_a_failed, true),
+            Err(AcceptError::AttestationRejected { .. })
+        ));
+    }
+
+    #[test]
+    fn gate_response_code_follows_policy() {
+        let p = policy(MinAttestation::A, false);
+        let p = AcceptSecurityPolicy {
+            min_attestation_response: 488,
+            ..p
+        };
+        let err =
+            apply_attestation_gate(&p, MinAttestation::A, &passing(AttestationLevel::B), true)
+                .unwrap_err();
+        assert_eq!(err.sip_status(), (488, "Not Acceptable Here"));
+    }
+
+    #[test]
+    fn accept_error_security_mappings() {
+        let rejected = AcceptError::AttestationRejected {
+            required: MinAttestation::B,
+            code: 403,
+        };
+        assert_eq!(rejected.sip_status(), (403, "Forbidden"));
+        assert_eq!(rejected.reject_metric_label(), "rejected_attestation");
+        assert!(rejected.reason_header().unwrap().contains("cause=21"));
+
+        let no_id = AcceptError::IdentityRequired;
+        assert_eq!(no_id.sip_status(), (428, "Use Identity Header"));
+        assert_eq!(no_id.reject_metric_label(), "rejected_attestation");
+        assert_eq!(no_id.reason_header(), None);
+
+        // A non-security rejection keeps the plain bucket and no Reason.
+        let other = AcceptError::Controller("boom".into());
+        assert_eq!(other.reject_metric_label(), "rejected");
+        assert_eq!(other.reason_header(), None);
+    }
+
+    #[test]
+    fn resolve_min_attestation_strict_override() {
+        use siphon_ai_routes::{compile, RawRoute, RawRouteFile, RawRouteMatch, SecurityOverride};
+        let route = |over: Option<&str>| {
+            let raw = RawRoute {
+                name: "r".into(),
+                match_: RawRouteMatch {
+                    any: true,
+                    ..Default::default()
+                },
+                bridge: Default::default(),
+                media: Default::default(),
+                security: SecurityOverride {
+                    min_attestation: over.map(String::from),
+                },
+            };
+            compile(RawRouteFile { routes: vec![raw] })
+                .unwrap()
+                .iter()
+                .next()
+                .unwrap()
+                .clone()
+        };
+
+        // No override → inherit global.
+        assert_eq!(
+            resolve_min_attestation(MinAttestation::B, &route(None)),
+            MinAttestation::B
+        );
+        // Strict override replaces global, even when more permissive.
+        assert_eq!(
+            resolve_min_attestation(MinAttestation::B, &route(Some("C"))),
+            MinAttestation::C
+        );
+        assert_eq!(
+            resolve_min_attestation(MinAttestation::None, &route(Some("A"))),
+            MinAttestation::A
+        );
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -12,9 +12,9 @@ pub mod transfer;
 
 pub use acceptor::{
     build_bridge_config, build_start_msg, extract_offer_sdp, extract_sip_call_id, resolve_barge_in,
-    resolve_codecs, resolve_dtmf_pt, AcceptError, BargeInConfig, BargeInMode, BridgeBuildError,
-    BridgeDefaults, BridgingAcceptor, CallIdFactory, CallProgressMode, OfferError, PreparedCall,
-    SrtpMode,
+    resolve_codecs, resolve_dtmf_pt, AcceptError, AcceptSecurityPolicy, BargeInConfig, BargeInMode,
+    BridgeBuildError, BridgeDefaults, BridgingAcceptor, CallIdFactory, CallProgressMode,
+    OfferError, PreparedCall, SrtpMode,
 };
 pub use call::{
     CallController, CallControllerConfig, CallError, CallHandle, CallOutcome, CallState,

--- a/crates/routes/src/compile.rs
+++ b/crates/routes/src/compile.rs
@@ -102,6 +102,7 @@ fn compile_one(index: usize, route: RawRoute) -> Result<CompiledRoute, RouteErro
         match_,
         bridge,
         media,
+        security,
     } = route;
 
     let compiled_match = compile_match(index, &name, match_)?;
@@ -111,6 +112,7 @@ fn compile_one(index: usize, route: RawRoute) -> Result<CompiledRoute, RouteErro
         match_: compiled_match,
         bridge,
         media,
+        security,
     })
 }
 
@@ -224,7 +226,7 @@ fn build_matcher(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::raw::{BridgeOverride, MediaOverride};
+    use crate::raw::{BridgeOverride, MediaOverride, SecurityOverride};
 
     fn raw_with_match(name: &str, m: RawRouteMatch) -> RawRoute {
         RawRoute {
@@ -232,6 +234,7 @@ mod tests {
             match_: m,
             bridge: BridgeOverride::default(),
             media: MediaOverride::default(),
+            security: SecurityOverride::default(),
         }
     }
 

--- a/crates/routes/src/compiled.rs
+++ b/crates/routes/src/compiled.rs
@@ -10,7 +10,7 @@
 
 use regex::Regex;
 
-use crate::raw::{BridgeOverride, MediaOverride};
+use crate::raw::{BridgeOverride, MediaOverride, SecurityOverride};
 
 /// One pre-compiled match predicate (string or regex). Stored per
 /// match key so a route can mix string keys (most common) with
@@ -84,6 +84,7 @@ pub struct CompiledRoute {
     pub(crate) match_: CompiledMatch,
     pub bridge: BridgeOverride,
     pub media: MediaOverride,
+    pub security: SecurityOverride,
 }
 
 impl CompiledRoute {

--- a/crates/routes/src/lib.rs
+++ b/crates/routes/src/lib.rs
@@ -38,6 +38,7 @@ pub use compile::{compile, RouteError};
 pub use compiled::{CompiledRoute, RouteSet};
 pub use raw::{
     BargeInOverride, BridgeOverride, MediaOverride, RawRoute, RawRouteFile, RawRouteMatch,
+    SecurityOverride,
 };
 
 /// Convenience: parse a TOML string into a [`RawRouteFile`] and

--- a/crates/routes/src/raw.rs
+++ b/crates/routes/src/raw.rs
@@ -38,6 +38,9 @@ pub struct RawRoute {
 
     #[serde(default)]
     pub media: MediaOverride,
+
+    #[serde(default)]
+    pub security: SecurityOverride,
 }
 
 /// `[route.match]` block — the matcher's input grammar.
@@ -121,4 +124,19 @@ pub struct MediaOverride {
     /// `"preferred"`, `"required"` overrides. Validated at config
     /// load via the same path as the global field.
     pub srtp: Option<String>,
+}
+
+/// `[route.security]` overrides. Same merge rules as the other override
+/// blocks — `None` inherits the global `[security]` value. Kept as the
+/// raw string so the routes crate stays free of a dependency on the
+/// security-policy types; the config crate validates it and the accept
+/// path parses it against the global default.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+pub struct SecurityOverride {
+    /// `[route.security].min_attestation` — per-route override of the
+    /// global `[security].min_attestation` gate. `None` inherits; any of
+    /// `"none"`, `"A"`, `"B"`, `"C"` overrides (strict override, matching
+    /// `[route.media].srtp` semantics — the route value fully replaces the
+    /// global, even when more permissive).
+    pub min_attestation: Option<String>,
 }

--- a/crates/security/src/policy.rs
+++ b/crates/security/src/policy.rs
@@ -36,6 +36,17 @@ impl MinAttestation {
         }
     }
 
+    /// The config/wire token: `"none"` / `"A"` / `"B"` / `"C"`. The inverse
+    /// of [`parse`](Self::parse), for logs and diagnostics.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::C => "C",
+            Self::B => "B",
+            Self::A => "A",
+        }
+    }
+
     /// The required rank, or `None` when there is no requirement. Mirrors
     /// [`AttestationLevel::rank`] so the two compare directly.
     fn required_rank(self) -> Option<u8> {
@@ -102,6 +113,19 @@ mod tests {
     #[test]
     fn default_is_none() {
         assert_eq!(MinAttestation::default(), MinAttestation::None);
+    }
+
+    #[test]
+    fn as_str_inverts_parse() {
+        for m in [
+            MinAttestation::None,
+            MinAttestation::A,
+            MinAttestation::B,
+            MinAttestation::C,
+        ] {
+            assert_eq!(MinAttestation::parse(m.as_str()), Some(m));
+        }
+        assert_eq!(MinAttestation::None.as_str(), "none");
     }
 
     #[test]

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -41,9 +41,11 @@ use thiserror::Error;
 // ─── Counters ───────────────────────────────────────────────────────
 
 /// Total INVITEs the daemon has seen. Labeled by `result`:
-/// `accepted`, `rejected`, `no_match`. `rejected` covers every 4xx/
-/// 5xx final response from the routing layer (see
-/// `siphon_ai_core::AcceptError::sip_status`).
+/// `accepted`, `rejected`, `rejected_attestation`, `no_match`. `rejected`
+/// covers every 4xx/5xx final response from the routing/media layer (see
+/// `siphon_ai_core::AcceptError::sip_status`); `rejected_attestation` is
+/// carved out for STIR/SHAKEN policy rejections (`min_attestation` gate or
+/// `require_identity`) so fraud-control alerts don't bury in routing noise.
 pub const INVITES_TOTAL: &str = "siphon_ai_invites_total";
 
 /// Calls that completed (controller exited). Labeled by `cause`:
@@ -176,7 +178,7 @@ pub fn install_recorder() -> Result<PrometheusHandle, InitError> {
 pub fn register_descriptions() {
     describe_counter!(
         INVITES_TOTAL,
-        "Inbound INVITEs by routing result (accepted, rejected, no_match)."
+        "Inbound INVITEs by result (accepted, rejected, rejected_attestation, no_match)."
     );
     describe_counter!(
         CALLS_TOTAL,

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -172,6 +172,8 @@ on_ws_failure = "hangup"         # v1 only supports "hangup"
 codecs = ["pcma", "pcmu"]        # override the global priority for this route
 dtmf = "off"
 inactivity_timeout_secs = 30     # override [media].inactivity_timeout_secs
+[route.security]
+min_attestation = "A"            # strict override of [security].min_attestation
 ```
 
 Match keys (any combination, all AND together): `request_uri_user`,
@@ -309,7 +311,25 @@ The gate admits a call only when verification **fully passed** and the claimed a
 | `"B"` | ✓ | ✓ | reject | reject | reject |
 | `"A"` | ✓ | reject | reject | reject | reject |
 
-A per-route override (`[route.security].min_attestation`, strict override of the global) is a follow-on chunk.
+A rejected call gets the configured status plus a `Reason: Q.850;cause=21` header so a Homer/upstream sees *why* it was screened. The gate runs before media bring-up, so a rejected call never allocates an RTP port or WS bridge.
+
+**Per-route override.** `[route.security].min_attestation` overrides the global for calls that match a route — a *strict* override (the route value fully replaces the global, even when more permissive), matching `[route.media].srtp` semantics. Unset → inherit the global. Like the global, a non-`none` override **requires** `stir_shaken.enabled = true` (fail-loud at load otherwise); `"none"` is an always-allowed no-op override.
+
+```toml
+[[route]]
+name = "vip_inbound"
+[route.match]
+to_user = "2000"
+[route.security]
+min_attestation = "A"   # this route admits only fully-attested calls
+
+[[route]]
+name = "consumer_inbound"
+[route.match]
+any = true
+[route.security]
+min_attestation = "C"   # looser than a stricter global, by design
+```
 
 ### `[security.stir_shaken]`
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -407,7 +407,7 @@ on the metrics crate's defaults (CLAUDE.md §7.4).
 
 | Metric                                  | Type      | Labels                                | What it measures |
 |-----------------------------------------|-----------|---------------------------------------|------------------|
-| `siphon_ai_invites_total`               | counter   | `result=accepted\|rejected`           | INVITEs by acceptance outcome. |
+| `siphon_ai_invites_total`               | counter   | `result=accepted\|rejected\|rejected_attestation\|no_match` | INVITEs by acceptance outcome. `rejected_attestation` is a STIR/SHAKEN policy reject (`min_attestation` gate or `require_identity`) — separately alertable from ordinary routing/media `rejected`. |
 | `siphon_ai_calls_total`                 | counter   | `cause=server_hangup\|local_shutdown\|bridge_ended\|tap_ended` | Ended calls by termination cause. |
 | `siphon_ai_calls_active`                | gauge     | —                                     | Currently-running calls. |
 | `siphon_ai_route_match_total`           | counter   | `route`                               | Calls per matched route. |

--- a/docs/DIALPLAN.md
+++ b/docs/DIALPLAN.md
@@ -50,6 +50,10 @@ Each `[[route]]` has:
   `[bridge]` block. Anything not specified inherits.
 - `[route.media]` *(optional)* — overrides for the global `[media]`
   block. Same merge rules.
+- `[route.security]` *(optional)* — overrides for the global
+  `[security]` block (currently `min_attestation`). **Strict**
+  override: the route value fully replaces the global, even when more
+  permissive. See `docs/CONFIG.md` `[security]`.
 
 ---
 
@@ -63,10 +67,10 @@ These rules are CLAUDE.md §4.6 cardinal — don't try to bend them:
    numbers, scores, or weighted matching.
 2. **AND across keys within a route.** All match keys must hold.
    For OR semantics, write multiple routes.
-3. **Per-route override.** Set fields in `[route.bridge]` or
-   `[route.media]` override the corresponding global fields *for
-   that call only*. Unset fields inherit from globals — a route
-   never silently ignores a global setting.
+3. **Per-route override.** Set fields in `[route.bridge]`,
+   `[route.media]`, or `[route.security]` override the corresponding
+   global fields *for that call only*. Unset fields inherit from
+   globals — a route never silently ignores a global setting.
 4. **No match → SIP 404.** If you want a catch-all, write a default
    route at the end with `any = true`. Production deployments
    without a default get a startup warning.


### PR DESCRIPTION
## What

Adds the **policy gate** that acts on the verification verdict the accept path now produces (#117). With `[security].min_attestation` set — or `[security.stir_shaken].require_identity` — inbound calls that don't meet the bar are rejected *before any media is allocated*. Implements Week 4 of the 0.4.0 plan.

**Stacked on #117** (which is stacked on #116). Merge order: **#116 → #117 → this**.

## The gate (`crates/core/src/acceptor.rs`)

- `AcceptError::IdentityRequired` → **428 Use Identity Header** (RFC 8224 §6.2.2) when `require_identity` is set and the INVITE carried no `Identity` header.
- `AcceptError::AttestationRejected { required, code }` → the configured `min_attestation_response` (**403**/488/606) when the call's *trusted* attestation is below the floor. `permits()` only trusts an attestation when verification fully passed, so unsigned/failed calls can never satisfy a non-`none` floor.
- Rejections carry `Reason: Q.850;cause=21` (plan §9 decision 4) and tick `siphon_ai_invites_total{result="rejected_attestation"}` — separately alertable from ordinary routing/media `rejected`.
- The gate (`apply_attestation_gate`, a pure free fn) runs **before media bring-up**, so a rejected call never allocates a forge session or RTP port.
- `AcceptSecurityPolicy` + `with_security_policy` builder; the daemon threads the compiled `[security]` knobs in. **Inert by default** (`min_attestation = none`, `require_identity = false`).

The §4 policy matrix:

| `min_attestation` | A | B | C | unsigned / no header | invalid sig |
|---|---|---|---|---|---|
| `none` | ✓ | ✓ | ✓ | ✓ | ✓ |
| `C` | ✓ | ✓ | ✓ | reject | reject |
| `B` | ✓ | ✓ | reject | reject | reject |
| `A` | ✓ | reject | reject | reject | reject |

## Per-route override (`[route.security].min_attestation`)

- **routes crate:** new `SecurityOverride { min_attestation: Option<String> }` on `RawRoute` / `CompiledRoute` (kept string-typed so routes stays free of the policy types).
- **config:** validates the value at load (`UnknownRouteMinAttestation`) and cross-checks that a non-`none` override requires `stir_shaken.enabled` (`RouteMinAttestationWithoutStirShaken`); `"none"` is an exempt no-op.
- **core `resolve_min_attestation`:** strict override — the route value fully replaces the global, even when more permissive (matching `[route.media].srtp` semantics).

```toml
[[route]]
name = "vip_inbound"
[route.match]
to_user = "2000"
[route.security]
min_attestation = "A"   # this route admits only fully-attested calls
```

Also adds `MinAttestation::as_str` (security crate) for the structured log line.

## Docs

CONFIG.md (per-route block, Reason header, pre-media behaviour), DIALPLAN.md (`[route.security]` override), DEPLOY.md (`rejected_attestation` label).

## Verification

- ~18 new tests: gate matrix, `require_identity`, response-code passthrough, `AcceptError` status/label/Reason mappings, strict-override resolution (via a real compiled route), and config validation + cross-check (invalid value, override-without-stir_shaken, `none` exemption).
- Full workspace suite green (535 tests); `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Remaining 0.4.0 work
- HEP verstat chunk (telemetry, vendor 0x0000)
- Ship `contrib/sti-pa-roots.pem`
- SIPp scenario (needs an x5u test-cert HTTPS fixture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)