### PR TITLE
feat(telemetry,core): ship STIR/SHAKEN verstat as a HEP3 Verstat chunk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,7 +581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1075,7 +1075,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "hep-rs"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/hep-rs?branch=main#26ed2d31b42bd483d9cbf006045f02225246587d"
+source = "git+https://github.com/thevoiceguy/hep-rs?branch=main#392baf4286939750ae76ef63a8f9788aca746d9f"
 dependencies = [
  "bytes",
  "thiserror 2.0.18",
@@ -1282,7 +1282,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2034,7 +2034,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2071,7 +2071,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -2376,7 +2376,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3466,7 +3466,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4123,7 +4123,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -251,7 +251,10 @@ impl Runtime {
                 .with_session_timer_policy(session_timer_policy)
                 .with_call_progress(sip.call_progress)
                 .with_verifier(verifier)
-                .with_security_policy(security_policy),
+                .with_security_policy(security_policy)
+                // Share the same HEP worker the SIP/RTCP/CDR emitters use so
+                // the verstat chunk lands on the same Homer call view.
+                .with_hep_telemetry(hep_telemetry.clone()),
         );
 
         // ─── Registration manager ──────────────────────────────────

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -18,6 +18,8 @@ uuid.workspace        = true
 chrono.workspace      = true
 parking_lot.workspace = true
 metrics.workspace     = true
+# Serialize the verstat verdict to JSON for the HEP3 Verstat chunk.
+serde_json.workspace  = true
 
 # Internal crates
 siphon-ai-bridge.workspace     = true

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -79,8 +79,8 @@ use siphon_ai_security::MinAttestation;
 use siphon_ai_sip_glue::{CallAcceptor, InviteFacts, MatchedCall};
 use siphon_ai_stir_shaken::Verifier;
 use siphon_ai_telemetry::{
-    CALLS_ACTIVE, CALLS_TOTAL, CALL_DURATION_SECONDS, INVITES_TOTAL, ROUTE_MATCH_TOTAL,
-    SDP_NEGOTIATE_SECONDS, VERSTAT_TOTAL,
+    HepTelemetry, CALLS_ACTIVE, CALLS_TOTAL, CALL_DURATION_SECONDS, INVITES_TOTAL,
+    ROUTE_MATCH_TOTAL, SDP_NEGOTIATE_SECONDS, VERSTAT_TOTAL,
 };
 use siphon_ai_webhooks::{
     CallEndEvent, CallStartEvent, NullSink as WebhookNullSink, WebhookEvent, WebhookSinkHandle,
@@ -1406,6 +1406,11 @@ pub struct BridgingAcceptor {
     /// permissive; only consulted when `verifier` is `Some` (a verdict
     /// exists to gate on).
     security: AcceptSecurityPolicy,
+    /// HEP/Homer telemetry handle, present only when `[hep].enabled`. When
+    /// set and a verstat verdict is produced, the accept path ships it as a
+    /// `HepProtocol::Verstat` chunk correlated by SIP Call-ID. `None` → no
+    /// HEP emission (the rest of the verdict surfacing is unaffected).
+    hep: Option<Arc<HepTelemetry>>,
 }
 
 /// Daemon-wide REFER plumbing (shared across every accepted call).
@@ -1555,6 +1560,7 @@ impl BridgingAcceptor {
             dtls_cert,
             verifier: None,
             security: AcceptSecurityPolicy::default(),
+            hep: None,
         }
     }
 
@@ -1643,6 +1649,15 @@ impl BridgingAcceptor {
     /// permissive; the gate is only consulted when a verifier is installed.
     pub fn with_security_policy(mut self, policy: AcceptSecurityPolicy) -> Self {
         self.security = policy;
+        self
+    }
+
+    /// Install the HEP/Homer telemetry handle. `None` (the default) means
+    /// no verstat chunk is shipped. The daemon passes `Some` when
+    /// `[hep].enabled = true`, sharing the same `UdpHepSink` worker the SIP
+    /// / RTCP / CDR emitters use.
+    pub fn with_hep_telemetry(mut self, hep: Option<Arc<HepTelemetry>>) -> Self {
+        self.hep = hep;
         self
     }
 
@@ -2668,6 +2683,7 @@ impl BridgingAcceptor {
         facts: &InviteFacts,
         route: &CompiledRoute,
         bridge_call_id: &str,
+        sip_call_id: &str,
     ) -> Result<Option<Box<siphon_ai_security::VerificationResult>>, AcceptError> {
         let Some((verdict, had_identity)) =
             run_identity_verification(self.verifier.as_deref(), facts).await
@@ -2691,8 +2707,37 @@ impl BridgingAcceptor {
             "STIR/SHAKEN verification complete"
         );
 
+        // Ship the verdict to Homer as a Verstat chunk, correlated by SIP
+        // Call-ID so it threads onto the same call view as the SIP / RTCP /
+        // CDR chunks. Emitted regardless of the gate outcome below — a
+        // rejected call's verdict is exactly what an operator wants to see.
+        self.emit_verstat_chunk(&verdict, sip_call_id, bridge_call_id);
+
         apply_attestation_gate(&self.security, effective_min, &verdict, had_identity)?;
         Ok(Some(Box::new(verdict)))
+    }
+
+    /// Best-effort HEP emission of a verstat verdict. No-op when HEP is
+    /// disabled. A serialization failure (not expected for our own type) is
+    /// logged and swallowed — HEP is observability, never call control
+    /// (CLAUDE.md §4.7).
+    fn emit_verstat_chunk(
+        &self,
+        verdict: &siphon_ai_security::VerificationResult,
+        sip_call_id: &str,
+        bridge_call_id: &str,
+    ) {
+        let Some(hep) = &self.hep else {
+            return;
+        };
+        match serde_json::to_vec(verdict) {
+            Ok(payload) => hep.emit_verstat(&payload, sip_call_id),
+            Err(e) => warn!(
+                call_id = %bridge_call_id,
+                error = %e,
+                "failed to serialize verstat for HEP; dropping chunk"
+            ),
+        }
     }
 
     /// Run every step from "matched route" up to "ready-to-run
@@ -2768,7 +2813,7 @@ impl BridgingAcceptor {
         // or RTP port. Returns the verdict to ride `start` → CDR; an `Err`
         // here is a gate rejection the async wrapper turns into a 4xx/428.
         let verstat = self
-            .run_security(facts, route, bridge_call_id.as_str())
+            .run_security(facts, route, bridge_call_id.as_str(), &sip_call_id)
             .await?;
 
         debug!(

--- a/crates/telemetry/src/hep.rs
+++ b/crates/telemetry/src/hep.rs
@@ -158,6 +158,28 @@ impl HepTelemetry {
         });
     }
 
+    /// Emit a STIR/SHAKEN verdict as a HEP3 chunk-type 102
+    /// (`HepProtocol::Verstat`). `payload` is the verdict already
+    /// serialized (siphon-ai serializes the `VerificationResult` as JSON,
+    /// the same shape as `start.verstat`); this crate stays free of the
+    /// security types. `correlation_id` MUST be the SIP `Call-ID` so Homer
+    /// threads the verdict onto the same call view as the SIP + RTCP + CDR
+    /// chunks. Best-effort like every emit here — drops on a full queue.
+    pub fn emit_verstat(&self, payload: &[u8], correlation_id: &str) {
+        let zero = unspecified_addr();
+        self.sink.send(HepPacket {
+            capture_id: self.capture_id,
+            capture_password: self.capture_password.clone(),
+            protocol: HepProtocol::Verstat,
+            transport: IpProto::Udp,
+            src: zero,
+            dst: zero,
+            timestamp: SystemTime::now(),
+            correlation_id: Some(correlation_id.to_string()),
+            payload: payload.to_vec(),
+        });
+    }
+
     /// Node identifier the daemon was configured with (`[node].id`).
     /// Surfaced so loggers can prepend it to their text payloads
     /// without re-reading config.
@@ -206,4 +228,54 @@ pub enum HepBuildError {
     /// collector address surfaces here.
     #[error(transparent)]
     Udp(#[from] UdpHepSinkError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hep_rs::HepSink;
+    use std::sync::Mutex;
+
+    /// In-memory sink that records every packet, so tests can assert on
+    /// the composed HEP3 shape without a real UDP collector.
+    #[derive(Default)]
+    struct Capture {
+        seen: Mutex<Vec<HepPacket>>,
+    }
+    impl HepSink for Capture {
+        fn send(&self, packet: HepPacket) {
+            self.seen.lock().unwrap().push(packet);
+        }
+    }
+
+    fn telemetry_with(sink: HepSinkHandle) -> HepTelemetry {
+        HepTelemetry {
+            sink,
+            capture_id: 2002,
+            capture_password: Some("homer-secret".into()),
+            node_id: "node-a".into(),
+        }
+    }
+
+    #[test]
+    fn emit_verstat_composes_verstat_chunk_with_correlation() {
+        let cap = Arc::new(Capture::default());
+        let tel = telemetry_with(cap.clone() as HepSinkHandle);
+
+        let payload = br#"{"attest":"A","signature_valid":true}"#;
+        tel.emit_verstat(payload, "abc-123@pbx.example.com");
+
+        let seen = cap.seen.lock().unwrap();
+        assert_eq!(seen.len(), 1);
+        let pkt = &seen[0];
+        assert_eq!(pkt.protocol, HepProtocol::Verstat);
+        assert_eq!(pkt.capture_id, 2002);
+        assert_eq!(pkt.capture_password.as_deref(), Some("homer-secret"));
+        // Correlation is the SIP Call-ID — the stitch into the call view.
+        assert_eq!(
+            pkt.correlation_id.as_deref(),
+            Some("abc-123@pbx.example.com")
+        );
+        assert_eq!(pkt.payload, payload);
+    }
 }

--- a/docs/HEP.md
+++ b/docs/HEP.md
@@ -27,6 +27,8 @@ one queue and one UDP socket through the daemon-wide `HepSink`:
    │ (telemetry)  │     HepProtocol::Log (chunk type 0x64)
    │              │ ──► Full CDR JSON when a call ends
    │              │     HepProtocol::Cdr (chunk type 0x65)
+   │              │ ──► STIR/SHAKEN verdict JSON per inbound call
+   │              │     HepProtocol::Verstat (chunk type 0x66)
    └──────────────┘
                   └────────────► HepSink ──UDP──► heplify-server
                                        (Arc-shared, single worker task)
@@ -96,6 +98,25 @@ When the scenario also exchanges RTP (`uac_with_rtp.xml`, post-v1), the
 QoS panel populates from forge's per-RR `RtpQos` chunks: jitter,
 fractional loss, cumulative loss, the SSRC of each direction.
 
+## STIR/SHAKEN verstat chunk (0x66)
+
+When `[security.stir_shaken].enabled = true`, the accept path ships one
+`HepProtocol::Verstat` (chunk type 0x66) per inbound call, correlated by
+SIP `Call-ID`, so the verdict threads onto the same call view as the SIP
+ladder and the CDR. The payload is the verdict as JSON — the same shape as
+`start.verstat` (PROTOCOL.md) and the `verstat_*` CDR fields:
+
+```json
+{ "attest": "A", "orig_tn": "+12155551212", "orig_passed": true,
+  "dest_passed": true, "cert_chain_valid": true, "signature_valid": true }
+```
+
+The chunk is emitted for **every** inbound call while verification is on —
+including unsigned calls (`signature_valid: false`, `attest` absent) and
+gate-rejected ones (the verdict is exactly what an investigator wants when
+a call was screened). `attest` is the *claimed* level; trust it only when
+the booleans all hold. No chunk is emitted when verification is disabled.
+
 ## Local validation
 
 `examples/homer-stack/` is a full Homer + heplify-server + Postgres compose
@@ -127,7 +148,7 @@ work the diagnostics in order:
 
 ## Adding new emissions
 
-The four chunk types above cover v1. If you have an event Homer should
+The chunk types above cover v1. If you have an event Homer should
 know about that doesn't fit them — say, a `route_match` event with the
 matched route name — the right path is:
 


### PR DESCRIPTION
## What

Completes the STIR/SHAKEN observability story: when `[hep].enabled` and verification is on, the accept path ships each inbound call's verdict to Homer as a `HepProtocol::Verstat` (chunk type **0x66**) packet, correlated by SIP `Call-ID` so it threads onto the same call view as the SIP ladder, RTCP/QoS, and CDR already do. Implements Week 5 (HEP) of the 0.4.0 plan.

**Stacked on #118 → #117 → #116.** Merge bottom-up.

## Cross-repo dependency

Depends on **thevoiceguy/hep-rs#1** (merged to `main`, commit `392baf4`), which adds `HepProtocol::Verstat = 102` as a vendor-convention protocol type alongside `Log = 100` / `Cdr = 101` (generic vendor 0x0000 namespace, per plan §9 decision 6). This PR bumps the hep-rs pin (`cargo update -p hep-rs`).

## Changes

- **telemetry:** `HepTelemetry::emit_verstat(payload, correlation_id)` composes the Verstat packet over the shared UDP worker. Payload-agnostic (raw bytes) so telemetry stays free of the security types.
- **core:** `BridgingAcceptor` gains `hep: Option<Arc<HepTelemetry>>` + `with_hep_telemetry`. `run_security` serializes the `VerificationResult` to JSON (same shape as `start.verstat` and the CDR fields) and emits it — for **every** inbound call, including unsigned and gate-rejected ones, since a screened call's verdict is exactly what an investigator wants. Best-effort: a serialize failure is logged and swallowed (HEP is observability, never call control — CLAUDE.md §4.7). `serde_json` promoted to a core runtime dep.
- **daemon:** shares the same HEP worker the SIP/RTCP/CDR emitters use, so verstat lands on the same call view.

Payload shape (JSON, per the design choice confirmed for this chunk):

```json
{ "attest": "A", "orig_tn": "+12155551212", "orig_passed": true,
  "dest_passed": true, "cert_chain_valid": true, "signature_valid": true }
```

## Docs

HEP.md gains the 0x66 chunk section (payload shape, emit-for-every-call semantics, correlation) and a diagram entry.

## Verification

- telemetry `emit_verstat` capture-sink test (protocol = Verstat, correlation = Call-ID, payload passthrough); hep-rs side has the wire-byte roundtrip + value-pin tests.
- Full workspace suite green (536 tests); `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Remaining 0.4.0 work
- Ship `contrib/sti-pa-roots.pem`
- SIPp scenario (needs an x5u test-cert HTTPS fixture)
- Release prep (CHANGELOG, version bump, tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)