### PR TITLE
test(sipp): STIR/SHAKEN accept-path gate scenarios (428 + 403)

### DIFF
--- a/test-harness/sipp-scenarios/README.md
+++ b/test-harness/sipp-scenarios/README.md
@@ -46,6 +46,14 @@ sipp -sf basic_call_then_bye.xml -m 1 -p 5070 -s 1000 127.0.0.1:5060
 | `caller_cancels_during_setup.xml`   | RFC 3261 §9.2 — CANCEL races the 200 OK; 487/200 both acceptable |
 | `unsupported_codec_488.xml`         | SDP with only G.722 → 488 Not Acceptable Here|
 | `blind_transfer.xml`                | WS-initiated REFER, 202 + BYE teardown       |
+| `stir_shaken_no_identity_428.xml`   | STIR/SHAKEN `require_identity`: INVITE with no `Identity` header → 428 Use Identity Header (stir_shaken phase) |
+| `stir_shaken_attestation_403.xml`   | STIR/SHAKEN gate: `Identity` present but unverifiable (unreachable `x5u`) below `min_attestation = "A"` → 403 Forbidden (stir_shaken phase) |
+
+The `stir_shaken_*` scenarios run in `run-all.sh`'s always-on
+**stir_shaken** auxiliary phase, which starts a daemon with verification
+enabled (`require_identity = true`, `min_attestation = "A"`) and a
+throwaway openssl-generated trust anchor. Both reject before media, so no
+reachable `x5u` or WS bridge is needed.
 
 ## Adding a new scenario
 

--- a/test-harness/sipp-scenarios/run-all.sh
+++ b/test-harness/sipp-scenarios/run-all.sh
@@ -165,6 +165,63 @@ run_scenario session_progress_then_answer.xml || failures=$((failures + 1))
 sp_cleanup
 trap - EXIT
 
+# ─── Always-on auxiliary phase: STIR/SHAKEN gate ─────────────────
+# Verifies the accept-path STIR/SHAKEN gate rejects before media:
+#   * no Identity header + require_identity        → 428
+#   * Identity present but unverifiable + min "A"  → 403
+# Both reject paths are pre-media, so no x5u is reachable and no WS
+# bridge is involved. A throwaway self-signed cert satisfies the
+# load-time trust-anchor check (verification never validates a real
+# chain on these paths — the 403 fails at the unreachable x5u fetch).
+echo
+echo "─── auxiliary phase: stir_shaken gate ─────────────────"
+SS_DAEMON_LOG=$(mktemp -t siphon-ai-ss.XXXXXX.log)
+SS_CONFIG=$(mktemp -t siphon-ai-ss.XXXXXX.toml)
+SS_KEY=$(mktemp -t siphon-ai-ss-key.XXXXXX.pem)
+SS_TA=$(mktemp -t siphon-ai-ss-ta.XXXXXX.pem)
+openssl ecparam -name prime256v1 -genkey -noout -out "$SS_KEY" 2>/dev/null
+openssl req -x509 -new -key "$SS_KEY" -out "$SS_TA" -days 3650 \
+    -subj "/CN=siphon-test-sti-pa-root" 2>/dev/null
+cat >"$SS_CONFIG" <<EOF
+[node]
+id = "siphon-ai-sipp-ss"
+[sip]
+listen = "127.0.0.1:$DAEMON_PORT"
+[media]
+codecs = ["pcmu"]
+[bridge]
+ws_url = "ws://127.0.0.1:8765/"
+[security]
+min_attestation = "A"
+[security.stir_shaken]
+enabled = true
+trust_anchors = "$SS_TA"
+require_identity = true
+[[route]]
+name = "default"
+[route.match]
+any = true
+EOF
+
+RUST_LOG=siphon_ai=info "$DAEMON_BIN" --config "$SS_CONFIG" \
+    >"$SS_DAEMON_LOG" 2>&1 &
+SS_DAEMON_PID=$!
+ss_cleanup() {
+    if kill -0 "$SS_DAEMON_PID" 2>/dev/null; then
+        kill "$SS_DAEMON_PID" 2>/dev/null || true
+        wait "$SS_DAEMON_PID" 2>/dev/null || true
+    fi
+}
+trap ss_cleanup EXIT
+sleep 1.2
+
+total=$((total + 2))
+run_scenario stir_shaken_no_identity_428.xml || failures=$((failures + 1))
+run_scenario stir_shaken_attestation_403.xml || failures=$((failures + 1))
+
+ss_cleanup
+trap - EXIT
+
 # ─── Optional third phase: blind_transfer ─────────────────────────
 # Needs a WS server that proactively emits BridgeIn::Transfer. The
 # runner stops the daemon, brings up an echo-ws that auto-emits

--- a/test-harness/sipp-scenarios/stir_shaken_attestation_403.xml
+++ b/test-harness/sipp-scenarios/stir_shaken_attestation_403.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  stir_shaken_attestation_403 — daemon with STIR/SHAKEN verification
+  enabled and `[security].min_attestation = "A"` receives an INVITE
+  carrying a well-formed `Identity` header whose PASSporT claims
+  attestation A but whose `x5u` is unreachable (https://127.0.0.1:1).
+  Verification can't fetch/validate the signing cert, so the verdict
+  is untrusted and the attestation gate rejects with the configured
+  403 Forbidden + `Reason: Q.850;cause=21`, before any media setup.
+
+  The PASSporT is static and intentionally NOT cryptographically
+  valid — the point is that verification fails (here at the x5u fetch,
+  which is refused on loopback port 1), so a claimed "A" is not
+  trusted. Paired with the STIR/SHAKEN phase in run-all.sh.
+-->
+<scenario name="stir_shaken_attestation_403">
+  <send retrans="500">
+<![CDATA[
+INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+Max-Forwards: 70
+From: <sip:+12155551212@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:+12155551212@[local_ip]:[local_port]>
+Identity: eyJhbGciOiJFUzI1NiIsInR5cCI6InBhc3Nwb3J0IiwicHB0Ijoic2hha2VuIiwieDV1IjoiaHR0cHM6Ly8xMjcuMC4wLjE6MS9jLmNydCJ9.eyJhdHRlc3QiOiJBIiwiZGVzdCI6eyJ0biI6WyIxMDAwIl19LCJpYXQiOjE3MTYwMDAwMDAsIm9yaWciOnsidG4iOiIrMTIxNTU1NTEyMTIifX0.AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ;info=<https://127.0.0.1:1/c.crt>;alg=ES256;ppt=shaken
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=user1 53655765 2353687637 IN IP4 [local_ip]
+s=-
+c=IN IP4 [local_ip]
+t=0 0
+m=audio 9000 RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+]]>
+  </send>
+
+  <recv response="100" optional="true"/>
+
+  <!-- Untrusted attestation below min_attestation=A → 403. -->
+  <recv response="403" rtd="true"/>
+
+  <ResponseTimeRepartition value="200, 500, 1000"/>
+</scenario>

--- a/test-harness/sipp-scenarios/stir_shaken_no_identity_428.xml
+++ b/test-harness/sipp-scenarios/stir_shaken_no_identity_428.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  stir_shaken_no_identity_428 — daemon with STIR/SHAKEN verification
+  enabled and `[security.stir_shaken].require_identity = true` receives
+  an INVITE that carries NO `Identity` header. MUST reject with
+  428 Use Identity Header (RFC 8224 §6.2.2), before any media setup.
+
+  Paired with the STIR/SHAKEN phase in run-all.sh, which starts the
+  daemon with verification on + require_identity + a throwaway trust
+  anchor. The reject happens at the accept-path gate, so no x5u fetch,
+  WS bridge, or RTP is involved.
+-->
+<scenario name="stir_shaken_no_identity_428">
+  <send retrans="500">
+<![CDATA[
+INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+Max-Forwards: 70
+From: <sip:+12155551212@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:+12155551212@[local_ip]:[local_port]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=user1 53655765 2353687637 IN IP4 [local_ip]
+s=-
+c=IN IP4 [local_ip]
+t=0 0
+m=audio 9000 RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+]]>
+  </send>
+
+  <recv response="100" optional="true"/>
+
+  <!-- No Identity header + require_identity → 428. The transaction
+       layer auto-ACKs the non-2xx final (RFC 3261 §17.1.1.3). -->
+  <recv response="428" rtd="true"/>
+
+  <ResponseTimeRepartition value="200, 500, 1000"/>
+</scenario>


### PR DESCRIPTION
## What

The first STIR/SHAKEN SIPp signaling regressions — they exercise the accept-path gate end-to-end over real SIP. Both reject **before media**, so no reachable `x5u` and no WS bridge are needed (which is what makes them CI-stable; a *passing*-verification scenario would need a local HTTPS cert server the fetch trusts).

**Stacked on #120 → #119 → #118 → #117 → #116.**

## Scenarios

- **`stir_shaken_no_identity_428.xml`** — verification on + `require_identity = true`, INVITE with no `Identity` header → **428 Use Identity Header** (RFC 8224 §6.2.2).
- **`stir_shaken_attestation_403.xml`** — `Identity` present but unverifiable (PASSporT `x5u` points at unreachable `https://127.0.0.1:1`), below `min_attestation = "A"` → **403 Forbidden** + `Reason: Q.850;cause=21`. The PASSporT is static and intentionally not crypto-valid: verification fails at the refused `x5u` fetch, so a claimed `A` is untrusted and the gate rejects.

## Harness

`run-all.sh` gains an always-on **stir_shaken** auxiliary phase (mirroring the session_progress phase): it starts a daemon with verification enabled (`require_identity`, `min_attestation = "A"`) and a throwaway openssl-generated trust anchor (satisfies the load-time anchor check — neither reject path validates a real chain). CI runs `run-all.sh`, so both scenarios gate CI.

## Verification

Run locally against a debug daemon — both return the expected codes, and the daemon logs confirm the exact path:

```
verstat_result="unsigned" ... → rejecting INVITE ... code=428 reason="Use Identity Header"
verstat_result="failed" verstat_attest="A" ... x5u request failed ... → rejecting INVITE ... code=403 reason="Forbidden"
```

`bash -n run-all.sh` clean. No Rust changes.

## Remaining 0.4.0 work
- Release prep (CHANGELOG, version bump, tag)
- (A *passing* attestation SIPp scenario is deferred — needs a local HTTPS x5u cert fixture the verifier's TLS trusts.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)