### PR TITLE
feat(security): PASSporT iat freshness check (replay protection)

### DIFF
--- a/crates/bridge/src/protocol.rs
+++ b/crates/bridge/src/protocol.rs
@@ -1018,12 +1018,14 @@ mod tests {
             dest_passed: true,
             cert_chain_valid: true,
             signature_valid: true,
+            iat_passed: true,
             error: None,
         };
         let v: Value = serde_json::to_value(mk(Some(verdict.clone()))).unwrap();
         assert_eq!(v["verstat"]["attest"], json!("A"));
         assert_eq!(v["verstat"]["orig_tn"], json!("+12155551212"));
         assert_eq!(v["verstat"]["signature_valid"], json!(true));
+        assert_eq!(v["verstat"]["iat_passed"], json!(true));
         // error is None → omitted; attest present → no null.
         assert!(!v["verstat"].as_object().unwrap().contains_key("error"));
         let round: BridgeOut = serde_json::from_value(v).unwrap();

--- a/crates/config/src/compile.rs
+++ b/crates/config/src/compile.rs
@@ -775,6 +775,7 @@ pub(crate) fn compile_srtp_mode(
 fn compile_security(raw: RawSecurity) -> Result<SecurityConfig, CompileError> {
     use siphon_ai_security::{
         validate_trust_anchors, MinAttestation, StirShakenConfig, DEFAULT_CERT_CACHE_TTL,
+        DEFAULT_IAT_FRESHNESS,
     };
 
     let min_attestation = match raw.min_attestation.as_deref() {
@@ -797,6 +798,12 @@ fn compile_security(raw: RawSecurity) -> Result<SecurityConfig, CompileError> {
         .map(Duration::from_secs)
         .unwrap_or(DEFAULT_CERT_CACHE_TTL);
     let require_identity = stir.require_identity.unwrap_or(false);
+    // `iat_freshness_secs = 0` is a deliberate "disable the check" value, so
+    // map it straight through (Duration::ZERO); absent → the 60 s default.
+    let iat_freshness = stir
+        .iat_freshness_secs
+        .map(Duration::from_secs)
+        .unwrap_or(DEFAULT_IAT_FRESHNESS);
 
     // A minimum-attestation gate is meaningless without verification: with
     // stir_shaken off, no call yields a trusted attestation, so the gate
@@ -829,6 +836,7 @@ fn compile_security(raw: RawSecurity) -> Result<SecurityConfig, CompileError> {
             trust_anchors,
             cert_cache_ttl,
             require_identity,
+            iat_freshness,
         },
     })
 }
@@ -1558,6 +1566,7 @@ mod security_tests {
                 trust_anchors: Some(path.to_string_lossy().into_owned()),
                 cert_cache_ttl_secs: Some(1800),
                 require_identity: Some(true),
+                iat_freshness_secs: Some(30),
             },
         };
         let c = compile_security(raw).unwrap();
@@ -1569,9 +1578,33 @@ mod security_tests {
             c.stir_shaken.cert_cache_ttl,
             std::time::Duration::from_secs(1800)
         );
+        assert_eq!(
+            c.stir_shaken.iat_freshness,
+            std::time::Duration::from_secs(30)
+        );
         assert_eq!(c.stir_shaken.trust_anchors, path);
 
         let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn iat_freshness_defaults_and_zero_disables() {
+        // Absent → 60 s default.
+        let c = compile_security(RawSecurity::default()).unwrap();
+        assert_eq!(
+            c.stir_shaken.iat_freshness,
+            std::time::Duration::from_secs(60)
+        );
+        // 0 maps straight through (disables the check), not the default.
+        let raw = RawSecurity {
+            stir_shaken: RawStirShaken {
+                iat_freshness_secs: Some(0),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let c = compile_security(raw).unwrap();
+        assert_eq!(c.stir_shaken.iat_freshness, std::time::Duration::ZERO);
     }
 
     #[test]

--- a/crates/config/src/raw.rs
+++ b/crates/config/src/raw.rs
@@ -249,6 +249,10 @@ pub struct RawStirShaken {
     /// instead of admitting them as unsigned. Default `false`.
     #[serde(default)]
     pub require_identity: Option<bool>,
+    /// PASSporT `iat` freshness window, in seconds (replay protection,
+    /// ATIS-1000074). `None` → 60. `0` disables the check.
+    #[serde(default)]
+    pub iat_freshness_secs: Option<u64>,
 }
 
 /// `[cdr]` — call detail record sinks. v1 supports a JSONL file

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -4329,7 +4329,12 @@ a=sendrecv\r\n",
 
     /// A verifier with a throwaway (never-consulted on these paths) anchor.
     fn dummy_verifier() -> Verifier {
-        Verifier::new(vec![vec![0u8; 8]], Duration::from_secs(3600)).expect("build verifier")
+        Verifier::new(
+            vec![vec![0u8; 8]],
+            Duration::from_secs(3600),
+            Duration::from_secs(60),
+        )
+        .expect("build verifier")
     }
 
     #[tokio::test]
@@ -4380,6 +4385,7 @@ a=sendrecv\r\n",
         v.cert_chain_valid = true;
         v.orig_passed = true;
         v.dest_passed = true;
+        v.iat_passed = true;
         assert!(v.passed());
         assert_eq!(verstat_metric_result(&v, true), "passed");
     }
@@ -4397,6 +4403,7 @@ a=sendrecv\r\n",
             dest_passed: true,
             cert_chain_valid: true,
             signature_valid: true,
+            iat_passed: true,
             error: None,
         }
     }

--- a/crates/security/src/config.rs
+++ b/crates/security/src/config.rs
@@ -15,6 +15,10 @@ use thiserror::Error;
 /// semantics on the `x5u`/`info` cert responses (plan §9 decision 2).
 pub const DEFAULT_CERT_CACHE_TTL: Duration = Duration::from_secs(3600);
 
+/// Default PASSporT `iat` freshness window (60 s) — replay protection per
+/// ATIS-1000074. `0` disables the check.
+pub const DEFAULT_IAT_FRESHNESS: Duration = Duration::from_secs(60);
+
 /// Compiled `[security.stir_shaken]` block.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StirShakenConfig {
@@ -32,6 +36,11 @@ pub struct StirShakenConfig {
     /// ("Use Identity Header", RFC 8224 §6.2.2) instead of admitting them
     /// as unsigned.
     pub require_identity: bool,
+    /// How far the PASSporT `iat` may be from now (past or future) before
+    /// the verdict's `iat_passed` is `false` — replay protection per
+    /// ATIS-1000074. `Duration::ZERO` disables the check (any `iat` passes),
+    /// an escape hatch for upstreams with broken clocks.
+    pub iat_freshness: Duration,
 }
 
 impl Default for StirShakenConfig {
@@ -41,6 +50,7 @@ impl Default for StirShakenConfig {
             trust_anchors: PathBuf::new(),
             cert_cache_ttl: DEFAULT_CERT_CACHE_TTL,
             require_identity: false,
+            iat_freshness: DEFAULT_IAT_FRESHNESS,
         }
     }
 }
@@ -97,6 +107,7 @@ mod tests {
         assert!(!c.enabled);
         assert!(!c.require_identity);
         assert_eq!(c.cert_cache_ttl, DEFAULT_CERT_CACHE_TTL);
+        assert_eq!(c.iat_freshness, DEFAULT_IAT_FRESHNESS);
     }
 
     #[test]

--- a/crates/security/src/lib.rs
+++ b/crates/security/src/lib.rs
@@ -38,6 +38,7 @@ mod verstat;
 pub use attestation::AttestationLevel;
 pub use config::{
     validate_trust_anchors, StirShakenConfig, TrustAnchorError, DEFAULT_CERT_CACHE_TTL,
+    DEFAULT_IAT_FRESHNESS,
 };
 pub use policy::MinAttestation;
 pub use verstat::VerificationResult;

--- a/crates/security/src/policy.rs
+++ b/crates/security/src/policy.rs
@@ -97,6 +97,7 @@ mod tests {
             dest_passed: passed,
             cert_chain_valid: passed,
             signature_valid: passed,
+            iat_passed: passed,
             error: None,
         }
     }

--- a/crates/security/src/verstat.rs
+++ b/crates/security/src/verstat.rs
@@ -6,7 +6,7 @@ use crate::attestation::AttestationLevel;
 
 /// Outcome of STIR/SHAKEN verification for one inbound INVITE.
 ///
-/// The five booleans plus the optional error let a downstream consumer
+/// The booleans plus the optional error let a downstream consumer
 /// reconstruct the precise failure mode without re-parsing the Identity
 /// header. This is the shape surfaced on `BridgeOut::Start.verstat`, the
 /// CDR, and the HEP verstat chunk.
@@ -31,6 +31,12 @@ pub struct VerificationResult {
     pub cert_chain_valid: bool,
     /// The ES256 signature over the PASSporT verified against that cert.
     pub signature_valid: bool,
+    /// The PASSporT `iat` is within the configured freshness window (replay
+    /// protection, ATIS-1000074). `#[serde(default)]` so an older verstat
+    /// JSON without the field deserializes to `false` rather than erroring —
+    /// the field is additive (added in 0.4.1).
+    #[serde(default)]
+    pub iat_passed: bool,
     /// Human-readable failure reason when verification did not fully pass.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
@@ -48,6 +54,7 @@ impl VerificationResult {
             dest_passed: false,
             cert_chain_valid: false,
             signature_valid: false,
+            iat_passed: false,
             error: None,
         }
     }
@@ -55,7 +62,11 @@ impl VerificationResult {
     /// Composite pass: every check succeeded. This is the `verstat_passed`
     /// CDR field and the precondition for trusting `attest`.
     pub fn passed(&self) -> bool {
-        self.signature_valid && self.cert_chain_valid && self.orig_passed && self.dest_passed
+        self.signature_valid
+            && self.cert_chain_valid
+            && self.orig_passed
+            && self.dest_passed
+            && self.iat_passed
     }
 
     /// The attestation level we are willing to *trust* — the claimed level
@@ -83,6 +94,7 @@ mod tests {
             dest_passed: true,
             cert_chain_valid: true,
             signature_valid: true,
+            iat_passed: true,
             error: None,
         }
     }
@@ -93,6 +105,16 @@ mod tests {
         let mut r = good(AttestationLevel::A);
         r.signature_valid = false;
         assert!(!r.passed());
+    }
+
+    #[test]
+    fn stale_iat_fails_the_composite() {
+        // A cryptographically-valid call with a stale iat is not passed —
+        // and so yields no trusted attestation (replay protection).
+        let mut r = good(AttestationLevel::A);
+        r.iat_passed = false;
+        assert!(!r.passed());
+        assert_eq!(r.trusted_attestation(), None);
     }
 
     #[test]

--- a/crates/stir-shaken/src/verifier.rs
+++ b/crates/stir-shaken/src/verifier.rs
@@ -67,13 +67,20 @@ pub struct Verifier {
     cache: Arc<CertCache>,
     http: reqwest::Client,
     cache_ttl: Duration,
+    /// PASSporT `iat` freshness window; `Duration::ZERO` disables the check.
+    iat_freshness: Duration,
 }
 
 impl Verifier {
-    /// Build a verifier from already-decoded trust-anchor DERs and a cache
-    /// TTL. Prefer [`Verifier::from_config`] from daemon code; this is the
+    /// Build a verifier from already-decoded trust-anchor DERs, a cache TTL,
+    /// and an `iat` freshness window (`Duration::ZERO` disables the freshness
+    /// check). Prefer [`Verifier::from_config`] from daemon code; this is the
     /// seam for tests and embedders that hold anchors in memory.
-    pub fn new(trust_anchors: Vec<Vec<u8>>, cache_ttl: Duration) -> Result<Self, BuildError> {
+    pub fn new(
+        trust_anchors: Vec<Vec<u8>>,
+        cache_ttl: Duration,
+        iat_freshness: Duration,
+    ) -> Result<Self, BuildError> {
         let http = reqwest::Client::builder()
             .timeout(FETCH_TIMEOUT)
             // x5u is a direct cert URL; never chase a redirect to an
@@ -86,15 +93,17 @@ impl Verifier {
             cache: Arc::new(CertCache::new()),
             http,
             cache_ttl,
+            iat_freshness,
         })
     }
 
     /// Build a verifier from the compiled `[security.stir_shaken]` config:
     /// load + decode the trust-anchor PEM file and adopt the configured
-    /// cache TTL. Fails loud if the anchor file is unreadable or empty.
+    /// cache TTL and `iat` freshness window. Fails loud if the anchor file is
+    /// unreadable or empty.
     pub fn from_config(cfg: &StirShakenConfig) -> Result<Self, BuildError> {
         let anchors = load_trust_anchors(&cfg.trust_anchors)?;
-        Self::new(anchors, cfg.cert_cache_ttl)
+        Self::new(anchors, cfg.cert_cache_ttl, cfg.iat_freshness)
     }
 
     /// Verify the `Identity` header of an inbound INVITE.
@@ -123,12 +132,20 @@ impl Verifier {
             }
         };
 
+        let now = now_unix();
         let x5u = header.passport.header.x5u.clone();
         let chain = match self.resolve_chain(&x5u).await {
             Ok(chain) => chain,
             Err(e) => {
                 warn!(%x5u, error = %e, "x5u certificate fetch failed");
-                return fetch_failure(&header.passport, from_user, to_user, e);
+                return fetch_failure(
+                    &header.passport,
+                    from_user,
+                    to_user,
+                    e,
+                    now,
+                    self.iat_freshness,
+                );
             }
         };
 
@@ -138,7 +155,8 @@ impl Verifier {
             to_user,
             &chain,
             &self.trust_anchors,
-            now_unix(),
+            now,
+            self.iat_freshness,
         )
     }
 
@@ -181,6 +199,8 @@ fn fetch_failure(
     from_user: &str,
     to_user: &str,
     e: FetchError,
+    now: UnixTime,
+    iat_freshness: Duration,
 ) -> VerificationResult {
     VerificationResult {
         attest: passport.claims.attest.map(map_attest),
@@ -189,6 +209,7 @@ fn fetch_failure(
         dest_passed: dest_matches(passport, to_user),
         cert_chain_valid: false,
         signature_valid: false,
+        iat_passed: iat_fresh(passport.claims.iat, now, iat_freshness),
         error: Some(format!("x5u certificate fetch failed: {e}")),
     }
 }
@@ -204,16 +225,20 @@ fn build_result(
     chain: &[Vec<u8>],
     anchors: &[Vec<u8>],
     now: UnixTime,
+    iat_freshness: Duration,
 ) -> VerificationResult {
     let orig_passed = orig_matches(passport, from_user);
     let dest_passed = dest_matches(passport, to_user);
+    let iat_passed = iat_fresh(passport.claims.iat, now, iat_freshness);
     let (cert_chain_valid, signature_valid, crypto_err) =
         run_chain_verify(passport, chain, anchors, now);
 
-    // The crypto failure (if any) is the headline reason; otherwise surface
-    // a claim mismatch so a fully-cryptographically-valid call that fails
-    // the TN binding still says why it didn't pass.
-    let error = crypto_err.or_else(|| claim_mismatch(orig_passed, dest_passed));
+    // Headline reason, in priority order: a crypto failure, then a TN-claim
+    // mismatch, then a stale `iat` — so a fully-valid call that fails only
+    // freshness still says why it didn't pass.
+    let error = crypto_err
+        .or_else(|| claim_mismatch(orig_passed, dest_passed))
+        .or_else(|| (!iat_passed).then(|| iat_error(passport.claims.iat)));
 
     VerificationResult {
         attest: passport.claims.attest.map(map_attest),
@@ -222,7 +247,31 @@ fn build_result(
         dest_passed,
         cert_chain_valid,
         signature_valid,
+        iat_passed,
         error,
+    }
+}
+
+/// Whether the PASSporT `iat` is within `window` of `now` (past or future).
+/// A zero `window` disables the check (always fresh). A missing `iat` is
+/// never fresh — ATIS-1000074 requires the claim, so its absence is a
+/// verification failure, not a pass.
+fn iat_fresh(iat: Option<i64>, now: UnixTime, window: Duration) -> bool {
+    if window.is_zero() {
+        return true;
+    }
+    let Some(iat) = iat else {
+        return false;
+    };
+    let skew = (now.as_secs() as i64 - iat).unsigned_abs();
+    skew <= window.as_secs()
+}
+
+/// Human-readable reason for an `iat` freshness failure.
+fn iat_error(iat: Option<i64>) -> String {
+    match iat {
+        Some(_) => "PASSporT iat outside the freshness window".to_string(),
+        None => "PASSporT has no iat claim".to_string(),
     }
 }
 
@@ -352,6 +401,13 @@ mod tests {
     const HEADER: &str =
         r#"{"alg":"ES256","typ":"passport","ppt":"shaken","x5u":"https://c.example/c.crt"}"#;
 
+    /// `iat` that matches `make_fixture`'s `mid_validity` (both derive from
+    /// the same not_before/not_after constants), so the default fixture is
+    /// `iat`-fresh when verified at `mid_validity`.
+    const FRESH_IAT: i64 = 1_715_768_000;
+    /// A non-disabling freshness window for the chain/sig/TN tests.
+    const WINDOW: Duration = Duration::from_secs(60);
+
     /// A throwaway STI-PA-style CA + leaf and a PASSporT signed by the leaf,
     /// mirroring the `sip-identity` chain-test fixture so we exercise the
     /// real crypto path through `build_result`.
@@ -363,8 +419,12 @@ mod tests {
     }
 
     fn payload(attest: &str, orig: &str, dest: &str) -> String {
+        payload_with_iat(attest, orig, dest, FRESH_IAT)
+    }
+
+    fn payload_with_iat(attest: &str, orig: &str, dest: &str, iat: i64) -> String {
         format!(
-            r#"{{"attest":"{attest}","dest":{{"tn":["{dest}"]}},"iat":1443208345,"orig":{{"tn":"{orig}"}},"origid":"123e4567-e89b-12d3-a456-426655440000"}}"#
+            r#"{{"attest":"{attest}","dest":{{"tn":["{dest}"]}},"iat":{iat},"orig":{{"tn":"{orig}"}},"origid":"123e4567-e89b-12d3-a456-426655440000"}}"#
         )
     }
 
@@ -416,6 +476,7 @@ mod tests {
             std::slice::from_ref(&f.leaf_der),
             std::slice::from_ref(&f.ca_der),
             f.mid_validity,
+            WINDOW,
         );
         assert!(r.passed(), "expected pass, got {r:?}");
         assert!(r.cert_chain_valid && r.signature_valid && r.orig_passed && r.dest_passed);
@@ -434,6 +495,7 @@ mod tests {
             std::slice::from_ref(&f.leaf_der),
             std::slice::from_ref(&f.ca_der),
             f.mid_validity,
+            WINDOW,
         );
         assert!(r.orig_passed && r.dest_passed && r.passed());
     }
@@ -449,6 +511,7 @@ mod tests {
             std::slice::from_ref(&f.leaf_der),
             std::slice::from_ref(&other.ca_der), // wrong anchor
             f.mid_validity,
+            WINDOW,
         );
         assert!(!r.cert_chain_valid && !r.signature_valid && !r.passed());
         assert!(r.error.unwrap().contains("chain"));
@@ -465,6 +528,7 @@ mod tests {
             std::slice::from_ref(&f.leaf_der),
             std::slice::from_ref(&f.ca_der),
             way_future,
+            WINDOW,
         );
         assert!(!r.cert_chain_valid && !r.passed());
     }
@@ -479,6 +543,7 @@ mod tests {
             std::slice::from_ref(&f.leaf_der),
             std::slice::from_ref(&f.ca_der),
             f.mid_validity,
+            WINDOW,
         );
         // Crypto valid, but the TN binding failed → not passed.
         assert!(r.cert_chain_valid && r.signature_valid);
@@ -498,6 +563,7 @@ mod tests {
             std::slice::from_ref(&f.leaf_der),
             std::slice::from_ref(&f.ca_der),
             f.mid_validity,
+            WINDOW,
         );
         assert!(r.orig_passed && !r.dest_passed && !r.passed());
         assert_eq!(r.error.as_deref(), Some("dest.tn did not match SIP To"));
@@ -527,6 +593,7 @@ mod tests {
             std::slice::from_ref(&f.leaf_der),
             std::slice::from_ref(&f.ca_der),
             f.mid_validity,
+            WINDOW,
         );
         assert!(r.cert_chain_valid && !r.signature_valid && !r.passed());
         assert_eq!(
@@ -545,6 +612,7 @@ mod tests {
             &[],
             std::slice::from_ref(&f.ca_der),
             f.mid_validity,
+            WINDOW,
         );
         assert!(!r.cert_chain_valid && !r.signature_valid);
         assert!(r.error.unwrap().contains("no certificates"));
@@ -573,5 +641,109 @@ mod tests {
             map_attest(sip_identity::AttestationLevel::C),
             AttestationLevel::C
         );
+    }
+
+    // ─── iat freshness ───────────────────────────────────────────
+
+    #[test]
+    fn iat_fresh_helper_window_and_disable() {
+        let now = UnixTime::since_unix_epoch(Duration::from_secs(1000));
+        let w = Duration::from_secs(60);
+        assert!(iat_fresh(Some(1000), now, w)); // exact
+        assert!(iat_fresh(Some(1060), now, w)); // +60 boundary
+        assert!(iat_fresh(Some(940), now, w)); // -60 boundary
+        assert!(!iat_fresh(Some(1061), now, w)); // future skew > window
+        assert!(!iat_fresh(Some(939), now, w)); // past skew > window
+        assert!(!iat_fresh(None, now, w)); // missing iat is never fresh
+        assert!(iat_fresh(None, now, Duration::ZERO)); // window 0 disables
+        assert!(iat_fresh(Some(1), now, Duration::ZERO));
+    }
+
+    /// A fully-valid call whose only failure is a stale `iat`: crypto + TN
+    /// all hold, but `iat_passed` is false → not passed, not trusted, and
+    /// the headline error names the freshness failure.
+    #[test]
+    fn stale_iat_rejected_even_with_valid_crypto() {
+        let f = make_fixture(&payload_with_iat(
+            "A",
+            "+12155551212",
+            "+12155551213",
+            FRESH_IAT - 3600, // an hour stale vs mid_validity
+        ));
+        let r = build_result(
+            &f.passport,
+            "+12155551212",
+            "+12155551213",
+            std::slice::from_ref(&f.leaf_der),
+            std::slice::from_ref(&f.ca_der),
+            f.mid_validity,
+            WINDOW,
+        );
+        assert!(r.cert_chain_valid && r.signature_valid && r.orig_passed && r.dest_passed);
+        assert!(!r.iat_passed && !r.passed());
+        assert_eq!(r.trusted_attestation(), None);
+        assert_eq!(
+            r.error.as_deref(),
+            Some("PASSporT iat outside the freshness window")
+        );
+    }
+
+    #[test]
+    fn future_iat_rejected() {
+        let f = make_fixture(&payload_with_iat(
+            "A",
+            "+12155551212",
+            "+12155551213",
+            FRESH_IAT + 3600, // an hour in the future
+        ));
+        let r = build_result(
+            &f.passport,
+            "+12155551212",
+            "+12155551213",
+            std::slice::from_ref(&f.leaf_der),
+            std::slice::from_ref(&f.ca_der),
+            f.mid_validity,
+            WINDOW,
+        );
+        assert!(!r.iat_passed && !r.passed());
+    }
+
+    #[test]
+    fn missing_iat_rejected() {
+        // PASSporT with no `iat` claim at all.
+        let pl = r#"{"attest":"A","dest":{"tn":["+12155551213"]},"orig":{"tn":"+12155551212"}}"#;
+        let f = make_fixture(pl);
+        let r = build_result(
+            &f.passport,
+            "+12155551212",
+            "+12155551213",
+            std::slice::from_ref(&f.leaf_der),
+            std::slice::from_ref(&f.ca_der),
+            f.mid_validity,
+            WINDOW,
+        );
+        assert!(!r.iat_passed && !r.passed());
+        assert_eq!(r.error.as_deref(), Some("PASSporT has no iat claim"));
+    }
+
+    #[test]
+    fn zero_window_disables_iat_check() {
+        // A wildly stale iat still passes when the window is disabled.
+        let f = make_fixture(&payload_with_iat(
+            "A",
+            "+12155551212",
+            "+12155551213",
+            FRESH_IAT - 100_000,
+        ));
+        let r = build_result(
+            &f.passport,
+            "+12155551212",
+            "+12155551213",
+            std::slice::from_ref(&f.leaf_der),
+            std::slice::from_ref(&f.ca_der),
+            f.mid_validity,
+            Duration::ZERO,
+        );
+        assert!(r.iat_passed && r.passed());
     }
 }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -293,6 +293,7 @@ enabled            = false           # master switch
 trust_anchors      = "/etc/siphon-ai/sti-pa-roots.pem"
 cert_cache_ttl_secs = 3600           # signing-cert cache TTL (seconds)
 require_identity   = false           # reject unsigned INVITEs with 428
+iat_freshness_secs = 60              # PASSporT iat replay window (0 disables)
 ```
 
 ### `[security]`
@@ -339,6 +340,7 @@ min_attestation = "C"   # looser than a stricter global, by design
 | `trust_anchors` | string | — | Path to the PEM bundle of STI-PA trust anchors. `contrib/sti-pa-roots.pem` is a **template** — populate it with the authentic STI-PA root(s) per `contrib/README.md` (we don't vendor a baked-in root; a stale/wrong anchor is a security defect). **Required when `enabled = true`**; validated at load time (must exist and contain ≥1 PEM certificate, so the unpopulated template fails loud by design). |
 | `cert_cache_ttl_secs` | int | `3600` | How long a fetched signing certificate is cached before re-fetch. (Seconds, matching the other duration fields in this config.) |
 | `require_identity` | bool | `false` | Reject inbound INVITEs that carry no `Identity` header with `428 Use Identity Header` (RFC 8224 §6.2.2) instead of admitting them as unsigned. |
+| `iat_freshness_secs` | int | `60` | PASSporT `iat` freshness window, in seconds (replay protection, ATIS-1000074). The verdict's `iat_passed` is `false` when `iat` is more than this far from now (past **or** future), or absent. `0` disables the check (any `iat` passes) — an escape hatch for upstreams with broken clocks. |
 
 ## `[cdr]`
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -142,6 +142,7 @@ MAY use it to detect dropped frames in their own logs.
 | `verstat.dest_passed` | bool | A `dest` TN matched the SIP `To` / request URI. |
 | `verstat.cert_chain_valid` | bool | Signing cert chained to a configured STI-PA trust anchor. |
 | `verstat.signature_valid` | bool | ES256 signature over the PASSporT verified against that cert. |
+| `verstat.iat_passed` | bool | PASSporT `iat` was within the configured freshness window (replay protection). Added in 0.4.1; `false` for a stale/future/missing `iat`. Like the other booleans, it's part of the composite a server should treat as "trusted". |
 | `verstat.error` | string \| absent | Human-readable reason when verification did not fully pass; absent on success. |
 
 The `srtp` field is omitted from the JSON when SRTP is off; a v1


### PR DESCRIPTION
**0.4.1 chunk 1** (per `docs/DEV_PLAN_0.4.1.md` §6). Closes the deferred upstream `iat`-freshness item — implemented **app-side** in the verifier (the locked decision), consistent with the `orig`/`dest` claim checks.

With STIR/SHAKEN enabled, a PASSporT whose `iat` is outside the freshness window (past or future) — or missing entirely — now fails verification (ATIS-1000074 replay protection).

### Changes
- **security:** `VerificationResult.iat_passed` (additive, `#[serde(default)]` for backward-compat deser), folded into `passed()` so a stale call yields no trusted attestation.
- **stir-shaken:** `iat_fresh()` in `build_result`; `Verifier::new`/`from_config` carry the window; the headline `error` names an `iat` failure after the crypto + TN-claim reasons.
- **config:** `[security.stir_shaken].iat_freshness_secs` (u64, default `60`, `0` disables). `0` maps straight through (not the default).
- **Surfaces for free:** `iat_passed` on `start.verstat` (protocol stays `version: "1"`), the `verstat_passed` CDR composite, and the HEP verstat JSON.

### Behaviour note
A call that passed in 0.4.0 but carries a stale `iat` will now fail — **only** for deployments that opted into `stir_shaken`, and tunable/disablable via the window. Called out for the 0.4.1 CHANGELOG.

### Verification
- New tests: `iat_fresh` helper (window boundaries + disable), stale/future/missing-`iat` rejected, zero-window disables, composite gating.
- Full workspace suite green (544); `clippy --workspace --all-targets -- -D warnings` clean.
- Docs: PROTOCOL.md (`verstat.iat_passed`) + CONFIG.md (`iat_freshness_secs` + example).

Base `main` (chunk 2 `x5u_tls_extra_ca` follows once this lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)