### PR TITLE
feat(security): x5u_tls_extra_ca — supplemental CA roots for the x5u fetch

### DIFF
--- a/crates/config/src/compile.rs
+++ b/crates/config/src/compile.rs
@@ -433,6 +433,9 @@ pub enum CompileError {
     #[error("[security.stir_shaken].trust_anchors {path:?} is invalid: {err}")]
     StirShakenTrustAnchorsInvalid { path: String, err: String },
 
+    #[error("[security.stir_shaken].x5u_tls_extra_ca {path:?} is invalid: {err}")]
+    StirShakenExtraCaInvalid { path: String, err: String },
+
     #[error("[media].rtp_port_range {min}-{max} is invalid (min must be < max and even)")]
     BadRtpPortRange { min: u16, max: u16 },
 
@@ -804,6 +807,7 @@ fn compile_security(raw: RawSecurity) -> Result<SecurityConfig, CompileError> {
         .iat_freshness_secs
         .map(Duration::from_secs)
         .unwrap_or(DEFAULT_IAT_FRESHNESS);
+    let x5u_tls_extra_ca = stir.x5u_tls_extra_ca.map(PathBuf::from);
 
     // A minimum-attestation gate is meaningless without verification: with
     // stir_shaken off, no call yields a trusted attestation, so the gate
@@ -826,6 +830,17 @@ fn compile_security(raw: RawSecurity) -> Result<SecurityConfig, CompileError> {
                 err: err.to_string(),
             }
         })?;
+
+        // The supplemental x5u-fetch CA, when set, gets the same load-time
+        // existence + ≥1-cert check so a typo fails at startup.
+        if let Some(extra) = &x5u_tls_extra_ca {
+            validate_trust_anchors(extra).map_err(|err| {
+                CompileError::StirShakenExtraCaInvalid {
+                    path: extra.display().to_string(),
+                    err: err.to_string(),
+                }
+            })?;
+        }
     }
 
     Ok(SecurityConfig {
@@ -837,6 +852,7 @@ fn compile_security(raw: RawSecurity) -> Result<SecurityConfig, CompileError> {
             cert_cache_ttl,
             require_identity,
             iat_freshness,
+            x5u_tls_extra_ca,
         },
     })
 }
@@ -1567,6 +1583,7 @@ mod security_tests {
                 cert_cache_ttl_secs: Some(1800),
                 require_identity: Some(true),
                 iat_freshness_secs: Some(30),
+                x5u_tls_extra_ca: None,
             },
         };
         let c = compile_security(raw).unwrap();
@@ -1585,6 +1602,32 @@ mod security_tests {
         assert_eq!(c.stir_shaken.trust_anchors, path);
 
         let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn invalid_x5u_extra_ca_rejected_at_load() {
+        // A valid trust-anchor bundle but a bogus x5u_tls_extra_ca path →
+        // loud failure at config load (only checked when enabled).
+        let anchors = std::env::temp_dir().join("siphon_x5u_ca_test_anchors.pem");
+        std::fs::write(
+            &anchors,
+            "-----BEGIN CERTIFICATE-----\nMIIB...\n-----END CERTIFICATE-----\n",
+        )
+        .unwrap();
+        let raw = RawSecurity {
+            stir_shaken: RawStirShaken {
+                enabled: Some(true),
+                trust_anchors: Some(anchors.to_string_lossy().into_owned()),
+                x5u_tls_extra_ca: Some("/nonexistent/lab-ca.pem".into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(matches!(
+            compile_security(raw),
+            Err(CompileError::StirShakenExtraCaInvalid { .. })
+        ));
+        let _ = std::fs::remove_file(&anchors);
     }
 
     #[test]

--- a/crates/config/src/raw.rs
+++ b/crates/config/src/raw.rs
@@ -253,6 +253,11 @@ pub struct RawStirShaken {
     /// ATIS-1000074). `None` → 60. `0` disables the check.
     #[serde(default)]
     pub iat_freshness_secs: Option<u64>,
+    /// Optional PEM bundle of extra CA cert(s) trusted for the `x5u` HTTPS
+    /// fetch only (private/lab x5u hosting). `None` → public web PKI only.
+    /// Validated at load when `enabled`.
+    #[serde(default)]
+    pub x5u_tls_extra_ca: Option<String>,
 }
 
 /// `[cdr]` — call detail record sinks. v1 supports a JSONL file

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -4333,6 +4333,7 @@ a=sendrecv\r\n",
             vec![vec![0u8; 8]],
             Duration::from_secs(3600),
             Duration::from_secs(60),
+            Vec::new(),
         )
         .expect("build verifier")
     }

--- a/crates/security/src/config.rs
+++ b/crates/security/src/config.rs
@@ -41,6 +41,12 @@ pub struct StirShakenConfig {
     /// ATIS-1000074. `Duration::ZERO` disables the check (any `iat` passes),
     /// an escape hatch for upstreams with broken clocks.
     pub iat_freshness: Duration,
+    /// Optional supplemental CA certificate bundle (PEM path) trusted **for
+    /// the `x5u` HTTPS fetch only** — added to the public web-PKI roots, for
+    /// operators hosting `x5u` behind a private/lab CA. `None` (default)
+    /// trusts only the public roots. This widens *fetch* trust, NOT the
+    /// SHAKEN chain trust (that stays [`trust_anchors`](Self::trust_anchors)).
+    pub x5u_tls_extra_ca: Option<PathBuf>,
 }
 
 impl Default for StirShakenConfig {
@@ -51,6 +57,7 @@ impl Default for StirShakenConfig {
             cert_cache_ttl: DEFAULT_CERT_CACHE_TTL,
             require_identity: false,
             iat_freshness: DEFAULT_IAT_FRESHNESS,
+            x5u_tls_extra_ca: None,
         }
     }
 }

--- a/crates/stir-shaken/src/verifier.rs
+++ b/crates/stir-shaken/src/verifier.rs
@@ -54,6 +54,9 @@ pub enum BuildError {
     /// The HTTP client could not be built (TLS backend init, …).
     #[error("building HTTP client: {0}")]
     HttpClient(String),
+    /// A supplemental x5u-TLS CA certificate could not be parsed.
+    #[error("x5u_tls_extra_ca certificate invalid: {0}")]
+    ExtraCa(String),
 }
 
 /// Verifies inbound `Identity` headers against the STI-PA trust anchors.
@@ -73,19 +76,30 @@ pub struct Verifier {
 
 impl Verifier {
     /// Build a verifier from already-decoded trust-anchor DERs, a cache TTL,
-    /// and an `iat` freshness window (`Duration::ZERO` disables the freshness
-    /// check). Prefer [`Verifier::from_config`] from daemon code; this is the
-    /// seam for tests and embedders that hold anchors in memory.
+    /// an `iat` freshness window (`Duration::ZERO` disables the freshness
+    /// check), and optional supplemental CA DERs trusted **for the `x5u`
+    /// HTTPS fetch only** (added to the public web-PKI roots; empty = public
+    /// roots only). Prefer [`Verifier::from_config`] from daemon code; this
+    /// is the seam for tests and embedders that hold anchors in memory.
     pub fn new(
         trust_anchors: Vec<Vec<u8>>,
         cache_ttl: Duration,
         iat_freshness: Duration,
+        x5u_extra_roots: Vec<Vec<u8>>,
     ) -> Result<Self, BuildError> {
-        let http = reqwest::Client::builder()
+        let mut builder = reqwest::Client::builder()
             .timeout(FETCH_TIMEOUT)
             // x5u is a direct cert URL; never chase a redirect to an
             // attacker-chosen or internal host.
-            .redirect(reqwest::redirect::Policy::none())
+            .redirect(reqwest::redirect::Policy::none());
+        for der in &x5u_extra_roots {
+            // Additive to the default web roots, applied to the fetch TLS
+            // handshake only — never to the SHAKEN chain (that's `anchors`).
+            let cert = reqwest::Certificate::from_der(der)
+                .map_err(|e| BuildError::ExtraCa(e.to_string()))?;
+            builder = builder.add_root_certificate(cert);
+        }
+        let http = builder
             .build()
             .map_err(|e| BuildError::HttpClient(e.to_string()))?;
         Ok(Self {
@@ -98,12 +112,21 @@ impl Verifier {
     }
 
     /// Build a verifier from the compiled `[security.stir_shaken]` config:
-    /// load + decode the trust-anchor PEM file and adopt the configured
-    /// cache TTL and `iat` freshness window. Fails loud if the anchor file is
-    /// unreadable or empty.
+    /// load + decode the trust-anchor PEM file, the optional supplemental
+    /// x5u-TLS CA bundle, and adopt the configured cache TTL and `iat`
+    /// freshness window. Fails loud if either PEM file is unreadable or empty.
     pub fn from_config(cfg: &StirShakenConfig) -> Result<Self, BuildError> {
         let anchors = load_trust_anchors(&cfg.trust_anchors)?;
-        Self::new(anchors, cfg.cert_cache_ttl, cfg.iat_freshness)
+        let x5u_extra_roots = match &cfg.x5u_tls_extra_ca {
+            Some(path) => load_trust_anchors(path)?,
+            None => Vec::new(),
+        };
+        Self::new(
+            anchors,
+            cfg.cert_cache_ttl,
+            cfg.iat_freshness,
+            x5u_extra_roots,
+        )
     }
 
     /// Verify the `Identity` header of an inbound INVITE.
@@ -745,5 +768,24 @@ mod tests {
             Duration::ZERO,
         );
         assert!(r.iat_passed && r.passed());
+    }
+
+    // ─── x5u TLS extra-CA ─────────────────────────────────────────
+
+    #[tokio::test]
+    async fn new_accepts_a_valid_x5u_extra_ca() {
+        // A real DER cert (the fixture CA) is accepted as a supplemental
+        // x5u-fetch root and the client builds. (Malformed cert DER isn't
+        // rejected eagerly — the rustls backend defers it to the TLS
+        // handshake; the operator-facing guard is the config-layer
+        // existence/≥1-cert check on the PEM file.)
+        let f = make_fixture(&payload("A", "+12155551212", "+12155551213"));
+        let v = Verifier::new(
+            Vec::new(),
+            Duration::from_secs(3600),
+            Duration::from_secs(60),
+            vec![f.ca_der.clone()],
+        );
+        assert!(v.is_ok());
     }
 }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -341,6 +341,7 @@ min_attestation = "C"   # looser than a stricter global, by design
 | `cert_cache_ttl_secs` | int | `3600` | How long a fetched signing certificate is cached before re-fetch. (Seconds, matching the other duration fields in this config.) |
 | `require_identity` | bool | `false` | Reject inbound INVITEs that carry no `Identity` header with `428 Use Identity Header` (RFC 8224 §6.2.2) instead of admitting them as unsigned. |
 | `iat_freshness_secs` | int | `60` | PASSporT `iat` freshness window, in seconds (replay protection, ATIS-1000074). The verdict's `iat_passed` is `false` when `iat` is more than this far from now (past **or** future), or absent. `0` disables the check (any `iat` passes) — an escape hatch for upstreams with broken clocks. |
+| `x5u_tls_extra_ca` | string | — | Optional PEM bundle of extra CA cert(s) trusted **only** for the `x5u` HTTPS fetch — added to the public web-PKI roots, for operators hosting `x5u` behind a private/lab CA. Validated at load (exists + ≥1 cert) when `enabled`. **Note the two distinct trust domains:** this widens *fetch-TLS* trust; it does **not** affect the SHAKEN chain, which always validates against `trust_anchors`. Leave unset in production unless your `x5u` is privately hosted. |
 
 ## `[cdr]`
 


### PR DESCRIPTION
**0.4.1 chunk 2** (per `docs/DEV_PLAN_0.4.1.md` §6). Lets operators host the `x5u` certificate behind a private/lab CA, and is the enabler for the CI-gated passing-attestation scenario (chunk 3).

### Changes
- **config:** `[security.stir_shaken].x5u_tls_extra_ca` (optional PEM path), validated at load when `enabled` (exists + ≥1 cert) → `CompileError::StirShakenExtraCaInvalid`.
- **stir-shaken:** `Verifier::new` gains the extra-roots arg; `from_config` loads the bundle and passes the DERs to `reqwest`'s `add_root_certificate`.

### The two trust domains (documented in CONFIG.md)
The extra roots apply to the **`x5u` fetch TLS handshake only** — added to the public web-PKI roots. They do **not** affect the SHAKEN chain, which always validates against `trust_anchors`. This is the #1 source of confusion, so the config doc spells it out.

### Note on validation
The rustls backend stores the cert DER and defers malformed-cert errors to the TLS handshake, so eager startup rejection of a *malformed* cert isn't guaranteed. The operator-facing guard is the config-layer existence/≥1-cert check on the PEM file (the common misconfig — typo'd or empty path — fails loud at load).

### Verification
- Tests: a valid extra CA builds the client; a bogus `x5u_tls_extra_ca` path is rejected at config load.
- Full workspace suite green (546); `clippy --workspace --all-targets -- -D warnings` clean. Docs: CONFIG.md.

Base `main` (chunk 3 — passing SIPp scenario + `gen-test-passport`, which uses this — follows once this lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)