### PR TITLE
test(sipp): passing-attestation scenario + gen-test-passport helper

### DIFF
--- a/crates/stir-shaken/examples/gen_test_passport.rs
+++ b/crates/stir-shaken/examples/gen_test_passport.rs
@@ -1,0 +1,123 @@
+//! Generate a self-contained STIR/SHAKEN test rig: a throwaway CA, a leaf
+//! signing cert, an x5u TLS server cert, and a fully ES256-signed PASSporT
+//! `Identity` header whose `iat` is *now* — so a verifier configured to
+//! trust the CA accepts the resulting call.
+//!
+//! Used by `test-harness/sipp-scenarios/run-all.sh` for the passing-
+//! attestation scenario, and handy as an operator lab tool. Everything is
+//! generated at run time so the cert validity window and `iat` are current.
+//!
+//! Usage:
+//!   gen_test_passport <out_dir> <x5u_url> <orig_tn> <dest_tn>
+//!
+//! Writes into `<out_dir>`:
+//!   ca.pem       — the CA (use as both `trust_anchors` and
+//!                  `x5u_tls_extra_ca`)
+//!   leaf.crt     — the SHAKEN signing cert, served at `<x5u_url>`
+//!   server.crt   — the x5u HTTPS server cert (SAN: IP 127.0.0.1)
+//!   server.key   — its private key
+//! Prints the full `Identity` header value to stdout (and nothing else).
+
+use std::error::Error;
+use std::net::{IpAddr, Ipv4Addr};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use rcgen::{
+    BasicConstraints, CertificateParams, DistinguishedName, DnType, ExtendedKeyUsagePurpose, IsCa,
+    KeyPair, KeyUsagePurpose, SanType, PKCS_ECDSA_P256_SHA256,
+};
+use ring::rand::SystemRandom;
+use ring::signature::{EcdsaKeyPair, ECDSA_P256_SHA256_FIXED_SIGNING};
+use time::OffsetDateTime;
+
+fn b64(bytes: &[u8]) -> String {
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 5 {
+        eprintln!("usage: gen_test_passport <out_dir> <x5u_url> <orig_tn> <dest_tn>");
+        std::process::exit(2);
+    }
+    let out_dir = std::path::PathBuf::from(&args[1]);
+    let x5u_url = &args[2];
+    let orig_tn = &args[3];
+    let dest_tn = &args[4];
+
+    let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() as i64;
+    let not_before = OffsetDateTime::from_unix_timestamp(now - 3600)?;
+    let not_after = OffsetDateTime::from_unix_timestamp(now + 365 * 24 * 3600)?;
+
+    // Distinct DNs per cert — if subject == issuer the certs look
+    // self-signed to a verifier and the chain won't build.
+    let dn = |cn: &str| {
+        let mut d = DistinguishedName::new();
+        d.push(DnType::CommonName, cn);
+        d
+    };
+
+    // ── CA (acts as the STI-PA root AND the x5u-TLS root) ──────────────
+    let ca_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256)?;
+    let mut ca_params = CertificateParams::new(Vec::new())?;
+    ca_params.distinguished_name = dn("siphon-test-sti-pa-root");
+    ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    ca_params.key_usages = vec![
+        KeyUsagePurpose::KeyCertSign,
+        KeyUsagePurpose::CrlSign,
+        KeyUsagePurpose::DigitalSignature,
+    ];
+    ca_params.not_before = not_before;
+    ca_params.not_after = not_after;
+    let ca = ca_params.self_signed(&ca_key)?;
+
+    // ── Leaf SHAKEN signing cert (chains to the CA) ────────────────────
+    let leaf_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256)?;
+    let mut leaf_params = CertificateParams::new(Vec::new())?;
+    leaf_params.distinguished_name = dn("sti.test.siphon");
+    leaf_params.not_before = not_before;
+    leaf_params.not_after = not_after;
+    let leaf = leaf_params.signed_by(&leaf_key, &ca, &ca_key)?;
+
+    // ── x5u HTTPS server cert (TLS; SAN must match the fetch host) ─────
+    let server_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256)?;
+    let mut server_params = CertificateParams::new(Vec::new())?;
+    server_params.distinguished_name = dn("x5u.test.siphon");
+    server_params.subject_alt_names = vec![SanType::IpAddress(IpAddr::V4(Ipv4Addr::LOCALHOST))];
+    server_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
+    server_params.not_before = not_before;
+    server_params.not_after = not_after;
+    let server = server_params.signed_by(&server_key, &ca, &ca_key)?;
+
+    // ── Sign the PASSporT with the leaf's key (ES256, JOSE fixed r‖s) ──
+    let header = format!(r#"{{"alg":"ES256","typ":"passport","ppt":"shaken","x5u":"{x5u_url}"}}"#);
+    let payload = format!(
+        r#"{{"attest":"A","dest":{{"tn":["{dest_tn}"]}},"iat":{now},"orig":{{"tn":"{orig_tn}"}},"origid":"123e4567-e89b-12d3-a456-426655440000"}}"#
+    );
+    let signing_input = format!("{}.{}", b64(header.as_bytes()), b64(payload.as_bytes()));
+    let rng = SystemRandom::new();
+    let signer = EcdsaKeyPair::from_pkcs8(
+        &ECDSA_P256_SHA256_FIXED_SIGNING,
+        &leaf_key.serialize_der(),
+        &rng,
+    )
+    .map_err(|e| format!("load leaf key into ring: {e}"))?;
+    let sig = signer
+        .sign(&rng, signing_input.as_bytes())
+        .map_err(|e| format!("sign PASSporT: {e}"))?;
+    let token = format!("{signing_input}.{}", b64(sig.as_ref()));
+    let identity = format!("{token};info=<{x5u_url}>;alg=ES256;ppt=shaken");
+
+    // ── Emit ──────────────────────────────────────────────────────────
+    std::fs::create_dir_all(&out_dir)?;
+    std::fs::write(out_dir.join("ca.pem"), ca.pem())?;
+    std::fs::write(out_dir.join("leaf.crt"), leaf.pem())?;
+    std::fs::write(out_dir.join("server.crt"), server.pem())?;
+    std::fs::write(out_dir.join("server.key"), server_key.serialize_pem())?;
+
+    // Only the Identity header value goes to stdout, so callers can capture it.
+    println!("{identity}");
+    Ok(())
+}

--- a/test-harness/sipp-scenarios/README.md
+++ b/test-harness/sipp-scenarios/README.md
@@ -48,12 +48,26 @@ sipp -sf basic_call_then_bye.xml -m 1 -p 5070 -s 1000 127.0.0.1:5060
 | `blind_transfer.xml`                | WS-initiated REFER, 202 + BYE teardown       |
 | `stir_shaken_no_identity_428.xml`   | STIR/SHAKEN `require_identity`: INVITE with no `Identity` header → 428 Use Identity Header (stir_shaken phase) |
 | `stir_shaken_attestation_403.xml`   | STIR/SHAKEN gate: `Identity` present but unverifiable (unreachable `x5u`) below `min_attestation = "A"` → 403 Forbidden (stir_shaken phase) |
+| `stir_shaken_attestation_pass.xml`  | STIR/SHAKEN happy path: a fully-verifiable `Identity` (fresh PASSporT, real x5u fetch, chain to the test anchor) → **200 admitted** (stir_shaken phase). Templated — `__IDENTITY__` is substituted at run time; does not run standalone. |
 
 The `stir_shaken_*` scenarios run in `run-all.sh`'s always-on
-**stir_shaken** auxiliary phase, which starts a daemon with verification
-enabled (`require_identity = true`, `min_attestation = "A"`) and a
-throwaway openssl-generated trust anchor. Both reject before media, so no
-reachable `x5u` or WS bridge is needed.
+**stir_shaken** auxiliary phase. It builds + runs the
+`gen_test_passport` example (a `siphon-ai-stir-shaken` example) to mint a
+fresh CA + leaf + x5u TLS server cert + signed PASSporT, serves the leaf
+over a local HTTPS `x5u` (stdlib `http.server` + `ssl`), and starts a
+daemon with verification enabled (`require_identity = true`,
+`min_attestation = "A"`) trusting the test CA as both the STI-PA anchor and
+the `x5u_tls_extra_ca`. The 428/403 rejects happen before media (no x5u/WS
+needed); the pass case is a full admitted call through the echo WS bridge.
+
+`gen_test_passport` doubles as an operator lab tool:
+
+```sh
+cargo run -p siphon-ai-stir-shaken --example gen_test_passport -- \
+    /tmp/rig "https://127.0.0.1:8443/leaf.crt" "+12155551212" "1000"
+# writes ca.pem / leaf.crt / server.crt / server.key into /tmp/rig,
+# prints the Identity header value to stdout
+```
 
 ## Adding a new scenario
 

--- a/test-harness/sipp-scenarios/run-all.sh
+++ b/test-harness/sipp-scenarios/run-all.sh
@@ -165,23 +165,48 @@ run_scenario session_progress_then_answer.xml || failures=$((failures + 1))
 sp_cleanup
 trap - EXIT
 
-# ─── Always-on auxiliary phase: STIR/SHAKEN gate ─────────────────
-# Verifies the accept-path STIR/SHAKEN gate rejects before media:
-#   * no Identity header + require_identity        → 428
-#   * Identity present but unverifiable + min "A"  → 403
-# Both reject paths are pre-media, so no x5u is reachable and no WS
-# bridge is involved. A throwaway self-signed cert satisfies the
-# load-time trust-anchor check (verification never validates a real
-# chain on these paths — the 403 fails at the unreachable x5u fetch).
+# ─── Always-on auxiliary phase: STIR/SHAKEN ──────────────────────
+# Exercises the accept-path verifier + gate end-to-end:
+#   * no Identity header + require_identity        → 428 (reject)
+#   * Identity present but unverifiable + min "A"  → 403 (reject)
+#   * fully-verifiable Identity + min "A"          → 200 (admitted)
+#
+# The passing case needs a real, current rig: the `gen_test_passport`
+# example mints a throwaway CA, a leaf signing cert, an x5u TLS server
+# cert (SAN 127.0.0.1), and a freshly-signed PASSporT whose `iat` is now.
+# A local HTTPS server serves the leaf at the x5u URL; the daemon trusts
+# the CA both as the STI-PA anchor (chain) and via `x5u_tls_extra_ca`
+# (fetch TLS). The 428/403 rejects are pre-media and don't depend on the
+# rig, so all three share one daemon config.
 echo
-echo "─── auxiliary phase: stir_shaken gate ─────────────────"
+echo "─── auxiliary phase: stir_shaken ──────────────────────"
 SS_DAEMON_LOG=$(mktemp -t siphon-ai-ss.XXXXXX.log)
 SS_CONFIG=$(mktemp -t siphon-ai-ss.XXXXXX.toml)
-SS_KEY=$(mktemp -t siphon-ai-ss-key.XXXXXX.pem)
-SS_TA=$(mktemp -t siphon-ai-ss-ta.XXXXXX.pem)
-openssl ecparam -name prime256v1 -genkey -noout -out "$SS_KEY" 2>/dev/null
-openssl req -x509 -new -key "$SS_KEY" -out "$SS_TA" -days 3650 \
-    -subj "/CN=siphon-test-sti-pa-root" 2>/dev/null
+SS_RIG=$(mktemp -d -t siphon-ai-ss-rig.XXXXXX)
+SS_X5U_PORT=8443
+SS_X5U_LOG=$(mktemp -t siphon-ai-ss-x5u.XXXXXX.log)
+
+# Build + run the rig generator (reuses the stir-shaken crate's dev-deps).
+echo "generating STIR/SHAKEN test rig …"
+cargo build -q -p siphon-ai-stir-shaken --example gen_test_passport
+SS_IDENTITY=$("$REPO_ROOT/target/debug/examples/gen_test_passport" \
+    "$SS_RIG" "https://127.0.0.1:$SS_X5U_PORT/leaf.crt" "+12155551212" "1000")
+
+# Serve the leaf cert over HTTPS with the rig's TLS server cert. Stdlib
+# only (http.server + ssl) — no pip deps. Backgrounded; chdir's into the
+# rig dir so GET /leaf.crt returns the leaf certificate.
+python3 - "$SS_X5U_PORT" "$SS_RIG" >"$SS_X5U_LOG" 2>&1 <<'PY' &
+import http.server, ssl, sys, os
+port = int(sys.argv[1]); d = sys.argv[2]
+os.chdir(d)
+ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+ctx.load_cert_chain(os.path.join(d, "server.crt"), os.path.join(d, "server.key"))
+httpd = http.server.HTTPServer(("127.0.0.1", port), http.server.SimpleHTTPRequestHandler)
+httpd.socket = ctx.wrap_socket(httpd.socket, server_side=True)
+httpd.serve_forever()
+PY
+SS_X5U_PID=$!
+
 cat >"$SS_CONFIG" <<EOF
 [node]
 id = "siphon-ai-sipp-ss"
@@ -195,7 +220,8 @@ ws_url = "ws://127.0.0.1:8765/"
 min_attestation = "A"
 [security.stir_shaken]
 enabled = true
-trust_anchors = "$SS_TA"
+trust_anchors = "$SS_RIG/ca.pem"
+x5u_tls_extra_ca = "$SS_RIG/ca.pem"
 require_identity = true
 [[route]]
 name = "default"
@@ -207,17 +233,29 @@ RUST_LOG=siphon_ai=info "$DAEMON_BIN" --config "$SS_CONFIG" \
     >"$SS_DAEMON_LOG" 2>&1 &
 SS_DAEMON_PID=$!
 ss_cleanup() {
-    if kill -0 "$SS_DAEMON_PID" 2>/dev/null; then
-        kill "$SS_DAEMON_PID" 2>/dev/null || true
-        wait "$SS_DAEMON_PID" 2>/dev/null || true
-    fi
+    kill "$SS_DAEMON_PID" "$SS_X5U_PID" 2>/dev/null || true
+    wait "$SS_DAEMON_PID" 2>/dev/null || true
 }
 trap ss_cleanup EXIT
 sleep 1.2
 
-total=$((total + 2))
+# Substitute the freshly-minted Identity into the passing scenario.
+SS_PASS_XML=$(mktemp -t siphon-ai-ss-pass.XXXXXX.xml)
+sed "s|__IDENTITY__|$SS_IDENTITY|" \
+    "$SCRIPT_DIR/stir_shaken_attestation_pass.xml" >"$SS_PASS_XML"
+
+total=$((total + 3))
 run_scenario stir_shaken_no_identity_428.xml || failures=$((failures + 1))
 run_scenario stir_shaken_attestation_403.xml || failures=$((failures + 1))
+# Run the (generated) passing scenario by absolute path.
+echo "─── stir_shaken_attestation_pass ─────────────────────"
+if sipp -sf "$SS_PASS_XML" -m 1 -timeout 15s -trace_err \
+        -p "$SIPP_PORT" -s 1000 "127.0.0.1:$DAEMON_PORT" >/dev/null 2>&1; then
+    echo "  OK"
+else
+    echo "  FAIL (see stir_shaken_attestation_pass_*errors.log; daemon: $SS_DAEMON_LOG)"
+    failures=$((failures + 1))
+fi
 
 ss_cleanup
 trap - EXIT

--- a/test-harness/sipp-scenarios/stir_shaken_attestation_pass.xml
+++ b/test-harness/sipp-scenarios/stir_shaken_attestation_pass.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  stir_shaken_attestation_pass — the happy path: a fully-verifiable
+  STIR/SHAKEN call is ADMITTED (200 OK), not rejected. The daemon runs
+  with verification enabled, `min_attestation = "A"`, and trusts the test
+  CA both as the STI-PA anchor and (via `x5u_tls_extra_ca`) for the x5u
+  HTTPS fetch. The PASSporT is freshly signed by a leaf that chains to that
+  CA, served from a local HTTPS x5u, with `orig.tn` = the From user and a
+  `dest.tn` matching the To user, and a current `iat`.
+
+  TEMPLATED: the `Identity:` line's `__IDENTITY__` is substituted at run
+  time by run-all.sh with the value emitted by the `gen_test_passport`
+  example (certs + PASSporT are generated fresh so the cert window and
+  `iat` are current). This file does not run standalone.
+
+  From user is `+12155551212` to match the generated `orig.tn`; SIPp's
+  `-s 1000` makes the To/Request-URI user `1000`, matching `dest.tn`.
+-->
+<scenario name="stir_shaken_attestation_pass">
+  <send>
+<![CDATA[
+INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+Max-Forwards: 70
+From: <sip:+12155551212@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:+12155551212@[local_ip]:[local_port]>
+Identity: __IDENTITY__
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=user1 53655765 2353687637 IN IP4 [local_ip]
+s=-
+c=IN IP4 [local_ip]
+t=0 0
+m=audio 9000 RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+]]>
+  </send>
+
+  <recv response="100" optional="true"/>
+  <recv response="180" optional="true"/>
+  <recv response="183" optional="true"/>
+
+  <!-- Admitted: verstat passed, so the attestation gate lets it through. -->
+  <recv response="200" rtd="true"/>
+
+  <send>
+<![CDATA[
+ACK sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]-ack
+Max-Forwards: 70
+From: <sip:+12155551212@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="500"/>
+
+  <send>
+<![CDATA[
+BYE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]-bye
+Max-Forwards: 70
+From: <sip:+12155551212@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 BYE
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="200" rtd="true"/>
+</scenario>


### PR DESCRIPTION
**0.4.1 chunk 3** (per `docs/DEV_PLAN_0.4.1.md` §6). The first **green** verstat path under CI: a fully-verifiable STIR/SHAKEN call is **admitted (200)**, alongside the existing 428/403 reject scenarios. Builds on chunk 2's `x5u_tls_extra_ca` (already merged).

### What's new
- **`crates/stir-shaken/examples/gen_test_passport.rs`** — mints a throwaway CA, a leaf signing cert, an x5u TLS server cert (SAN `127.0.0.1`), and a freshly ES256-signed PASSporT whose `iat` is *now*; prints the `Identity` header value. Reuses the crate's existing dev-deps (`rcgen`/`ring`/`base64`/`time`) — no new deps, no new workspace crate. Doubles as an **operator lab tool**.
- **`stir_shaken_attestation_pass.xml`** — templated (`__IDENTITY__`) scenario: INVITE → 200 → ACK → BYE → 200.
- **`run-all.sh`** stir_shaken phase now: builds + runs the generator, serves the leaf over a local HTTPS x5u (stdlib `http.server` + `ssl`, no pip deps), and starts a daemon trusting the test CA as both the STI-PA anchor and the `x5u_tls_extra_ca`. All three scenarios share one config; the passing call bridges through the echo WS.

### Why a generator + the x5u extra-CA
The verifier fetches `x5u` over HTTPS trusting only the public web PKI; a self-signed local server fails the handshake. Chunk 2's `x5u_tls_extra_ca` lets the test daemon trust the rig's CA, which is what makes a CI-gated *pass* possible.

### Validation
Ran the **full** suite locally — all 10 scenarios pass (incl. the new one). Daemon log on the passing call:
```
verstat_result="passed" verstat_attest="A" verstat_passed=true → admitted
```
Workspace unit tests unchanged (546). `clippy --all-targets -- -D warnings` clean (incl. the example).

The two reject scenarios from 0.4.0 now share the real-CA config (they reject before media, so the anchor value doesn't matter to them).

Base `main`. Chunks 4 (Twilio recipe) and 5 (SECURITY doc) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)