### PR TITLE
docs(twilio): STIR/SHAKEN cross-check recipe + verstat-compare example

### DIFF
--- a/docs/INTEGRATIONS_TWILIO.md
+++ b/docs/INTEGRATIONS_TWILIO.md
@@ -147,6 +147,52 @@ smoke test" recipe is in [`docs/DEPLOY.md`](DEPLOY.md) § TLS
 deployment (landed in 0.2.0). mTLS for the bridge WS leg and SRTP
 for the media leg are still 0.2.1 / 0.3.0 — see CHANGELOG.
 
+### Cross-checking STIR/SHAKEN against `X-Twilio-VerStat` (0.4.x)
+
+US-originated calls reach your trunk already carrying Twilio's own
+attestation verdict in the `X-Twilio-VerStat` SIP header — one of
+`TN-Validation-Passed-A` / `-B` / `-C`, `TN-Validation-Failed-…`, or
+`No-TN-Validation`. SiphonAI can **independently verify** the same call's
+`Identity` header (fetch the `x5u` cert, validate the chain to the STI-PA
+anchor, check the ES256 signature, the orig/dest TN binding, and `iat`
+freshness) and surface the result as `start.verstat`. Comparing the two is
+the cleanest sanity check during rollout: they should agree, and a wall of
+disagreement usually means *your* config is off (e.g. a stale trust anchor),
+not that Twilio is wrong.
+
+Turn on verification and forward Twilio's header so your WS server sees both:
+
+```toml
+[bridge]
+ws_url = "ws://127.0.0.1:8765/"
+forward_headers = ["X-Twilio-VerStat"]   # surfaces on start.sip.headers
+
+[security]
+min_attestation = "none"                 # observe-only — don't gate yet
+
+[security.stir_shaken]
+enabled       = true
+trust_anchors = "/etc/siphon-ai/sti-pa-roots.pem"   # the authentic STI-PA root(s)
+```
+
+Keep `min_attestation = "none"` until the verdicts agree in practice — that
+way a divergence is logged, not call-rejecting. Then your WS server has, on
+the `start` message:
+
+- `start.verstat` — SiphonAI's independent verdict (trust the `attest` only
+  when every boolean holds), and
+- `start.sip.headers["X-Twilio-VerStat"]` — Twilio's claim.
+
+The runnable [`examples/verstat-compare-py`](../examples/verstat-compare-py/)
+server logs `AGREE` / `DIVERGE` per call so you can watch them line up
+before you enable the `min_attestation` gate. Once you trust the setup,
+raise `min_attestation` (and optionally `require_identity`) to start
+rejecting — see [`docs/CONFIG.md`](CONFIG.md) `[security]`.
+
+**What attestation does and doesn't mean** — `A` means the carrier
+authenticated the caller's right to that number, *not* that the call is
+trustworthy. See [`docs/SECURITY_STIR_SHAKEN.md`](SECURITY_STIR_SHAKEN.md).
+
 ---
 
 ## Path 2 — Programmable Voice + `<Dial><Sip>` (alternative)

--- a/examples/verstat-compare-py/README.md
+++ b/examples/verstat-compare-py/README.md
@@ -1,0 +1,58 @@
+# verstat-compare — cross-check SiphonAI vs Twilio's `X-Twilio-VerStat`
+
+A diagnostic WebSocket server that compares two independent signals about
+the same inbound call:
+
+- **ours** — `start.verstat`, where SiphonAI *verified* the PASSporT itself
+  (x5u fetch, chain to the STI-PA anchor, ES256 signature, orig/dest TN
+  binding, `iat` freshness), and
+- **Twilio's** — the `X-Twilio-VerStat` SIP header Twilio sets on inbound
+  calls, forwarded to the WS server via `[bridge].forward_headers`.
+
+It logs `AGREE` / `DIVERGE` per call and plays no audio. Use it during
+initial STIR/SHAKEN rollout to confirm your verification matches what the
+carrier already told you — and to catch misconfiguration (a stale trust
+anchor that fails every call Twilio says passed shows up as a wall of
+`DIVERGE`).
+
+## Run
+
+```bash
+python3 -m venv .venv && .venv/bin/pip install websockets
+.venv/bin/python server.py --bind 127.0.0.1:8765
+```
+
+Point SiphonAI at it and make sure the daemon both verifies and forwards
+Twilio's header:
+
+```toml
+[bridge]
+ws_url = "ws://127.0.0.1:8765/"
+forward_headers = ["X-Twilio-VerStat"]   # surface Twilio's claim on `start`
+
+[security]
+min_attestation = "none"                 # observe only — don't gate yet
+
+[security.stir_shaken]
+enabled       = true
+trust_anchors = "/etc/siphon-ai/sti-pa-roots.pem"
+```
+
+`min_attestation = "none"` keeps it observe-only so a divergence doesn't
+reject calls while you're still validating the setup.
+
+## What the log lines mean
+
+- `AGREE` — our verdict and Twilio's match (same pass/fail, same
+  attestation when passed). Expected for healthy US-originated calls.
+- `DIVERGE` — they disagree. Common causes: a stale/missing `trust_anchors`
+  bundle (we fail what Twilio passed), a clock skew tripping `iat`
+  freshness, or a genuinely interesting call. Investigate before turning on
+  a `min_attestation` gate.
+- "no SiphonAI verstat" — `[security.stir_shaken].enabled` is false.
+- "no X-Twilio-VerStat" — not a Twilio call, or the header isn't in
+  `[bridge].forward_headers`.
+
+See [`docs/INTEGRATIONS_TWILIO.md`](../../docs/INTEGRATIONS_TWILIO.md) for
+the full recipe and [`docs/SECURITY_STIR_SHAKEN.md`](../../docs/SECURITY_STIR_SHAKEN.md)
+for what attestation does and doesn't tell you.

--- a/examples/verstat-compare-py/server.py
+++ b/examples/verstat-compare-py/server.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Cross-check SiphonAI's STIR/SHAKEN verdict against Twilio's claim.
+
+A diagnostic WebSocket server: it accepts a SiphonAI bridge connection,
+reads the ``start`` message, and compares two independent signals about the
+same call —
+
+  * **ours** — ``start.verstat`` (SiphonAI verified the PASSporT itself:
+    fetched the x5u cert, validated the chain to the STI-PA anchor, checked
+    the ES256 signature, the orig/dest TN binding, and ``iat`` freshness),
+  * **Twilio's** — the ``X-Twilio-VerStat`` SIP header Twilio sets on
+    inbound calls, surfaced here via ``[bridge].forward_headers``.
+
+It logs AGREE / DIVERGE per call. Useful during initial deployment to
+confirm our verification matches what the carrier already told us, and to
+catch misconfiguration (e.g. a stale trust anchor that fails every call
+Twilio says passed). It does not play any audio — it just drains the
+stream after the comparison.
+
+Run:  python3 server.py --bind 127.0.0.1:8765
+Needs: websockets  (pip install websockets)
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+
+from websockets.asyncio.server import ServerConnection, serve
+
+LOG = logging.getLogger("verstat-compare")
+SUBPROTOCOL = "siphon-ai.v1"
+
+
+def parse_twilio_verstat(value: str | None):
+    """Parse an ``X-Twilio-VerStat`` value into (passed, attest).
+
+    Twilio sets one of: ``TN-Validation-Passed-{A,B,C}``,
+    ``TN-Validation-Failed-{A,B,C}``, or ``No-TN-Validation``. Returns
+    ``(None, None)`` when the header is absent or unrecognised.
+    """
+    if not value:
+        return (None, None)
+    v = value.strip()
+    if v == "No-TN-Validation":
+        return (False, None)
+    if v.startswith("TN-Validation-Passed-"):
+        return (True, v.rsplit("-", 1)[-1])
+    if v.startswith("TN-Validation-Failed-"):
+        return (False, v.rsplit("-", 1)[-1])
+    return (None, None)
+
+
+def our_verdict(verstat: dict | None):
+    """Reduce ``start.verstat`` to (passed, trusted_attest).
+
+    ``passed`` mirrors SiphonAI's composite: every check must hold. The
+    attestation is trustworthy only when ``passed``.
+    """
+    if not verstat:
+        return (None, None)
+    passed = all(
+        verstat.get(k)
+        for k in (
+            "signature_valid",
+            "cert_chain_valid",
+            "orig_passed",
+            "dest_passed",
+            "iat_passed",
+        )
+    )
+    return (passed, verstat.get("attest") if passed else None)
+
+
+def compare(call_id: str, verstat: dict | None, twilio_header: str | None) -> None:
+    ours_passed, ours_attest = our_verdict(verstat)
+    tw_passed, tw_attest = parse_twilio_verstat(twilio_header)
+
+    if verstat is None:
+        LOG.warning(
+            "call_id=%s no SiphonAI verstat (is [security.stir_shaken] enabled?); "
+            "Twilio says passed=%s attest=%s",
+            call_id, tw_passed, tw_attest,
+        )
+        return
+    if twilio_header is None:
+        LOG.warning(
+            "call_id=%s no X-Twilio-VerStat (not a Twilio call, or not in "
+            "[bridge].forward_headers); ours passed=%s attest=%s",
+            call_id, ours_passed, ours_attest,
+        )
+        return
+
+    agree = (ours_passed == tw_passed) and (
+        not ours_passed or ours_attest == tw_attest
+    )
+    level = LOG.info if agree else LOG.warning
+    level(
+        "call_id=%s %s — ours(passed=%s attest=%s) vs twilio(passed=%s attest=%s) [%r]",
+        call_id,
+        "AGREE" if agree else "DIVERGE",
+        ours_passed, ours_attest, tw_passed, tw_attest, twilio_header,
+    )
+
+
+async def handle(connection: ServerConnection) -> None:
+    try:
+        async for message in connection:
+            if isinstance(message, (bytes, bytearray)):
+                continue  # audio frame — drain, we don't play anything back
+            try:
+                msg = json.loads(message)
+            except json.JSONDecodeError:
+                continue
+            if msg.get("type") == "start":
+                sip_headers = msg.get("sip", {}).get("headers", {})
+                compare(
+                    msg.get("call_id"),
+                    msg.get("verstat"),
+                    sip_headers.get("X-Twilio-VerStat"),
+                )
+    except Exception as e:  # noqa: BLE001 — diagnostic server, never crash a call
+        LOG.debug("connection ended: %s", e)
+
+
+async def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--bind", default="127.0.0.1:8765")
+    ap.add_argument("--log-level", default="INFO")
+    args = ap.parse_args()
+    logging.basicConfig(level=args.log_level, format="%(asctime)s %(levelname)s %(message)s")
+    host, _, port = args.bind.partition(":")
+    async with serve(handle, host, int(port), subprotocols=[SUBPROTOCOL]):
+        LOG.info("verstat-compare listening on %s (subprotocol %s)", args.bind, SUBPROTOCOL)
+        await asyncio.get_event_loop().create_future()  # run forever
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
**0.4.1 chunk 4** (per `docs/DEV_PLAN_0.4.1.md` §6 / the deferred §5.3 stretch item). Shows operators how to confirm SiphonAI's independent verstat verdict agrees with Twilio's `X-Twilio-VerStat` header during rollout — and to catch misconfiguration (a stale trust anchor that fails calls Twilio passed shows up as a wall of `DIVERGE`).

### What's new
- **`examples/verstat-compare-py/`** — a runnable diagnostic WS server that reads `start.verstat` (ours) and `start.sip.headers["X-Twilio-VerStat"]` (Twilio's), parses both, and logs **AGREE / DIVERGE** per call. Plays no audio; `websockets`-only.
- **`docs/INTEGRATIONS_TWILIO.md`** — new "Cross-checking STIR/SHAKEN against `X-Twilio-VerStat`" section: the header's values, the config to add (`enable stir_shaken` + `forward_headers = ["X-Twilio-VerStat"]`, observe-only `min_attestation = "none"`), and what the WS server then sees.

### Notes
- Docs + example only — **no daemon code**.
- The recipe forward-links `docs/SECURITY_STIR_SHAKEN.md` (chunk 5); the link resolves once that lands (both ship in 0.4.1).
- Compare/parse logic unit-checked locally: `AGREE` on a match; `DIVERGE` on attestation mismatch and on our-fail-vs-Twilio-pass; py_compile clean.

Base `main`. Chunk 5 (SECURITY_STIR_SHAKEN.md) next, then chunk 6 (release 0.4.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)