### PR TITLE
chore: release 0.4.1 — complete the STIR/SHAKEN theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-06-07
+
+Completes the 0.4.0 STIR/SHAKEN theme — the four items deferred from that
+release, plus the small feature that makes the passing path testable. Still
+**off by default**; protocol stays at `version: "1"` (the one new `verstat`
+field is additive).
+
+### Added
+
+- **PASSporT `iat` freshness check (replay protection).** With verification
+  enabled, a PASSporT whose `iat` is outside `[security.stir_shaken]
+  .iat_freshness_secs` of now (past **or** future), or missing, now fails —
+  surfaced as the new `verstat.iat_passed` boolean and folded into the
+  composite pass. Default window 60 s (ATIS-1000074); `0` disables the check
+  for upstreams with broken clocks.
+- **`[security.stir_shaken].x5u_tls_extra_ca`** — optional supplemental CA
+  bundle trusted **for the `x5u` HTTPS fetch only** (added to the public
+  web-PKI roots), for operators hosting `x5u` behind a private/lab CA.
+  Validated at load when enabled. Does not affect the SHAKEN chain, which
+  always validates against `trust_anchors`.
+- **`docs/SECURITY_STIR_SHAKEN.md`** — the STIR/SHAKEN security model:
+  attestation is a signal not a verdict, the two trust domains, the
+  `verstat` trust rule, replay/freshness, observe-first gate rollout,
+  monitoring, and limitations.
+- **Twilio Caller Identity cross-check recipe** — a `docs/INTEGRATIONS_TWILIO.md`
+  section and a runnable `examples/verstat-compare-py` server that compares
+  SiphonAI's independent `verstat` against Twilio's `X-Twilio-VerStat`
+  header (forwarded via `[bridge].forward_headers`), logging AGREE/DIVERGE.
+- **Passing-attestation SIPp regression** (`stir_shaken_attestation_pass.xml`)
+  plus the `gen_test_passport` example (a `siphon-ai-stir-shaken` example
+  that mints a CA + leaf + x5u TLS cert + fresh signed PASSporT, doubling as
+  an operator lab tool). The first *green* verstat path under CI — a
+  fully-verifiable call is admitted, alongside the 0.4.0 428/403 rejects.
+
+### Changed
+
+- **`verstat.iat_passed` is part of the composite `passed()`** — a
+  deployment that already opted into `stir_shaken` will now reject a
+  previously-passing call that carries a stale `iat`. This is the
+  spec-correct outcome; tune or disable it via `iat_freshness_secs`.
+
 ## [0.4.0] - 2026-06-07
 
 Theme: **STIR/SHAKEN call authentication.** Inbound INVITEs carrying an

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2899,7 +2899,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "base64",
  "bytes",
@@ -2920,7 +2920,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2937,7 +2937,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "regex",
  "serde",
@@ -2953,7 +2953,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2991,7 +2991,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -3006,7 +3006,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3027,7 +3027,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "regex",
  "serde",
@@ -3038,7 +3038,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3047,7 +3047,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3070,7 +3070,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "base64",
  "rcgen",
@@ -3088,7 +3088,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
+**v0.4.1** — patch release completing the 0.4.0 STIR/SHAKEN theme: PASSporT
+`iat` freshness (replay protection, `verstat.iat_passed`), an
+`x5u_tls_extra_ca` knob for privately-hosted `x5u`, the security-model doc
+([`docs/SECURITY_STIR_SHAKEN.md`](docs/SECURITY_STIR_SHAKEN.md)), a Twilio
+`X-Twilio-VerStat` cross-check recipe, and the first CI-gated *passing*
+attestation scenario. Still off by default; protocol stays `version: "1"`.
+Full notes: [`CHANGELOG.md`](CHANGELOG.md).
+
 **v0.4.0** — fourth release. Theme: **STIR/SHAKEN call authentication.**
 Inbound INVITEs with an RFC 8224 `Identity` header are verified end-to-end
 (PASSporT/RFC 8225 decode, ES256, X.509 chain to a configured STI-PA trust


### PR DESCRIPTION
Release prep for **0.4.1**. No functional code — version bump + release docs.

- **Version** `0.4.0 → 0.4.1` (workspace package; all crates inherit) + `Cargo.lock`.
- **CHANGELOG** `[0.4.1]` section: the four 0.4.0 deferrals + the enabler (#125–#129), with the `iat`-freshness behaviour note under Changed. Fresh `[Unreleased]`.
- **README** status entry for v0.4.1.

0.4.1 completes the STIR/SHAKEN theme: `iat` freshness (replay protection), `x5u_tls_extra_ca`, the passing-attestation SIPp scenario + `gen_test_passport` tool, the Twilio `X-Twilio-VerStat` cross-check recipe + `verstat-compare` example, and `docs/SECURITY_STIR_SHAKEN.md`. **Off by default**; protocol stays `version: "1"`.

## Verification
- `cargo fmt --all -- --check` clean; `clippy --workspace --all-targets -- -D warnings` clean.
- Full workspace suite green (546) at 0.4.1.
- All content PRs (#125–#129) already on `main`.

After merge: tag `v0.4.1` + GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)