### PR TITLE
feat(recording): capture core — stereo WAV per call, off the hot path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2944,6 +2944,7 @@ dependencies = [
  "siphon-ai-bridge",
  "siphon-ai-core",
  "siphon-ai-media-glue",
+ "siphon-ai-recording",
  "siphon-ai-routes",
  "siphon-ai-security",
  "thiserror 1.0.69",
@@ -2976,6 +2977,7 @@ dependencies = [
  "siphon-ai-bridge",
  "siphon-ai-cdr",
  "siphon-ai-media-glue",
+ "siphon-ai-recording",
  "siphon-ai-routes",
  "siphon-ai-security",
  "siphon-ai-sip-glue",
@@ -3019,10 +3021,20 @@ dependencies = [
  "forge-sdp",
  "metrics 0.23.1",
  "siphon-ai-bridge",
+ "siphon-ai-recording",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "siphon-ai-recording"
+version = "0.4.1"
+dependencies = [
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/core",
     "crates/http",
     "crates/media-glue",
+    "crates/recording",
     "crates/routes",
     "crates/security",
     "crates/stir-shaken",
@@ -33,6 +34,7 @@ siphon-ai-config      = { path = "crates/config" }
 siphon-ai-core        = { path = "crates/core" }
 siphon-ai-http        = { path = "crates/http" }
 siphon-ai-media-glue  = { path = "crates/media-glue" }
+siphon-ai-recording   = { path = "crates/recording" }
 siphon-ai-routes      = { path = "crates/routes" }
 siphon-ai-security    = { path = "crates/security" }
 siphon-ai-stir-shaken = { path = "crates/stir-shaken" }

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -141,6 +141,7 @@ impl Runtime {
             registrations,
             trunks,
             security,
+            recording,
             cdr,
             observability,
             webhooks,
@@ -254,7 +255,8 @@ impl Runtime {
                 .with_security_policy(security_policy)
                 // Share the same HEP worker the SIP/RTCP/CDR emitters use so
                 // the verstat chunk lands on the same Homer call view.
-                .with_hep_telemetry(hep_telemetry.clone()),
+                .with_hep_telemetry(hep_telemetry.clone())
+                .with_recording(recording),
         );
 
         // ─── Registration manager ──────────────────────────────────

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -22,5 +22,6 @@ tracing.workspace    = true
 siphon-ai-bridge.workspace     = true
 siphon-ai-core.workspace       = true
 siphon-ai-media-glue.workspace = true
+siphon-ai-recording.workspace  = true
 siphon-ai-routes.workspace     = true
 siphon-ai-security.workspace   = true

--- a/crates/config/src/compile.rs
+++ b/crates/config/src/compile.rs
@@ -35,8 +35,8 @@ use thiserror::Error;
 use tracing::warn;
 
 use crate::raw::{
-    RawBridge, RawCdr, RawConfig, RawHep, RawMedia, RawNode, RawObservability, RawRegister,
-    RawSecurity, RawSip, RawSipTls, RawWebhooks,
+    RawBridge, RawCdr, RawConfig, RawHep, RawMedia, RawNode, RawObservability, RawRecording,
+    RawRegister, RawSecurity, RawSip, RawSipTls, RawWebhooks,
 };
 
 /// Compiled, ready-to-pass daemon config.
@@ -62,6 +62,7 @@ pub struct Config {
     /// inbound INVITE must match a trunk or it's 403'd.
     pub trunks: Vec<TrunkConfig>,
     pub security: SecurityConfig,
+    pub recording: siphon_ai_recording::RecordingConfig,
     pub cdr: CdrConfig,
     pub observability: ObservabilityConfig,
     pub webhooks: WebhooksConfig,
@@ -436,6 +437,15 @@ pub enum CompileError {
     #[error("[security.stir_shaken].x5u_tls_extra_ca {path:?} is invalid: {err}")]
     StirShakenExtraCaInvalid { path: String, err: String },
 
+    #[error("[recording].mode is {0:?}; expected \"off\" or \"always\"")]
+    UnknownRecordingMode(String),
+
+    #[error("[recording].dir is required when mode is not \"off\"")]
+    RecordingDirRequired,
+
+    #[error("[recording].dir {path:?} could not be created: {err}")]
+    RecordingDirInvalid { path: String, err: String },
+
     #[error("[media].rtp_port_range {min}-{max} is invalid (min must be < max and even)")]
     BadRtpPortRange { min: u16, max: u16 },
 
@@ -541,6 +551,7 @@ pub fn compile(raw: RawConfig) -> Result<Config, CompileError> {
     let registrations = compile_registrations(raw.registrations)?;
     let trunks = compile_trunks(raw.trunks)?;
     let security = compile_security(raw.security)?;
+    let recording = compile_recording(raw.recording)?;
     let cdr = compile_cdr(raw.cdr)?;
     let observability = compile_observability(raw.observability)?;
     let webhooks = compile_webhooks(raw.webhooks)?;
@@ -611,6 +622,7 @@ pub fn compile(raw: RawConfig) -> Result<Config, CompileError> {
         registrations,
         trunks,
         security,
+        recording,
         cdr,
         observability,
         webhooks,
@@ -855,6 +867,31 @@ fn compile_security(raw: RawSecurity) -> Result<SecurityConfig, CompileError> {
             x5u_tls_extra_ca,
         },
     })
+}
+
+/// Compile and validate `[recording]`. Off by default. When recording is
+/// on, the output directory is required and **created at load** so a bad
+/// path fails loud at startup, not on the first recorded call.
+fn compile_recording(
+    raw: RawRecording,
+) -> Result<siphon_ai_recording::RecordingConfig, CompileError> {
+    use siphon_ai_recording::{RecordingConfig, RecordingMode};
+    let mode = match raw.mode.as_deref() {
+        None | Some("") | Some("off") => RecordingMode::Off,
+        Some("always") => RecordingMode::Always,
+        Some(other) => return Err(CompileError::UnknownRecordingMode(other.to_string())),
+    };
+    let dir = raw.dir.map(PathBuf::from).unwrap_or_default();
+    if mode != RecordingMode::Off {
+        if dir.as_os_str().is_empty() {
+            return Err(CompileError::RecordingDirRequired);
+        }
+        std::fs::create_dir_all(&dir).map_err(|err| CompileError::RecordingDirInvalid {
+            path: dir.display().to_string(),
+            err: err.to_string(),
+        })?;
+    }
+    Ok(RecordingConfig { mode, dir })
 }
 
 fn min_attestation_label(m: siphon_ai_security::MinAttestation) -> &'static str {

--- a/crates/config/src/raw.rs
+++ b/crates/config/src/raw.rs
@@ -53,6 +53,9 @@ pub struct RawConfig {
     pub security: RawSecurity,
 
     #[serde(default)]
+    pub recording: RawRecording,
+
+    #[serde(default)]
     pub cdr: RawCdr,
 
     #[serde(default)]
@@ -258,6 +261,17 @@ pub struct RawStirShaken {
     /// Validated at load when `enabled`.
     #[serde(default)]
     pub x5u_tls_extra_ca: Option<String>,
+}
+
+/// `[recording]` — per-call audio recording (0.5.0). Off by default.
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct RawRecording {
+    /// `"off"` (default) / `"always"`. (`"on_demand"` is a later chunk.)
+    #[serde(default)]
+    pub mode: Option<String>,
+    /// Directory recordings are written to. Required when `mode != "off"`.
+    #[serde(default)]
+    pub dir: Option<String>,
 }
 
 /// `[cdr]` — call detail record sinks. v1 supports a JSONL file

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -25,6 +25,7 @@ serde_json.workspace  = true
 siphon-ai-bridge.workspace     = true
 siphon-ai-cdr.workspace        = true
 siphon-ai-media-glue.workspace = true
+siphon-ai-recording.workspace  = true
 siphon-ai-routes.workspace     = true
 siphon-ai-security.workspace   = true
 siphon-ai-stir-shaken.workspace = true

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -74,6 +74,7 @@ use siphon_ai_media_glue::{
     AnswerOutcome, Codec, InboundAccepted, InboundCall, MediaSetup, MediaTapError, SdpError,
     SetupError, TapDisconnect,
 };
+use siphon_ai_recording::{RecordingConfig, RecordingMode, RecordingSetup};
 use siphon_ai_routes::CompiledRoute;
 use siphon_ai_security::MinAttestation;
 use siphon_ai_sip_glue::{CallAcceptor, InviteFacts, MatchedCall};
@@ -1411,6 +1412,9 @@ pub struct BridgingAcceptor {
     /// `HepProtocol::Verstat` chunk correlated by SIP Call-ID. `None` → no
     /// HEP emission (the rest of the verdict surfacing is unaffected).
     hep: Option<Arc<HepTelemetry>>,
+    /// Recording policy. Default is `Off` (no recording). When `Always`,
+    /// every accepted call gets a per-call WAV writer.
+    recording: RecordingConfig,
 }
 
 /// Daemon-wide REFER plumbing (shared across every accepted call).
@@ -1561,6 +1565,7 @@ impl BridgingAcceptor {
             verifier: None,
             security: AcceptSecurityPolicy::default(),
             hep: None,
+            recording: RecordingConfig::default(),
         }
     }
 
@@ -1658,6 +1663,14 @@ impl BridgingAcceptor {
     /// / RTCP / CDR emitters use.
     pub fn with_hep_telemetry(mut self, hep: Option<Arc<HepTelemetry>>) -> Self {
         self.hep = hep;
+        self
+    }
+
+    /// Install the recording policy (`[recording]`). Default is `Off`; the
+    /// daemon passes the compiled config so `mode = "always"` records every
+    /// accepted call.
+    pub fn with_recording(mut self, recording: RecordingConfig) -> Self {
+        self.recording = recording;
         self
     }
 
@@ -2911,12 +2924,22 @@ impl BridgingAcceptor {
             dialog_manager: Arc::clone(&installed.dialog_manager),
         });
 
+        // Recording: `always` mode records every accepted call to
+        // `<dir>/<call_id>.wav`. (`on_demand` + per-route are later chunks.)
+        let recording = match self.recording.mode {
+            RecordingMode::Always => Some(RecordingSetup {
+                path: self.recording.path_for(bridge_call_id.as_str()),
+            }),
+            RecordingMode::Off => None,
+        };
+
         let cfg = CallControllerConfig {
             call_id: bridge_call_id.clone(),
             bridge: bridge_config.clone(),
             start: start.clone(),
             media_tap: tap,
             transfer,
+            recording,
         };
         let (controller, handle) = CallController::new(cfg);
 

--- a/crates/core/src/call.rs
+++ b/crates/core/src/call.rs
@@ -64,6 +64,9 @@ use siphon_ai_bridge::{
     ErrorCode, OutgoingEvent, StartMsg, StopReason,
 };
 use siphon_ai_media_glue::{MediaTap, MediaTapError, TapCommand, TapDisconnect};
+use siphon_ai_recording::{
+    RecFrame, RecordingError, RecordingSetup, RecordingStats, RecordingWriter,
+};
 use thiserror::Error;
 use tokio::sync::{mpsc, Notify};
 use tokio::task::JoinHandle;
@@ -75,6 +78,11 @@ use crate::transfer::{TransferContext, TransferOutcome};
 /// of audio; per CLAUDE.md §6.2 audio channels are bounded for
 /// roughly that span.
 const AUDIO_CHANNEL_CAPACITY: usize = 10;
+
+/// Bounded capacity for the recording fork — generous (≈2 s) slack so the
+/// writer keeps up; a full channel drops frames best-effort rather than
+/// stalling the audio path (CLAUDE.md §4.3).
+const RECORDING_CHANNEL_CAPACITY: usize = 100;
 
 /// Bounded channel capacity for control-plane messages. Per
 /// CLAUDE.md §6.2, control channels get small bounded buffers.
@@ -103,6 +111,12 @@ pub struct CallControllerConfig {
     /// it for every accepted call when the daemon-wide
     /// `IntegratedUAC` is installed.
     pub transfer: Option<TransferContext>,
+
+    /// Optional recording. `Some` when `[recording]` selects this call
+    /// (e.g. `mode = "always"`); the controller spawns a per-call writer
+    /// task, forks both audio legs to it via the tap, and finalizes the WAV
+    /// at teardown. `None` → no recording.
+    pub recording: Option<RecordingSetup>,
 }
 
 /// Where in its life a call is. State transitions are logged at
@@ -290,6 +304,7 @@ impl CallController {
             start,
             media_tap,
             transfer,
+            recording,
         } = cfg;
 
         log_state(&call_id, CallState::Initializing);
@@ -325,6 +340,20 @@ impl CallController {
 
         // ─── Spawn sub-tasks ─────────────────────────────────────
         log_state(&call_id, CallState::Connecting);
+
+        // Recording (optional). Spawn the per-call writer task and fork both
+        // legs to it via the tap. The writer does its file I/O off the audio
+        // path; the tap only `try_send`s copies (§4.3). `media_tap` is
+        // rebound with the fork sender installed before it's spawned.
+        let mut recording_task: Option<JoinHandle<Result<RecordingStats, RecordingError>>> = None;
+        let media_tap = if let Some(setup) = recording {
+            let (rec_tx, rec_rx) = mpsc::channel::<RecFrame>(RECORDING_CHANNEL_CAPACITY);
+            let writer = RecordingWriter::new(setup.path, media_tap.sample_rate());
+            recording_task = Some(tokio::spawn(writer.run(rec_rx)));
+            media_tap.with_recording(Some(rec_tx))
+        } else {
+            media_tap
+        };
 
         let mut bridge_task: JoinHandle<Result<DisconnectReason, BridgeError>> =
             tokio::spawn(connect_and_run(bridge, start, channels));
@@ -630,6 +659,29 @@ impl CallController {
         } else if !tap_task.is_finished() {
             if let Ok(inner) = (&mut tap_task).await {
                 tap_result = Some(inner);
+            }
+        }
+
+        // Finalize the recording. The tap has now exited, dropping its fork
+        // sender → the writer sees EOF, flushes, and patches the WAV header.
+        // Give it a budget so a slow final flush can't wedge teardown.
+        if let Some(mut rec_task) = recording_task.take() {
+            match tokio::time::timeout(Duration::from_millis(500), &mut rec_task).await {
+                Ok(Ok(Ok(stats))) => debug!(
+                    call_id = %call_id,
+                    path = %stats.path.display(),
+                    frames = stats.frames,
+                    "recording written"
+                ),
+                Ok(Ok(Err(e))) => warn!(call_id = %call_id, error = %e, "recording failed"),
+                Ok(Err(join_err)) => {
+                    warn!(call_id = %call_id, error = %join_err, "recording task panicked")
+                }
+                Err(_) => {
+                    warn!(call_id = %call_id, "recording did not finalize within 500 ms; aborting");
+                    rec_task.abort();
+                    let _ = (&mut rec_task).await;
+                }
             }
         }
 

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -258,6 +258,7 @@ mod tests {
             },
             media_tap: tap,
             transfer: None,
+            recording: None,
         };
         let (controller, handle) = CallController::new(cfg);
         // Drop the controller without running it; the handle still

--- a/crates/core/tests/controller_lifecycle.rs
+++ b/crates/core/tests/controller_lifecycle.rs
@@ -116,6 +116,7 @@ fn make_controller(port: u16, call_id: &str) -> (CallController, siphon_ai_core:
         start: start_msg(call_id),
         media_tap: tap,
         transfer: None,
+        recording: None,
     };
     CallController::new(cfg)
 }

--- a/crates/core/tests/hold_resume.rs
+++ b/crates/core/tests/hold_resume.rs
@@ -106,6 +106,7 @@ async fn push_bridge_event_emits_hold_and_resume_on_ws() {
         },
         media_tap: tap,
         transfer: None,
+        recording: None,
     };
     let (controller, handle) = CallController::new(cfg);
     let run = tokio::spawn(async move { controller.run().await });

--- a/crates/core/tests/registry_bye.rs
+++ b/crates/core/tests/registry_bye.rs
@@ -128,6 +128,7 @@ async fn dispatch_bye_wakes_running_controller_via_registry() {
         },
         media_tap: tap,
         transfer: None,
+        recording: None,
     };
     let (controller, handle) = CallController::new(cfg);
 
@@ -213,6 +214,7 @@ async fn bye_drives_wire_stop_with_caller_hangup_reason() {
         },
         media_tap: tap,
         transfer: None,
+        recording: None,
     };
     let (controller, handle) = CallController::new(cfg);
 

--- a/crates/media-glue/Cargo.toml
+++ b/crates/media-glue/Cargo.toml
@@ -19,6 +19,7 @@ metrics.workspace     = true
 
 # Sibling SiphonAI crates
 siphon-ai-bridge.workspace = true
+siphon-ai-recording.workspace = true
 
 # Upstream media stack
 forge-core.workspace   = true

--- a/crates/media-glue/src/tap.rs
+++ b/crates/media-glue/src/tap.rs
@@ -70,6 +70,7 @@ use forge_engine::{
 use siphon_ai_bridge::{
     pack_pcm16_le, unpack_pcm16_le, AudioError, DtmfMethod, OutgoingEvent, Reframer,
 };
+use siphon_ai_recording::RecFrame;
 use thiserror::Error;
 use tokio::sync::{broadcast, mpsc};
 use tracing::{debug, instrument, warn};
@@ -258,6 +259,11 @@ pub struct MediaTap {
     /// [`Self::with_rtp_stats_interval`] before `run()`. See
     /// `crates/media-glue/src/rtp_stats.rs` for the rationale.
     rtp_stats: RtpStatsTracker,
+    /// Recording fork. `None` (default) → no recording. When set, the tap
+    /// `try_send`s a copy of each leg's 20 ms frame here — best-effort and
+    /// non-blocking, so a backed-up recording writer never stalls the audio
+    /// path (CLAUDE.md §4.3). The `CallController` sets this before `run()`.
+    recording: Option<mpsc::Sender<RecFrame>>,
 }
 
 impl std::fmt::Debug for MediaTap {
@@ -322,6 +328,7 @@ impl MediaTap {
             muted: false,
             idle_detector: IdleDetector::new(None, None, Instant::now()),
             rtp_stats: RtpStatsTracker::new(None),
+            recording: None,
         })
     }
 
@@ -352,6 +359,15 @@ impl MediaTap {
     /// override). `None` disables the event for this call.
     pub fn with_rtp_stats_interval(mut self, interval: Option<Duration>) -> Self {
         self.rtp_stats = RtpStatsTracker::new(interval);
+        self
+    }
+
+    /// Install the recording fork. `Some(tx)` makes the tap copy each leg's
+    /// 20 ms frame to `tx` (non-blocking `try_send`); `None` (default) is no
+    /// recording. The `CallController` sets this before `run()` when the call
+    /// is being recorded.
+    pub fn with_recording(mut self, recording: Option<mpsc::Sender<RecFrame>>) -> Self {
+        self.recording = recording;
         self
     }
 
@@ -474,6 +490,12 @@ impl MediaTap {
                     if self.muted {
                         continue;
                     }
+                    // Recording fork (right channel): only non-muted playout
+                    // is recorded, so a muted span shows as silence on the
+                    // bot side — what the caller actually heard.
+                    if let Some(rec) = &self.recording {
+                        let _ = rec.try_send(RecFrame::Bot(bytes.clone()));
+                    }
                     let samples = unpack_pcm16_le(&bytes)?;
                     let frame = OutboundMediaFrame {
                         target: MediaTarget::A,
@@ -521,6 +543,10 @@ impl MediaTap {
                     reframer.push(&frame.samples);
                     while let Some(samples) = reframer.pop_frame() {
                         let bytes = pack_pcm16_le(&samples);
+                        // Recording fork (left channel), best-effort.
+                        if let Some(rec) = &self.recording {
+                            let _ = rec.try_send(RecFrame::Caller(bytes.clone()));
+                        }
                         if caller_audio_tx.send(bytes).await.is_err() {
                             debug!("caller_audio_tx closed; ending tap");
                             return Ok(TapDisconnect::ControllerHungUp);

--- a/crates/recording/Cargo.toml
+++ b/crates/recording/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name        = "siphon-ai-recording"
+description = "Per-call audio recording: stereo WAV writer fed off the media tap, off the audio hot path."
+version.workspace      = true
+edition.workspace      = true
+rust-version.workspace = true
+license.workspace      = true
+authors.workspace      = true
+repository.workspace   = true
+
+[dependencies]
+tokio     = { workspace = true }
+tracing.workspace   = true
+thiserror.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/crates/recording/src/config.rs
+++ b/crates/recording/src/config.rs
@@ -1,0 +1,47 @@
+//! Compiled `[recording]` configuration.
+
+use std::path::PathBuf;
+
+/// When to record. (`on_demand` — WS-server-driven — lands in a later
+/// chunk; 0.5.0 chunk 1 ships `off` / `always`.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RecordingMode {
+    /// No recording (default) — zero behaviour change.
+    #[default]
+    Off,
+    /// Record every call that reaches a controller.
+    Always,
+}
+
+/// Compiled `[recording]` block.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordingConfig {
+    pub mode: RecordingMode,
+    /// Directory recordings are written to (required when `mode != Off`).
+    pub dir: PathBuf,
+}
+
+impl Default for RecordingConfig {
+    fn default() -> Self {
+        Self {
+            mode: RecordingMode::Off,
+            dir: PathBuf::new(),
+        }
+    }
+}
+
+impl RecordingConfig {
+    /// The output path for `call_id` under this config's directory.
+    /// (Templating beyond `<dir>/<call_id>.wav` is a later chunk.)
+    pub fn path_for(&self, call_id: &str) -> PathBuf {
+        self.dir.join(format!("{call_id}.wav"))
+    }
+}
+
+/// Per-call recording instructions handed to the `CallController` when a
+/// call should be recorded. Carries the resolved output path; the sample
+/// rate is taken from the call's media tap.
+#[derive(Debug, Clone)]
+pub struct RecordingSetup {
+    pub path: PathBuf,
+}

--- a/crates/recording/src/frame.rs
+++ b/crates/recording/src/frame.rs
@@ -1,0 +1,15 @@
+//! The audio frames forked off the media tap for recording.
+
+/// One 20 ms PCM16-LE mono frame, tagged with the leg it came from. The
+/// media tap `try_send`s these (best-effort, never blocking the audio path)
+/// to the per-call [`RecordingWriter`](crate::RecordingWriter), which mixes
+/// the two legs into a stereo WAV.
+#[derive(Debug, Clone)]
+pub enum RecFrame {
+    /// Audio from the caller (inbound RTP, decoded) — the **left** channel.
+    Caller(Vec<u8>),
+    /// Audio played toward the caller (from the WS server) — the **right**
+    /// channel. Muted playout is intentionally *not* forwarded, so a muted
+    /// span records as silence on the right (what the caller actually heard).
+    Bot(Vec<u8>),
+}

--- a/crates/recording/src/lib.rs
+++ b/crates/recording/src/lib.rs
@@ -1,0 +1,21 @@
+//! Per-call audio recording for SiphonAI.
+//!
+//! Records a call's audio to a stereo WAV (caller = left, bot = right) by
+//! forking the two legs off the media tap. The defining constraint is
+//! CLAUDE.md §4.3: the audio hot path must never block on recording. So the
+//! tap only ever does a non-blocking `try_send` of frame copies onto a
+//! bounded channel; a per-call [`RecordingWriter`] task drains that channel,
+//! mixes on a 20 ms clock, and does the (batched) file I/O off the audio
+//! task.
+//!
+//! 0.5.0 chunk 1 ships the capture core: `[recording].mode = "always"` → a
+//! stereo WAV per call. Control messages (start/stop/pause), per-route
+//! overrides, the CDR pointer, and metrics land in later chunks.
+
+mod config;
+mod frame;
+mod writer;
+
+pub use config::{RecordingConfig, RecordingMode, RecordingSetup};
+pub use frame::RecFrame;
+pub use writer::{RecordingError, RecordingStats, RecordingWriter};

--- a/crates/recording/src/writer.rs
+++ b/crates/recording/src/writer.rs
@@ -1,0 +1,272 @@
+//! The per-call recording writer task.
+//!
+//! Mixes the two tapped legs into a stereo WAV on a 20 ms monotonic clock
+//! and writes it out. It runs as its own per-call task — **never on the
+//! audio hot path** (CLAUDE.md §4.3): the tap `try_send`s frame copies to
+//! the bounded channel this task drains, and the (batched) file I/O happens
+//! here, not on the media task.
+//!
+//! Layout: dual-channel stereo PCM16-LE — caller on the **left**, bot on the
+//! **right**. Each 20 ms tick emits exactly one stereo frame using the most
+//! recent frame seen for each leg, or silence for a leg that produced
+//! nothing — so the recording stays time-aligned to the call's wall clock
+//! and its duration tracks the call. (Two frames for the same leg between
+//! ticks: the later wins — a rare 20 ms drop under jitter, not a desync.)
+
+use std::io::SeekFrom;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use thiserror::Error;
+use tokio::fs::File;
+use tokio::io::{AsyncSeekExt, AsyncWriteExt, BufWriter};
+use tokio::sync::mpsc;
+use tracing::{debug, warn};
+
+use crate::frame::RecFrame;
+
+/// Recording cadence — one stereo frame per 20 ms, matching the bridge.
+const FRAME_MS: u64 = 20;
+/// Flush the in-memory buffer to disk once it reaches this size (~1 s of
+/// stereo 16 kHz audio). Batches syscalls so the writer task rarely blocks.
+const FLUSH_BYTES: usize = 64 * 1024;
+/// WAV header length (canonical 44-byte PCM header).
+const WAV_HEADER_LEN: usize = 44;
+
+/// Outcome of a finished recording.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordingStats {
+    pub path: PathBuf,
+    pub frames: u64,
+    pub data_bytes: u64,
+}
+
+#[derive(Debug, Error)]
+pub enum RecordingError {
+    #[error("recording I/O failed for {path:?}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("unsupported sample rate {0} (8000 or 16000 only)")]
+    UnsupportedSampleRate(u32),
+}
+
+/// Per-call recording writer. Build with [`RecordingWriter::new`], then
+/// drive with [`RecordingWriter::run`], feeding it the tap's `RecFrame`s.
+pub struct RecordingWriter {
+    path: PathBuf,
+    sample_rate: u32,
+}
+
+impl RecordingWriter {
+    pub fn new(path: PathBuf, sample_rate: u32) -> Self {
+        Self { path, sample_rate }
+    }
+
+    /// Run until `rx` closes (the call ended and the tap dropped its
+    /// sender), then flush and finalize the WAV header. Returns the
+    /// recording stats, or an error if the file couldn't be written.
+    pub async fn run(
+        self,
+        mut rx: mpsc::Receiver<RecFrame>,
+    ) -> Result<RecordingStats, RecordingError> {
+        let mono_samples = match self.sample_rate {
+            8000 => 160usize,
+            16000 => 320usize,
+            other => return Err(RecordingError::UnsupportedSampleRate(other)),
+        };
+        let mono_bytes = mono_samples * 2; // PCM16
+        let io_err = |source| RecordingError::Io {
+            path: self.path.clone(),
+            source,
+        };
+
+        let file = File::create(&self.path).await.map_err(io_err)?;
+        let mut out = BufWriter::new(file);
+        // Placeholder header; patched with the real sizes at finalize.
+        out.write_all(&wav_header(self.sample_rate, 0))
+            .await
+            .map_err(io_err)?;
+
+        let mut latest_caller: Option<Vec<u8>> = None;
+        let mut latest_bot: Option<Vec<u8>> = None;
+        let mut buf: Vec<u8> = Vec::with_capacity(FLUSH_BYTES + mono_bytes * 2);
+        let mut frames: u64 = 0;
+        let mut data_bytes: u64 = 0;
+
+        let mut tick = tokio::time::interval(Duration::from_millis(FRAME_MS));
+        // Missed ticks are skipped (not bunched) so the recording stays
+        // wall-clock aligned rather than writing a catch-up burst of silence.
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        loop {
+            tokio::select! {
+                biased;
+                maybe = rx.recv() => match maybe {
+                    Some(RecFrame::Caller(b)) => latest_caller = Some(b),
+                    Some(RecFrame::Bot(b)) => latest_bot = Some(b),
+                    None => break, // tap dropped its sender → call over
+                },
+                _ = tick.tick() => {
+                    interleave_into(
+                        &mut buf,
+                        latest_caller.take().as_deref(),
+                        latest_bot.take().as_deref(),
+                        mono_bytes,
+                    );
+                    frames += 1;
+                    data_bytes += (mono_bytes * 2) as u64;
+                    if buf.len() >= FLUSH_BYTES {
+                        out.write_all(&buf).await.map_err(io_err)?;
+                        buf.clear();
+                    }
+                }
+            }
+        }
+
+        // Flush the tail, then patch the RIFF/data sizes into the header.
+        if !buf.is_empty() {
+            out.write_all(&buf).await.map_err(io_err)?;
+        }
+        out.flush().await.map_err(io_err)?;
+        let data_u32 = u32::try_from(data_bytes).unwrap_or(u32::MAX);
+        out.seek(SeekFrom::Start(4)).await.map_err(io_err)?;
+        out.write_all(&(36u32.wrapping_add(data_u32)).to_le_bytes())
+            .await
+            .map_err(io_err)?;
+        out.seek(SeekFrom::Start(40)).await.map_err(io_err)?;
+        out.write_all(&data_u32.to_le_bytes())
+            .await
+            .map_err(io_err)?;
+        out.flush().await.map_err(io_err)?;
+
+        debug!(path = %self.path.display(), frames, data_bytes, "recording finalized");
+        if data_bytes > u32::MAX as u64 {
+            warn!(path = %self.path.display(), "recording exceeded 4 GiB; WAV header sizes saturated");
+        }
+        Ok(RecordingStats {
+            path: self.path,
+            frames,
+            data_bytes,
+        })
+    }
+}
+
+/// Append one interleaved stereo frame (L = caller, R = bot) to `buf`.
+/// Each leg is taken as exactly `mono_bytes` (truncated or zero-padded);
+/// a `None` leg is silence.
+fn interleave_into(
+    buf: &mut Vec<u8>,
+    caller: Option<&[u8]>,
+    bot: Option<&[u8]>,
+    mono_bytes: usize,
+) {
+    let sample = |src: Option<&[u8]>, i: usize| -> [u8; 2] {
+        match src {
+            Some(s) if i + 1 < s.len() => [s[i], s[i + 1]],
+            _ => [0, 0],
+        }
+    };
+    let mut i = 0;
+    while i < mono_bytes {
+        buf.extend_from_slice(&sample(caller, i)); // left
+        buf.extend_from_slice(&sample(bot, i)); // right
+        i += 2;
+    }
+}
+
+/// Canonical 44-byte PCM WAV header for stereo 16-bit at `sample_rate`,
+/// with `data_len` bytes of sample data (0 for the streaming placeholder).
+fn wav_header(sample_rate: u32, data_len: u32) -> [u8; WAV_HEADER_LEN] {
+    const CHANNELS: u16 = 2;
+    const BITS: u16 = 16;
+    let block_align: u16 = CHANNELS * (BITS / 8);
+    let byte_rate: u32 = sample_rate * block_align as u32;
+    let mut h = [0u8; WAV_HEADER_LEN];
+    h[0..4].copy_from_slice(b"RIFF");
+    h[4..8].copy_from_slice(&(36u32.wrapping_add(data_len)).to_le_bytes());
+    h[8..12].copy_from_slice(b"WAVE");
+    h[12..16].copy_from_slice(b"fmt ");
+    h[16..20].copy_from_slice(&16u32.to_le_bytes()); // fmt chunk size
+    h[20..22].copy_from_slice(&1u16.to_le_bytes()); // PCM
+    h[22..24].copy_from_slice(&CHANNELS.to_le_bytes());
+    h[24..28].copy_from_slice(&sample_rate.to_le_bytes());
+    h[28..32].copy_from_slice(&byte_rate.to_le_bytes());
+    h[32..34].copy_from_slice(&block_align.to_le_bytes());
+    h[34..36].copy_from_slice(&BITS.to_le_bytes());
+    h[36..40].copy_from_slice(b"data");
+    h[40..44].copy_from_slice(&data_len.to_le_bytes());
+    h
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn header_is_well_formed() {
+        let h = wav_header(8000, 320);
+        assert_eq!(&h[0..4], b"RIFF");
+        assert_eq!(&h[8..12], b"WAVE");
+        assert_eq!(&h[36..40], b"data");
+        assert_eq!(u32::from_le_bytes(h[4..8].try_into().unwrap()), 36 + 320);
+        assert_eq!(u32::from_le_bytes(h[40..44].try_into().unwrap()), 320);
+        assert_eq!(u16::from_le_bytes(h[22..24].try_into().unwrap()), 2); // stereo
+        assert_eq!(u32::from_le_bytes(h[24..28].try_into().unwrap()), 8000);
+        // byte_rate = 8000 * 2ch * 2bytes = 32000
+        assert_eq!(u32::from_le_bytes(h[28..32].try_into().unwrap()), 32000);
+    }
+
+    #[test]
+    fn interleave_pairs_legs_left_right() {
+        let mut buf = Vec::new();
+        // 2 samples (4 bytes) per leg.
+        let caller = [0x11, 0x11, 0x22, 0x22];
+        let bot = [0x33, 0x33, 0x44, 0x44];
+        interleave_into(&mut buf, Some(&caller), Some(&bot), 4);
+        assert_eq!(buf, vec![0x11, 0x11, 0x33, 0x33, 0x22, 0x22, 0x44, 0x44]);
+    }
+
+    #[test]
+    fn interleave_silences_missing_leg() {
+        let mut buf = Vec::new();
+        let caller = [0xab, 0xcd];
+        interleave_into(&mut buf, Some(&caller), None, 2);
+        assert_eq!(buf, vec![0xab, 0xcd, 0x00, 0x00]); // bot silent
+    }
+
+    #[tokio::test]
+    async fn writes_a_valid_stereo_wav() {
+        let dir = std::env::temp_dir().join(format!("siphon_rec_test_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("c.wav");
+        let (tx, rx) = mpsc::channel(64);
+        let writer = RecordingWriter::new(path.clone(), 8000);
+        let h = tokio::spawn(writer.run(rx));
+        // Feed a few frames of each leg, then close.
+        for _ in 0..5 {
+            tx.send(RecFrame::Caller(vec![1u8; 320])).await.unwrap();
+            tx.send(RecFrame::Bot(vec![2u8; 320])).await.unwrap();
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        drop(tx);
+        let stats = h.await.unwrap().unwrap();
+        assert!(
+            stats.frames >= 4,
+            "expected several frames, got {}",
+            stats.frames
+        );
+
+        let bytes = std::fs::read(&path).unwrap();
+        assert_eq!(&bytes[0..4], b"RIFF");
+        assert_eq!(&bytes[8..12], b"WAVE");
+        assert_eq!(u16::from_le_bytes(bytes[22..24].try_into().unwrap()), 2);
+        let data_len = u32::from_le_bytes(bytes[40..44].try_into().unwrap()) as usize;
+        // Header sizes are consistent with the file length.
+        assert_eq!(bytes.len(), WAV_HEADER_LEN + data_len);
+        assert_eq!(data_len as u64, stats.data_bytes);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -346,6 +346,29 @@ min_attestation = "C"   # looser than a stricter global, by design
 | `iat_freshness_secs` | int | `60` | PASSporT `iat` freshness window, in seconds (replay protection, ATIS-1000074). The verdict's `iat_passed` is `false` when `iat` is more than this far from now (past **or** future), or absent. `0` disables the check (any `iat` passes) — an escape hatch for upstreams with broken clocks. |
 | `x5u_tls_extra_ca` | string | — | Optional PEM bundle of extra CA cert(s) trusted **only** for the `x5u` HTTPS fetch — added to the public web-PKI roots, for operators hosting `x5u` behind a private/lab CA. Validated at load (exists + ≥1 cert) when `enabled`. **Note the two distinct trust domains:** this widens *fetch-TLS* trust; it does **not** affect the SHAKEN chain, which always validates against `trust_anchors`. Leave unset in production unless your `x5u` is privately hosted. |
 
+## `[recording]` — call recording
+
+Records each call's audio to a stereo WAV (caller = left channel, bot/WS =
+right). Off by default. Recording runs off the audio hot path — a backed-up
+writer can never stall live audio.
+
+```toml
+[recording]
+mode = "always"            # "off" (default) | "always"
+dir  = "/var/lib/siphon-ai/recordings"
+```
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `mode` | string | `"off"` | `"off"` = no recording (zero behaviour change). `"always"` = record every accepted call. (`"on_demand"` — WS-server-driven — and per-route overrides land in later 0.5.0 chunks.) |
+| `dir` | string | — | Directory recordings are written to as `<dir>/<call_id>.wav`. **Required when `mode != "off"`**; created at startup (a bad path fails loud at load). |
+
+Operational notes: recordings are uncompressed PCM16 stereo (≈115 MB/hour
+at 16 kHz; ≈58 MB/hour at 8 kHz) — size your disk and **manage retention
+yourself** (the daemon does not delete recordings). Recording consent and
+any "this call is recorded" announcement are the operator's responsibility
+(see `docs/SECURITY_STIR_SHAKEN.md` for the analogous trust-model framing).
+
 ## `[cdr]`
 
 ```toml


### PR DESCRIPTION
**0.5.0 chunk 1** (per `docs/DEV_PLAN_0.5.0.md` §7 Week 1). The recording capture core: with `[recording].mode = "always"`, every accepted call is recorded to `<dir>/<call_id>.wav` as dual-channel stereo PCM16 (caller = left, bot = right).

### Design — the §4.3 hot path is the binding constraint
Both audio legs already pass through the **MediaTap**, so it's the single fork point. The tap only ever does a **non-blocking `try_send`** of frame copies to a bounded channel; a per-call **`RecordingWriter`** task drains it, mixes on a 20 ms monotonic clock into a streaming stereo WAV, and does the (batched `tokio::fs`) file I/O — never on the audio task.

### Changes
- **New `crates/recording`** — `RecordingWriter` (mix + WAV writer, header finalized at close), `RecFrame`, `RecordingConfig`/`Mode`/`Setup`. Leaf crate (tokio + tracing + thiserror).
- **media-glue** — the tap forks each leg via `try_send` (`with_recording`). Muted playout isn't recorded → a muted span is silence on the bot channel (what the caller heard).
- **core** — `CallController` spawns the writer when `recording` is set, installs the fork on the tap, finalizes the WAV at teardown (after the tap drains, 500 ms budget).
- **config** — `[recording]` (`mode` off/always, `dir`); the dir is created at load so a bad path fails loud.

### Scope
Off by default. Control messages (start/stop/pause), per-route override, the CDR pointer, and metrics are later chunks.

### Verification
- Validated locally end-to-end: a real call (echo WS + SIPp) writes a **valid stereo WAV** — Python's `wave` reads it as 2ch / 8000 Hz / 16-bit, duration = call length.
- Recording-crate unit tests: WAV header well-formed, stereo interleave (incl. silent-leg), full writer round-trip producing a header-consistent file.
- Full workspace suite green (550); `clippy --workspace --all-targets -- -D warnings` clean. CONFIG.md documents `[recording]`.

Base `main`. Chunk 2 (control messages + modes) follows once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)