### PR TITLE
feat(recording): control messages + on_demand mode

### DIFF
--- a/crates/bridge/src/conn.rs
+++ b/crates/bridge/src/conn.rs
@@ -180,6 +180,20 @@ pub enum OutgoingEvent {
         code: ErrorCode,
         message: String,
     },
+    /// A recording began. The conn stamps `seq` and emits
+    /// [`BridgeOut::RecordingStarted`].
+    RecordingStarted {
+        recording_id: String,
+    },
+    /// A recording finalized → [`BridgeOut::RecordingStopped`].
+    RecordingStopped {
+        recording_id: String,
+    },
+    /// A recording failed → [`BridgeOut::RecordingFailed`].
+    RecordingFailed {
+        recording_id: String,
+        reason: String,
+    },
 }
 
 /// Why the connection task ended cleanly.
@@ -558,6 +572,25 @@ fn build_bridge_out(event: OutgoingEvent, call_id: CallId, seq: Seq) -> BridgeOu
             code,
             message,
         },
+        OutgoingEvent::RecordingStarted { recording_id } => BridgeOut::RecordingStarted {
+            call_id,
+            seq,
+            recording_id,
+        },
+        OutgoingEvent::RecordingStopped { recording_id } => BridgeOut::RecordingStopped {
+            call_id,
+            seq,
+            recording_id,
+        },
+        OutgoingEvent::RecordingFailed {
+            recording_id,
+            reason,
+        } => BridgeOut::RecordingFailed {
+            call_id,
+            seq,
+            recording_id,
+            reason,
+        },
     }
 }
 
@@ -570,6 +603,10 @@ fn bridge_in_call_id(msg: &BridgeIn) -> &str {
         BridgeIn::SendDtmf { call_id, .. } => call_id.as_str(),
         BridgeIn::Mute { call_id } => call_id.as_str(),
         BridgeIn::Unmute { call_id } => call_id.as_str(),
+        BridgeIn::StartRecording { call_id } => call_id.as_str(),
+        BridgeIn::StopRecording { call_id } => call_id.as_str(),
+        BridgeIn::PauseRecording { call_id } => call_id.as_str(),
+        BridgeIn::ResumeRecording { call_id } => call_id.as_str(),
     }
 }
 

--- a/crates/bridge/src/protocol.rs
+++ b/crates/bridge/src/protocol.rs
@@ -162,6 +162,32 @@ pub enum BridgeOut {
         name: String,
     },
 
+    /// A recording has begun (auto on `mode = "always"`, or in response to
+    /// [`BridgeIn::StartRecording`]). `recording_id` identifies it for
+    /// correlation. Added in 0.5.0.
+    RecordingStarted {
+        call_id: CallId,
+        seq: Seq,
+        recording_id: String,
+    },
+
+    /// A recording finalized (call ended, or [`BridgeIn::StopRecording`]).
+    RecordingStopped {
+        call_id: CallId,
+        seq: Seq,
+        recording_id: String,
+    },
+
+    /// A recording could not start or write (e.g. disk error). The call is
+    /// unaffected — recording is best-effort.
+    RecordingFailed {
+        call_id: CallId,
+        seq: Seq,
+        recording_id: String,
+        /// Human-readable reason.
+        reason: String,
+    },
+
     /// Last message SiphonAI sends. Followed by a clean WS close (1000).
     Stop {
         call_id: CallId,
@@ -389,6 +415,24 @@ pub enum BridgeIn {
     /// Resume AI-side playout after a [`BridgeIn::Mute`]. A no-op
     /// if the call is not muted.
     Unmute { call_id: CallId },
+
+    /// Begin recording this call (when `[recording].mode = "on_demand"`).
+    /// No-op if recording is off for the call or already in progress.
+    /// SiphonAI replies with [`BridgeOut::RecordingStarted`] (or
+    /// [`BridgeOut::RecordingFailed`]).
+    StartRecording { call_id: CallId },
+
+    /// Finalize the recording now (close the file early). SiphonAI replies
+    /// with [`BridgeOut::RecordingStopped`].
+    StopRecording { call_id: CallId },
+
+    /// Suspend recording — the paused span is **omitted** from the file
+    /// (e.g. while the caller reads a card number), not silenced. No-op if
+    /// not recording.
+    PauseRecording { call_id: CallId },
+
+    /// Resume recording after a [`BridgeIn::PauseRecording`].
+    ResumeRecording { call_id: CallId },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -784,6 +828,72 @@ mod tests {
         let raw = r#"{ "type": "unmute", "call_id": "c" }"#;
         let msg: BridgeIn = assert_round_trip(raw);
         assert!(matches!(msg, BridgeIn::Unmute { ref call_id } if call_id.as_str() == "c"));
+    }
+
+    #[test]
+    fn bridge_in_recording_controls() {
+        for (wire, ok) in [
+            (
+                "start_recording",
+                matches!(
+                    serde_json::from_str::<BridgeIn>(r#"{"type":"start_recording","call_id":"c"}"#)
+                        .unwrap(),
+                    BridgeIn::StartRecording { .. }
+                ),
+            ),
+            (
+                "stop_recording",
+                matches!(
+                    serde_json::from_str::<BridgeIn>(r#"{"type":"stop_recording","call_id":"c"}"#)
+                        .unwrap(),
+                    BridgeIn::StopRecording { .. }
+                ),
+            ),
+            (
+                "pause_recording",
+                matches!(
+                    serde_json::from_str::<BridgeIn>(r#"{"type":"pause_recording","call_id":"c"}"#)
+                        .unwrap(),
+                    BridgeIn::PauseRecording { .. }
+                ),
+            ),
+            (
+                "resume_recording",
+                matches!(
+                    serde_json::from_str::<BridgeIn>(
+                        r#"{"type":"resume_recording","call_id":"c"}"#
+                    )
+                    .unwrap(),
+                    BridgeIn::ResumeRecording { .. }
+                ),
+            ),
+        ] {
+            assert!(ok, "{wire} did not parse to its variant");
+            let raw = format!(r#"{{ "type": "{wire}", "call_id": "c" }}"#);
+            let _: BridgeIn = assert_round_trip(&raw);
+        }
+    }
+
+    #[test]
+    fn bridge_out_recording_started_stopped() {
+        let started: BridgeOut = assert_round_trip(
+            r#"{ "type": "recording_started", "call_id": "c", "seq": 5, "recording_id": "c" }"#,
+        );
+        assert!(matches!(started, BridgeOut::RecordingStarted { .. }));
+        let stopped: BridgeOut = assert_round_trip(
+            r#"{ "type": "recording_stopped", "call_id": "c", "seq": 6, "recording_id": "c" }"#,
+        );
+        assert!(matches!(stopped, BridgeOut::RecordingStopped { .. }));
+    }
+
+    #[test]
+    fn bridge_out_recording_failed() {
+        let raw = r#"{ "type": "recording_failed", "call_id": "c", "seq": 7, "recording_id": "c", "reason": "disk full" }"#;
+        let msg: BridgeOut = assert_round_trip(raw);
+        let BridgeOut::RecordingFailed { reason, .. } = msg else {
+            panic!("expected RecordingFailed");
+        };
+        assert_eq!(reason, "disk full");
     }
 
     // ─── Negative cases ─────────────────────────────────────────────────

--- a/crates/config/src/compile.rs
+++ b/crates/config/src/compile.rs
@@ -879,6 +879,7 @@ fn compile_recording(
     let mode = match raw.mode.as_deref() {
         None | Some("") | Some("off") => RecordingMode::Off,
         Some("always") => RecordingMode::Always,
+        Some("on_demand") => RecordingMode::OnDemand,
         Some(other) => return Err(CompileError::UnknownRecordingMode(other.to_string())),
     };
     let dir = raw.dir.map(PathBuf::from).unwrap_or_default();

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -2924,11 +2924,17 @@ impl BridgingAcceptor {
             dialog_manager: Arc::clone(&installed.dialog_manager),
         });
 
-        // Recording: `always` mode records every accepted call to
-        // `<dir>/<call_id>.wav`. (`on_demand` + per-route are later chunks.)
+        // Recording setup. `always` auto-starts; `on_demand` wires the
+        // writer idle, ready for a `StartRecording`. `off` → no recording.
+        // (Per-route override is a later chunk.)
         let recording = match self.recording.mode {
             RecordingMode::Always => Some(RecordingSetup {
                 path: self.recording.path_for(bridge_call_id.as_str()),
+                auto_start: true,
+            }),
+            RecordingMode::OnDemand => Some(RecordingSetup {
+                path: self.recording.path_for(bridge_call_id.as_str()),
+                auto_start: false,
             }),
             RecordingMode::Off => None,
         };

--- a/crates/core/src/call.rs
+++ b/crates/core/src/call.rs
@@ -65,7 +65,7 @@ use siphon_ai_bridge::{
 };
 use siphon_ai_media_glue::{MediaTap, MediaTapError, TapCommand, TapDisconnect};
 use siphon_ai_recording::{
-    RecFrame, RecordingError, RecordingSetup, RecordingStats, RecordingWriter,
+    RecControl, RecEvent, RecFrame, RecordingError, RecordingSetup, RecordingStats, RecordingWriter,
 };
 use thiserror::Error;
 use tokio::sync::{mpsc, Notify};
@@ -344,12 +344,25 @@ impl CallController {
         // Recording (optional). Spawn the per-call writer task and fork both
         // legs to it via the tap. The writer does its file I/O off the audio
         // path; the tap only `try_send`s copies (§4.3). `media_tap` is
-        // rebound with the fork sender installed before it's spawned.
-        let mut recording_task: Option<JoinHandle<Result<RecordingStats, RecordingError>>> = None;
+        // rebound with the fork sender installed before it's spawned. The
+        // controller drives the writer's state machine over `rec_ctrl_tx`
+        // (from `BridgeIn` recording messages) and ferries the writer's
+        // lifecycle events back out via `rec_evt_rx`.
+        let mut recording_task: Option<JoinHandle<Result<Option<RecordingStats>, RecordingError>>> =
+            None;
+        let mut rec_ctrl_tx: Option<mpsc::Sender<RecControl>> = None;
+        let mut rec_evt_rx: Option<mpsc::Receiver<RecEvent>> = None;
+        // One recording per call in this revision → recording_id = call_id.
+        let recording_id = call_id.as_str().to_string();
         let media_tap = if let Some(setup) = recording {
             let (rec_tx, rec_rx) = mpsc::channel::<RecFrame>(RECORDING_CHANNEL_CAPACITY);
-            let writer = RecordingWriter::new(setup.path, media_tap.sample_rate());
-            recording_task = Some(tokio::spawn(writer.run(rec_rx)));
+            let (ctrl_tx, ctrl_rx) = mpsc::channel::<RecControl>(CONTROL_CHANNEL_CAPACITY);
+            let (evt_tx, evt_rx) = mpsc::channel::<RecEvent>(CONTROL_CHANNEL_CAPACITY);
+            let writer =
+                RecordingWriter::new(setup.path, media_tap.sample_rate(), setup.auto_start);
+            recording_task = Some(tokio::spawn(writer.run(rec_rx, ctrl_rx, evt_tx)));
+            rec_ctrl_tx = Some(ctrl_tx);
+            rec_evt_rx = Some(evt_rx);
             media_tap.with_recording(Some(rec_tx))
         } else {
             media_tap
@@ -478,6 +491,18 @@ impl CallController {
                             if let Err(e) = tap_cmd_tx.try_send(TapCommand::Unmute) {
                                 warn!(error = %e, "tap command channel full or closed; dropping Unmute");
                             }
+                        }
+                        Some(BridgeIn::StartRecording { call_id: cid }) => {
+                            route_rec_control(&rec_ctrl_tx, RecControl::Start, "StartRecording", &cid);
+                        }
+                        Some(BridgeIn::StopRecording { call_id: cid }) => {
+                            route_rec_control(&rec_ctrl_tx, RecControl::Stop, "StopRecording", &cid);
+                        }
+                        Some(BridgeIn::PauseRecording { call_id: cid }) => {
+                            route_rec_control(&rec_ctrl_tx, RecControl::Pause, "PauseRecording", &cid);
+                        }
+                        Some(BridgeIn::ResumeRecording { call_id: cid }) => {
+                            route_rec_control(&rec_ctrl_tx, RecControl::Resume, "ResumeRecording", &cid);
                         }
                         Some(BridgeIn::Mark { call_id: cid, name }) => {
                             debug!(ws_call_id = %cid, %name, "forwarding Mark to tap");
@@ -611,6 +636,31 @@ impl CallController {
                     termination = CallTermination::TapEnded;
                     break;
                 }
+
+                // Recording writer lifecycle event → relay to the WS server.
+                maybe_evt = recv_rec_evt(&mut rec_evt_rx) => {
+                    match maybe_evt {
+                        Some(evt) => {
+                            let out = match evt {
+                                RecEvent::Started => {
+                                    debug!(call_id = %call_id, recording_id = %recording_id, "recording started");
+                                    OutgoingEvent::RecordingStarted { recording_id: recording_id.clone() }
+                                }
+                                RecEvent::Stopped { data_bytes, frames } => {
+                                    debug!(call_id = %call_id, data_bytes, frames, "recording stopped");
+                                    OutgoingEvent::RecordingStopped { recording_id: recording_id.clone() }
+                                }
+                                RecEvent::Failed { reason } => {
+                                    warn!(call_id = %call_id, %reason, "recording failed");
+                                    OutgoingEvent::RecordingFailed { recording_id: recording_id.clone(), reason }
+                                }
+                            };
+                            let _ = control_out_tx.send(out).await;
+                        }
+                        // Writer task ended → stop polling this arm.
+                        None => rec_evt_rx = None,
+                    }
+                }
             }
         }
 
@@ -667,12 +717,14 @@ impl CallController {
         // Give it a budget so a slow final flush can't wedge teardown.
         if let Some(mut rec_task) = recording_task.take() {
             match tokio::time::timeout(Duration::from_millis(500), &mut rec_task).await {
-                Ok(Ok(Ok(stats))) => debug!(
+                Ok(Ok(Ok(Some(stats)))) => debug!(
                     call_id = %call_id,
                     path = %stats.path.display(),
                     frames = stats.frames,
                     "recording written"
                 ),
+                // on-demand recording that was never started, or stopped early.
+                Ok(Ok(Ok(None))) => debug!(call_id = %call_id, "no recording for this call"),
                 Ok(Ok(Err(e))) => warn!(call_id = %call_id, error = %e, "recording failed"),
                 Ok(Err(join_err)) => {
                     warn!(call_id = %call_id, error = %join_err, "recording task panicked")
@@ -698,6 +750,39 @@ impl CallController {
 
 fn log_state(call_id: &CallId, state: CallState) {
     info!(call_id = %call_id, ?state, "call state");
+}
+
+/// Forward a recording control to the writer (best-effort, non-blocking).
+/// `None` sender → recording isn't enabled for this call; log and drop.
+fn route_rec_control(
+    tx: &Option<mpsc::Sender<RecControl>>,
+    ctrl: RecControl,
+    label: &str,
+    cid: &CallId,
+) {
+    match tx {
+        Some(tx) => {
+            debug!(ws_call_id = %cid, label, "forwarding recording control to writer");
+            if let Err(e) = tx.try_send(ctrl) {
+                warn!(error = %e, label, "recording control channel full or closed; dropping");
+            }
+        }
+        None => debug!(
+            ws_call_id = %cid,
+            label,
+            "recording control ignored; recording not enabled for this call"
+        ),
+    }
+}
+
+/// `select!`-friendly receive over the optional recording-event channel.
+/// Pends forever when there's no channel (recording off, or the writer
+/// already ended), so the arm never busy-loops.
+async fn recv_rec_evt(rx: &mut Option<mpsc::Receiver<RecEvent>>) -> Option<RecEvent> {
+    match rx {
+        Some(r) => r.recv().await,
+        None => std::future::pending().await,
+    }
 }
 
 /// One-shot REFER round-trip. Lookup → URI parse → send_refer →

--- a/crates/recording/src/config.rs
+++ b/crates/recording/src/config.rs
@@ -2,8 +2,7 @@
 
 use std::path::PathBuf;
 
-/// When to record. (`on_demand` — WS-server-driven — lands in a later
-/// chunk; 0.5.0 chunk 1 ships `off` / `always`.)
+/// When to record.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum RecordingMode {
     /// No recording (default) — zero behaviour change.
@@ -11,6 +10,9 @@ pub enum RecordingMode {
     Off,
     /// Record every call that reaches a controller.
     Always,
+    /// Wire the per-call writer but leave it idle — the WS server drives it
+    /// with `StartRecording` / `StopRecording` (and `Pause` / `Resume`).
+    OnDemand,
 }
 
 /// Compiled `[recording]` block.
@@ -39,9 +41,12 @@ impl RecordingConfig {
 }
 
 /// Per-call recording instructions handed to the `CallController` when a
-/// call should be recorded. Carries the resolved output path; the sample
-/// rate is taken from the call's media tap.
+/// call may be recorded. Carries the resolved output path; the sample rate
+/// is taken from the call's media tap.
 #[derive(Debug, Clone)]
 pub struct RecordingSetup {
     pub path: PathBuf,
+    /// `true` (mode `always`) → start recording immediately. `false` (mode
+    /// `on_demand`) → wait for a `StartRecording` from the WS server.
+    pub auto_start: bool,
 }

--- a/crates/recording/src/control.rs
+++ b/crates/recording/src/control.rs
@@ -1,0 +1,30 @@
+//! Control messages to, and events from, the recording writer.
+
+/// A control the `CallController` routes to the writer (from a WS
+/// `BridgeIn` recording message).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecControl {
+    /// Begin recording (on-demand). No-op if already recording.
+    Start,
+    /// Suspend recording — the paused span is **omitted** from the WAV
+    /// (PCI "stop while the caller reads a card number"), not silenced.
+    Pause,
+    /// Resume after a [`RecControl::Pause`].
+    Resume,
+    /// Finalize the recording now (close the file early). The writer goes
+    /// terminal for this call; further controls are ignored.
+    Stop,
+}
+
+/// An event the writer reports back to the `CallController`, which maps it
+/// to a WS `BridgeOut` recording event. The controller tags it with the
+/// recording id.
+#[derive(Debug, Clone)]
+pub enum RecEvent {
+    /// Recording began (file open).
+    Started,
+    /// Recording finalized cleanly (file written + header patched).
+    Stopped { data_bytes: u64, frames: u64 },
+    /// Recording could not start or write.
+    Failed { reason: String },
+}

--- a/crates/recording/src/lib.rs
+++ b/crates/recording/src/lib.rs
@@ -8,14 +8,17 @@
 //! mixes on a 20 ms clock, and does the (batched) file I/O off the audio
 //! task.
 //!
-//! 0.5.0 chunk 1 ships the capture core: `[recording].mode = "always"` → a
-//! stereo WAV per call. Control messages (start/stop/pause), per-route
-//! overrides, the CDR pointer, and metrics land in later chunks.
+//! Modes: `always` records the whole call; `on_demand` wires the writer
+//! idle and the WS server drives it with start/stop/pause/resume (a pause
+//! omits the span). Per-route overrides, the CDR pointer, and metrics land
+//! in later chunks.
 
 mod config;
+mod control;
 mod frame;
 mod writer;
 
 pub use config::{RecordingConfig, RecordingMode, RecordingSetup};
+pub use control::{RecControl, RecEvent};
 pub use frame::RecFrame;
 pub use writer::{RecordingError, RecordingStats, RecordingWriter};

--- a/crates/recording/src/writer.rs
+++ b/crates/recording/src/writer.rs
@@ -1,17 +1,20 @@
 //! The per-call recording writer task.
 //!
-//! Mixes the two tapped legs into a stereo WAV on a 20 ms monotonic clock
-//! and writes it out. It runs as its own per-call task — **never on the
-//! audio hot path** (CLAUDE.md §4.3): the tap `try_send`s frame copies to
-//! the bounded channel this task drains, and the (batched) file I/O happens
-//! here, not on the media task.
+//! Mixes the two tapped legs into a stereo WAV on a 20 ms monotonic clock.
+//! It runs as its own per-call task — **never on the audio hot path**
+//! (CLAUDE.md §4.3): the tap `try_send`s frame copies to the bounded
+//! channel this task drains, and the (batched) file I/O happens here.
 //!
-//! Layout: dual-channel stereo PCM16-LE — caller on the **left**, bot on the
-//! **right**. Each 20 ms tick emits exactly one stereo frame using the most
+//! Layout: dual-channel stereo PCM16-LE — caller **left**, bot **right**.
+//! Each 20 ms tick (while recording) emits one stereo frame from the most
 //! recent frame seen for each leg, or silence for a leg that produced
-//! nothing — so the recording stays time-aligned to the call's wall clock
-//! and its duration tracks the call. (Two frames for the same leg between
-//! ticks: the later wins — a rare 20 ms drop under jitter, not a desync.)
+//! nothing — so the recording tracks the call's wall clock.
+//!
+//! Control: `auto_start = true` (mode `always`) records the whole call.
+//! Otherwise the writer starts **idle** and a [`RecControl::Start`] begins
+//! it. [`RecControl::Pause`] **omits** the paused span (it stops writing —
+//! the paused audio is dropped, not silenced — for PCI "pause while the
+//! caller reads a card number"); `Resume` continues; `Stop` finalizes early.
 
 use std::io::SeekFrom;
 use std::path::PathBuf;
@@ -23,6 +26,7 @@ use tokio::io::{AsyncSeekExt, AsyncWriteExt, BufWriter};
 use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
+use crate::control::{RecControl, RecEvent};
 use crate::frame::RecFrame;
 
 /// Recording cadence — one stereo frame per 20 ms, matching the bridge.
@@ -53,103 +57,231 @@ pub enum RecordingError {
     UnsupportedSampleRate(u32),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Status {
+    Idle,
+    Recording,
+    Paused,
+    Done,
+}
+
 /// Per-call recording writer. Build with [`RecordingWriter::new`], then
-/// drive with [`RecordingWriter::run`], feeding it the tap's `RecFrame`s.
+/// drive with [`RecordingWriter::run`].
 pub struct RecordingWriter {
     path: PathBuf,
     sample_rate: u32,
+    auto_start: bool,
 }
 
 impl RecordingWriter {
-    pub fn new(path: PathBuf, sample_rate: u32) -> Self {
-        Self { path, sample_rate }
+    /// `auto_start = true` begins recording immediately (mode `always`);
+    /// `false` waits for a [`RecControl::Start`] (mode `on_demand`).
+    pub fn new(path: PathBuf, sample_rate: u32, auto_start: bool) -> Self {
+        Self {
+            path,
+            sample_rate,
+            auto_start,
+        }
     }
 
-    /// Run until `rx` closes (the call ended and the tap dropped its
-    /// sender), then flush and finalize the WAV header. Returns the
-    /// recording stats, or an error if the file couldn't be written.
+    /// Run until `audio_rx` closes (call ended). `ctrl_rx` drives the
+    /// recording state machine; lifecycle events are reported on `evt_tx`.
+    /// Returns the stats if anything was recorded, or `None` (on-demand
+    /// never started). An I/O failure returns `Err` and emits `Failed`.
     pub async fn run(
         self,
-        mut rx: mpsc::Receiver<RecFrame>,
-    ) -> Result<RecordingStats, RecordingError> {
-        let mono_samples = match self.sample_rate {
-            8000 => 160usize,
-            16000 => 320usize,
+        mut audio_rx: mpsc::Receiver<RecFrame>,
+        mut ctrl_rx: mpsc::Receiver<RecControl>,
+        evt_tx: mpsc::Sender<RecEvent>,
+    ) -> Result<Option<RecordingStats>, RecordingError> {
+        let mono_bytes = match self.sample_rate {
+            8000 => 320usize,  // 160 samples * 2 bytes
+            16000 => 640usize, // 320 samples * 2 bytes
             other => return Err(RecordingError::UnsupportedSampleRate(other)),
         };
-        let mono_bytes = mono_samples * 2; // PCM16
-        let io_err = |source| RecordingError::Io {
-            path: self.path.clone(),
-            source,
-        };
 
-        let file = File::create(&self.path).await.map_err(io_err)?;
-        let mut out = BufWriter::new(file);
-        // Placeholder header; patched with the real sizes at finalize.
-        out.write_all(&wav_header(self.sample_rate, 0))
-            .await
-            .map_err(io_err)?;
-
+        let mut open: Option<Open> = None;
+        let mut status = Status::Idle;
         let mut latest_caller: Option<Vec<u8>> = None;
         let mut latest_bot: Option<Vec<u8>> = None;
-        let mut buf: Vec<u8> = Vec::with_capacity(FLUSH_BYTES + mono_bytes * 2);
-        let mut frames: u64 = 0;
-        let mut data_bytes: u64 = 0;
+        let mut ctrl_open = true;
+        let mut last_stats: Option<RecordingStats> = None;
+
+        // Helper to surface an I/O failure: emit `Failed`, then return Err.
+        macro_rules! fail {
+            ($e:expr) => {{
+                let err = RecordingError::Io {
+                    path: self.path.clone(),
+                    source: $e,
+                };
+                let _ = evt_tx
+                    .send(RecEvent::Failed {
+                        reason: err.to_string(),
+                    })
+                    .await;
+                return Err(err);
+            }};
+        }
+
+        if self.auto_start {
+            match Open::create(&self.path, self.sample_rate).await {
+                Ok(o) => {
+                    open = Some(o);
+                    status = Status::Recording;
+                    let _ = evt_tx.send(RecEvent::Started).await;
+                }
+                Err(e) => fail!(e),
+            }
+        }
 
         let mut tick = tokio::time::interval(Duration::from_millis(FRAME_MS));
-        // Missed ticks are skipped (not bunched) so the recording stays
-        // wall-clock aligned rather than writing a catch-up burst of silence.
         tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         loop {
             tokio::select! {
                 biased;
-                maybe = rx.recv() => match maybe {
+                maybe = audio_rx.recv() => match maybe {
                     Some(RecFrame::Caller(b)) => latest_caller = Some(b),
                     Some(RecFrame::Bot(b)) => latest_bot = Some(b),
-                    None => break, // tap dropped its sender → call over
+                    None => break, // call over
+                },
+                maybe = ctrl_rx.recv(), if ctrl_open => match maybe {
+                    Some(RecControl::Start) if status == Status::Idle => {
+                        match Open::create(&self.path, self.sample_rate).await {
+                            Ok(o) => {
+                                open = Some(o);
+                                status = Status::Recording;
+                                let _ = evt_tx.send(RecEvent::Started).await;
+                            }
+                            Err(e) => fail!(e),
+                        }
+                    }
+                    Some(RecControl::Pause) if status == Status::Recording => {
+                        status = Status::Paused;
+                    }
+                    Some(RecControl::Resume) if status == Status::Paused => {
+                        status = Status::Recording;
+                    }
+                    Some(RecControl::Stop)
+                        if matches!(status, Status::Recording | Status::Paused) =>
+                    {
+                        if let Some(o) = open.take() {
+                            match o.finalize().await {
+                                Ok(stats) => {
+                                    let _ = evt_tx.send(RecEvent::Stopped {
+                                        data_bytes: stats.data_bytes,
+                                        frames: stats.frames,
+                                    }).await;
+                                    last_stats = Some(stats);
+                                }
+                                Err(e) => fail!(e),
+                            }
+                        }
+                        status = Status::Done;
+                    }
+                    Some(_) => {} // control invalid for the current state — ignore
+                    None => ctrl_open = false,
                 },
                 _ = tick.tick() => {
-                    interleave_into(
-                        &mut buf,
-                        latest_caller.take().as_deref(),
-                        latest_bot.take().as_deref(),
-                        mono_bytes,
-                    );
-                    frames += 1;
-                    data_bytes += (mono_bytes * 2) as u64;
-                    if buf.len() >= FLUSH_BYTES {
-                        out.write_all(&buf).await.map_err(io_err)?;
-                        buf.clear();
+                    let caller = latest_caller.take();
+                    let bot = latest_bot.take();
+                    if status == Status::Recording {
+                        if let Some(o) = open.as_mut() {
+                            if let Err(e) = o.write_frame(caller.as_deref(), bot.as_deref(), mono_bytes).await {
+                                fail!(e);
+                            }
+                        }
                     }
+                    // Paused/Idle/Done: drop the frames (pause omits the span).
                 }
             }
         }
 
-        // Flush the tail, then patch the RIFF/data sizes into the header.
-        if !buf.is_empty() {
-            out.write_all(&buf).await.map_err(io_err)?;
+        // Call ended while still recording/paused → finalize it.
+        if let Some(o) = open.take() {
+            match o.finalize().await {
+                Ok(stats) => {
+                    let _ = evt_tx
+                        .send(RecEvent::Stopped {
+                            data_bytes: stats.data_bytes,
+                            frames: stats.frames,
+                        })
+                        .await;
+                    last_stats = Some(stats);
+                }
+                Err(e) => fail!(e),
+            }
         }
-        out.flush().await.map_err(io_err)?;
-        let data_u32 = u32::try_from(data_bytes).unwrap_or(u32::MAX);
-        out.seek(SeekFrom::Start(4)).await.map_err(io_err)?;
-        out.write_all(&(36u32.wrapping_add(data_u32)).to_le_bytes())
-            .await
-            .map_err(io_err)?;
-        out.seek(SeekFrom::Start(40)).await.map_err(io_err)?;
-        out.write_all(&data_u32.to_le_bytes())
-            .await
-            .map_err(io_err)?;
-        out.flush().await.map_err(io_err)?;
+        Ok(last_stats)
+    }
+}
 
-        debug!(path = %self.path.display(), frames, data_bytes, "recording finalized");
-        if data_bytes > u32::MAX as u64 {
+/// An open WAV file mid-recording.
+struct Open {
+    path: PathBuf,
+    sample_rate: u32,
+    out: BufWriter<File>,
+    buf: Vec<u8>,
+    frames: u64,
+    data_bytes: u64,
+}
+
+impl Open {
+    async fn create(path: &PathBuf, sample_rate: u32) -> std::io::Result<Self> {
+        let file = File::create(path).await?;
+        let mut out = BufWriter::new(file);
+        out.write_all(&wav_header(sample_rate, 0)).await?; // placeholder
+        Ok(Self {
+            path: path.clone(),
+            sample_rate,
+            out,
+            buf: Vec::with_capacity(FLUSH_BYTES * 2),
+            frames: 0,
+            data_bytes: 0,
+        })
+    }
+
+    async fn write_frame(
+        &mut self,
+        caller: Option<&[u8]>,
+        bot: Option<&[u8]>,
+        mono_bytes: usize,
+    ) -> std::io::Result<()> {
+        interleave_into(&mut self.buf, caller, bot, mono_bytes);
+        self.frames += 1;
+        self.data_bytes += (mono_bytes * 2) as u64;
+        if self.buf.len() >= FLUSH_BYTES {
+            let buf = std::mem::take(&mut self.buf);
+            self.out.write_all(&buf).await?;
+            self.buf = buf;
+            self.buf.clear();
+        }
+        Ok(())
+    }
+
+    async fn finalize(mut self) -> std::io::Result<RecordingStats> {
+        if !self.buf.is_empty() {
+            let buf = std::mem::take(&mut self.buf);
+            self.out.write_all(&buf).await?;
+        }
+        self.out.flush().await?;
+        let data_u32 = u32::try_from(self.data_bytes).unwrap_or(u32::MAX);
+        self.out.seek(SeekFrom::Start(4)).await?;
+        self.out
+            .write_all(&36u32.wrapping_add(data_u32).to_le_bytes())
+            .await?;
+        self.out.seek(SeekFrom::Start(40)).await?;
+        self.out.write_all(&data_u32.to_le_bytes()).await?;
+        self.out.flush().await?;
+        debug!(path = %self.path.display(), frames = self.frames, data_bytes = self.data_bytes, "recording finalized");
+        if self.data_bytes > u32::MAX as u64 {
             warn!(path = %self.path.display(), "recording exceeded 4 GiB; WAV header sizes saturated");
         }
+        let _ = self.sample_rate;
         Ok(RecordingStats {
             path: self.path,
-            frames,
-            data_bytes,
+            frames: self.frames,
+            data_bytes: self.data_bytes,
         })
     }
 }
@@ -186,7 +318,7 @@ fn wav_header(sample_rate: u32, data_len: u32) -> [u8; WAV_HEADER_LEN] {
     let byte_rate: u32 = sample_rate * block_align as u32;
     let mut h = [0u8; WAV_HEADER_LEN];
     h[0..4].copy_from_slice(b"RIFF");
-    h[4..8].copy_from_slice(&(36u32.wrapping_add(data_len)).to_le_bytes());
+    h[4..8].copy_from_slice(&36u32.wrapping_add(data_len).to_le_bytes());
     h[8..12].copy_from_slice(b"WAVE");
     h[12..16].copy_from_slice(b"fmt ");
     h[16..20].copy_from_slice(&16u32.to_le_bytes()); // fmt chunk size
@@ -205,68 +337,121 @@ fn wav_header(sample_rate: u32, data_len: u32) -> [u8; WAV_HEADER_LEN] {
 mod tests {
     use super::*;
 
+    fn temp_path(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("siphon_rec_{}_{}", std::process::id(), tag));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir.join("c.wav")
+    }
+
+    fn read_data_len(path: &PathBuf) -> usize {
+        let b = std::fs::read(path).unwrap();
+        assert_eq!(&b[0..4], b"RIFF");
+        assert_eq!(&b[8..12], b"WAVE");
+        assert_eq!(u16::from_le_bytes(b[22..24].try_into().unwrap()), 2);
+        let data = u32::from_le_bytes(b[40..44].try_into().unwrap()) as usize;
+        assert_eq!(b.len(), WAV_HEADER_LEN + data); // header sizes consistent
+        data
+    }
+
     #[test]
     fn header_is_well_formed() {
         let h = wav_header(8000, 320);
         assert_eq!(&h[0..4], b"RIFF");
-        assert_eq!(&h[8..12], b"WAVE");
-        assert_eq!(&h[36..40], b"data");
         assert_eq!(u32::from_le_bytes(h[4..8].try_into().unwrap()), 36 + 320);
         assert_eq!(u32::from_le_bytes(h[40..44].try_into().unwrap()), 320);
-        assert_eq!(u16::from_le_bytes(h[22..24].try_into().unwrap()), 2); // stereo
-        assert_eq!(u32::from_le_bytes(h[24..28].try_into().unwrap()), 8000);
-        // byte_rate = 8000 * 2ch * 2bytes = 32000
-        assert_eq!(u32::from_le_bytes(h[28..32].try_into().unwrap()), 32000);
+        assert_eq!(u32::from_le_bytes(h[28..32].try_into().unwrap()), 32000); // byte rate
     }
 
     #[test]
     fn interleave_pairs_legs_left_right() {
         let mut buf = Vec::new();
-        // 2 samples (4 bytes) per leg.
-        let caller = [0x11, 0x11, 0x22, 0x22];
-        let bot = [0x33, 0x33, 0x44, 0x44];
-        interleave_into(&mut buf, Some(&caller), Some(&bot), 4);
+        interleave_into(
+            &mut buf,
+            Some(&[0x11, 0x11, 0x22, 0x22]),
+            Some(&[0x33, 0x33, 0x44, 0x44]),
+            4,
+        );
         assert_eq!(buf, vec![0x11, 0x11, 0x33, 0x33, 0x22, 0x22, 0x44, 0x44]);
     }
 
-    #[test]
-    fn interleave_silences_missing_leg() {
-        let mut buf = Vec::new();
-        let caller = [0xab, 0xcd];
-        interleave_into(&mut buf, Some(&caller), None, 2);
-        assert_eq!(buf, vec![0xab, 0xcd, 0x00, 0x00]); // bot silent
+    #[tokio::test]
+    async fn always_records_whole_call() {
+        let path = temp_path("always");
+        let (atx, arx) = mpsc::channel(64);
+        let (_ctx, crx) = mpsc::channel(8);
+        let (etx, mut erx) = mpsc::channel(8);
+        let h = tokio::spawn(RecordingWriter::new(path.clone(), 8000, true).run(arx, crx, etx));
+        // First event is Started (auto-start).
+        assert!(matches!(erx.recv().await, Some(RecEvent::Started)));
+        for _ in 0..5 {
+            atx.send(RecFrame::Caller(vec![1u8; 320])).await.unwrap();
+            atx.send(RecFrame::Bot(vec![2u8; 320])).await.unwrap();
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        drop(atx);
+        let stats = h.await.unwrap().unwrap().unwrap();
+        assert!(stats.frames >= 4);
+        assert!(matches!(erx.recv().await, Some(RecEvent::Stopped { .. })));
+        assert_eq!(read_data_len(&path) as u64, stats.data_bytes);
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
     }
 
     #[tokio::test]
-    async fn writes_a_valid_stereo_wav() {
-        let dir = std::env::temp_dir().join(format!("siphon_rec_test_{}", std::process::id()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("c.wav");
-        let (tx, rx) = mpsc::channel(64);
-        let writer = RecordingWriter::new(path.clone(), 8000);
-        let h = tokio::spawn(writer.run(rx));
-        // Feed a few frames of each leg, then close.
-        for _ in 0..5 {
-            tx.send(RecFrame::Caller(vec![1u8; 320])).await.unwrap();
-            tx.send(RecFrame::Bot(vec![2u8; 320])).await.unwrap();
+    async fn on_demand_idle_until_start_then_stop() {
+        let path = temp_path("ondemand");
+        let (atx, arx) = mpsc::channel(64);
+        let (ctx, crx) = mpsc::channel(8);
+        let (etx, mut erx) = mpsc::channel(8);
+        let h = tokio::spawn(RecordingWriter::new(path.clone(), 8000, false).run(arx, crx, etx));
+        // No file yet — feed audio while idle; it's dropped.
+        atx.send(RecFrame::Caller(vec![1u8; 320])).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        assert!(!path.exists(), "no file before Start");
+        ctx.send(RecControl::Start).await.unwrap();
+        assert!(matches!(erx.recv().await, Some(RecEvent::Started)));
+        for _ in 0..4 {
+            atx.send(RecFrame::Caller(vec![1u8; 320])).await.unwrap();
             tokio::time::sleep(Duration::from_millis(25)).await;
         }
-        drop(tx);
-        let stats = h.await.unwrap().unwrap();
+        ctx.send(RecControl::Stop).await.unwrap();
+        assert!(matches!(erx.recv().await, Some(RecEvent::Stopped { .. })));
+        // Audio after Stop is ignored.
+        atx.send(RecFrame::Caller(vec![1u8; 320])).await.unwrap();
+        drop(atx);
+        let stats = h.await.unwrap().unwrap().unwrap();
+        assert!(stats.frames >= 2);
+        assert_eq!(read_data_len(&path) as u64, stats.data_bytes);
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[tokio::test]
+    async fn pause_omits_the_span() {
+        let path = temp_path("pause");
+        let (atx, arx) = mpsc::channel(64);
+        let (ctx, crx) = mpsc::channel(8);
+        let (etx, _erx) = mpsc::channel(8);
+        let h = tokio::spawn(RecordingWriter::new(path.clone(), 8000, true).run(arx, crx, etx));
+        // Record ~5 ticks, pause for ~5 ticks, resume for ~5 ticks.
+        for _ in 0..5 {
+            atx.send(RecFrame::Caller(vec![1u8; 320])).await.unwrap();
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        ctx.send(RecControl::Pause).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await; // ~5 ticks omitted
+        ctx.send(RecControl::Resume).await.unwrap();
+        for _ in 0..5 {
+            atx.send(RecFrame::Caller(vec![1u8; 320])).await.unwrap();
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        drop(atx);
+        let stats = h.await.unwrap().unwrap().unwrap();
+        // The paused span produced no frames — total well under the ~15 ticks
+        // of wall-clock the test spanned.
         assert!(
-            stats.frames >= 4,
-            "expected several frames, got {}",
+            stats.frames < 14,
+            "paused span should be omitted, got {} frames",
             stats.frames
         );
-
-        let bytes = std::fs::read(&path).unwrap();
-        assert_eq!(&bytes[0..4], b"RIFF");
-        assert_eq!(&bytes[8..12], b"WAVE");
-        assert_eq!(u16::from_le_bytes(bytes[22..24].try_into().unwrap()), 2);
-        let data_len = u32::from_le_bytes(bytes[40..44].try_into().unwrap()) as usize;
-        // Header sizes are consistent with the file length.
-        assert_eq!(bytes.len(), WAV_HEADER_LEN + data_len);
-        assert_eq!(data_len as u64, stats.data_bytes);
-        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
     }
 }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -354,14 +354,14 @@ writer can never stall live audio.
 
 ```toml
 [recording]
-mode = "always"            # "off" (default) | "always"
+mode = "always"            # "off" (default) | "always" | "on_demand"
 dir  = "/var/lib/siphon-ai/recordings"
 ```
 
 | Field | Type | Default | Notes |
 |---|---|---|---|
-| `mode` | string | `"off"` | `"off"` = no recording (zero behaviour change). `"always"` = record every accepted call. (`"on_demand"` — WS-server-driven — and per-route overrides land in later 0.5.0 chunks.) |
-| `dir` | string | — | Directory recordings are written to as `<dir>/<call_id>.wav`. **Required when `mode != "off"`**; created at startup (a bad path fails loud at load). |
+| `mode` | string | `"off"` | `"off"` = no recording (zero behaviour change). `"always"` = record every accepted call for its full duration. `"on_demand"` = the WS server drives recording with `start_recording` / `stop_recording` / `pause_recording` / `resume_recording` (see `docs/PROTOCOL.md` §4.7); SiphonAI emits `recording_started` / `recording_stopped` / `recording_failed` back. (Per-route overrides land in a later 0.5.0 chunk.) |
+| `dir` | string | — | Directory recordings are written to as `<dir>/<call_id>.wav`. **Required when `mode != "off"`**; created at startup (a bad path fails loud at load). A `pause` omits the paused span from the file (the audio is dropped, not silenced). |
 
 Operational notes: recordings are uncompressed PCM16 stereo (≈115 MB/hour
 at 16 kHz; ≈58 MB/hour at 8 kHz) — size your disk and **manage retention

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -331,6 +331,21 @@ then closes the WebSocket cleanly (close code 1000).
 `error` is always followed by `stop` (with `reason: "error"`) and a
 clean close.
 
+### 3.11 `recording_started` / `recording_stopped` / `recording_failed` — recording lifecycle (0.5.0)
+
+Emitted when call recording is on (`[recording].mode`). `recording_started`
+fires automatically on `always`, or in response to a `start_recording`
+control on `on_demand`; `recording_stopped` on call end or `stop_recording`.
+
+```json
+{ "type": "recording_started", "call_id": "...", "seq": 12, "recording_id": "..." }
+{ "type": "recording_stopped", "call_id": "...", "seq": 40, "recording_id": "..." }
+{ "type": "recording_failed",  "call_id": "...", "seq": 13, "recording_id": "...", "reason": "disk full" }
+```
+
+`recording_id` identifies the recording (one per call in this release).
+Recording is best-effort — `recording_failed` never tears the call down.
+
 ---
 
 ## 4. Server → SiphonAI messages
@@ -427,6 +442,24 @@ fired in response to caller barge-in — that drains pending playout
 once and then accepts new audio. `mute` is sustained, requires an
 explicit `unmute` to release, and is the right primitive for "put
 this call on hold from the AI side."
+
+### 4.7 `start_recording` / `stop_recording` / `pause_recording` / `resume_recording` — on-demand recording (0.5.0)
+
+```json
+{ "type": "start_recording",  "call_id": "..." }
+{ "type": "stop_recording",   "call_id": "..." }
+{ "type": "pause_recording",  "call_id": "..." }
+{ "type": "resume_recording", "call_id": "..." }
+```
+
+Drive recording when `[recording].mode = "on_demand"`. `start_recording`
+begins it (SiphonAI replies `recording_started`, or `recording_failed`);
+`stop_recording` finalizes it (`recording_stopped`). `pause_recording`
+**omits** the paused span from the file — the paused audio is dropped, not
+silenced (e.g. while the caller reads a card number) — and `resume_recording`
+continues. All are no-ops if recording isn't enabled for the call or the
+control is invalid for the current state. (With `mode = "always"` recording
+covers the whole call; these controls aren't needed.)
 
 ---
 


### PR DESCRIPTION
**0.5.0 chunk 2** (`docs/DEV_PLAN_0.5.0.md` §7 Week 2). Adds the on-demand recording mode and its WS control surface, on top of chunk 1's always-mode capture core (#132).

### Modes
`[recording].mode` gains **`on_demand`** — the per-call writer is wired idle and the WS server drives it. `always` still records the whole call.

### Protocol (additive — version stays `"1"`)
- **BridgeIn**: `start_recording` / `stop_recording` / `pause_recording` / `resume_recording` (per `call_id`).
- **BridgeOut**: `recording_started` / `recording_stopped` / `recording_failed` (`call_id`, `seq`, `recording_id` [+ `reason`]).
- Wire round-trip tests; PROTOCOL.md §3.11 (events) + §4.7 (controls).

### Writer state machine (Idle / Recording / Paused / Done)
- `Start` creates the file and emits `Started`; `Stop` finalizes early; **`Pause` omits the span** (the paused audio is *dropped, not silenced* — PCI "pause while the caller reads a card number"); `Resume` continues.
- `run()` now returns `Option<RecordingStats>` (`None` = on-demand never started). Control/event plumbing via `RecControl` / `RecEvent`.
- `CallController` routes the BridgeIn controls to the writer (best-effort `try_send`) and relays the writer's lifecycle events back out as BridgeOut (`recording_id = call_id` this release).

### Verification
- **End-to-end**: a WS server sends `start_recording` → file created + `recording_started` delivered (seq 1); `pause`/`resume` → the paused span is **omitted** (0.26 s recorded vs a 0.5 s call); valid stereo WAV. `on_demand` with no controls → no file (idle), call clean.
- Recording-crate state-machine unit tests (always / on_demand Start→Stop / pause-omits-span); bridge round-trip tests. Full workspace suite green; `clippy --all-targets -- -D warnings` clean.

Base `main`. Chunk 3 (per-route override + CDR pointer + metrics) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)