### PR TITLE
feat(recording): per-route override, CDR pointer, and metrics

### DIFF
--- a/crates/cdr/src/file.rs
+++ b/crates/cdr/src/file.rs
@@ -172,6 +172,8 @@ mod tests {
             },
             verstat_attest: None,
             verstat_passed: None,
+            recording_id: None,
+            recording_path: None,
         }
     }
 

--- a/crates/cdr/src/hep.rs
+++ b/crates/cdr/src/hep.rs
@@ -139,6 +139,8 @@ mod tests {
             },
             verstat_attest: None,
             verstat_passed: None,
+            recording_id: None,
+            recording_path: None,
         }
     }
 

--- a/crates/cdr/src/schema.rs
+++ b/crates/cdr/src/schema.rs
@@ -22,8 +22,8 @@
 //! - **No SDP body** — the negotiated codec / sample rate / payload
 //!   type are flat fields; the raw SDP would balloon the record and
 //!   isn't operator-readable.
-//! - **No call audio** — recording is a different feature
-//!   (CLAUDE.md §8 calls it post-v1).
+//! - **No call audio** — the record carries a `recording_path` *pointer*
+//!   when recording is on (`[recording]`), never the audio itself.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -76,6 +76,15 @@ pub struct CdrRecord {
     /// an `Identity` header was present but did not fully verify.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub verstat_passed: Option<bool>,
+
+    /// Recording identifier, present when the call was recorded
+    /// (`[recording]`). Equals `call_id` in this release. Additive optional
+    /// field → CDR schema stays at version 1.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recording_id: Option<String>,
+    /// Filesystem path of the recording, when one was written.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recording_path: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -163,6 +172,8 @@ mod tests {
             },
             verstat_attest: None,
             verstat_passed: None,
+            recording_id: None,
+            recording_path: None,
         }
     }
 

--- a/crates/cdr/src/sink.rs
+++ b/crates/cdr/src/sink.rs
@@ -118,6 +118,8 @@ mod tests {
             },
             verstat_attest: None,
             verstat_passed: None,
+            recording_id: None,
+            recording_path: None,
         }
     }
 

--- a/crates/config/src/compile.rs
+++ b/crates/config/src/compile.rs
@@ -446,6 +446,12 @@ pub enum CompileError {
     #[error("[recording].dir {path:?} could not be created: {err}")]
     RecordingDirInvalid { path: String, err: String },
 
+    #[error("[route.recording].mode on route {route:?} is {value:?}; expected \"off\", \"always\", or \"on_demand\"")]
+    RouteRecordingModeInvalid { route: String, value: String },
+
+    #[error("route {route:?} enables recording but [recording].dir is not set")]
+    RouteRecordingWithoutDir { route: String },
+
     #[error("[media].rtp_port_range {min}-{max} is invalid (min must be < max and even)")]
     BadRtpPortRange { min: u16, max: u16 },
 
@@ -579,6 +585,24 @@ pub fn compile(raw: RawConfig) -> Result<Config, CompileError> {
                 .is_some_and(|m| m != siphon_ai_security::MinAttestation::None);
             if overrides_gate {
                 return Err(CompileError::RouteMinAttestationWithoutStirShaken {
+                    route: route.name.clone(),
+                });
+            }
+        }
+    }
+
+    // A per-route recording override that enables recording needs an output
+    // directory. The dir lives on the global `[recording]` block; require it
+    // (created at load by `compile_recording`) when any route turns recording
+    // on, even if the global mode is `off`.
+    if recording.dir.as_os_str().is_empty() {
+        for route in routes.iter() {
+            let enables = matches!(
+                route.recording.mode.as_deref(),
+                Some("always") | Some("on_demand")
+            );
+            if enables {
+                return Err(CompileError::RouteRecordingWithoutDir {
                     route: route.name.clone(),
                 });
             }
@@ -883,10 +907,14 @@ fn compile_recording(
         Some(other) => return Err(CompileError::UnknownRecordingMode(other.to_string())),
     };
     let dir = raw.dir.map(PathBuf::from).unwrap_or_default();
-    if mode != RecordingMode::Off {
-        if dir.as_os_str().is_empty() {
-            return Err(CompileError::RecordingDirRequired);
-        }
+    if mode != RecordingMode::Off && dir.as_os_str().is_empty() {
+        return Err(CompileError::RecordingDirRequired);
+    }
+    // Create the dir at load whenever one is configured — even with the
+    // global mode `off`, a per-route `[route.recording]` may enable
+    // recording, so the directory must already exist. A bad path fails loud
+    // here, not on the first recorded call.
+    if !dir.as_os_str().is_empty() {
         std::fs::create_dir_all(&dir).map_err(|err| CompileError::RecordingDirInvalid {
             path: dir.display().to_string(),
             err: err.to_string(),
@@ -1070,6 +1098,16 @@ fn compile_dialplan(routes: Vec<siphon_ai_routes::RawRoute>) -> Result<RouteSet,
         if let Some(value) = route.security.min_attestation.as_deref() {
             if siphon_ai_security::MinAttestation::parse(value).is_none() {
                 return Err(CompileError::UnknownRouteMinAttestation {
+                    route: route.name.clone(),
+                    value: value.to_string(),
+                });
+            }
+        }
+        // Validate the per-route recording override the same way. The
+        // dir-required cross-check happens in `compile` (global scope).
+        if let Some(value) = route.recording.mode.as_deref() {
+            if !matches!(value, "off" | "always" | "on_demand") {
+                return Err(CompileError::RouteRecordingModeInvalid {
                     route: route.name.clone(),
                     value: value.to_string(),
                 });
@@ -1513,6 +1551,77 @@ mod srtp_mode_tests {
         assert!(matches!(
             compile_srtp_mode(Some("PREFERRED")),
             Err(CompileError::UnknownSrtpMode(_))
+        ));
+    }
+}
+
+#[cfg(test)]
+mod recording_tests {
+    use super::{compile_dialplan, compile_recording, CompileError, RawRecording};
+    use siphon_ai_recording::RecordingMode;
+    use siphon_ai_routes::{RawRoute, RawRouteMatch, RecordingOverride};
+
+    fn raw(mode: Option<&str>, dir: Option<&str>) -> RawRecording {
+        RawRecording {
+            mode: mode.map(str::to_string),
+            dir: dir.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn default_is_off() {
+        let c = compile_recording(RawRecording::default()).unwrap();
+        assert_eq!(c.mode, RecordingMode::Off);
+    }
+
+    #[test]
+    fn modes_parse() {
+        let dir = std::env::temp_dir().join("siphon_rec_cfg_test");
+        let d = dir.to_str();
+        assert_eq!(
+            compile_recording(raw(Some("always"), d)).unwrap().mode,
+            RecordingMode::Always
+        );
+        assert_eq!(
+            compile_recording(raw(Some("on_demand"), d)).unwrap().mode,
+            RecordingMode::OnDemand
+        );
+    }
+
+    #[test]
+    fn unknown_mode_fails_loud() {
+        assert!(matches!(
+            compile_recording(raw(Some("sometimes"), Some("/tmp/x"))),
+            Err(CompileError::UnknownRecordingMode(s)) if s == "sometimes"
+        ));
+    }
+
+    #[test]
+    fn enabled_requires_dir() {
+        assert!(matches!(
+            compile_recording(raw(Some("always"), None)),
+            Err(CompileError::RecordingDirRequired)
+        ));
+    }
+
+    #[test]
+    fn per_route_invalid_mode_fails_loud() {
+        let route = RawRoute {
+            name: "r".into(),
+            match_: RawRouteMatch {
+                any: true,
+                ..Default::default()
+            },
+            bridge: Default::default(),
+            media: Default::default(),
+            security: Default::default(),
+            recording: RecordingOverride {
+                mode: Some("sometimes".into()),
+            },
+        };
+        assert!(matches!(
+            compile_dialplan(vec![route]),
+            Err(CompileError::RouteRecordingModeInvalid { value, .. }) if value == "sometimes"
         ));
     }
 }

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -81,7 +81,7 @@ use siphon_ai_sip_glue::{CallAcceptor, InviteFacts, MatchedCall};
 use siphon_ai_stir_shaken::Verifier;
 use siphon_ai_telemetry::{
     HepTelemetry, CALLS_ACTIVE, CALLS_TOTAL, CALL_DURATION_SECONDS, INVITES_TOTAL,
-    ROUTE_MATCH_TOTAL, SDP_NEGOTIATE_SECONDS, VERSTAT_TOTAL,
+    RECORDINGS_TOTAL, ROUTE_MATCH_TOTAL, SDP_NEGOTIATE_SECONDS, VERSTAT_TOTAL,
 };
 use siphon_ai_webhooks::{
     CallEndEvent, CallStartEvent, NullSink as WebhookNullSink, WebhookEvent, WebhookSinkHandle,
@@ -91,7 +91,9 @@ use thiserror::Error;
 use tracing::{debug, info, instrument, warn};
 use uuid::Uuid;
 
-use crate::call::{CallController, CallControllerConfig, CallOutcome, CallTermination};
+use crate::call::{
+    CallController, CallControllerConfig, CallOutcome, CallTermination, RecordingSummary,
+};
 use crate::registry::CallRegistry;
 use crate::transfer::TransferContext;
 
@@ -1728,6 +1730,16 @@ impl CallStart {
                 .as_ref()
                 .and_then(|v| v.attest.map(|a| a.as_str().to_string())),
             verstat_passed: self.verstat.as_ref().map(|v| v.passed()),
+            // recording_id == call_id this release; both omitted when the
+            // call wasn't recorded, keeping the CDR at v1.
+            recording_id: outcome
+                .recording
+                .as_ref()
+                .map(|_| self.bridge_call_id.as_str().to_string()),
+            recording_path: outcome
+                .recording
+                .as_ref()
+                .map(|r| r.path.display().to_string()),
         }
     }
 }
@@ -1738,6 +1750,9 @@ struct CallTerminationView {
     cause: CdrTerminationCause,
     bridge_detail: String,
     tap_detail: String,
+    /// Recording outcome, when the call was recorded. Feeds the CDR
+    /// `recording_path` and the `siphon_ai_recordings_total` metric.
+    recording: Option<RecordingSummary>,
 }
 
 impl CallTerminationView {
@@ -1747,6 +1762,7 @@ impl CallTerminationView {
                 cause: map_cause(o.termination),
                 bridge_detail: bridge_detail(o.bridge),
                 tap_detail: tap_detail(o.tap),
+                recording: o.recording,
             },
             Err(e) => Self {
                 // Treat a panic / join error as "bridge ended" —
@@ -1755,6 +1771,7 @@ impl CallTerminationView {
                 cause: CdrTerminationCause::BridgeEnded,
                 bridge_detail: format!("controller error: {e}"),
                 tap_detail: String::new(),
+                recording: None,
             },
         }
     }
@@ -2618,6 +2635,9 @@ impl BridgingAcceptor {
             )
             .increment(1);
             metrics::histogram!(CALL_DURATION_SECONDS).record(duration_secs);
+            if let Some(rec) = view.recording.as_ref() {
+                metrics::counter!(RECORDINGS_TOTAL, "result" => rec.result.as_str()).increment(1);
+            }
 
             let end_event = WebhookEvent::CallEnd(CallEndEvent {
                 version: WEBHOOK_VERSION,
@@ -2924,10 +2944,18 @@ impl BridgingAcceptor {
             dialog_manager: Arc::clone(&installed.dialog_manager),
         });
 
-        // Recording setup. `always` auto-starts; `on_demand` wires the
-        // writer idle, ready for a `StartRecording`. `off` → no recording.
-        // (Per-route override is a later chunk.)
-        let recording = match self.recording.mode {
+        // Recording setup. The matched route's `[route.recording].mode`
+        // strictly overrides the global `[recording].mode` (validated at
+        // load); `None` inherits. `always` auto-starts; `on_demand` wires the
+        // writer idle for a `StartRecording`; `off` → no recording. The
+        // output dir is always the global one.
+        let effective_mode = match route.recording.mode.as_deref() {
+            Some("off") => RecordingMode::Off,
+            Some("always") => RecordingMode::Always,
+            Some("on_demand") => RecordingMode::OnDemand,
+            _ => self.recording.mode,
+        };
+        let recording = match effective_mode {
             RecordingMode::Always => Some(RecordingSetup {
                 path: self.recording.path_for(bridge_call_id.as_str()),
                 auto_start: true,
@@ -4551,6 +4579,7 @@ a=sendrecv\r\n",
                 security: SecurityOverride {
                     min_attestation: over.map(String::from),
                 },
+                recording: Default::default(),
             };
             compile(RawRouteFile { routes: vec![raw] })
                 .unwrap()

--- a/crates/core/src/call.rs
+++ b/crates/core/src/call.rs
@@ -55,7 +55,8 @@
 //!   yet — they're logged. Hangup terminates the call.
 //! - No CDR / webhook emission.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 use sip_core::SipUri;
@@ -165,6 +166,39 @@ pub struct CallOutcome {
     pub termination: CallTermination,
     pub bridge: Option<Result<DisconnectReason, BridgeError>>,
     pub tap: Option<Result<TapDisconnect, MediaTapError>>,
+    /// Recording outcome, `Some` when the call was recorded (or recording was
+    /// attempted). `None` when recording was off, or on-demand and never
+    /// started. Feeds the CDR `recording_path` and the recordings metric.
+    pub recording: Option<RecordingSummary>,
+}
+
+/// Per-call recording outcome surfaced on [`CallOutcome`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordingSummary {
+    pub path: std::path::PathBuf,
+    pub result: RecordingResult,
+}
+
+/// How a recording finished — the `result` label on `siphon_ai_recordings_total`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecordingResult {
+    /// Written cleanly.
+    Ok,
+    /// Some 20 ms frames were dropped under writer back-pressure — the file
+    /// is short, not corrupt.
+    Degraded,
+    /// An I/O error; the recording is incomplete or absent.
+    Failed,
+}
+
+impl RecordingResult {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            RecordingResult::Ok => "ok",
+            RecordingResult::Degraded => "degraded",
+            RecordingResult::Failed => "failed",
+        }
+    }
 }
 
 #[derive(Debug, Error)]
@@ -352,18 +386,26 @@ impl CallController {
             None;
         let mut rec_ctrl_tx: Option<mpsc::Sender<RecControl>> = None;
         let mut rec_evt_rx: Option<mpsc::Receiver<RecEvent>> = None;
+        // Dropped-frame counter shared with the tap: incremented when the
+        // recording channel is full (back-pressure) → classifies the
+        // recording `degraded`. `None` when recording is off for the call.
+        let mut rec_drops: Option<Arc<AtomicU64>> = None;
+        let mut rec_path: Option<std::path::PathBuf> = None;
         // One recording per call in this revision → recording_id = call_id.
         let recording_id = call_id.as_str().to_string();
         let media_tap = if let Some(setup) = recording {
             let (rec_tx, rec_rx) = mpsc::channel::<RecFrame>(RECORDING_CHANNEL_CAPACITY);
             let (ctrl_tx, ctrl_rx) = mpsc::channel::<RecControl>(CONTROL_CHANNEL_CAPACITY);
             let (evt_tx, evt_rx) = mpsc::channel::<RecEvent>(CONTROL_CHANNEL_CAPACITY);
+            let drops = Arc::new(AtomicU64::new(0));
+            rec_path = Some(setup.path.clone());
             let writer =
                 RecordingWriter::new(setup.path, media_tap.sample_rate(), setup.auto_start);
             recording_task = Some(tokio::spawn(writer.run(rec_rx, ctrl_rx, evt_tx)));
             rec_ctrl_tx = Some(ctrl_tx);
             rec_evt_rx = Some(evt_rx);
-            media_tap.with_recording(Some(rec_tx))
+            rec_drops = Some(Arc::clone(&drops));
+            media_tap.with_recording(Some((rec_tx, drops)))
         } else {
             media_tap
         };
@@ -714,28 +756,62 @@ impl CallController {
 
         // Finalize the recording. The tap has now exited, dropping its fork
         // sender → the writer sees EOF, flushes, and patches the WAV header.
-        // Give it a budget so a slow final flush can't wedge teardown.
-        if let Some(mut rec_task) = recording_task.take() {
+        // Give it a budget so a slow final flush can't wedge teardown. The
+        // tap is done, so the drop counter is final: any drops → `degraded`.
+        let recording_summary = if let Some(mut rec_task) = recording_task.take() {
+            let dropped = rec_drops
+                .as_ref()
+                .map(|d| d.load(Ordering::Relaxed))
+                .unwrap_or(0);
+            let failed_path = || rec_path.clone().unwrap_or_default();
             match tokio::time::timeout(Duration::from_millis(500), &mut rec_task).await {
-                Ok(Ok(Ok(Some(stats)))) => debug!(
-                    call_id = %call_id,
-                    path = %stats.path.display(),
-                    frames = stats.frames,
-                    "recording written"
-                ),
-                // on-demand recording that was never started, or stopped early.
-                Ok(Ok(Ok(None))) => debug!(call_id = %call_id, "no recording for this call"),
-                Ok(Ok(Err(e))) => warn!(call_id = %call_id, error = %e, "recording failed"),
+                Ok(Ok(Ok(Some(stats)))) => {
+                    let result = if dropped > 0 {
+                        warn!(call_id = %call_id, dropped, path = %stats.path.display(),
+                            "recording degraded: frames dropped under writer back-pressure");
+                        RecordingResult::Degraded
+                    } else {
+                        debug!(call_id = %call_id, path = %stats.path.display(),
+                            frames = stats.frames, "recording written");
+                        RecordingResult::Ok
+                    };
+                    Some(RecordingSummary {
+                        path: stats.path,
+                        result,
+                    })
+                }
+                // on-demand recording that was never started.
+                Ok(Ok(Ok(None))) => {
+                    debug!(call_id = %call_id, "no recording for this call");
+                    None
+                }
+                Ok(Ok(Err(e))) => {
+                    warn!(call_id = %call_id, error = %e, "recording failed");
+                    Some(RecordingSummary {
+                        path: failed_path(),
+                        result: RecordingResult::Failed,
+                    })
+                }
                 Ok(Err(join_err)) => {
-                    warn!(call_id = %call_id, error = %join_err, "recording task panicked")
+                    warn!(call_id = %call_id, error = %join_err, "recording task panicked");
+                    Some(RecordingSummary {
+                        path: failed_path(),
+                        result: RecordingResult::Failed,
+                    })
                 }
                 Err(_) => {
                     warn!(call_id = %call_id, "recording did not finalize within 500 ms; aborting");
                     rec_task.abort();
                     let _ = (&mut rec_task).await;
+                    Some(RecordingSummary {
+                        path: failed_path(),
+                        result: RecordingResult::Failed,
+                    })
                 }
             }
-        }
+        } else {
+            None
+        };
 
         log_state(&call_id, CallState::Done);
 
@@ -744,6 +820,7 @@ impl CallController {
             termination,
             bridge: bridge_result,
             tap: tap_result,
+            recording: recording_summary,
         })
     }
 }

--- a/crates/media-glue/src/tap.rs
+++ b/crates/media-glue/src/tap.rs
@@ -55,6 +55,7 @@
 //!   from forge-vad. Each transition publishes once — hysteresis
 //!   inside the detector filters per-frame jitter.
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -260,10 +261,13 @@ pub struct MediaTap {
     /// `crates/media-glue/src/rtp_stats.rs` for the rationale.
     rtp_stats: RtpStatsTracker,
     /// Recording fork. `None` (default) → no recording. When set, the tap
-    /// `try_send`s a copy of each leg's 20 ms frame here — best-effort and
-    /// non-blocking, so a backed-up recording writer never stalls the audio
-    /// path (CLAUDE.md §4.3). The `CallController` sets this before `run()`.
-    recording: Option<mpsc::Sender<RecFrame>>,
+    /// `try_send`s a copy of each leg's 20 ms frame to the sender —
+    /// best-effort and non-blocking, so a backed-up recording writer never
+    /// stalls the audio path (CLAUDE.md §4.3). A `Full` channel increments
+    /// the shared drop counter (→ the recording is flagged `degraded`); a
+    /// `Closed` channel (writer already stopped) is ignored. Set by the
+    /// `CallController` before `run()`.
+    recording: Option<(mpsc::Sender<RecFrame>, Arc<AtomicU64>)>,
 }
 
 impl std::fmt::Debug for MediaTap {
@@ -362,11 +366,14 @@ impl MediaTap {
         self
     }
 
-    /// Install the recording fork. `Some(tx)` makes the tap copy each leg's
-    /// 20 ms frame to `tx` (non-blocking `try_send`); `None` (default) is no
-    /// recording. The `CallController` sets this before `run()` when the call
-    /// is being recorded.
-    pub fn with_recording(mut self, recording: Option<mpsc::Sender<RecFrame>>) -> Self {
+    /// Install the recording fork: a sender for the per-leg frame copies and
+    /// a shared counter the tap bumps when the channel is full (drops →
+    /// `degraded`). `None` (default) is no recording. The `CallController`
+    /// sets this before `run()` when the call is being recorded.
+    pub fn with_recording(
+        mut self,
+        recording: Option<(mpsc::Sender<RecFrame>, Arc<AtomicU64>)>,
+    ) -> Self {
         self.recording = recording;
         self
     }
@@ -493,8 +500,12 @@ impl MediaTap {
                     // Recording fork (right channel): only non-muted playout
                     // is recorded, so a muted span shows as silence on the
                     // bot side — what the caller actually heard.
-                    if let Some(rec) = &self.recording {
-                        let _ = rec.try_send(RecFrame::Bot(bytes.clone()));
+                    if let Some((rec, drops)) = &self.recording {
+                        if let Err(mpsc::error::TrySendError::Full(_)) =
+                            rec.try_send(RecFrame::Bot(bytes.clone()))
+                        {
+                            drops.fetch_add(1, Ordering::Relaxed);
+                        }
                     }
                     let samples = unpack_pcm16_le(&bytes)?;
                     let frame = OutboundMediaFrame {
@@ -544,8 +555,12 @@ impl MediaTap {
                     while let Some(samples) = reframer.pop_frame() {
                         let bytes = pack_pcm16_le(&samples);
                         // Recording fork (left channel), best-effort.
-                        if let Some(rec) = &self.recording {
-                            let _ = rec.try_send(RecFrame::Caller(bytes.clone()));
+                        if let Some((rec, drops)) = &self.recording {
+                            if let Err(mpsc::error::TrySendError::Full(_)) =
+                                rec.try_send(RecFrame::Caller(bytes.clone()))
+                            {
+                                drops.fetch_add(1, Ordering::Relaxed);
+                            }
                         }
                         if caller_audio_tx.send(bytes).await.is_err() {
                             debug!("caller_audio_tx closed; ending tap");

--- a/crates/routes/src/compile.rs
+++ b/crates/routes/src/compile.rs
@@ -103,6 +103,7 @@ fn compile_one(index: usize, route: RawRoute) -> Result<CompiledRoute, RouteErro
         bridge,
         media,
         security,
+        recording,
     } = route;
 
     let compiled_match = compile_match(index, &name, match_)?;
@@ -113,6 +114,7 @@ fn compile_one(index: usize, route: RawRoute) -> Result<CompiledRoute, RouteErro
         bridge,
         media,
         security,
+        recording,
     })
 }
 
@@ -226,7 +228,7 @@ fn build_matcher(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::raw::{BridgeOverride, MediaOverride, SecurityOverride};
+    use crate::raw::{BridgeOverride, MediaOverride, RecordingOverride, SecurityOverride};
 
     fn raw_with_match(name: &str, m: RawRouteMatch) -> RawRoute {
         RawRoute {
@@ -235,6 +237,7 @@ mod tests {
             bridge: BridgeOverride::default(),
             media: MediaOverride::default(),
             security: SecurityOverride::default(),
+            recording: RecordingOverride::default(),
         }
     }
 

--- a/crates/routes/src/compiled.rs
+++ b/crates/routes/src/compiled.rs
@@ -10,7 +10,7 @@
 
 use regex::Regex;
 
-use crate::raw::{BridgeOverride, MediaOverride, SecurityOverride};
+use crate::raw::{BridgeOverride, MediaOverride, RecordingOverride, SecurityOverride};
 
 /// One pre-compiled match predicate (string or regex). Stored per
 /// match key so a route can mix string keys (most common) with
@@ -85,6 +85,7 @@ pub struct CompiledRoute {
     pub bridge: BridgeOverride,
     pub media: MediaOverride,
     pub security: SecurityOverride,
+    pub recording: RecordingOverride,
 }
 
 impl CompiledRoute {

--- a/crates/routes/src/lib.rs
+++ b/crates/routes/src/lib.rs
@@ -38,7 +38,7 @@ pub use compile::{compile, RouteError};
 pub use compiled::{CompiledRoute, RouteSet};
 pub use raw::{
     BargeInOverride, BridgeOverride, MediaOverride, RawRoute, RawRouteFile, RawRouteMatch,
-    SecurityOverride,
+    RecordingOverride, SecurityOverride,
 };
 
 /// Convenience: parse a TOML string into a [`RawRouteFile`] and

--- a/crates/routes/src/raw.rs
+++ b/crates/routes/src/raw.rs
@@ -41,6 +41,9 @@ pub struct RawRoute {
 
     #[serde(default)]
     pub security: SecurityOverride,
+
+    #[serde(default)]
+    pub recording: RecordingOverride,
 }
 
 /// `[route.match]` block — the matcher's input grammar.
@@ -139,4 +142,16 @@ pub struct SecurityOverride {
     /// `[route.media].srtp` semantics — the route value fully replaces the
     /// global, even when more permissive).
     pub min_attestation: Option<String>,
+}
+
+/// `[route.recording]` overrides. Same merge rules — `None` inherits the
+/// global `[recording].mode`. Kept as the raw string so the routes crate
+/// stays free of a dependency on the recording types; the config crate
+/// validates it and the accept path resolves it against the global.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+pub struct RecordingOverride {
+    /// `[route.recording].mode` — per-route override of the global
+    /// `[recording].mode`. `None` inherits; `"off"` / `"always"` /
+    /// `"on_demand"` override (strict — fully replaces the global).
+    pub mode: Option<String>,
 }

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -35,7 +35,7 @@ pub use log_filter::{LogFilterError, LogFilterHandle};
 // direct dep on `metrics-exporter-prometheus`.
 pub use metrics::{
     install_recorder, prometheus_builder, register_descriptions, InitError, CALLS_ACTIVE,
-    CALLS_TOTAL, CALL_DURATION_BUCKETS, CALL_DURATION_SECONDS, INVITES_TOTAL,
+    CALLS_TOTAL, CALL_DURATION_BUCKETS, CALL_DURATION_SECONDS, INVITES_TOTAL, RECORDINGS_TOTAL,
     REGISTER_ATTEMPTS_TOTAL, REGISTER_STATE, ROUTE_MATCH_TOTAL, SDP_NEGOTIATE_BUCKETS,
     SDP_NEGOTIATE_SECONDS, VERSTAT_TOTAL, WS_CONNECT_BUCKETS, WS_CONNECT_SECONDS,
 };

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -65,6 +65,13 @@ pub const ROUTE_MATCH_TOTAL: &str = "siphon_ai_route_match_total";
 /// (`verstat_attest`/`verstat_passed`) and in traces.
 pub const VERSTAT_TOTAL: &str = "siphon_ai_verstat_total";
 
+/// Recordings finished, when `[recording]` is on. Labeled by `result`:
+/// `ok` (written cleanly), `degraded` (some 20 ms frames were dropped under
+/// writer back-pressure — the file is short, not corrupt), `failed` (an I/O
+/// error). Bounded cardinality (three values); the per-call recording path
+/// lives on the CDR (`recording_path`).
+pub const RECORDINGS_TOTAL: &str = "siphon_ai_recordings_total";
+
 /// REGISTER attempts the daemon has driven. Labeled by `name`
 /// (the `[[register]].name`) and `outcome`:
 /// `registered` / `auth_failed` / `transport_error` / `timeout` /
@@ -188,6 +195,10 @@ pub fn register_descriptions() {
     describe_counter!(
         VERSTAT_TOTAL,
         "STIR/SHAKEN verification outcomes by result (passed, failed, unsigned)."
+    );
+    describe_counter!(
+        RECORDINGS_TOTAL,
+        "Call recordings finished by result (ok, degraded, failed)."
     );
     describe_counter!(
         REGISTER_ATTEMPTS_TOTAL,

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -363,6 +363,25 @@ dir  = "/var/lib/siphon-ai/recordings"
 | `mode` | string | `"off"` | `"off"` = no recording (zero behaviour change). `"always"` = record every accepted call for its full duration. `"on_demand"` = the WS server drives recording with `start_recording` / `stop_recording` / `pause_recording` / `resume_recording` (see `docs/PROTOCOL.md` §4.7); SiphonAI emits `recording_started` / `recording_stopped` / `recording_failed` back. (Per-route overrides land in a later 0.5.0 chunk.) |
 | `dir` | string | — | Directory recordings are written to as `<dir>/<call_id>.wav`. **Required when `mode != "off"`**; created at startup (a bad path fails loud at load). A `pause` omits the paused span from the file (the audio is dropped, not silenced). |
 
+**Per-route override.** A `[route.recording]` block overrides the global
+`mode` for calls that match that route (strict override — the route value
+fully replaces the global, like `[route.security]`). The output `dir` is
+always the global one, so `[recording].dir` must be set whenever any route
+enables recording — even if the global `mode = "off"`:
+
+```toml
+[recording]
+mode = "off"                         # global default: don't record
+dir  = "/var/lib/siphon-ai/recordings"
+
+[[route]]
+name = "support"
+[route.match]
+to = "5000"
+[route.recording]
+mode = "always"                      # …but always record the support line
+```
+
 Operational notes: recordings are uncompressed PCM16 stereo (≈115 MB/hour
 at 16 kHz; ≈58 MB/hour at 8 kHz) — size your disk and **manage retention
 yourself** (the daemon does not delete recordings). Recording consent and

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -368,6 +368,15 @@ entirely when verification is disabled):
 and `verstat_passed: false` is a call that asserted full attestation but
 failed verification.
 
+Two optional recording fields appear when the call was recorded (added in
+0.5.0; schema stays at version 1 — both omitted when recording is off):
+
+- `recording_id` — identifies the recording (equals `call_id` in this
+  release).
+- `recording_path` — filesystem path of the WAV. Present even when the
+  recording `failed` (it points at where the file would be); cross-check
+  with the `siphon_ai_recordings_total` metric for the outcome.
+
 The webhook sink delivers the same JSON to `[cdr.webhook].url` with
 `Content-Type: application/json`. Retries on non-2xx up to
 `[cdr.webhook].retry_max` times with exponential backoff.
@@ -412,6 +421,7 @@ on the metrics crate's defaults (CLAUDE.md §7.4).
 | `siphon_ai_calls_active`                | gauge     | —                                     | Currently-running calls. |
 | `siphon_ai_route_match_total`           | counter   | `route`                               | Calls per matched route. |
 | `siphon_ai_verstat_total`               | counter   | `result=passed\|failed\|unsigned`     | STIR/SHAKEN verification outcomes per inbound INVITE. Emitted only when `[security.stir_shaken].enabled = true`. `passed` = every check held; `failed` = `Identity` header present but verification didn't fully pass; `unsigned` = no `Identity` header. |
+| `siphon_ai_recordings_total`            | counter   | `result=ok\|degraded\|failed`         | Recordings finished, when `[recording]` is on. `ok` = written cleanly; `degraded` = some 20 ms frames dropped under writer back-pressure (file is short, not corrupt); `failed` = an I/O error. |
 | `siphon_ai_call_duration_seconds`       | histogram | —                                     | Wall-clock duration of ended calls. |
 | `siphon_ai_sdp_negotiate_seconds`       | histogram | `result=ok\|error`                    | Time spent in `prepare_call` (negotiate + port alloc + tap attach). |
 | `siphon_ai_ws_connect_seconds`          | histogram | —                                     | WS handshake time. |

--- a/docs/DIALPLAN.md
+++ b/docs/DIALPLAN.md
@@ -54,6 +54,11 @@ Each `[[route]]` has:
   `[security]` block (currently `min_attestation`). **Strict**
   override: the route value fully replaces the global, even when more
   permissive. See `docs/CONFIG.md` `[security]`.
+- `[route.recording]` *(optional)* — overrides the global
+  `[recording].mode` (`off` / `always` / `on_demand`). **Strict**
+  override. The output `dir` is always the global one, so
+  `[recording].dir` must be set when any route enables recording. See
+  `docs/CONFIG.md` `[recording]`.
 
 ---
 
@@ -68,9 +73,9 @@ These rules are CLAUDE.md §4.6 cardinal — don't try to bend them:
 2. **AND across keys within a route.** All match keys must hold.
    For OR semantics, write multiple routes.
 3. **Per-route override.** Set fields in `[route.bridge]`,
-   `[route.media]`, or `[route.security]` override the corresponding
-   global fields *for that call only*. Unset fields inherit from
-   globals — a route never silently ignores a global setting.
+   `[route.media]`, `[route.security]`, or `[route.recording]` override
+   the corresponding global fields *for that call only*. Unset fields
+   inherit from globals — a route never silently ignores a global setting.
 4. **No match → SIP 404.** If you want a catch-all, write a default
    route at the end with `any = true`. Production deployments
    without a default get a startup warning.


### PR DESCRIPTION
**0.5.0 chunk 3** (`docs/DEV_PLAN_0.5.0.md` §7 Week 3). Adds per-route control, the CDR pointer, and observability on top of chunks 1–2 (#132, #133).

### Per-route override
`[route.recording].mode` (`off` / `always` / `on_demand`) strictly overrides the global `[recording].mode` for matched calls (mirrors `[route.security]`). The output dir is always the global one, so `[recording].dir` is required (and created at load) whenever **any** route enables recording — even with the global mode `off`. Load-time validation: an unknown route mode and a route enabling recording with no dir both fail loud.

### CDR pointer
`recording_id` / `recording_path` — additive optional fields, so the CDR schema stays at **version 1**. `recording_id == call_id` this release.

### Metric
`siphon_ai_recordings_total{result=ok|degraded|failed}`, once per recorded call.

### Degraded detection (DoD: "overflow surfaced as degraded, not silent loss")
The tap counts frames dropped on a **full** recording channel (a `Closed` channel — writer already stopped — is *not* a drop) into a shared atomic; any drops → the recording is classified `degraded`. The result flows `CallOutcome` → CDR + metric. The audio path still only `try_send`s (§4.3).

### Verification
- **End-to-end**: global `mode = "off"` + a route `[route.recording].mode = "always"` → the call records (override works); the CDR carries `recording_id` + `recording_path`; `/metrics` shows `siphon_ai_recordings_total{result="ok"} 1`.
- Config-validation unit tests (mode parsing, dir-required, per-route invalid mode); full workspace suite green (559); `clippy --all-targets -- -D warnings` clean.
- Docs: CONFIG.md (`[route.recording]`), DIALPLAN.md (override list), DEPLOY.md (metric + CDR fields).

Base `main`. Chunk 4 (SRTP re-key on a timer) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)