### PR TITLE
docs(recording): RECORDING.md guide + SIPp recording phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ sit them behind an authenticating reverse proxy.
 4. `docs/INSTALL_DEBIAN13.md` + `docs/FREESWITCH_INTEGRATION.md` +
    `docs/BOT_LOCALHOST_SETUP.md` — the deploy-the-thing path.
 5. `docs/CONFIG.md` — every TOML field documented.
+6. `docs/RECORDING.md` — call recording (stereo WAV, on-demand control, CDR).
 
 ## Upstream dependencies
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -350,7 +350,7 @@ min_attestation = "C"   # looser than a stricter global, by design
 
 Records each call's audio to a stereo WAV (caller = left channel, bot/WS =
 right). Off by default. Recording runs off the audio hot path — a backed-up
-writer can never stall live audio.
+writer can never stall live audio. **Full guide: `docs/RECORDING.md`.**
 
 ```toml
 [recording]

--- a/docs/RECORDING.md
+++ b/docs/RECORDING.md
@@ -1,0 +1,157 @@
+# Call Recording
+
+SiphonAI can record each call's audio to a stereo WAV for compliance and QA.
+Recording is **off by default** and added in v0.5.0.
+
+- **What you get:** one `.wav` per recorded call — dual-channel stereo
+  PCM16, **caller on the left channel, bot/WS on the right** (per-speaker
+  separation, ideal for QA and per-channel transcription).
+- **What it is not:** SiphonAI does not analyze the audio. Transcription,
+  sentiment, and QA scoring are the WS server's job — the recording is the
+  perfect *input* to such a tool, but that tool is yours, not the bridge's
+  (CLAUDE.md §4.1).
+
+---
+
+## 1. Enabling
+
+Recording is configured under `[recording]` (see `docs/CONFIG.md`):
+
+```toml
+[recording]
+mode = "always"                       # "off" (default) | "always" | "on_demand"
+dir  = "/var/lib/siphon-ai/recordings"
+```
+
+- **`mode = "off"`** (default) — no recording; zero behaviour change.
+- **`mode = "always"`** — record every accepted call, for its full duration.
+- **`mode = "on_demand"`** — wire recording for the call but stay idle; the
+  WS server starts/stops it (see §3).
+- **`dir`** — output directory; required when `mode != "off"`. Created at
+  startup, so a bad path fails loud at config load. Files are written as
+  `<dir>/<call_id>.wav`.
+
+### Per-route override
+
+A `[route.recording]` block overrides the global `mode` for matched calls
+(strict override — see `docs/DIALPLAN.md`). The output `dir` is always the
+global one, so `[recording].dir` must be set whenever any route enables
+recording, even if the global `mode = "off"`:
+
+```toml
+[recording]
+mode = "off"                          # don't record by default…
+dir  = "/var/lib/siphon-ai/recordings"
+
+[[route]]
+name = "support"
+[route.match]
+to = "5000"
+[route.recording]
+mode = "always"                       # …but always record the support line
+```
+
+---
+
+## 2. Output
+
+| Property | Value |
+|---|---|
+| Container | WAV (RIFF), uncompressed |
+| Sample format | PCM16, little-endian |
+| Channels | 2 (stereo) — **L = caller, R = bot/WS** |
+| Sample rate | The call's negotiated rate (8 kHz or 16 kHz) |
+| Path | `<dir>/<call_id>.wav` |
+
+The `call_id` in the path is the same one on the WS `start` message and the
+CDR, so a recording correlates 1:1 with its call.
+
+---
+
+## 3. On-demand control (WS protocol)
+
+With `mode = "on_demand"`, the WS server drives recording with these control
+messages (full spec in `docs/PROTOCOL.md` §4.7):
+
+| Server → SiphonAI | Effect |
+|---|---|
+| `start_recording` | Begin recording. SiphonAI replies `recording_started` (or `recording_failed`). |
+| `stop_recording` | Finalize and close the file now. SiphonAI replies `recording_stopped`. |
+| `pause_recording` | Suspend recording — the paused span is **omitted** from the file (dropped, not silenced). |
+| `resume_recording` | Resume after a pause. |
+
+SiphonAI emits these back (PROTOCOL.md §3.11):
+
+| SiphonAI → Server | Meaning |
+|---|---|
+| `recording_started` | Recording began; carries `recording_id`. |
+| `recording_stopped` | Recording finalized (on `stop_recording` or call end). |
+| `recording_failed` | Recording could not start or write (best-effort — the call is unaffected). |
+
+**Pause is the PCI primitive:** to keep card numbers out of a recording,
+`pause_recording` before the caller reads the number and `resume_recording`
+after. The paused audio is never written — the recording skips straight from
+before to after.
+
+`mode = "always"` covers the whole call automatically; these controls aren't
+needed there (a `start_recording` on an already-recording call is a no-op).
+
+> One recording per call in this release; `recording_id` equals `call_id`.
+
+---
+
+## 4. Observability
+
+- **CDR** (`docs/DEPLOY.md`): a recorded call's CDR carries `recording_id`
+  and `recording_path`. Both are omitted when the call wasn't recorded, so
+  the CDR schema stays at version 1.
+- **Metric:** `siphon_ai_recordings_total{result="ok"|"degraded"|"failed"}`
+  ticks once per recorded call.
+  - `ok` — written cleanly.
+  - `degraded` — some 20 ms frames were dropped under writer back-pressure;
+    the file is **short, not corrupt** (see §5). `recording_path` is still
+    on the CDR.
+  - `failed` — an I/O error (e.g. disk full); the file is incomplete or
+    absent.
+
+---
+
+## 5. How it stays off the hot path
+
+The audio path is sacred (CLAUDE.md §4.3): per-call audio runs at 50
+frames/sec and must never block. So recording never touches the audio task —
+the media tap only does a **non-blocking copy** of each frame onto a bounded
+channel, and a dedicated per-call writer task does the file I/O. If the
+writer can't keep up and that channel fills, frames are **dropped** (and the
+recording is flagged `degraded`) rather than stalling or gapping the live
+call. A recording is always best-effort; it never degrades call quality.
+
+---
+
+## 6. Operating
+
+- **Disk sizing:** recordings are uncompressed — ≈115 MB/hour at 16 kHz,
+  ≈58 MB/hour at 8 kHz (stereo PCM16). With `mode = "always"`, size the disk
+  for your peak concurrent-call-hours.
+- **Retention:** the daemon **does not delete recordings**. Manage retention
+  yourself (lifecycle policy on the storage, or a cron job) per your
+  compliance window.
+- **Consent / announcement:** recording has jurisdiction-specific consent
+  law (e.g. two-party-consent regions). Playing any "this call is recorded"
+  announcement and obtaining consent are the **operator's responsibility** —
+  SiphonAI does not insert prompts. (Your WS server can play the prompt.)
+
+---
+
+## 7. Limitations (v0.5.0)
+
+- One recording per call (`recording_id == call_id`).
+- Path is `<dir>/<call_id>.wav` — no templating yet.
+- WAV/PCM16 only; no compressed (Opus) format yet.
+- Local-file sink only; no object-storage (S3) sink yet.
+- WAV `data`/`RIFF` sizes are 32-bit, so a single recording over ~4 GiB
+  (many hours of 16 kHz stereo) saturates the header sizes — not a concern
+  for normal call lengths.
+
+The compressed-format and object-storage sinks are tracked as 0.5.x
+stretch items (see `docs/DEV_PLAN_0.5.0.md` §4).

--- a/test-harness/sipp-scenarios/README.md
+++ b/test-harness/sipp-scenarios/README.md
@@ -50,6 +50,12 @@ sipp -sf basic_call_then_bye.xml -m 1 -p 5070 -s 1000 127.0.0.1:5060
 | `stir_shaken_attestation_403.xml`   | STIR/SHAKEN gate: `Identity` present but unverifiable (unreachable `x5u`) below `min_attestation = "A"` → 403 Forbidden (stir_shaken phase) |
 | `stir_shaken_attestation_pass.xml`  | STIR/SHAKEN happy path: a fully-verifiable `Identity` (fresh PASSporT, real x5u fetch, chain to the test anchor) → **200 admitted** (stir_shaken phase). Templated — `__IDENTITY__` is substituted at run time; does not run standalone. |
 
+`run-all.sh` also has an always-on **recording** auxiliary phase: it starts
+a daemon with `[recording].mode = "always"` writing to a temp dir, runs one
+`basic_call_then_bye.xml` call through the echo WS bridge, then asserts the
+written file is a valid stereo PCM16 WAV with audio in it (via Python's
+`wave`). It reuses `basic_call_then_bye.xml` — no dedicated scenario file.
+
 The `stir_shaken_*` scenarios run in `run-all.sh`'s always-on
 **stir_shaken** auxiliary phase. It builds + runs the
 `gen_test_passport` example (a `siphon-ai-stir-shaken` example) to mint a

--- a/test-harness/sipp-scenarios/run-all.sh
+++ b/test-harness/sipp-scenarios/run-all.sh
@@ -260,6 +260,75 @@ fi
 ss_cleanup
 trap - EXIT
 
+# ─── Always-on auxiliary phase: recording ─────────────────────────
+# Verifies `[recording].mode = "always"` writes a valid stereo WAV. A
+# fresh daemon records to a temp dir; after one basic call we assert the
+# file exists and is a well-formed stereo PCM16 WAV with audio in it.
+# (A signaling-only call records silence frames over the call's duration,
+# which still exercises the whole tap → writer → finalize path.) Reuses
+# the echo WS on :8765 that the rest of the suite already needs.
+echo
+echo "─── auxiliary phase: recording ────────────────────────"
+REC_DAEMON_LOG=$(mktemp -t siphon-ai-rec.XXXXXX.log)
+REC_CONFIG=$(mktemp -t siphon-ai-rec.XXXXXX.toml)
+REC_DIR=$(mktemp -d -t siphon-ai-rec.XXXXXX)
+cat >"$REC_CONFIG" <<EOF
+[node]
+id = "siphon-ai-sipp-rec"
+[sip]
+listen = "127.0.0.1:$DAEMON_PORT"
+[media]
+codecs = ["pcmu"]
+[bridge]
+ws_url = "ws://127.0.0.1:8765/"
+[recording]
+mode = "always"
+dir = "$REC_DIR"
+[[route]]
+name = "default"
+[route.match]
+any = true
+EOF
+
+RUST_LOG=siphon_ai=info "$DAEMON_BIN" --config "$REC_CONFIG" \
+    >"$REC_DAEMON_LOG" 2>&1 &
+REC_DAEMON_PID=$!
+rec_cleanup() {
+    kill "$REC_DAEMON_PID" 2>/dev/null || true
+    wait "$REC_DAEMON_PID" 2>/dev/null || true
+    rm -rf "$REC_DIR" 2>/dev/null || true
+}
+trap rec_cleanup EXIT
+sleep 1.2
+
+total=$((total + 1))
+echo "─── recording_writes_valid_wav ───────────────────────"
+rec_ok=0
+if sipp -sf "$SCRIPT_DIR/basic_call_then_bye.xml" -m 1 -timeout 15s -trace_err \
+        -p "$SIPP_PORT" -s 1000 "127.0.0.1:$DAEMON_PORT" >/dev/null 2>&1; then
+    sleep 0.6  # let teardown finalize the WAV header
+    if python3 - "$REC_DIR" <<'PY'
+import sys, glob, wave
+wavs = glob.glob(sys.argv[1] + "/*.wav")
+assert len(wavs) == 1, f"expected exactly 1 recording, found {len(wavs)}"
+w = wave.open(wavs[0], "rb")
+assert w.getnchannels() == 2, f"expected stereo, got {w.getnchannels()}"
+assert w.getsampwidth() == 2, "expected PCM16"
+assert w.getframerate() in (8000, 16000), f"unexpected rate {w.getframerate()}"
+assert w.getnframes() > 0, "recording is empty"
+PY
+    then rec_ok=1; fi
+fi
+if (( rec_ok )); then
+    echo "  OK"
+else
+    echo "  FAIL (recording invalid or call failed; daemon: $REC_DAEMON_LOG)"
+    failures=$((failures + 1))
+fi
+
+rec_cleanup
+trap - EXIT
+
 # ─── Optional third phase: blind_transfer ─────────────────────────
 # Needs a WS server that proactively emits BridgeIn::Transfer. The
 # runner stops the daemon, brings up an echo-ws that auto-emits


### PR DESCRIPTION
**0.5.0 chunk 5** (`docs/DEV_PLAN_0.5.0.md` §7 — hardening + docs). Docs + harness only; no Rust changes.

### `docs/RECORDING.md`
End-to-end recording guide: enabling (`always` / `on_demand` / per-route), output format (stereo PCM16 WAV, caller L / bot R), on-demand WS control, CDR fields, the `siphon_ai_recordings_total` metric, the §4.3 hot-path / `degraded` story, operating notes (disk sizing, operator-managed retention, consent/legal), and v0.5.0 limitations. Linked from the README docs list and the CONFIG.md `[recording]` section.

### Recording SIPp phase
`run-all.sh` gains an always-on **recording** auxiliary phase: it boots a daemon with `[recording].mode = "always"` writing to a temp dir, runs one `basic_call_then_bye.xml` call through the echo WS, then asserts the written file is a **valid stereo PCM16 WAV with audio** (Python's `wave`). Reuses the existing scenario file (no new XML); documented in the scenarios README.

### Verification
Full SIPp suite green locally — **"all 11 scenarios passed"** (was 10), with `recording_writes_valid_wav OK`.

Base `main`. Chunk 6 (release 0.5.0) is the last one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)