### PR TITLE
chore(release): v0.5.0 — call recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-08
+
+Theme: **call recording.** Each call's audio can be captured to a stereo WAV
+(caller on the left channel, bot/WS on the right) for compliance and QA.
+**Off by default** — a 0.4.x deployment upgrades with zero behaviour change
+until `[recording].mode` is set. The WS protocol stays at `version: "1"`
+(the new recording messages are additive) and the CDR schema stays at
+version 1 (the new fields are additive optionals).
+
+### Added
+
+- **Call recording** (`[recording]`) — writes `<dir>/<call_id>.wav`, stereo
+  PCM16 at the call's negotiated rate. `mode = "off"` (default) / `"always"`
+  (whole call) / `"on_demand"` (WS-server-driven). The recorder runs off the
+  audio hot path (CLAUDE.md §4.3): the media tap only does a non-blocking
+  copy onto a bounded channel, and a per-call writer task does the file I/O —
+  a backed-up writer drops frames (flagged `degraded`) rather than ever
+  stalling or gapping the live call. See `docs/RECORDING.md`.
+- **Per-route override** — `[route.recording].mode` strictly overrides the
+  global mode for matched calls (mirrors `[route.security]`). The output
+  `dir` is the global one, so `[recording].dir` is required (and created at
+  load) whenever any route enables recording, even with the global mode
+  `off`.
+- **On-demand control (WS protocol).** New `BridgeIn`: `start_recording` /
+  `stop_recording` / `pause_recording` / `resume_recording`. New
+  `BridgeOut`: `recording_started` / `recording_stopped` /
+  `recording_failed` (each with `recording_id`). `pause_recording` **omits**
+  the paused span from the file (dropped, not silenced) — the PCI
+  "pause while the caller reads a card number" primitive. PROTOCOL.md §3.11 /
+  §4.7.
+- **CDR pointer** — `recording_id` / `recording_path` on the CDR (additive
+  optionals, omitted when the call wasn't recorded → schema stays at v1).
+- **Metric** — `siphon_ai_recordings_total{result="ok"|"degraded"|"failed"}`.
+- **`docs/RECORDING.md`** — the recording guide (enabling, output format,
+  on-demand control, observability, the hot-path/degraded story, disk
+  sizing, retention, consent, and limitations), plus an always-on recording
+  phase in the SIPp regression suite that asserts a valid stereo WAV.
+
+### Notes
+
+- Recordings are written **decrypted** — even for SRTP-encrypted calls, the
+  WAV on disk is plaintext PCM (forge decrypts the media to bridge it; the
+  recorder taps the decoded audio). The recording directory is sensitive
+  data; protect it at rest (disk encryption, permissions) and manage
+  retention yourself — the daemon never deletes recordings. Consent and any
+  "this call is recorded" announcement are the operator's responsibility.
+- **SRTP re-key on a timer** was planned to ride along but was **deferred**:
+  forge-media has no coordinated mid-call re-key (DTLS renegotiation is
+  blocked; a unilateral key swap would break media), so it needs upstream
+  work first. See `docs/DEV_PLAN_0.5.0.md` §3.2 / §6.
+
 ## [0.4.1] - 2026-06-07
 
 Completes the 0.4.0 STIR/SHAKEN theme — the four items deferred from that
@@ -533,7 +584,10 @@ the WebSocket server's job.
 - Reference WebSocket servers in `examples/`: echo (Python / Node),
   an OpenAI Realtime bridge, and a Deepgram + LLM voice bot.
 
-[Unreleased]: https://github.com/thevoiceguy/siphon-ai/compare/v0.3.2...HEAD
+[Unreleased]: https://github.com/thevoiceguy/siphon-ai/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/thevoiceguy/siphon-ai/compare/v0.4.1...v0.5.0
+[0.4.1]: https://github.com/thevoiceguy/siphon-ai/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/thevoiceguy/siphon-ai/compare/v0.3.2...v0.4.0
 [0.3.2]: https://github.com/thevoiceguy/siphon-ai/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/thevoiceguy/siphon-ai/compare/v0.2.0...v0.3.1
 [0.2.0]: https://github.com/thevoiceguy/siphon-ai/compare/v0.1.0...v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2899,7 +2899,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "base64",
  "bytes",
@@ -2920,7 +2920,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2937,7 +2937,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "regex",
  "serde",
@@ -2954,7 +2954,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2993,7 +2993,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -3008,7 +3008,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3030,7 +3030,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "thiserror 1.0.69",
  "tokio",
@@ -3039,7 +3039,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "regex",
  "serde",
@@ -3050,7 +3050,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3059,7 +3059,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3082,7 +3082,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -3100,7 +3100,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3121,7 +3121,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
+**v0.5.0** — fifth release. Theme: **call recording.** Each call's audio can
+be captured to a stereo WAV (caller left, bot/WS right) for compliance and
+QA — `[recording].mode` = `off` (default) / `always` / `on_demand`, with a
+per-route `[route.recording]` override. On-demand recording is driven over
+the WS protocol (`start`/`stop`/`pause`/`resume_recording`; a pause *omits*
+the span — the PCI primitive), and surfaced on the CDR (`recording_id` /
+`recording_path`) and a `siphon_ai_recordings_total` metric. The recorder
+runs off the audio hot path — a backed-up writer drops frames (`degraded`)
+rather than ever stalling the live call. **Off by default**; a 0.4.x
+deployment upgrades with zero behaviour change. Protocol stays `version: "1"`
+and the CDR schema stays at version 1 (both additions are additive). See
+[`docs/RECORDING.md`](docs/RECORDING.md). (A timed SRTP re-key was planned to
+ride along but was deferred — forge-media has no coordinated re-key API.)
+Full notes: [`CHANGELOG.md`](CHANGELOG.md).
+
 **v0.4.1** — patch release completing the 0.4.0 STIR/SHAKEN theme: PASSporT
 `iat` freshness (replay protection, `verstat.iat_passed`), an
 `x5u_tls_extra_ca` knob for privately-hosted `x5u`, the security-model doc

--- a/docs/RECORDING.md
+++ b/docs/RECORDING.md
@@ -130,6 +130,14 @@ call. A recording is always best-effort; it never degrades call quality.
 
 ## 6. Operating
 
+- **Recordings are plaintext at rest — even for encrypted calls.** Recording
+  works on SRTP calls (the recorder taps the *decoded* audio — forge already
+  decrypts the media to bridge it to your WS server), so the WAV on disk is
+  always cleartext PCM regardless of `[media].srtp`. SRTP protects the media
+  *in transit*; it does nothing for the recording *at rest*. Treat the
+  recording directory as sensitive PII/PCI: protect it with volume
+  encryption, filesystem permissions, and access controls. SiphonAI does not
+  encrypt recordings.
 - **Disk sizing:** recordings are uncompressed — ≈115 MB/hour at 16 kHz,
   ≈58 MB/hour at 8 kHz (stereo PCM16). With `mode = "always"`, size the disk
   for your peak concurrent-call-hours.


### PR DESCRIPTION
**0.5.0 chunk 6 — release.** Bumps the workspace version `0.4.1 → 0.5.0` and finalizes the call-recording release.

### Theme: call recording
Per-call stereo WAV (caller L / bot R), **off by default**. Shipped across chunks 1-3 + 5:
- Modes `off` / `always` / `on_demand` + per-route `[route.recording]` override (#132, #134).
- On-demand WS control: `start`/`stop`/`pause`/`resume_recording` → `recording_started`/`stopped`/`failed`; **pause omits the span** (PCI) (#133).
- CDR `recording_id` / `recording_path`; `siphon_ai_recordings_total{result}` metric; degraded-on-overflow (#134).
- `docs/RECORDING.md` + a SIPp recording phase (#136).
- Off the audio hot path — a backed-up writer drops frames (`degraded`), never stalls the call.

Protocol stays `version: "1"`; CDR schema stays at version 1 (both additions additive). A 0.4.x deployment upgrades with zero behaviour change.

### Not included
**SRTP re-key** (the planned ride-along) was **deferred** — forge-media has no coordinated mid-call re-key API (#135).

### This PR
- `Cargo.toml`: version `0.5.0`
- `CHANGELOG.md`: `[0.5.0]` entry + fixed the stale version-compare link refs (filled the 0.4.x gap)
- `README.md`: v0.5.0 status entry
- `docs/RECORDING.md`: added the "recordings are plaintext at rest, even for SRTP calls" security note

### Verification
559 workspace tests + all 11 SIPp scenarios green; fmt + clippy clean. Tag `v0.5.0` + GitHub release follow the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)