### PR TITLE
docs(plan): SRTP re-key — SDES primitive landed (forge-media#72)

### DIFF
--- a/docs/DEV_PLAN_0.5.0.md
+++ b/docs/DEV_PLAN_0.5.0.md
@@ -131,13 +131,15 @@ left 0.5.0; pinning their homes:
   on the roadmap. **Proposed target: a dedicated theme once outbound lands.**
 - **AMD** — a later audio-analysis release; the `forge-amd` primitive is
   ready to pick up when outbound makes it pay off.
-- **SRTP re-key on a timer** (was §3.2) — needs a coordinated key rotation
-  forge-media doesn't expose (DTLS renegotiation is blocked; SDES would need
-  a UAS-initiated re-INVITE). **Tracked upstream as
-  [forge-media#71](https://github.com/thevoiceguy/forge-media/issues/71)**
-  (DTLS-SRTP re-key: renegotiate + re-export, and/or SDES re-offer
-  coordination). Once a re-key API lands, siphon-ai exposes
-  `[media.srtp].rekey_after_seconds`. Target a later release.
+- **SRTP re-key on a timer** (was §3.2) — the **SDES** upstream primitive now
+  exists: forge-media [#72](https://github.com/thevoiceguy/forge-media/pull/72)
+  (merged) added `SrtpContext::rekey()` + `rekey_srtp_keys()`, which rotate the
+  master keys mid-stream while preserving ROC/replay. So the siphon-ai side is
+  **unblocked for SDES**: expose `[media.srtp].rekey_after_seconds` + originate
+  a UAS re-INVITE carrying fresh `a=crypto:` and call `rekey_srtp_keys` on the
+  200-OK. (The DTLS-SRTP renegotiation path remains parked upstream —
+  [forge-media#73](https://github.com/thevoiceguy/forge-media/issues/73).)
+  Target a later release.
 
 Confirm the outbound-vs-conferencing ordering in §9 decision 8.
 

--- a/docs/DEV_PLAN_0.6.0.md
+++ b/docs/DEV_PLAN_0.6.0.md
@@ -170,8 +170,11 @@ off, but it carries a forge-media dependency.
   0.6.0.
 - **Conferencing / whisper / barge + call park** — the other big theme;
   still post-outbound. A dedicated release.
-- **SRTP re-key** — tracked upstream as
-  [forge-media#71](https://github.com/thevoiceguy/forge-media/issues/71).
+- **SRTP re-key** — the SDES upstream primitive landed
+  ([forge-media#72](https://github.com/thevoiceguy/forge-media/pull/72)); the
+  siphon-ai SDES re-key trigger is unblocked for a later release. DTLS-SRTP
+  renegotiation is parked
+  ([forge-media#73](https://github.com/thevoiceguy/forge-media/issues/73)).
 - **Campaigns / scheduling** — bulk/scheduled outbound (dialer lists, pacing)
   is a layer *above* single-call origination; out of 0.6.0. The originate API
   is the primitive a campaign tool would call.
@@ -281,5 +284,6 @@ APIs.
 
 Campaign/bulk/scheduled dialing (the API is the primitive; the dialer is a
 layer above), **attended transfer (locked to 0.6.1, §6/§9.7)**, AMD (§6),
-conferencing/whisper/barge/park, SRTP re-key (forge-media#71), video, WebRTC,
+conferencing/whisper/barge/park, SRTP re-key (SDES primitive done,
+forge-media#72; DTLS parked, forge-media#73), video, WebRTC,
 and the outbound *bot* logic itself (WS-server example).


### PR DESCRIPTION
forge-media#71 split: SDES re-key primitive shipped in [forge-media#72](https://github.com/thevoiceguy/forge-media/pull/72) (merged — `SrtpContext::rekey` + `rekey_srtp_keys`, ROC/replay preserved). The siphon-ai SDES re-key trigger is now unblocked for a later release; DTLS-SRTP renegotiation is parked ([forge-media#73](https://github.com/thevoiceguy/forge-media/issues/73)). Updates the 0.5.0/0.6.0 plan cross-references. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)