### PR TITLE
feat(media-glue): outbound call media — offer generation + answer binding

### DIFF
--- a/crates/media-glue/src/lib.rs
+++ b/crates/media-glue/src/lib.rs
@@ -14,8 +14,11 @@ pub mod setup;
 pub mod tap;
 
 pub use sdp::{
-    audio_remote_addr, build_answer, negotiate_answer, parse_offer, AnswerOutcome, Codec,
-    LocalCapabilities, MediaDirection, SdpError,
+    audio_remote_addr, build_answer, generate_offer, negotiate_answer, negotiate_offer_answer,
+    parse_offer, AnswerOutcome, Codec, LocalCapabilities, MediaDirection, SdpError,
 };
-pub use setup::{InboundAccepted, InboundCall, MediaSetup, SetupError};
+pub use setup::{
+    InboundAccepted, InboundCall, MediaSetup, OutboundAccepted, OutboundOffer,
+    OutboundOfferRequest, SetupError, TapOptions,
+};
 pub use tap::{BargeInAction, MediaTap, MediaTapError, TapCommand, TapDisconnect};

--- a/crates/media-glue/src/sdp.rs
+++ b/crates/media-glue/src/sdp.rs
@@ -1,8 +1,10 @@
-//! SDP offer/answer for inbound INVITEs.
+//! SDP offer/answer for inbound and outbound calls.
 //!
-//! Per CLAUDE.md §4.8 we don't write our own SDP parser or
-//! negotiator — `forge-sdp` (and through it `sip-sdp`) already does
-//! both. This module is a thin shim that:
+//! Inbound, we answer a peer's offer ([`negotiate_answer`]); outbound, we
+//! make the offer ([`generate_offer`]) and read the peer's answer
+//! ([`negotiate_offer_answer`]). Per CLAUDE.md §4.8 we don't write our own
+//! SDP parser or negotiator — `forge-sdp` (and through it `sip-sdp`) already
+//! does both. This module is a thin shim that:
 //!
 //! 1. Defines the small [`Codec`] enum SiphonAI v1 actually
 //!    supports (G.711 µ-law/A-law, G.722, Opus).
@@ -407,6 +409,70 @@ pub fn build_answer(offer_sdp: &str, caps: &LocalCapabilities) -> Result<AnswerO
     negotiate_answer(&offer, caps)
 }
 
+/// Build the SDP **offer** for an outbound call — every configured codec,
+/// in priority order, at our `local_port`, `sendrecv`. This is the inverse
+/// of [`negotiate_answer`]: there we answer a peer's offer; here we make the
+/// first move. The result is the body for the outbound INVITE.
+pub fn generate_offer(caps: &LocalCapabilities) -> String {
+    caps.to_sdp().serialize()
+}
+
+/// Read the negotiated audio out of the peer's **answer** to an offer we
+/// sent (the offerer side of RFC 3264 §6.1). `offered` is the same
+/// capabilities [`generate_offer`] advertised — we validate the peer picked
+/// a codec we actually offered.
+///
+/// Returns an [`AnswerOutcome`] whose `answer` is the *received* answer (so
+/// callers can pull the peer's RTP endpoint via [`audio_remote_addr`]); the
+/// `negotiated_*` fields describe the agreed media. Mirrors
+/// [`negotiate_answer`]'s extraction so the inbound and outbound paths read
+/// the same.
+pub fn negotiate_offer_answer(
+    answer_sdp: &str,
+    offered: &LocalCapabilities,
+) -> Result<AnswerOutcome, SdpError> {
+    let answer = parse_offer(answer_sdp)?; // parses any SDP, offer or answer
+    let audio = answer
+        .find_media(MediaType::Audio)
+        .ok_or(SdpError::NoAudio)?;
+
+    // Port 0 → the peer rejected the audio stream (RFC 3264 §6).
+    if audio.port == 0 {
+        return Err(if audio.formats.is_empty() {
+            SdpError::NoCommonCodec
+        } else {
+            SdpError::AudioRejected
+        });
+    }
+
+    // The answer's primary format is the codec the peer settled on.
+    let primary = helpers::extract_primary_codec(audio).ok_or(SdpError::AudioRejected)?;
+    let codec = Codec::from_encoding_name(&primary.encoding_name).ok_or(SdpError::NoCommonCodec)?;
+    // A well-behaved peer only answers with a codec from our offer; if it
+    // didn't, we have no usable common codec.
+    if !offered.codecs.contains(&codec) {
+        return Err(SdpError::NoCommonCodec);
+    }
+
+    let negotiated_direction = audio
+        .direction()
+        .as_ref()
+        .map(|d| d.as_token())
+        .and_then(MediaDirection::from_attr)
+        .unwrap_or_default();
+
+    let answer_text = answer.serialize();
+    Ok(AnswerOutcome {
+        answer,
+        answer_text,
+        negotiated_codec: codec,
+        negotiated_payload_type: primary.payload_type,
+        negotiated_clock_rate: primary.clock_rate,
+        negotiated_audio_sample_rate: codec.audio_sample_rate(),
+        negotiated_direction,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -442,5 +508,79 @@ a=rtpmap:0 PCMU/8000\r\n";
         let s = parse_offer(SDP_MEDIA_LEVEL_C_WINS).unwrap();
         let addr = audio_remote_addr(&s).expect("address present");
         assert_eq!(addr.to_string(), "203.0.113.7:27492");
+    }
+
+    // ─── Outbound: offer generation + answer negotiation ─────────────────
+
+    fn caps(codecs: Vec<Codec>) -> LocalCapabilities {
+        LocalCapabilities {
+            local_ip: "198.51.100.10".into(),
+            local_port: 5000,
+            codecs,
+            dtmf_payload_type: Some(101),
+        }
+    }
+
+    /// A peer's answer to our offer, selecting `pt`/`name` at `198.51.100.20:4000`.
+    fn answer_sdp(port: u16, pt: u8, name: &str, clock: u32) -> String {
+        format!(
+            "v=0\r\n\
+o=peer 1 1 IN IP4 198.51.100.20\r\n\
+s=-\r\n\
+c=IN IP4 198.51.100.20\r\n\
+t=0 0\r\n\
+m=audio {port} RTP/AVP {pt}\r\n\
+a=rtpmap:{pt} {name}/{clock}\r\n\
+a=ptime:20\r\n\
+a=sendrecv\r\n"
+        )
+    }
+
+    #[test]
+    fn generate_offer_advertises_codecs_at_local_port() {
+        let sdp = generate_offer(&caps(vec![Codec::Pcmu, Codec::Pcma]));
+        let parsed = parse_offer(&sdp).expect("our own offer parses");
+        let audio = parsed
+            .find_media(MediaType::Audio)
+            .expect("audio media present");
+        assert_eq!(audio.port, 5000, "offer advertises our local port");
+        // Both offered codecs + telephone-event are present, PCMU first.
+        let fmts: Vec<&str> = audio.formats.iter().map(|f| f.as_str()).collect();
+        assert!(fmts.contains(&"0"), "PCMU offered");
+        assert!(fmts.contains(&"8"), "PCMA offered");
+        assert!(fmts.contains(&"101"), "telephone-event offered");
+        assert_eq!(fmts.first(), Some(&"0"), "preferred codec first");
+    }
+
+    #[test]
+    fn negotiate_offer_answer_reads_peer_selection() {
+        let offered = caps(vec![Codec::Pcmu, Codec::Pcma]);
+        let outcome = negotiate_offer_answer(&answer_sdp(4000, 0, "PCMU", 8000), &offered).unwrap();
+        assert_eq!(outcome.negotiated_codec, Codec::Pcmu);
+        assert_eq!(outcome.negotiated_payload_type, 0);
+        assert_eq!(outcome.negotiated_audio_sample_rate, 8000);
+        // The peer's RTP endpoint is read from the answer, not the offer.
+        let addr = audio_remote_addr(&outcome.answer).expect("answer carries remote addr");
+        assert_eq!(addr.to_string(), "198.51.100.20:4000");
+    }
+
+    #[test]
+    fn negotiate_offer_answer_rejects_port_zero() {
+        // m=audio 0 → the peer declined the audio stream.
+        let err = negotiate_offer_answer(&answer_sdp(0, 0, "PCMU", 8000), &caps(vec![Codec::Pcmu]))
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            SdpError::AudioRejected | SdpError::NoCommonCodec
+        ));
+    }
+
+    #[test]
+    fn negotiate_offer_answer_rejects_unoffered_codec() {
+        // We offered only PCMA but the peer answered PCMU — no usable codec.
+        let err =
+            negotiate_offer_answer(&answer_sdp(4000, 0, "PCMU", 8000), &caps(vec![Codec::Pcma]))
+                .unwrap_err();
+        assert!(matches!(err, SdpError::NoCommonCodec));
     }
 }

--- a/crates/media-glue/src/setup.rs
+++ b/crates/media-glue/src/setup.rs
@@ -50,7 +50,8 @@ use thiserror::Error;
 use tracing::{debug, info, instrument, warn};
 
 use crate::sdp::{
-    negotiate_answer, parse_offer, AnswerOutcome, Codec, LocalCapabilities, SdpError,
+    generate_offer, negotiate_answer, negotiate_offer_answer, parse_offer, AnswerOutcome, Codec,
+    LocalCapabilities, SdpError,
 };
 use crate::tap::{BargeInAction, MediaTap, MediaTapError};
 
@@ -134,6 +135,82 @@ impl std::fmt::Debug for InboundAccepted {
         // `MediaSession` and `MediaTap` (transitively) hold types
         // that don't impl Debug; keep the summary safe to log.
         f.debug_struct("InboundAccepted")
+            .field("answer", &self.answer)
+            .field("session_call_id", self.session.call_id())
+            .field("session_ports", &self.session.ports())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Tap-behaviour knobs for [`MediaSetup::apply_answer`] — the same set
+/// [`InboundCall`] carries inline, resolved by the acceptor from
+/// `[bridge]`/`[media]` plus any route override.
+#[derive(Debug, Clone)]
+pub struct TapOptions {
+    pub barge_in_action: BargeInAction,
+    pub inactivity_timeout: Option<std::time::Duration>,
+    pub silence_threshold: Option<std::time::Duration>,
+    pub dead_air_threshold: Option<std::time::Duration>,
+    pub rtp_stats_interval: Option<std::time::Duration>,
+}
+
+/// Inputs to [`MediaSetup::originate_offer`] — allocate a forge session and
+/// produce the SDP offer for an outbound INVITE. (Tap-side options come
+/// later, at [`MediaSetup::apply_answer`], once the call is answered.)
+///
+/// `participant_a` is the remote callee's leg (the SIP peer, as for inbound);
+/// `participant_b` is the synthetic other leg (pass a fresh
+/// [`ParticipantId::generate`]).
+#[derive(Debug, Clone)]
+pub struct OutboundOfferRequest {
+    pub call_id: CallId,
+    pub codecs: Vec<Codec>,
+    pub dtmf_payload_type: Option<u8>,
+    pub participant_a: ParticipantId,
+    pub participant_b: ParticipantId,
+    pub from_tag: Option<String>,
+    pub to_tag: Option<String>,
+}
+
+/// What [`MediaSetup::originate_offer`] hands back: the allocated session and
+/// the offer SDP for the outbound INVITE body. Hold it until the call is
+/// answered, then pass it to [`MediaSetup::apply_answer`].
+///
+/// **Lifecycle:** if the call never answers (busy / decline / timeout), the
+/// caller is responsible for tearing the session down via
+/// `SessionManager::stop_session(&call_id)`. Once handed to `apply_answer`,
+/// teardown-on-error becomes that method's job.
+pub struct OutboundOffer {
+    pub session: Arc<MediaSession>,
+    pub offer_sdp: String,
+    /// The capabilities advertised in `offer_sdp`; reused to validate the
+    /// peer's answer.
+    pub offered: LocalCapabilities,
+    pub call_id: CallId,
+}
+
+impl std::fmt::Debug for OutboundOffer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OutboundOffer")
+            .field("call_id", &self.call_id)
+            .field("session_ports", &self.session.ports())
+            .field("offer_len", &self.offer_sdp.len())
+            .finish_non_exhaustive()
+    }
+}
+
+/// What [`MediaSetup::apply_answer`] hands back on success — the outbound
+/// mirror of [`InboundAccepted`]. `answer` describes the negotiated media
+/// (its `answer_text` is the *received* answer, not anything we send).
+pub struct OutboundAccepted {
+    pub answer: AnswerOutcome,
+    pub session: Arc<MediaSession>,
+    pub tap: MediaTap,
+}
+
+impl std::fmt::Debug for OutboundAccepted {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OutboundAccepted")
             .field("answer", &self.answer)
             .field("session_call_id", self.session.call_id())
             .field("session_ports", &self.session.ports())
@@ -301,6 +378,134 @@ impl MediaSetup {
             tap,
         })
     }
+
+    /// Originate an outbound call's media: allocate a forge session and build
+    /// the SDP **offer** for the INVITE body — the inverse of
+    /// [`accept_inbound`](Self::accept_inbound), where we make the first move.
+    ///
+    /// On success the session is allocated and live; the caller sends the
+    /// INVITE carrying `OutboundOffer::offer_sdp` and, on a 2xx, calls
+    /// [`apply_answer`](Self::apply_answer). If the call never answers, the
+    /// caller tears the session down (see [`OutboundOffer`]).
+    #[instrument(skip(self, req), fields(call_id = %req.call_id))]
+    pub async fn originate_offer(
+        &self,
+        req: OutboundOfferRequest,
+    ) -> Result<OutboundOffer, SetupError> {
+        // Allocate the session — no remote SDP yet, we're the offerer.
+        let session = self
+            .session_manager
+            .create_session(
+                req.call_id.clone(),
+                req.participant_a.clone(),
+                req.participant_b.clone(),
+                None,
+                req.from_tag.clone(),
+                req.to_tag.clone(),
+            )
+            .await?;
+
+        let ports = session.ports();
+        let offered = LocalCapabilities {
+            local_ip: self.local_ip.clone(),
+            local_port: ports.rtp_port,
+            codecs: req.codecs.clone(),
+            dtmf_payload_type: req.dtmf_payload_type,
+        };
+        let offer_sdp = generate_offer(&offered);
+
+        debug!(
+            rtp_port = ports.rtp_port,
+            codecs = req.codecs.len(),
+            "generated outbound offer"
+        );
+
+        Ok(OutboundOffer {
+            session,
+            offer_sdp,
+            offered,
+            call_id: req.call_id,
+        })
+    }
+
+    /// Bind the peer's **answer** (from the outbound INVITE's 2xx) onto the
+    /// session and attach the audio tap — the inverse of
+    /// [`accept_inbound`](Self::accept_inbound) steps 3–5. On any error the
+    /// session is torn down before returning.
+    #[instrument(skip(self, offer, answer_sdp, tap), fields(call_id = %offer.call_id))]
+    pub async fn apply_answer(
+        &self,
+        offer: OutboundOffer,
+        answer_sdp: &str,
+        tap: TapOptions,
+    ) -> Result<OutboundAccepted, SetupError> {
+        let OutboundOffer {
+            session,
+            offered,
+            call_id,
+            ..
+        } = offer;
+
+        // From here on, any failure must release the session.
+        let mut guard = SessionGuard::new(&self.session_manager, &call_id);
+
+        // (1) Read the negotiated audio out of the peer's answer.
+        let answer = negotiate_offer_answer(answer_sdp, &offered)?;
+
+        // (2) Apply the negotiated codec AND the peer's RTP endpoint to leg A
+        //     — same as inbound, but the remote address comes from the answer
+        //     (the callee telling us where to send) rather than from an offer.
+        let codec_config = ParticipantCodecConfig {
+            payload_type: answer.negotiated_payload_type,
+            codec: forge_audio_codec(answer.negotiated_codec),
+            clock_rate: answer.negotiated_clock_rate,
+        };
+        let remote_addr = crate::sdp::audio_remote_addr(&answer.answer);
+        let media_update = ParticipantMediaUpdate {
+            codec_config: Some(codec_config),
+            telephone_event_payload_type: offered.dtmf_payload_type,
+            remote_addr: remote_addr.map(Some),
+            ..Default::default()
+        };
+        if let Some(addr) = remote_addr {
+            debug!(remote_addr = %addr, "seeding leg A remote RTP address from answer SDP");
+        }
+        self.session_manager
+            .update_participant_media(&call_id, ParticipantLabel::A, media_update)
+            .await
+            .map_err(SetupError::from)?;
+
+        // (3) Wire the bridge manager into the session and attach the tap.
+        session
+            .set_media_bridge_manager(Arc::clone(&self.bridge_manager))
+            .await;
+
+        let media_tap = MediaTap::attach_with_barge_in(
+            &self.bridge_manager,
+            &self.event_bus,
+            call_id.clone(),
+            answer.negotiated_audio_sample_rate,
+            tap.barge_in_action,
+        )?
+        .with_inactivity_timeout(tap.inactivity_timeout)
+        .with_idle_thresholds(tap.silence_threshold, tap.dead_air_threshold)
+        .with_rtp_stats_interval(tap.rtp_stats_interval);
+
+        guard.disarm();
+
+        info!(
+            negotiated = %answer.negotiated_codec.encoding_name(),
+            sample_rate = answer.negotiated_audio_sample_rate,
+            rtp_port = session.ports().rtp_port,
+            "outbound call media setup complete"
+        );
+
+        Ok(OutboundAccepted {
+            answer,
+            session,
+            tap: media_tap,
+        })
+    }
 }
 
 /// Map our SDP-layer [`Codec`] to forge's `AudioCodec`. The two enums
@@ -416,5 +621,117 @@ mod tests {
         // No session should have been created — port pool stays empty.
         let (allocated, _available) = session_mgr.port_pool_stats().await;
         assert_eq!(allocated, 0, "port pool must not allocate on parse failure");
+    }
+
+    // ─── Outbound origination ────────────────────────────────────────────
+
+    fn setup_with(session_mgr: &Arc<SessionManager>) -> MediaSetup {
+        MediaSetup::new(
+            Arc::clone(session_mgr),
+            Arc::new(MediaBridgeManager::new()),
+            Arc::new(forge_core::EventBus::new()),
+            "127.0.0.1",
+        )
+    }
+
+    fn outbound_req(call_id: &str, codecs: Vec<Codec>) -> OutboundOfferRequest {
+        OutboundOfferRequest {
+            call_id: CallId::new(call_id),
+            codecs,
+            dtmf_payload_type: Some(101),
+            participant_a: ParticipantId::generate(),
+            participant_b: ParticipantId::generate(),
+            from_tag: Some("ftag".into()),
+            to_tag: None,
+        }
+    }
+
+    fn peer_answer(port: u16, pt: u8, name: &str) -> String {
+        format!(
+            "v=0\r\n\
+o=peer 1 1 IN IP4 198.51.100.20\r\n\
+s=-\r\n\
+c=IN IP4 198.51.100.20\r\n\
+t=0 0\r\n\
+m=audio {port} RTP/AVP {pt}\r\n\
+a=rtpmap:{pt} {name}/8000\r\n\
+a=ptime:20\r\n\
+a=sendrecv\r\n"
+        )
+    }
+
+    fn tap_opts() -> TapOptions {
+        TapOptions {
+            barge_in_action: BargeInAction::Notify,
+            inactivity_timeout: None,
+            silence_threshold: None,
+            dead_air_threshold: None,
+            rtp_stats_interval: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn originate_offer_allocates_session_and_builds_offer() {
+        let session_mgr = small_session_manager(41000, 41100);
+        let setup = setup_with(&session_mgr);
+
+        let offer = setup
+            .originate_offer(outbound_req("c-out-1", vec![Codec::Pcmu, Codec::Pcma]))
+            .await
+            .expect("offer generated");
+
+        // A port pair was allocated, and the offer advertises it.
+        let (allocated, _) = session_mgr.port_pool_stats().await;
+        assert_eq!(allocated, 1, "one session allocated");
+        let rtp_port = offer.session.ports().rtp_port;
+        assert!(
+            offer.offer_sdp.contains(&format!("m=audio {rtp_port} ")),
+            "offer advertises the allocated port: {}",
+            offer.offer_sdp
+        );
+        assert!(offer.offer_sdp.contains("a=rtpmap:0 PCMU/8000"));
+        assert!(offer.offer_sdp.contains("a=rtpmap:8 PCMA/8000"));
+    }
+
+    #[tokio::test]
+    async fn apply_answer_binds_codec_and_attaches_tap() {
+        let session_mgr = small_session_manager(41200, 41300);
+        let setup = setup_with(&session_mgr);
+
+        let offer = setup
+            .originate_offer(outbound_req("c-out-2", vec![Codec::Pcmu, Codec::Pcma]))
+            .await
+            .expect("offer");
+
+        let accepted = setup
+            .apply_answer(offer, &peer_answer(4000, 0, "PCMU"), tap_opts())
+            .await
+            .expect("answer applied");
+
+        assert_eq!(accepted.answer.negotiated_codec, Codec::Pcmu);
+        assert_eq!(accepted.answer.negotiated_audio_sample_rate, 8000);
+        assert_eq!(accepted.tap.sample_rate(), 8000);
+        // The session survived — still allocated, not rolled back.
+        let (allocated, _) = session_mgr.port_pool_stats().await;
+        assert_eq!(allocated, 1);
+    }
+
+    #[tokio::test]
+    async fn apply_answer_rejects_unoffered_codec() {
+        let session_mgr = small_session_manager(41400, 41500);
+        let setup = setup_with(&session_mgr);
+
+        // Offer PCMA only; peer answers PCMU → no common codec.
+        let offer = setup
+            .originate_offer(outbound_req("c-out-3", vec![Codec::Pcma]))
+            .await
+            .expect("offer");
+        let result = setup
+            .apply_answer(offer, &peer_answer(4000, 0, "PCMU"), tap_opts())
+            .await;
+        assert!(matches!(
+            result,
+            Err(SetupError::Sdp(SdpError::NoCommonCodec))
+        ));
     }
 }


### PR DESCRIPTION
**0.6.0 chunk 1** (`docs/DEV_PLAN_0.6.0.md` §7). The media-glue side of outbound origination — the inverse of the inbound `accept_inbound` flow. **No SIP yet; fully unit-tested.**

### What it adds
- **`generate_offer(caps)`** — builds the SDP offer (our codecs at our allocated RTP port, `sendrecv`) for the outbound INVITE body. Reuses `LocalCapabilities::to_sdp`.
- **`negotiate_offer_answer(answer_sdp, offered)`** — reads the peer's answer (the *offerer* side of RFC 3264 §6.1): validates the peer picked a codec we offered, returns the negotiated codec/PT/clock/sample-rate, and the parsed answer so the caller can pull the peer's RTP endpoint via `audio_remote_addr`.
- **`MediaSetup::originate_offer(req) -> OutboundOffer`** — allocates the forge session (no remote SDP, we're the offerer) and builds the offer.
- **`MediaSetup::apply_answer(offer, answer_sdp, tap) -> OutboundAccepted`** — binds the negotiated codec + the peer's RTP address (**from the answer**, not an offer) onto leg A and attaches the `MediaTap` — the mirror of `accept_inbound` steps 3-5, with `SessionGuard` teardown-on-error.
- New types: `OutboundOfferRequest` / `OutboundOffer` / `OutboundAccepted` / `TapOptions`.

### Reuse
~Everything is shared with inbound: the SDP negotiator, the session/port allocation, the rollback guard, the tap. **siphon-rs and forge are unchanged** — this is the net-new glue the feasibility pass identified.

### Tests (7 new)
Offer advertises our codecs at the allocated port; answer negotiation reads the peer's selection + endpoint; rejects port-0 (declined) and unoffered-codec answers; full `originate_offer → apply_answer` round-trip binds codec + tap. 566 workspace tests green; clippy clean.

Base `main`. Chunk 2 (the UAC `OutboundOriginator` that drives the actual INVITE) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)