### PR TITLE
feat(config,core): outbound gateways + safety guardrails

### DIFF
--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -142,6 +142,10 @@ impl Runtime {
             trunks,
             security,
             recording,
+            // Outbound gateways + guardrails are validated at config load
+            // (compile_outbound); the daemon wires them in the originate-API
+            // chunk. Bound-but-unused until then.
+            outbound: _outbound,
             cdr,
             observability,
             webhooks,

--- a/crates/config/src/compile.rs
+++ b/crates/config/src/compile.rs
@@ -35,8 +35,8 @@ use thiserror::Error;
 use tracing::warn;
 
 use crate::raw::{
-    RawBridge, RawCdr, RawConfig, RawHep, RawMedia, RawNode, RawObservability, RawRecording,
-    RawRegister, RawSecurity, RawSip, RawSipTls, RawWebhooks,
+    RawBridge, RawCdr, RawConfig, RawGateway, RawHep, RawMedia, RawNode, RawObservability,
+    RawOutbound, RawRecording, RawRegister, RawSecurity, RawSip, RawSipTls, RawWebhooks,
 };
 
 /// Compiled, ready-to-pass daemon config.
@@ -63,10 +63,64 @@ pub struct Config {
     pub trunks: Vec<TrunkConfig>,
     pub security: SecurityConfig,
     pub recording: siphon_ai_recording::RecordingConfig,
+    pub outbound: OutboundConfig,
     pub cdr: CdrConfig,
     pub observability: ObservabilityConfig,
     pub webhooks: WebhooksConfig,
     pub hep: HepConfig,
+}
+
+/// Compiled `[outbound]` + `[[gateway]]` — outbound call origination
+/// (0.6.0). `max_concurrent == 0` means outbound is disabled (fail-closed).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct OutboundConfig {
+    pub max_concurrent: usize,
+    pub rate_limit_per_sec: Option<u32>,
+    pub gateways: Vec<Gateway>,
+}
+
+impl OutboundConfig {
+    /// Outbound origination is enabled only when a positive concurrency cap
+    /// is set (fail-closed — see `docs/DEV_PLAN_0.6.0.md` §9.5/§9.6).
+    pub fn enabled(&self) -> bool {
+        self.max_concurrent > 0
+    }
+
+    /// Look a gateway up by name.
+    pub fn gateway(&self, name: &str) -> Option<&Gateway> {
+        self.gateways.iter().find(|g| g.name == name)
+    }
+}
+
+/// One compiled outbound gateway (trunk/provider). `proxy_host` is left
+/// unresolved — siphon-rs does RFC 3263 resolution at INVITE time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Gateway {
+    pub name: String,
+    pub proxy_host: String,
+    pub proxy_port: u16,
+    /// Default caller-ID `sip:` URI.
+    pub from: String,
+    pub credentials: Option<GatewayCredentials>,
+}
+
+impl Gateway {
+    /// The Request-URI for dialing `destination` through this gateway —
+    /// `sip:<destination>@<proxy_host>:<proxy_port>`.
+    pub fn request_uri(&self, destination: &str) -> String {
+        format!(
+            "sip:{}@{}:{}",
+            destination, self.proxy_host, self.proxy_port
+        )
+    }
+}
+
+/// Digest credentials for a gateway's UAC (the `CredentialProvider` source).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GatewayCredentials {
+    pub username: String,
+    pub password: String,
+    pub realm: Option<String>,
 }
 
 /// Compiled `[security]` — the call-authentication policy (STIR/SHAKEN).
@@ -452,6 +506,34 @@ pub enum CompileError {
     #[error("route {route:?} enables recording but [recording].dir is not set")]
     RouteRecordingWithoutDir { route: String },
 
+    #[error("[[gateway]] #{index} has an empty name")]
+    GatewayEmptyName { index: usize },
+
+    #[error("duplicate [[gateway]] name {name:?}")]
+    GatewayDuplicateName { name: String },
+
+    #[error("[[gateway]] {name:?} needs either `proxy` or `register`")]
+    GatewayNeedsProxyOrRegister { name: String },
+
+    #[error("[[gateway]] {gateway:?} references unknown [[register]] {register:?}")]
+    GatewayUnknownRegister { gateway: String, register: String },
+
+    #[error("[[gateway]] {name:?} proxy {proxy:?} is invalid: {err}")]
+    GatewayBadProxy {
+        name: String,
+        proxy: String,
+        err: String,
+    },
+
+    #[error("[[gateway]] {name:?} needs a `from` caller-ID URI")]
+    GatewayFromRequired { name: String },
+
+    #[error("[[gateway]] {name:?} `from` {from:?} must be a sip:/sips: URI")]
+    GatewayBadFrom { name: String, from: String },
+
+    #[error("[[gateway]] {name:?} has `auth_username` without `auth_password` (or vice versa)")]
+    GatewayIncompleteAuth { name: String },
+
     #[error("[media].rtp_port_range {min}-{max} is invalid (min must be < max and even)")]
     BadRtpPortRange { min: u16, max: u16 },
 
@@ -558,6 +640,7 @@ pub fn compile(raw: RawConfig) -> Result<Config, CompileError> {
     let trunks = compile_trunks(raw.trunks)?;
     let security = compile_security(raw.security)?;
     let recording = compile_recording(raw.recording)?;
+    let outbound = compile_outbound(raw.outbound, raw.gateways, &registrations)?;
     let cdr = compile_cdr(raw.cdr)?;
     let observability = compile_observability(raw.observability)?;
     let webhooks = compile_webhooks(raw.webhooks)?;
@@ -647,6 +730,7 @@ pub fn compile(raw: RawConfig) -> Result<Config, CompileError> {
         trunks,
         security,
         recording,
+        outbound,
         cdr,
         observability,
         webhooks,
@@ -921,6 +1005,122 @@ fn compile_recording(
         })?;
     }
     Ok(RecordingConfig { mode, dir })
+}
+
+/// Compile `[outbound]` and `[[gateway]]`. Gateways resolve to a uniform
+/// "where and how to dial" shape: either a standalone trunk (a `proxy` plus
+/// a `from`, with optional digest auth) or a `[[register]]` reuse that
+/// inherits the registrar's server, credentials, and AOR. Validated at load:
+/// unique names, a proxy-or-register source, a `sip:` caller-ID, and
+/// complete auth.
+fn compile_outbound(
+    raw: RawOutbound,
+    gateways: Vec<RawGateway>,
+    registrations: &[RegisterConfig],
+) -> Result<OutboundConfig, CompileError> {
+    let max_concurrent = raw.max_concurrent.unwrap_or(0);
+    let rate_limit_per_sec = raw.rate_limit_per_sec.filter(|&r| r > 0);
+
+    let mut compiled: Vec<Gateway> = Vec::with_capacity(gateways.len());
+    for (i, g) in gateways.into_iter().enumerate() {
+        if g.name.trim().is_empty() {
+            return Err(CompileError::GatewayEmptyName { index: i });
+        }
+        if compiled.iter().any(|c| c.name == g.name) {
+            return Err(CompileError::GatewayDuplicateName { name: g.name });
+        }
+
+        let gw = if let Some(reg_name) = g.register.as_deref().filter(|s| !s.is_empty()) {
+            // Register reuse — inherit server + credentials + AOR.
+            let reg = registrations
+                .iter()
+                .find(|r| r.name == reg_name)
+                .ok_or_else(|| CompileError::GatewayUnknownRegister {
+                    gateway: g.name.clone(),
+                    register: reg_name.to_string(),
+                })?;
+            let from = g
+                .from
+                .clone()
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| format!("sip:{}@{}", reg.username, reg.server_host));
+            validate_gateway_from(&from, &g.name)?;
+            Gateway {
+                name: g.name.clone(),
+                proxy_host: reg.server_host.clone(),
+                proxy_port: reg.server_addr.port(),
+                from,
+                credentials: Some(GatewayCredentials {
+                    username: reg.auth_username.clone(),
+                    password: reg.password.clone(),
+                    realm: reg.realm.clone(),
+                }),
+            }
+        } else {
+            // Standalone trunk.
+            let proxy = g
+                .proxy
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| CompileError::GatewayNeedsProxyOrRegister {
+                    name: g.name.clone(),
+                })?;
+            let (proxy_host, proxy_port) =
+                parse_register_server(proxy, None, 5060).map_err(|err| {
+                    CompileError::GatewayBadProxy {
+                        name: g.name.clone(),
+                        proxy: proxy.to_string(),
+                        err,
+                    }
+                })?;
+            let from = g.from.clone().filter(|s| !s.is_empty()).ok_or_else(|| {
+                CompileError::GatewayFromRequired {
+                    name: g.name.clone(),
+                }
+            })?;
+            validate_gateway_from(&from, &g.name)?;
+            let user = g.auth_username.as_deref().filter(|s| !s.is_empty());
+            let pass = g.auth_password.as_deref().filter(|s| !s.is_empty());
+            let credentials = match (user, pass) {
+                (Some(u), Some(p)) => Some(GatewayCredentials {
+                    username: u.to_string(),
+                    password: p.to_string(),
+                    realm: g.realm.clone().filter(|s| !s.is_empty()),
+                }),
+                (None, None) => None,
+                _ => {
+                    return Err(CompileError::GatewayIncompleteAuth {
+                        name: g.name.clone(),
+                    })
+                }
+            };
+            Gateway {
+                name: g.name.clone(),
+                proxy_host,
+                proxy_port,
+                from,
+                credentials,
+            }
+        };
+        compiled.push(gw);
+    }
+
+    Ok(OutboundConfig {
+        max_concurrent,
+        rate_limit_per_sec,
+        gateways: compiled,
+    })
+}
+
+fn validate_gateway_from(from: &str, gateway: &str) -> Result<(), CompileError> {
+    if from.starts_with("sip:") || from.starts_with("sips:") {
+        Ok(())
+    } else {
+        Err(CompileError::GatewayBadFrom {
+            name: gateway.to_string(),
+            from: from.to_string(),
+        })
+    }
 }
 
 fn min_attestation_label(m: siphon_ai_security::MinAttestation) -> &'static str {
@@ -1622,6 +1822,161 @@ mod recording_tests {
         assert!(matches!(
             compile_dialplan(vec![route]),
             Err(CompileError::RouteRecordingModeInvalid { value, .. }) if value == "sometimes"
+        ));
+    }
+}
+
+#[cfg(test)]
+mod outbound_tests {
+    use super::{compile_outbound, CompileError, OutboundConfig, RegisterConfig};
+    use crate::raw::{RawGateway, RawOutbound};
+    use crate::SipTransport;
+    use std::net::SocketAddr;
+    use std::time::Duration;
+
+    fn gw(name: &str) -> RawGateway {
+        RawGateway {
+            name: name.into(),
+            ..Default::default()
+        }
+    }
+
+    fn register(name: &str) -> RegisterConfig {
+        RegisterConfig {
+            name: name.into(),
+            server_addr: "10.0.0.1:5061".parse::<SocketAddr>().unwrap(),
+            server_host: "pbx.example.com".into(),
+            transport: SipTransport::Tls,
+            username: "siphon".into(),
+            auth_username: "siphon-auth".into(),
+            password: "pw".into(),
+            realm: Some("pbx".into()),
+            expires: Duration::from_secs(3600),
+            register_on_startup: true,
+        }
+    }
+
+    #[test]
+    fn standalone_trunk_compiles_with_auth() {
+        let raw = RawGateway {
+            proxy: Some("twilio.example:5060".into()),
+            from: Some("sip:+13125551234@twilio.example".into()),
+            auth_username: Some("acct".into()),
+            auth_password: Some("token".into()),
+            ..gw("twilio")
+        };
+        let out = compile_outbound(RawOutbound::default(), vec![raw], &[]).unwrap();
+        let g = out.gateway("twilio").expect("gateway present");
+        assert_eq!(g.proxy_host, "twilio.example");
+        assert_eq!(g.proxy_port, 5060);
+        assert_eq!(
+            g.request_uri("+15551112222"),
+            "sip:+15551112222@twilio.example:5060"
+        );
+        let creds = g.credentials.as_ref().expect("creds");
+        assert_eq!(
+            (creds.username.as_str(), creds.password.as_str()),
+            ("acct", "token")
+        );
+    }
+
+    #[test]
+    fn register_reuse_inherits_server_and_creds() {
+        let raw = RawGateway {
+            register: Some("pbx".into()),
+            ..gw("pbx-out")
+        };
+        let out = compile_outbound(RawOutbound::default(), vec![raw], &[register("pbx")]).unwrap();
+        let g = out.gateway("pbx-out").unwrap();
+        assert_eq!(g.proxy_host, "pbx.example.com");
+        assert_eq!(g.proxy_port, 5061);
+        assert_eq!(g.from, "sip:siphon@pbx.example.com"); // default AOR
+        let creds = g.credentials.as_ref().unwrap();
+        assert_eq!(creds.username, "siphon-auth");
+        assert_eq!(creds.realm.as_deref(), Some("pbx"));
+    }
+
+    #[test]
+    fn max_concurrent_drives_enabled() {
+        assert!(!OutboundConfig::default().enabled());
+        let out = compile_outbound(
+            RawOutbound {
+                max_concurrent: Some(5),
+                rate_limit_per_sec: Some(2),
+            },
+            vec![],
+            &[],
+        )
+        .unwrap();
+        assert!(out.enabled());
+        assert_eq!(out.max_concurrent, 5);
+        assert_eq!(out.rate_limit_per_sec, Some(2));
+    }
+
+    #[test]
+    fn validation_failures_are_loud() {
+        let only = |g: RawGateway, regs: &[RegisterConfig]| {
+            compile_outbound(RawOutbound::default(), vec![g], regs).unwrap_err()
+        };
+        // No proxy and no register.
+        assert!(matches!(
+            only(gw("bare"), &[]),
+            CompileError::GatewayNeedsProxyOrRegister { .. }
+        ));
+        // Unknown register reference.
+        assert!(matches!(
+            only(
+                RawGateway {
+                    register: Some("nope".into()),
+                    ..gw("x")
+                },
+                &[]
+            ),
+            CompileError::GatewayUnknownRegister { .. }
+        ));
+        // from missing the sip: scheme.
+        assert!(matches!(
+            only(
+                RawGateway {
+                    proxy: Some("h:5060".into()),
+                    from: Some("+1555@h".into()),
+                    ..gw("x")
+                },
+                &[]
+            ),
+            CompileError::GatewayBadFrom { .. }
+        ));
+        // username without password.
+        assert!(matches!(
+            only(
+                RawGateway {
+                    proxy: Some("h:5060".into()),
+                    from: Some("sip:a@h".into()),
+                    auth_username: Some("u".into()),
+                    ..gw("x")
+                },
+                &[]
+            ),
+            CompileError::GatewayIncompleteAuth { .. }
+        ));
+        // duplicate names.
+        assert!(matches!(
+            compile_outbound(
+                RawOutbound::default(),
+                vec![
+                    RawGateway {
+                        register: Some("pbx".into()),
+                        ..gw("dup")
+                    },
+                    RawGateway {
+                        register: Some("pbx".into()),
+                        ..gw("dup")
+                    },
+                ],
+                &[register("pbx")]
+            )
+            .unwrap_err(),
+            CompileError::GatewayDuplicateName { .. }
         ));
     }
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -34,14 +34,15 @@ use std::path::Path;
 use thiserror::Error;
 
 pub use compile::{
-    compile, CdrConfig, CdrFileConfig, CdrWebhookConfig, CompileError, Config, HepConfig,
-    MediaConfig, NodeConfig, ObservabilityConfig, RegisterConfig, SecurityConfig, SipConfig,
-    SipTlsConfig, SipTransport, TrunkCidr, TrunkCidrParseError, TrunkConfig, WebhooksConfig,
+    compile, CdrConfig, CdrFileConfig, CdrWebhookConfig, CompileError, Config, Gateway,
+    GatewayCredentials, HepConfig, MediaConfig, NodeConfig, ObservabilityConfig, OutboundConfig,
+    RegisterConfig, SecurityConfig, SipConfig, SipTlsConfig, SipTransport, TrunkCidr,
+    TrunkCidrParseError, TrunkConfig, WebhooksConfig,
 };
 pub use env::{expand, expand_cow, EnvError, EnvSource, ProcessEnv};
 pub use raw::{
-    RawBridge, RawCdr, RawCdrFile, RawCdrWebhook, RawConfig, RawHep, RawMedia, RawNode,
-    RawObservability, RawRegister, RawSip, RawSipTls, RawTrunk, RawWebhooks,
+    RawBridge, RawCdr, RawCdrFile, RawCdrWebhook, RawConfig, RawGateway, RawHep, RawMedia, RawNode,
+    RawObservability, RawOutbound, RawRegister, RawSip, RawSipTls, RawTrunk, RawWebhooks,
 };
 
 /// Top-level error type. Loaders surface this; consumers match on

--- a/crates/config/src/raw.rs
+++ b/crates/config/src/raw.rs
@@ -55,6 +55,14 @@ pub struct RawConfig {
     #[serde(default)]
     pub recording: RawRecording,
 
+    /// `[[gateway]]` — outbound SIP trunks/providers SiphonAI dials
+    /// *through* for originated calls (0.6.0).
+    #[serde(default, rename = "gateway")]
+    pub gateways: Vec<RawGateway>,
+
+    #[serde(default)]
+    pub outbound: RawOutbound,
+
     #[serde(default)]
     pub cdr: RawCdr,
 
@@ -272,6 +280,52 @@ pub struct RawRecording {
     /// Directory recordings are written to. Required when `mode != "off"`.
     #[serde(default)]
     pub dir: Option<String>,
+}
+
+/// `[[gateway]]` — one outbound trunk/provider (0.6.0). A gateway is the
+/// SIP peer SiphonAI sends originated INVITEs *through*. Two forms:
+///
+/// - **Standalone trunk**: set `proxy` + `from` (+ optional digest auth).
+/// - **Register reuse**: set `register = "<name>"` to dial through a
+///   `[[register]]` entry, inheriting its server address, credentials, and
+///   AOR (used as the default `from`).
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct RawGateway {
+    pub name: String,
+    /// `host` or `host:port` of the trunk. Required unless `register` is set.
+    #[serde(default)]
+    pub proxy: Option<String>,
+    /// Default caller-ID — a full `sip:` URI. Required for standalone
+    /// trunks; defaults to the register AOR when `register` is set.
+    #[serde(default)]
+    pub from: Option<String>,
+    /// Name of a `[[register]]` to dial through (reuse its server + creds).
+    #[serde(default)]
+    pub register: Option<String>,
+    /// Digest username for the trunk (standalone form). `${VAR}`-expandable.
+    #[serde(default)]
+    pub auth_username: Option<String>,
+    /// Digest password for the trunk (standalone form).
+    #[serde(default)]
+    pub auth_password: Option<String>,
+    /// Optional digest realm hint.
+    #[serde(default)]
+    pub realm: Option<String>,
+}
+
+/// `[outbound]` — global outbound-origination controls (0.6.0). The native
+/// guardrails for the originate path (which has no built-in auth — the
+/// endpoint is fronted by a reverse proxy, see `docs/DEV_PLAN_0.6.0.md` §9.5).
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct RawOutbound {
+    /// Max simultaneous outbound calls. `0` (the default) disables outbound
+    /// origination entirely (fail-closed). Set a positive cap to enable it.
+    #[serde(default)]
+    pub max_concurrent: Option<usize>,
+    /// Optional ceiling on new outbound calls per second (token bucket).
+    /// `None` / `0` = no rate limit (the concurrency cap still applies).
+    #[serde(default)]
+    pub rate_limit_per_sec: Option<u32>,
 }
 
 /// `[cdr]` — call detail record sinks. v1 supports a JSONL file

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -21,6 +21,9 @@ pub use call::{
     CallController, CallControllerConfig, CallError, CallHandle, CallOutcome, CallState,
     CallTermination,
 };
-pub use outbound::{NotAnsweredCause, OutboundCall, OutboundError, OutboundOriginator};
+pub use outbound::{
+    NotAnsweredCause, OutboundCall, OutboundError, OutboundGuard, OutboundOriginator,
+    OutboundPermit, OutboundRejection, StaticCredentials,
+};
 pub use registry::{CallEntry, CallRegistry};
 pub use transfer::{TransferContext, TransferOutcome};

--- a/crates/core/src/outbound.rs
+++ b/crates/core/src/outbound.rs
@@ -18,16 +18,20 @@
 //! §4.4); this struct is process-wide plumbing (one shared UAC + media
 //! setup), not per-call state.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
+use async_trait::async_trait;
 use forge_core::CallId;
 use sip_core::SipUri;
 use sip_dialog::Dialog;
 use sip_uac::integrated::{CallHandle, IntegratedUAC, RequestTarget};
+use sip_uac::CredentialProvider;
 use siphon_ai_media_glue::{
     MediaSetup, OutboundAccepted, OutboundOfferRequest, SetupError, TapOptions,
 };
 use thiserror::Error;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tracing::{debug, info, instrument, warn};
 
 /// Places outbound calls through a shared UAC, allocating + binding media
@@ -188,6 +192,125 @@ fn classify_failure(code: u16, reason: &str) -> NotAnsweredCause {
     }
 }
 
+/// A static digest credential source for a gateway's UAC — supplies the
+/// configured username/password on any 401/407 challenge so the UAC's
+/// auto-retry can authenticate to the trunk. (One credential per UAC, so we
+/// answer every realm; build a UAC per gateway.)
+pub struct StaticCredentials {
+    username: String,
+    password: String,
+}
+
+impl StaticCredentials {
+    pub fn new(username: impl Into<String>, password: impl Into<String>) -> Self {
+        Self {
+            username: username.into(),
+            password: password.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl CredentialProvider for StaticCredentials {
+    async fn credentials(&self, _realm: &str) -> Option<(String, String)> {
+        Some((self.username.clone(), self.password.clone()))
+    }
+}
+
+/// Why the [`OutboundGuard`] refused to admit a new outbound call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutboundRejection {
+    /// `max_concurrent_outbound` is already in use.
+    AtCapacity,
+    /// The per-second rate limit was exceeded.
+    RateLimited,
+}
+
+/// The native guardrails on the originate path (the originate API has no
+/// built-in auth — see `docs/DEV_PLAN_0.6.0.md` §9.5/§9.6). A
+/// `max_concurrent` semaphore plus an optional per-second token-bucket rate
+/// limit. Acquire a permit before placing a call; hold it for the call's
+/// lifetime (dropping it frees the slot).
+pub struct OutboundGuard {
+    concurrency: Arc<Semaphore>,
+    rate: Option<Mutex<TokenBucket>>,
+}
+
+impl OutboundGuard {
+    pub fn new(max_concurrent: usize, rate_limit_per_sec: Option<u32>) -> Self {
+        Self {
+            concurrency: Arc::new(Semaphore::new(max_concurrent)),
+            rate: rate_limit_per_sec
+                .filter(|&r| r > 0)
+                .map(|r| Mutex::new(TokenBucket::new(r as f64, Instant::now()))),
+        }
+    }
+
+    /// Try to admit one new outbound call. On success returns a permit the
+    /// caller holds for the call's lifetime; the concurrency slot is freed
+    /// when it drops. The rate token (if any) is only consumed on admission.
+    pub fn try_admit(&self) -> Result<OutboundPermit, OutboundRejection> {
+        // Concurrency first — a rejected slot consumes nothing.
+        let permit = Arc::clone(&self.concurrency)
+            .try_acquire_owned()
+            .map_err(|_| OutboundRejection::AtCapacity)?;
+        if let Some(rate) = &self.rate {
+            if !rate
+                .lock()
+                .expect("rate bucket mutex")
+                .try_take(Instant::now())
+            {
+                drop(permit); // give the concurrency slot back
+                return Err(OutboundRejection::RateLimited);
+            }
+        }
+        Ok(OutboundPermit { _permit: permit })
+    }
+
+    /// Currently-available concurrency slots (for a metric / admin view).
+    pub fn available(&self) -> usize {
+        self.concurrency.available_permits()
+    }
+}
+
+/// Held for the lifetime of an admitted outbound call; frees the
+/// concurrency slot on drop.
+#[derive(Debug)]
+pub struct OutboundPermit {
+    _permit: OwnedSemaphorePermit,
+}
+
+/// A simple token bucket: `refill_per_sec` tokens/sec, burst = the rate.
+struct TokenBucket {
+    tokens: f64,
+    capacity: f64,
+    refill_per_sec: f64,
+    last: Instant,
+}
+
+impl TokenBucket {
+    fn new(rate: f64, now: Instant) -> Self {
+        Self {
+            tokens: rate,
+            capacity: rate,
+            refill_per_sec: rate,
+            last: now,
+        }
+    }
+
+    fn try_take(&mut self, now: Instant) -> bool {
+        let elapsed = now.saturating_duration_since(self.last).as_secs_f64();
+        self.last = now;
+        self.tokens = (self.tokens + elapsed * self.refill_per_sec).min(self.capacity);
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0;
+            true
+        } else {
+            false
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -235,5 +358,70 @@ mod tests {
                 "code {code} should fall back to Rejected"
             );
         }
+    }
+
+    #[test]
+    fn guard_caps_concurrency_and_releases_on_drop() {
+        let guard = OutboundGuard::new(2, None);
+        let p1 = guard.try_admit().expect("1st admit");
+        let _p2 = guard.try_admit().expect("2nd admit");
+        assert_eq!(guard.available(), 0);
+        assert_eq!(
+            guard.try_admit().unwrap_err(),
+            OutboundRejection::AtCapacity
+        );
+        drop(p1); // call ended → slot freed
+        assert_eq!(guard.available(), 1);
+        let _p3 = guard.try_admit().expect("admit after a call ended");
+    }
+
+    #[test]
+    fn guard_with_zero_capacity_always_rejects() {
+        let guard = OutboundGuard::new(0, None);
+        assert_eq!(
+            guard.try_admit().unwrap_err(),
+            OutboundRejection::AtCapacity
+        );
+    }
+
+    #[test]
+    fn token_bucket_limits_then_refills() {
+        let base = Instant::now();
+        let mut bucket = TokenBucket::new(2.0, base);
+        assert!(bucket.try_take(base), "burst token 1");
+        assert!(bucket.try_take(base), "burst token 2");
+        assert!(
+            !bucket.try_take(base),
+            "3rd within the same instant is limited"
+        );
+        // One second later, ~2 tokens have refilled.
+        let later = base + std::time::Duration::from_secs(1);
+        assert!(bucket.try_take(later), "refilled token available");
+    }
+
+    #[test]
+    fn guard_rate_limit_rejects_without_consuming_a_slot() {
+        // rate 1/s, cap 5 — the 2nd immediate admit is rate-limited, and the
+        // concurrency slot it briefly took is given back.
+        let guard = OutboundGuard::new(5, Some(1));
+        let _p1 = guard.try_admit().expect("1st admit");
+        assert_eq!(
+            guard.try_admit().unwrap_err(),
+            OutboundRejection::RateLimited
+        );
+        assert_eq!(
+            guard.available(),
+            4,
+            "rate-limited admit didn't keep a slot"
+        );
+    }
+
+    #[tokio::test]
+    async fn static_credentials_answers_any_realm() {
+        let creds = StaticCredentials::new("alice", "s3cret");
+        assert_eq!(
+            creds.credentials("sip.example.com").await,
+            Some(("alice".to_string(), "s3cret".to_string()))
+        );
     }
 }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -270,6 +270,47 @@ request_uri_user = "9000"
 - Digest auth on inbound INVITEs (RFC 3261 §22) is the proper
   "no trust in network" answer; it's a post-v1 feature.
 
+## `[outbound]` + `[[gateway]]` — outbound call origination (0.6.0)
+
+SiphonAI can **place** calls (not just answer them) and bridge them to a WS
+server on answer. Outbound is **disabled by default** and fail-closed: it
+turns on only when `[outbound].max_concurrent` is a positive number.
+
+```toml
+[outbound]
+max_concurrent     = 20      # 0 (default) = outbound disabled
+rate_limit_per_sec = 5       # optional new-calls/sec ceiling (token bucket)
+
+# A standalone trunk (static / IP-auth or digest):
+[[gateway]]
+name          = "twilio"
+proxy         = "siptrunk.example.com:5060"
+from          = "sip:+13125551234@siptrunk.example.com"   # caller-ID, sip: URI
+auth_username = "ACxxxx"                                   # optional digest
+auth_password = "${TWILIO_TRUNK_SECRET}"
+
+# Or dial through an existing [[register]] (reuse its server + credentials):
+[[gateway]]
+name     = "pbx-out"
+register = "pbx"            # name of a [[register]] block
+# from = "sip:..."         # optional; defaults to the register AOR
+```
+
+| Field | Block | Notes |
+|---|---|---|
+| `max_concurrent` | `[outbound]` | Max simultaneous outbound calls. `0` (default) disables outbound entirely. This + `rate_limit_per_sec` are the **native guardrails** — the originate API itself has no built-in auth (it's fronted by a reverse proxy / trusted network), so **you must restrict access to that endpoint and set a sane cap** to avoid toll fraud. |
+| `rate_limit_per_sec` | `[outbound]` | Optional ceiling on *new* outbound calls per second (token bucket, burst = the rate). `0`/unset = no rate limit. |
+| `name` | `[[gateway]]` | Unique gateway name; the originate request names one. |
+| `proxy` | `[[gateway]]` | `host` or `host:port` of the trunk (resolved per RFC 3263 at INVITE time). Required unless `register` is set. |
+| `from` | `[[gateway]]` | Default caller-ID — a full `sip:`/`sips:` URI. Required for standalone trunks; defaults to the register AOR when `register` is set. |
+| `register` | `[[gateway]]` | Name of a `[[register]]` to dial through, inheriting its server address, digest credentials, and AOR. |
+| `auth_username` / `auth_password` | `[[gateway]]` | Digest credentials for a standalone trunk (both or neither). Answered on any 401/407 challenge the trunk sends. |
+| `realm` | `[[gateway]]` | Optional digest realm hint. |
+
+All of the above is validated at config load — unknown `register` references,
+a `from` missing the `sip:` scheme, half-set credentials, duplicate names, or
+a bad `proxy` all fail loud at startup.
+
 ## `[security]` — STIR/SHAKEN call authentication
 
 Verifies the RFC 8224 `Identity` header (RFC 8225 PASSporT, SHAKEN profile)


### PR DESCRIPTION
**0.6.0 chunk 3** (`docs/DEV_PLAN_0.6.0.md` §7). The config + safety primitives for outbound origination — **no daemon trigger yet** (that's chunk 4); this lands the surface and validates it at load.

### Config — `[[gateway]]` + `[outbound]`
A **gateway** is the trunk SiphonAI dials *through*, in two forms (the §9.2 "both" decision):
- **Standalone trunk** — `proxy` + `from` (+ optional digest `auth_username`/`auth_password`).
- **`[[register]]` reuse** — `register = "<name>"` inherits the registrar's server, credentials, and AOR.

Both compile to a uniform `Gateway { proxy_host, proxy_port, from, credentials }` (proxy left unresolved — siphon-rs does RFC 3263 at INVITE time). `OutboundConfig { max_concurrent, rate_limit_per_sec, gateways }`; `enabled()` is **fail-closed** (`max_concurrent == 0` → outbound off). Loud load-time validation: unknown register ref, non-`sip:` `from`, half-set auth, duplicate names, bad proxy.

### core — credentials + guardrails
- **`StaticCredentials`** — a siphon-rs `CredentialProvider` answering any realm (one per gateway UAC), so the UAC's 401/407 auto-retry can authenticate to the trunk. (Chunk 2 noted the shared transfer UAC is credential-less — this is the fix.)
- **`OutboundGuard`** — the **native guardrails** (§9.5/§9.6; the originate API has no built-in auth, so these are the toll-fraud defense): a `max_concurrent` semaphore + an optional per-second token-bucket rate limit. `try_admit()` → a permit held for the call's lifetime (drop frees the slot) or `OutboundRejection::{AtCapacity, RateLimited}`.

### Tests / docs
Config-load validation (standalone, register-reuse, all the failure modes), the concurrency cap (admit/reject/release), the token bucket (limit + refill), and the credential provider — all unit-tested. CONFIG.md documents `[outbound]` + `[[gateway]]`. **577 tests**; clippy clean.

The daemon wires these in **chunk 4** (originate API). Base `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)