### PR TITLE
feat(protocol,core): outbound start direction + builder (chunk 4a)

### DIFF
--- a/crates/bridge/src/protocol.rs
+++ b/crates/bridge/src/protocol.rs
@@ -315,8 +315,12 @@ pub struct SipMeta {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Direction {
-    /// The only valid direction in v1.
+    /// SiphonAI answered an inbound call. The bot reacts to the caller.
     Inbound,
+    /// SiphonAI placed the call (outbound origination, 0.6.0). The bot
+    /// drives — it typically speaks first. Additive on the `start` message;
+    /// the protocol version stays `"1"`.
+    Outbound,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -524,6 +528,29 @@ mod tests {
             start.sip.headers.get("User-Agent").map(String::as_str),
             Some("Cisco-CP8841")
         );
+    }
+
+    #[test]
+    fn bridge_out_start_outbound_direction() {
+        // Outbound origination (0.6.0): `direction: "outbound"`, additive —
+        // protocol version stays "1".
+        let raw = r#"{
+          "type": "start",
+          "version": "1",
+          "call_id": "siphon-out-1",
+          "seq": 0,
+          "from": "+13125551234",
+          "to": "+15558675309",
+          "direction": "outbound",
+          "audio": { "encoding": "pcm16le", "sample_rate": 8000, "channels": 1, "frame_ms": 20 },
+          "sip": { "call_id": "out-abc@trunk.example", "headers": {} }
+        }"#;
+        let msg: BridgeOut = assert_round_trip(raw);
+        let BridgeOut::Start(start) = msg else {
+            panic!("expected Start variant");
+        };
+        assert_eq!(start.direction, Direction::Outbound);
+        assert_eq!(start.to, "+15558675309");
     }
 
     #[test]

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -1267,6 +1267,42 @@ pub fn build_start_msg(
     }
 }
 
+/// Build the WS `start` message for an **outbound** (originated) call —
+/// 0.6.0. The inbound counterpart [`build_start_msg`] reads `InviteFacts`
+/// from a received INVITE; here SiphonAI placed the call, so the
+/// gateway caller-ID (`from`), the dialed destination (`to`), and the
+/// `sip_call_id` of the dialog we created are passed in. `direction` is
+/// [`Direction::Outbound`]; there are no forwarded inbound headers, no SRTP
+/// info, and no verstat. The audio format comes from the negotiated answer.
+pub fn build_outbound_start_msg(
+    bridge_call_id: BridgeCallId,
+    from: &str,
+    to: &str,
+    sip_call_id: &str,
+    answer: &AnswerOutcome,
+) -> StartMsg {
+    StartMsg {
+        version: PROTOCOL_VERSION.to_string(),
+        call_id: bridge_call_id,
+        seq: 0,
+        from: from.to_string(),
+        to: to.to_string(),
+        direction: Direction::Outbound,
+        audio: AudioFormat {
+            encoding: AudioEncoding::Pcm16le,
+            sample_rate: answer.negotiated_audio_sample_rate,
+            channels: 1,
+            frame_ms: 20,
+        },
+        sip: SipMeta {
+            call_id: sip_call_id.to_string(),
+            headers: std::collections::HashMap::new(),
+        },
+        srtp: None,
+        verstat: None,
+    }
+}
+
 /// Produce the STIR/SHAKEN verdict for an inbound INVITE, or `None` when
 /// verification is disabled (no verifier installed). The `bool` is whether
 /// an `Identity` header was present — the caller needs it to distinguish an
@@ -3945,6 +3981,31 @@ a=sendrecv\r\n";
         assert_eq!(start.audio.frame_ms, 20);
         assert_eq!(start.sip.call_id, "abc-123@pbx");
         assert!(start.sip.headers.is_empty());
+    }
+
+    #[test]
+    fn outbound_start_msg_is_outbound_with_passed_endpoints() {
+        let answer = fake_answer();
+        let start = build_outbound_start_msg(
+            BridgeCallId::new("siphon-out-1"),
+            "+13125551234",
+            "+15558675309",
+            "out-abc@trunk.example",
+            &answer,
+        );
+        assert_eq!(start.direction, Direction::Outbound);
+        assert_eq!(start.from, "+13125551234");
+        assert_eq!(start.to, "+15558675309");
+        assert_eq!(start.sip.call_id, "out-abc@trunk.example");
+        assert_eq!(start.audio.sample_rate, 8000);
+        assert_eq!(start.version, PROTOCOL_VERSION);
+        assert_eq!(start.seq, 0);
+        assert!(start.sip.headers.is_empty());
+        assert!(start.verstat.is_none());
+        // Serializes with direction "outbound" (additive; protocol stays "1").
+        let json = serde_json::to_value(&start).expect("serialize");
+        assert_eq!(json["direction"], "outbound");
+        assert_eq!(json["version"], "1");
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -12,10 +12,10 @@ pub mod registry;
 pub mod transfer;
 
 pub use acceptor::{
-    build_bridge_config, build_start_msg, extract_offer_sdp, extract_sip_call_id, resolve_barge_in,
-    resolve_codecs, resolve_dtmf_pt, AcceptError, AcceptSecurityPolicy, BargeInConfig, BargeInMode,
-    BridgeBuildError, BridgeDefaults, BridgingAcceptor, CallIdFactory, CallProgressMode,
-    OfferError, PreparedCall, SrtpMode,
+    build_bridge_config, build_outbound_start_msg, build_start_msg, extract_offer_sdp,
+    extract_sip_call_id, resolve_barge_in, resolve_codecs, resolve_dtmf_pt, AcceptError,
+    AcceptSecurityPolicy, BargeInConfig, BargeInMode, BridgeBuildError, BridgeDefaults,
+    BridgingAcceptor, CallIdFactory, CallProgressMode, OfferError, PreparedCall, SrtpMode,
 };
 pub use call::{
     CallController, CallControllerConfig, CallError, CallHandle, CallOutcome, CallState,

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -125,12 +125,12 @@ MAY use it to detect dropped frames in their own logs.
 | `version` | string | Currently `"1"`. Strings, not numbers. |
 | `from` | string | E.164 number or SIP user; may be empty if PBX strips it. |
 | `to` | string | The dialed digits / extension / SIP user. |
-| `direction` | string | `"inbound"` only in v1. SiphonAI never originates. |
+| `direction` | string | `"inbound"` (SiphonAI answered the call) or `"outbound"` (SiphonAI placed it — outbound origination, 0.6.0). An outbound bot typically speaks first. Additive; the protocol version stays `"1"`. |
 | `audio.encoding` | string | `"pcm16le"` only in v1. |
 | `audio.sample_rate` | int | `8000` or `16000`. Set by the negotiated SIP codec. |
 | `audio.channels` | int | `1` only in v1. |
 | `audio.frame_ms` | int | `20` only in v1. |
-| `sip.call_id` | string | The SIP `Call-ID` from the inbound INVITE. |
+| `sip.call_id` | string | The SIP `Call-ID` of the call's dialog (the inbound INVITE's, or the one SiphonAI generated for an outbound call). |
 | `sip.headers` | object | Selected SIP headers, by name. The set is config-driven (`bridge.forward_headers` allowlist) — never assume any specific header is present. |
 | `srtp` | object \| absent | Present when the call's media leg was negotiated as SRTP; **absent** when the leg is plaintext `RTP/AVP` (the v0.1.0 / v0.2.0 default). Servers MUST treat absence and the v1 shape (no `srtp` key) as identical — this field was added in 0.3.0 and the protocol version stays `"1"`. |
 | `srtp.exchange` | string | `"sdes"` (RFC 4568, master key exchanged via `a=crypto:` on the SIP signalling plane) or `"dtls"` (RFC 5764 DTLS-SRTP, key derived from a DTLS handshake over the media path). |


### PR DESCRIPTION
**0.6.0 chunk 4a.** Chunk 4 (the originate API) is a big integration job, so I'm splitting it: **4a = the protocol surface + `start`-message builder** (lands reviewably on its own); **4b = the originate engine + endpoint + daemon wiring** (next).

- **protocol**: `Direction` gains `Outbound` — the §9.8 decision (additive; the WS protocol version stays `"1"`). An outbound bot drives the call (typically speaks first); `start.direction` tells it which side it's on.
- **core**: `build_outbound_start_msg(call_id, from, to, sip_call_id, answer)` — the outbound counterpart to `build_start_msg`. There's no inbound INVITE, so the gateway caller-ID (`from`), dialed destination (`to`), and the generated SIP Call-ID are passed in; `direction = Outbound`, no forwarded headers / SRTP info / verstat; audio from the negotiated answer.
- **docs**: PROTOCOL.md `direction` (+ `sip.call_id`) now describe both directions. A `direction: "outbound"` round-trip test (CLAUDE.md §4.2) + a builder test.

No dead code — the builder constructs `Direction::Outbound` and is tested. **579 tests**; clippy clean. Base `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)