### PR TITLE
feat(core,telemetry,bin): outbound originate API + service (chunk 4b)

### DIFF
--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -46,6 +46,7 @@
 //! - HEP / Homer (depends on the upstream `hep-rs` crate).
 //! - Admin endpoints (dynamic log level, force-hangup).
 
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -73,14 +74,17 @@ use siphon_ai_config::{
     CdrConfig, CdrFileConfig, CdrWebhookConfig, Config, HepConfig, MediaConfig, NodeConfig,
     ObservabilityConfig, SipConfig, SipTlsConfig, SipTransport, WebhooksConfig,
 };
-use siphon_ai_core::{BridgingAcceptor, CallRegistry};
+use siphon_ai_core::{
+    default_call_id_factory, BridgingAcceptor, CallRegistry, OutboundGateway, OutboundGuard,
+    OutboundOriginator, OutboundService, StaticCredentials,
+};
 use siphon_ai_media_glue::MediaSetup;
 use siphon_ai_sip_glue::{
     DialogTerminatorHandle, RegisterSourceResolver, RegistrationEntry, RegistrationManager,
     RoutingHandler,
 };
 use siphon_ai_telemetry::{
-    admin::{AdminCallRegistry, AdminState, CallRegistryHandle, RegistrationRow},
+    admin::{AdminCallRegistry, AdminOutbound, AdminState, CallRegistryHandle, RegistrationRow},
     install_recorder, HepTelemetry, HepTelemetryBuild, HepWorkerHandle, LogFilterHandle,
     ObservabilityServer, ReadinessFlag,
 };
@@ -142,10 +146,7 @@ impl Runtime {
             trunks,
             security,
             recording,
-            // Outbound gateways + guardrails are validated at config load
-            // (compile_outbound); the daemon wires them in the originate-API
-            // chunk. Bound-but-unused until then.
-            outbound: _outbound,
+            outbound,
             cdr,
             observability,
             webhooks,
@@ -248,6 +249,13 @@ impl Runtime {
             min_attestation_response: security.min_attestation_response,
             require_identity: security.stir_shaken.require_identity,
         };
+
+        // The acceptor consumes `media_setup` + `bridge_defaults`; the
+        // outbound service (built below) needs them too. Cheap clones (all
+        // Arc / already-cloneable). Used only in the `[outbound]`-enabled
+        // branch, so harmless when outbound is off.
+        let outbound_media = Arc::clone(&media_setup);
+        let outbound_bridge_defaults = bridge_defaults.clone();
 
         let acceptor = Arc::new(
             BridgingAcceptor::new(media_setup, bridge_defaults, registry.clone())
@@ -445,6 +453,59 @@ impl Runtime {
             tls_server_config,
         );
 
+        // ─── Outbound origination service (0.6.0) ──────────────────
+        // One authenticated UAC + originator per `[[gateway]]`, then the
+        // daemon-wide service the `POST /admin/v1/calls` endpoint drives.
+        // Only when `[outbound]` is enabled (a positive concurrency cap);
+        // otherwise the endpoint returns 501. The originate endpoint has no
+        // built-in auth — the cap + rate limit are the native guardrails
+        // (DEV_PLAN_0.6.0 §9.5/§9.6).
+        let outbound_handle: Option<AdminOutbound> = if outbound.enabled() {
+            let mut gateways = HashMap::with_capacity(outbound.gateways.len());
+            for gw in &outbound.gateways {
+                let uac = build_outbound_uac(
+                    TransferUacBuild {
+                        local_uri: &local_uri,
+                        contact_uri: &contact_uri,
+                        listen_addr: sip.listen_addr,
+                        public_addr: sip_public_addr(&node, &sip),
+                        transaction_mgr: Arc::clone(&transaction_mgr),
+                        dispatcher: Arc::clone(&dispatcher),
+                        sip_resolver: Arc::clone(&sip_resolver),
+                    },
+                    gw.credentials.as_ref(),
+                )?;
+                let originator = Arc::new(OutboundOriginator::new(
+                    (*outbound_media).clone(),
+                    Arc::new(uac),
+                ));
+                gateways.insert(
+                    gw.name.clone(),
+                    OutboundGateway {
+                        originator,
+                        proxy_host: gw.proxy_host.clone(),
+                        proxy_port: gw.proxy_port,
+                        from: gw.from.clone(),
+                    },
+                );
+            }
+            let guard = OutboundGuard::new(outbound.max_concurrent, outbound.rate_limit_per_sec);
+            let service = OutboundService::new(
+                gateways,
+                guard,
+                outbound_bridge_defaults,
+                default_call_id_factory(),
+            );
+            info!(
+                gateways = outbound.gateways.len(),
+                max_concurrent = outbound.max_concurrent,
+                "outbound origination enabled"
+            );
+            Some(Arc::new(service) as AdminOutbound)
+        } else {
+            None
+        };
+
         // ─── Build admin state + observability HTTP listener ──────
         // Deferred until now so admin endpoints have the call
         // registry, registration manager, hep telemetry, and log-
@@ -466,6 +527,7 @@ impl Runtime {
             })),
             log_filter: Some(log_filter),
             hep: hep_telemetry.clone(),
+            outbound: outbound_handle,
         };
         let observability_server = build_observability(
             observability,
@@ -1039,6 +1101,39 @@ fn build_transfer_uac(args: TransferUacBuild<'_>) -> Result<IntegratedUAC> {
     builder
         .build()
         .map_err(|e| anyhow!("transfer UAC build: {e}"))
+}
+
+/// Build a per-gateway outbound UAC. Same shape as [`build_transfer_uac`],
+/// but — unlike REFER, which inherits the dialog's auth — an originated
+/// INVITE may be challenged (401/407) by the trunk, so when the gateway has
+/// credentials we install a [`StaticCredentials`] provider for the UAC's
+/// auto-retry. One UAC per gateway keeps each trunk's credentials isolated.
+fn build_outbound_uac(
+    args: TransferUacBuild<'_>,
+    credentials: Option<&siphon_ai_config::GatewayCredentials>,
+) -> Result<IntegratedUAC> {
+    let mut builder = IntegratedUAC::builder()
+        .local_uri(args.local_uri)
+        .contact_uri(args.contact_uri)
+        .transaction_manager(args.transaction_mgr)
+        .dispatcher(args.dispatcher)
+        .resolver(args.sip_resolver)
+        .local_addr(args.listen_addr.to_string())
+        .map_err(|e| anyhow!("outbound UAC local_addr: {e}"))?;
+    if let Some(public) = args.public_addr {
+        builder = builder
+            .public_addr(public.to_string())
+            .map_err(|e| anyhow!("outbound UAC public_addr: {e}"))?;
+    }
+    if let Some(creds) = credentials {
+        builder = builder.credential_provider(Arc::new(StaticCredentials::new(
+            creds.username.clone(),
+            creds.password.clone(),
+        )));
+    }
+    builder
+        .build()
+        .map_err(|e| anyhow!("outbound UAC build: {e}"))
 }
 
 fn rtp_port_pool(media: &MediaConfig) -> Result<PortPoolConfig> {

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -1206,7 +1206,7 @@ fn attach_sdp_body(response: Response, sdp: &str) -> Response {
     Response::new(start, headers, bytes.into()).expect("valid response with SDP body")
 }
 
-fn barge_in_to_tap_action(cfg: &BargeInConfig) -> siphon_ai_media_glue::BargeInAction {
+pub(crate) fn barge_in_to_tap_action(cfg: &BargeInConfig) -> siphon_ai_media_glue::BargeInAction {
     if !cfg.enabled {
         return siphon_ai_media_glue::BargeInAction::Notify;
     }
@@ -1366,7 +1366,10 @@ fn canonical_header_name(name: &str) -> String {
 /// uses a v4 UUID prefixed with `siphon-`.
 pub type CallIdFactory = Arc<dyn Fn() -> BridgeCallId + Send + Sync>;
 
-fn default_call_id_factory() -> CallIdFactory {
+/// The default per-call bridge-id generator (`siphon-<uuid>`). Shared by the
+/// inbound acceptor and the outbound service so call ids look the same
+/// regardless of direction.
+pub fn default_call_id_factory() -> CallIdFactory {
     Arc::new(|| BridgeCallId::new(format!("siphon-{}", Uuid::new_v4().simple())))
 }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -8,14 +8,16 @@
 pub mod acceptor;
 pub mod call;
 pub mod outbound;
+pub mod outbound_service;
 pub mod registry;
 pub mod transfer;
 
 pub use acceptor::{
-    build_bridge_config, build_outbound_start_msg, build_start_msg, extract_offer_sdp,
-    extract_sip_call_id, resolve_barge_in, resolve_codecs, resolve_dtmf_pt, AcceptError,
-    AcceptSecurityPolicy, BargeInConfig, BargeInMode, BridgeBuildError, BridgeDefaults,
-    BridgingAcceptor, CallIdFactory, CallProgressMode, OfferError, PreparedCall, SrtpMode,
+    build_bridge_config, build_outbound_start_msg, build_start_msg, default_call_id_factory,
+    extract_offer_sdp, extract_sip_call_id, resolve_barge_in, resolve_codecs, resolve_dtmf_pt,
+    AcceptError, AcceptSecurityPolicy, BargeInConfig, BargeInMode, BridgeBuildError,
+    BridgeDefaults, BridgingAcceptor, CallIdFactory, CallProgressMode, OfferError, PreparedCall,
+    SrtpMode,
 };
 pub use call::{
     CallController, CallControllerConfig, CallError, CallHandle, CallOutcome, CallState,
@@ -25,5 +27,6 @@ pub use outbound::{
     NotAnsweredCause, OutboundCall, OutboundError, OutboundGuard, OutboundOriginator,
     OutboundPermit, OutboundRejection, StaticCredentials,
 };
+pub use outbound_service::{OutboundGateway, OutboundService};
 pub use registry::{CallEntry, CallRegistry};
 pub use transfer::{TransferContext, TransferOutcome};

--- a/crates/core/src/outbound.rs
+++ b/crates/core/src/outbound.rs
@@ -50,6 +50,9 @@ pub struct OutboundCall {
     pub dialog: Dialog,
     /// The live INVITE handle (keepalives / session timer / `cancel`).
     pub call_handle: CallHandle,
+    /// The forge session / bridge call id, for tearing the media session
+    /// down at the end of the call.
+    pub call_id: CallId,
 }
 
 impl std::fmt::Debug for OutboundCall {
@@ -124,7 +127,7 @@ impl OutboundOriginator {
         {
             Ok(h) => h,
             Err(e) => {
-                self.rollback(&call_id).await;
+                self.stop_session(&call_id).await;
                 return Err(OutboundError::Transport(e.to_string()));
             }
         };
@@ -134,7 +137,7 @@ impl OutboundOriginator {
         let response = match handle.await_final().await {
             Ok(r) => r,
             Err(e) => {
-                self.rollback(&call_id).await;
+                self.stop_session(&call_id).await;
                 return Err(OutboundError::Transport(e.to_string()));
             }
         };
@@ -143,7 +146,7 @@ impl OutboundOriginator {
         if !(200..300).contains(&code) {
             let cause = classify_failure(code, response.reason());
             debug!(code, ?cause, "outbound INVITE not answered");
-            self.rollback(&call_id).await;
+            self.stop_session(&call_id).await;
             return Err(OutboundError::NotAnswered(cause));
         }
 
@@ -158,21 +161,24 @@ impl OutboundOriginator {
             accepted,
             dialog,
             call_handle: handle,
+            call_id,
         })
     }
 
-    /// End an established outbound call by sending BYE on its dialog. The
-    /// daemon calls this after the `CallController` returns. Best-effort —
-    /// a BYE failure is logged, not propagated (the call is over either way).
-    pub async fn hangup(&self, call: &OutboundCall) {
-        if let Err(e) = self.uac.bye(&call.dialog).await {
+    /// Send BYE on an established call's dialog. The daemon calls this after
+    /// the `CallController` returns. Best-effort — a BYE failure is logged,
+    /// not propagated (the call is over either way).
+    pub async fn hangup(&self, dialog: &Dialog) {
+        if let Err(e) = self.uac.bye(dialog).await {
             warn!(error = %e, "outbound BYE failed");
         }
     }
 
-    async fn rollback(&self, call_id: &CallId) {
+    /// Tear down the call's forge media session. Used both to roll back a
+    /// failed origination and to clean up after a completed call.
+    pub async fn stop_session(&self, call_id: &CallId) {
         if let Err(e) = self.media.session_manager().stop_session(call_id).await {
-            warn!(call_id = %call_id, error = %e, "outbound session rollback failed");
+            warn!(call_id = %call_id, error = %e, "outbound session teardown failed");
         }
     }
 }

--- a/crates/core/src/outbound_service.rs
+++ b/crates/core/src/outbound_service.rs
@@ -1,0 +1,179 @@
+//! Outbound origination service — the daemon entry point for placing calls.
+//!
+//! Wires chunks 1-3 together: validate the request against the configured
+//! gateways + guardrails, then place the call ([`OutboundOriginator::place`]),
+//! run its audio bridge ([`CallController`]), and tear it down (BYE + stop the
+//! media session). Implements [`OutboundOriginateHandle`] so the admin
+//! `POST /admin/v1/calls` endpoint drives it.
+//!
+//! The originate call returns immediately with the bridge `call_id` (202) —
+//! the call proceeds on a spawned task. Its progress (ringing / answered /
+//! failed) surfaces via webhooks + the CDR in chunk 5. The concurrency permit
+//! from the guard is held for the spawned task's lifetime, so it's released
+//! exactly when the call ends.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use forge_core::{CallId, ParticipantId};
+use sip_core::SipUri;
+use siphon_ai_bridge::{BridgeConfig, CallId as BridgeCallId};
+use siphon_ai_media_glue::{OutboundOfferRequest, TapOptions};
+use siphon_ai_telemetry::{OriginateRejection, OriginateRequest, OutboundOriginateHandle};
+use tracing::{info, warn};
+
+use crate::acceptor::{
+    barge_in_to_tap_action, build_outbound_start_msg, BridgeDefaults, CallIdFactory,
+};
+use crate::call::{CallController, CallControllerConfig};
+use crate::outbound::{OutboundCall, OutboundGuard, OutboundOriginator, OutboundRejection};
+
+/// One configured outbound gateway, ready to dial. Built by the daemon from a
+/// compiled `[[gateway]]` (the `siphon-ai-config::Gateway`) plus a per-gateway
+/// UAC-backed [`OutboundOriginator`]. Kept as plain fields so this crate
+/// doesn't take a (cyclic) dependency on `siphon-ai-config`.
+pub struct OutboundGateway {
+    pub originator: Arc<OutboundOriginator>,
+    pub proxy_host: String,
+    pub proxy_port: u16,
+    /// Default caller-ID `sip:` URI for calls through this gateway.
+    pub from: String,
+}
+
+/// Daemon-wide outbound-origination service.
+pub struct OutboundService {
+    gateways: HashMap<String, OutboundGateway>,
+    guard: OutboundGuard,
+    defaults: BridgeDefaults,
+    call_id_factory: CallIdFactory,
+}
+
+impl OutboundService {
+    pub fn new(
+        gateways: HashMap<String, OutboundGateway>,
+        guard: OutboundGuard,
+        defaults: BridgeDefaults,
+        call_id_factory: CallIdFactory,
+    ) -> Self {
+        Self {
+            gateways,
+            guard,
+            defaults,
+            call_id_factory,
+        }
+    }
+}
+
+impl OutboundOriginateHandle for OutboundService {
+    fn originate(&self, req: OriginateRequest) -> Result<String, OriginateRejection> {
+        let gw = self
+            .gateways
+            .get(&req.gateway)
+            .ok_or_else(|| OriginateRejection::UnknownGateway(req.gateway.clone()))?;
+
+        // Cheap validation before we consume a concurrency permit.
+        let ws_url = req
+            .ws_url
+            .clone()
+            .or_else(|| self.defaults.ws_url.clone())
+            .filter(|s| !s.is_empty())
+            .ok_or(OriginateRejection::NoWsUrl)?;
+
+        let target_str = format!("sip:{}@{}:{}", req.to, gw.proxy_host, gw.proxy_port);
+        let target = SipUri::parse(&target_str)
+            .map_err(|e| OriginateRejection::BadTarget(format!("{target_str}: {e}")))?;
+
+        // Admit — the permit lives for the spawned call's whole lifetime.
+        let permit = self.guard.try_admit().map_err(|r| match r {
+            OutboundRejection::AtCapacity => OriginateRejection::AtCapacity,
+            OutboundRejection::RateLimited => OriginateRejection::RateLimited,
+        })?;
+
+        let bridge_id = (self.call_id_factory)();
+        let bridge_id_str = bridge_id.as_str().to_string();
+        let forge_id = CallId::new(bridge_id.as_str());
+
+        let offer_req = OutboundOfferRequest {
+            call_id: forge_id,
+            codecs: self.defaults.codecs.clone(),
+            dtmf_payload_type: self.defaults.dtmf_payload_type,
+            participant_a: ParticipantId::generate(),
+            participant_b: ParticipantId::generate(),
+            from_tag: None,
+            to_tag: None,
+        };
+        let tap = TapOptions {
+            barge_in_action: barge_in_to_tap_action(&self.defaults.barge_in),
+            inactivity_timeout: self.defaults.inactivity_timeout,
+            silence_threshold: self.defaults.silence_threshold,
+            dead_air_threshold: self.defaults.dead_air_threshold,
+            rtp_stats_interval: self.defaults.rtp_stats_interval,
+        };
+        let bridge = BridgeConfig {
+            ws_url,
+            auth_header: self.defaults.auth_header.clone(),
+            connect_timeout: self.defaults.connect_timeout,
+            tls: self.defaults.bridge_tls.clone(),
+        };
+        let from = req.from.clone().unwrap_or_else(|| gw.from.clone());
+        let to = req.to.clone();
+        let originator = Arc::clone(&gw.originator);
+
+        info!(call_id = %bridge_id_str, gateway = %req.gateway, "originating outbound call");
+        let log_id = bridge_id_str.clone();
+        tokio::spawn(async move {
+            let _permit = permit; // held until the call ends, then released
+            match originator.place(target, offer_req, tap).await {
+                Ok(call) => run_call(originator, call, bridge_id, bridge, from, to).await,
+                Err(e) => warn!(call_id = %log_id, error = %e, "outbound call did not connect"),
+            }
+        });
+
+        Ok(bridge_id_str)
+    }
+}
+
+/// Run an answered outbound call's audio bridge to completion, then tear it
+/// down (BYE the dialog + stop the media session).
+async fn run_call(
+    originator: Arc<OutboundOriginator>,
+    call: OutboundCall,
+    bridge_id: BridgeCallId,
+    bridge: BridgeConfig,
+    from: String,
+    to: String,
+) {
+    let OutboundCall {
+        accepted,
+        dialog,
+        call_handle,
+        call_id,
+    } = call;
+    let sip_call_id = dialog.id().call_id().to_string();
+    let start = build_outbound_start_msg(
+        bridge_id.clone(),
+        &from,
+        &to,
+        &sip_call_id,
+        &accepted.answer,
+    );
+    let cfg = CallControllerConfig {
+        call_id: bridge_id,
+        bridge,
+        start,
+        media_tap: accepted.tap,
+        transfer: None,
+        recording: None,
+    };
+    let (controller, _handle) = CallController::new(cfg);
+    match controller.run().await {
+        Ok(o) => {
+            info!(sip_call_id = %sip_call_id, termination = ?o.termination, "outbound call ended")
+        }
+        Err(e) => warn!(sip_call_id = %sip_call_id, error = %e, "outbound controller error"),
+    }
+    // The controller's done — BYE the dialog and release the media session.
+    originator.hangup(&dialog).await;
+    originator.stop_session(&call_id).await;
+    drop(call_handle); // stop keepalives / session-timer tasks
+}

--- a/crates/telemetry/src/admin.rs
+++ b/crates/telemetry/src/admin.rs
@@ -14,6 +14,7 @@
 //! | GET    | `/admin/log`                  | Current `tracing` filter directive   |
 //! | PUT    | `/admin/log`                  | Replace the filter (body = directive)|
 //! | POST   | `/admin/hep/test`             | Emit a probe HEP log packet          |
+//! | POST   | `/admin/v1/calls`             | Originate an outbound call (0.6.0)    |
 //!
 //! ## Threat model
 //!
@@ -38,7 +39,7 @@ use http_body_util::Full;
 use hyper::body::Bytes;
 use hyper::header::CONTENT_TYPE;
 use hyper::{Response, StatusCode};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::log_filter::LogFilterHandle;
@@ -53,6 +54,9 @@ pub struct AdminState {
     pub registration_snapshot: Option<RegistrationSnapshotFn>,
     pub log_filter: Option<LogFilterHandle>,
     pub hep: Option<Arc<HepTelemetry>>,
+    /// Outbound-origination handle (0.6.0). `None` when `[outbound]` is
+    /// disabled — `POST /admin/v1/calls` then returns 501.
+    pub outbound: Option<AdminOutbound>,
 }
 
 /// Minimal trait surface the admin endpoints need on the call
@@ -73,6 +77,50 @@ pub type AdminCallRegistry = Arc<dyn CallRegistryHandle>;
 /// admin request. Same indirection rationale as `CallRegistryHandle`
 /// — keeps `siphon-ai-sip-glue` out of the telemetry crate's deps.
 pub type RegistrationSnapshotFn = Arc<dyn Fn() -> Vec<RegistrationRow> + Send + Sync>;
+
+/// `POST /admin/v1/calls` request body — originate an outbound call (0.6.0).
+#[derive(Debug, Clone, Deserialize)]
+pub struct OriginateRequest {
+    /// Dialed destination (E.164 number or SIP user) — becomes the
+    /// Request-URI user dialed through the gateway.
+    pub to: String,
+    /// Name of the `[[gateway]]` (or `[[register]]` reuse) to dial through.
+    pub gateway: String,
+    /// WS server to bridge the answered call to. Falls back to
+    /// `[bridge].ws_url` when omitted.
+    #[serde(default)]
+    pub ws_url: Option<String>,
+    /// Caller-ID override (a `sip:` URI). Falls back to the gateway's `from`.
+    #[serde(default)]
+    pub from: Option<String>,
+}
+
+/// Why an originate request was refused synchronously (before the call is
+/// placed). The admin layer maps each to an HTTP status.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OriginateRejection {
+    /// No `[[gateway]]` with that name → 404.
+    UnknownGateway(String),
+    /// No `ws_url` and no `[bridge].ws_url` default → 400.
+    NoWsUrl,
+    /// The dialed destination didn't form a valid SIP URI → 400.
+    BadTarget(String),
+    /// `max_concurrent_outbound` reached → 503.
+    AtCapacity,
+    /// The per-second outbound rate limit was exceeded → 429.
+    RateLimited,
+}
+
+/// The outbound-origination entry point the admin endpoint calls. Defined
+/// here (not in `siphon-ai-core`) to avoid a dep cycle — `siphon-ai-core`
+/// implements it. Synchronous: it validates + admits + kicks off the call,
+/// returning the bridge `call_id` immediately (the call proceeds async).
+pub trait OutboundOriginateHandle: Send + Sync + 'static {
+    fn originate(&self, req: OriginateRequest) -> Result<String, OriginateRejection>;
+}
+
+/// Boxed handle the runtime installs into [`AdminState`].
+pub type AdminOutbound = Arc<dyn OutboundOriginateHandle>;
 
 /// One row of the `GET /admin/registrations` response. Mirrors
 /// `sip_glue::RegistrationState` but defined here so telemetry
@@ -108,6 +156,7 @@ pub async fn dispatch(
         (&hyper::Method::GET, "/admin/log") => get_log_filter(state),
         (&hyper::Method::PUT, "/admin/log") => set_log_filter(state, &body),
         (&hyper::Method::POST, "/admin/hep/test") => hep_test(state),
+        (&hyper::Method::POST, "/admin/v1/calls") => originate_call(state, &body),
         (m, p)
             if m == hyper::Method::POST
                 && p.starts_with("/admin/calls/")
@@ -244,6 +293,50 @@ fn hep_test(state: &AdminState) -> Response<Full<Bytes>> {
             "hint": "look for a chunk-type 100 log packet at the collector",
         }),
     )
+}
+
+fn originate_call(state: &AdminState, body: &Bytes) -> Response<Full<Bytes>> {
+    let Some(svc) = state.outbound.as_ref() else {
+        return json_response(
+            StatusCode::NOT_IMPLEMENTED,
+            &json!({ "error": "outbound origination not enabled ([outbound].max_concurrent = 0)" }),
+        );
+    };
+    let req: OriginateRequest = match serde_json::from_slice(body) {
+        Ok(r) => r,
+        Err(e) => {
+            return json_response(
+                StatusCode::BAD_REQUEST,
+                &json!({ "error": format!("invalid originate request: {e}") }),
+            )
+        }
+    };
+    match svc.originate(req) {
+        Ok(call_id) => json_response(StatusCode::ACCEPTED, &json!({ "call_id": call_id })),
+        Err(rej) => {
+            let (status, msg) = match rej {
+                OriginateRejection::UnknownGateway(g) => {
+                    (StatusCode::NOT_FOUND, format!("unknown gateway: {g}"))
+                }
+                OriginateRejection::NoWsUrl => (
+                    StatusCode::BAD_REQUEST,
+                    "no ws_url (and no [bridge].ws_url default)".to_string(),
+                ),
+                OriginateRejection::BadTarget(t) => {
+                    (StatusCode::BAD_REQUEST, format!("bad target: {t}"))
+                }
+                OriginateRejection::AtCapacity => (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "max_concurrent_outbound reached".to_string(),
+                ),
+                OriginateRejection::RateLimited => (
+                    StatusCode::TOO_MANY_REQUESTS,
+                    "outbound rate limit exceeded".to_string(),
+                ),
+            };
+            json_response(status, &json!({ "error": msg }))
+        }
+    }
 }
 
 // ─── Helpers ───────────────────────────────────────────────────────
@@ -420,5 +513,82 @@ mod tests {
     #[test]
     fn parse_filter_body_rejects_whitespace_only() {
         assert!(parse_filter_body(&Bytes::from_static(b"   \n   ")).is_err());
+    }
+
+    // ─── POST /admin/v1/calls (originate) ────────────────────────────
+
+    struct StubOutbound(Result<String, OriginateRejection>);
+    impl OutboundOriginateHandle for StubOutbound {
+        fn originate(&self, _req: OriginateRequest) -> Result<String, OriginateRejection> {
+            self.0.clone()
+        }
+    }
+
+    fn outbound_state(result: Result<String, OriginateRejection>) -> AdminState {
+        AdminState {
+            outbound: Some(Arc::new(StubOutbound(result)) as AdminOutbound),
+            ..AdminState::default()
+        }
+    }
+
+    async fn originate(state: &AdminState, body: &str) -> StatusCode {
+        dispatch(
+            &hyper::Method::POST,
+            "/admin/v1/calls",
+            Bytes::from(body.to_string()),
+            state,
+        )
+        .await
+        .expect("admin dispatch")
+        .status()
+    }
+
+    const GOOD_BODY: &str = r#"{"to":"+15558675309","gateway":"trunk"}"#;
+
+    #[tokio::test]
+    async fn originate_accepts_returns_202() {
+        let state = outbound_state(Ok("siphon-abc".into()));
+        assert_eq!(originate(&state, GOOD_BODY).await, StatusCode::ACCEPTED);
+    }
+
+    #[tokio::test]
+    async fn originate_501_when_outbound_disabled() {
+        // No outbound handle installed → 501.
+        assert_eq!(
+            originate(&empty_state(), GOOD_BODY).await,
+            StatusCode::NOT_IMPLEMENTED
+        );
+    }
+
+    #[tokio::test]
+    async fn originate_400_on_bad_json() {
+        let state = outbound_state(Ok("x".into()));
+        assert_eq!(originate(&state, "not json").await, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn originate_maps_rejections_to_status() {
+        for (rej, status) in [
+            (
+                OriginateRejection::UnknownGateway("g".into()),
+                StatusCode::NOT_FOUND,
+            ),
+            (OriginateRejection::NoWsUrl, StatusCode::BAD_REQUEST),
+            (
+                OriginateRejection::BadTarget("x".into()),
+                StatusCode::BAD_REQUEST,
+            ),
+            (
+                OriginateRejection::AtCapacity,
+                StatusCode::SERVICE_UNAVAILABLE,
+            ),
+            (
+                OriginateRejection::RateLimited,
+                StatusCode::TOO_MANY_REQUESTS,
+            ),
+        ] {
+            let state = outbound_state(Err(rej.clone()));
+            assert_eq!(originate(&state, GOOD_BODY).await, status, "{rej:?}");
+        }
     }
 }

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -26,7 +26,10 @@ pub mod log_filter;
 pub mod metrics;
 pub mod readiness;
 
-pub use admin::{AdminCallRegistry, AdminState, CallRegistryHandle, RegistrationRow};
+pub use admin::{
+    AdminCallRegistry, AdminOutbound, AdminState, CallRegistryHandle, OriginateRejection,
+    OriginateRequest, OutboundOriginateHandle, RegistrationRow,
+};
 pub use hep::{HepBuildError, HepTelemetry, HepTelemetryBuild, HepWorkerHandle};
 pub use http::ObservabilityServer;
 pub use log_filter::{LogFilterError, LogFilterHandle};

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -308,6 +308,36 @@ the listener on a private network.
 | GET    | `/admin/registrations`        | —               | Snapshot of every `[[register]]` row and its current state. |
 | GET    | `/admin/log`                  | —               | Current `tracing` filter directive. |
 | PUT    | `/admin/log`                  | text directive  | Replace the filter (e.g., `siphon_ai=info,siphon_ai_bridge=debug`). Returns the previous filter. |
+| POST   | `/admin/v1/calls`             | JSON (below)    | **Originate an outbound call** (0.6.0). Returns `202 {"call_id": "..."}`; the call proceeds asynchronously. `501` when `[outbound]` is disabled. |
+
+### `POST /admin/v1/calls` — outbound origination
+
+Requires `[outbound].max_concurrent > 0` and at least one `[[gateway]]` (see
+`docs/CONFIG.md`). **This endpoint places billable calls and has no built-in
+auth** — restrict access to it (bind to a private network / front with an
+authenticating reverse proxy). The `max_concurrent` cap + `rate_limit_per_sec`
+are the native guardrails.
+
+```sh
+curl -X POST http://localhost:9091/admin/v1/calls -d '{
+  "to": "+15558675309",
+  "gateway": "twilio",
+  "ws_url": "wss://my-bot.example/outbound"
+}'
+# → 202 {"call_id":"siphon-…"}
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `to` | yes | Dialed destination (E.164 / SIP user) — the Request-URI user dialed through the gateway. |
+| `gateway` | yes | Name of a `[[gateway]]`. `404` if unknown. |
+| `ws_url` | no | WS server to bridge the answered call to. Falls back to `[bridge].ws_url`; `400` if neither is set. |
+| `from` | no | Caller-ID override (`sip:` URI). Falls back to the gateway's `from`. |
+
+Responses: `202` (accepted — placing), `404` (unknown gateway), `400` (bad
+target / no ws_url / invalid JSON), `503` (`max_concurrent` reached), `429`
+(rate limited), `501` (outbound disabled). The call's progress (ringing /
+answered / failed) is reported via webhooks + the CDR (chunk 5).
 
 Example: bump bridge logging to debug for an incident, then revert.
 


### PR DESCRIPTION
**0.6.0 chunk 4b** — the integration crescendo. SiphonAI now **places** calls: `POST /admin/v1/calls` → it dials a gateway, bridges the answered call to a WS server, and tears it down. (4a was the protocol surface; this is the engine + endpoint + daemon wiring.)

### core — `OutboundService`
Implements a **sync** `OutboundOriginateHandle`: validate gateway → `guard.try_admit()` → spawn `OutboundOriginator::place()` → run a `CallController` → teardown (BYE + `stop_session`). Returns the bridge `call_id` immediately; the call proceeds on a spawned task and the guard permit is held for its lifetime. `OutboundGateway` carries the per-gateway originator + dial params (no cyclic `config` dep). `OutboundCall` gains `call_id`; `hangup` takes a `&Dialog`; `stop_session` is public; `default_call_id_factory` + `barge_in_to_tap_action` are reused from the inbound path.

### telemetry — the endpoint
`OutboundOriginateHandle` trait + `OriginateRequest`/`OriginateRejection` + `AdminState.outbound`, and the `POST /admin/v1/calls` handler (202 + `call_id`; 404/400/429/503/501). Same core-free trait pattern as the call registry. **No native auth** — the cap + rate limit are the guardrails; restrict the endpoint (§9.5/§9.6).

### runtime — wiring
Build one **authenticated UAC per `[[gateway]]`** (`StaticCredentials` when it has creds) → `OutboundOriginator` → `OutboundService`, installed into `AdminState` when `[outbound]` is enabled.

### Verification
- **End-to-end (local daemon)**: valid originate → **202 + call_id** (the background `place()` attempts the INVITE and cleans up the session on failure); unknown gateway → **404**; bad JSON → **400**. Daemon logs `outbound origination enabled` + `originating outbound call`.
- Endpoint dispatch unit tests (202 / 404 / 400 / 429 / 503 / 501). **583 tests**; clippy clean. DEPLOY.md documents the endpoint.
- The live SIP **answer path** (a peer actually answering our INVITE) is the chunk-6 SIPp scenario (SIPp as UAS).

This completes the originate API. Base `main`. Chunk 5 (observability — CDR `direction=outbound`, call-progress webhooks, metric) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)