### PR TITLE
feat(cdr,webhooks,core): outbound CDR + call-progress webhooks (chunk 5b)

### DIFF
--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -250,12 +250,14 @@ impl Runtime {
             require_identity: security.stir_shaken.require_identity,
         };
 
-        // The acceptor consumes `media_setup` + `bridge_defaults`; the
-        // outbound service (built below) needs them too. Cheap clones (all
-        // Arc / already-cloneable). Used only in the `[outbound]`-enabled
-        // branch, so harmless when outbound is off.
+        // The acceptor consumes `media_setup` + `bridge_defaults` + the CDR
+        // and webhook sinks; the outbound service (built below) needs them
+        // too. Cheap clones (all Arc / already-cloneable). Used only in the
+        // `[outbound]`-enabled branch, so harmless when outbound is off.
         let outbound_media = Arc::clone(&media_setup);
         let outbound_bridge_defaults = bridge_defaults.clone();
+        let outbound_cdr_sink = Arc::clone(&cdr_sink);
+        let outbound_webhook_sink = Arc::clone(&webhook_sink);
 
         let acceptor = Arc::new(
             BridgingAcceptor::new(media_setup, bridge_defaults, registry.clone())
@@ -495,6 +497,8 @@ impl Runtime {
                 guard,
                 outbound_bridge_defaults,
                 default_call_id_factory(),
+                outbound_cdr_sink,
+                outbound_webhook_sink,
             );
             info!(
                 gateways = outbound.gateways.len(),

--- a/crates/cdr/src/schema.rs
+++ b/crates/cdr/src/schema.rs
@@ -55,7 +55,8 @@ pub struct CdrRecord {
 
     /// Name of the matched `[[route]]` block (or `"unmatched"` if
     /// the route table didn't match — we don't currently emit CDRs
-    /// for those, but reserved).
+    /// for those, but reserved). For outbound calls this is the
+    /// `[[gateway]]` name the call was placed through.
     pub route: String,
     /// WebSocket URL the bridge connected to.
     pub ws_url: String,
@@ -90,9 +91,13 @@ pub struct CdrRecord {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Direction {
-    /// The only direction in v1; reserved for symmetry with future
-    /// outbound originated calls.
+    /// SiphonAI answered the call (trunk INVITE or registered line).
     Inbound,
+    /// SiphonAI placed the call (`POST /admin/v1/calls` through a
+    /// gateway). The field was reserved for this since v1, so the
+    /// schema version stays 1 (0.6.0 plan §9.4). For outbound CDRs
+    /// `route` carries the gateway name instead of a `[[route]]` name.
+    Outbound,
 }
 
 /// Audio metadata from the negotiated SDP answer. The wire-side
@@ -205,6 +210,22 @@ mod tests {
     fn direction_uses_snake_case_on_wire() {
         let v = serde_json::to_value(Direction::Inbound).unwrap();
         assert_eq!(v, serde_json::json!("inbound"));
+        let v = serde_json::to_value(Direction::Outbound).unwrap();
+        assert_eq!(v, serde_json::json!("outbound"));
+    }
+
+    #[test]
+    fn outbound_direction_is_additive_and_stays_at_v1() {
+        // §9.4: `direction` was reserved for outbound since v1, so an
+        // outbound CDR parses under the same schema version.
+        let mut rec = sample();
+        rec.direction = Direction::Outbound;
+        rec.route = "twilio_main".into(); // gateway name, not a route
+        let v: serde_json::Value = serde_json::to_value(&rec).unwrap();
+        assert_eq!(v["direction"], serde_json::json!("outbound"));
+        assert_eq!(v["version"], serde_json::json!(1));
+        let back: CdrRecord = serde_json::from_value(v).unwrap();
+        assert_eq!(back.direction, Direction::Outbound);
     }
 
     #[test]

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -1785,17 +1785,19 @@ impl CallStart {
 
 /// Flat view of `Result<CallOutcome, CallError>` for the CDR layer:
 /// just the cause + the human strings from the sub-task results.
-struct CallTerminationView {
-    cause: CdrTerminationCause,
-    bridge_detail: String,
-    tap_detail: String,
+/// `pub(crate)` so the outbound service's CDR assembly shares the
+/// exact same outcome→cause mapping as inbound.
+pub(crate) struct CallTerminationView {
+    pub(crate) cause: CdrTerminationCause,
+    pub(crate) bridge_detail: String,
+    pub(crate) tap_detail: String,
     /// Recording outcome, when the call was recorded. Feeds the CDR
     /// `recording_path` and the `siphon_ai_recordings_total` metric.
-    recording: Option<RecordingSummary>,
+    pub(crate) recording: Option<RecordingSummary>,
 }
 
 impl CallTerminationView {
-    fn from_run_result(result: Result<CallOutcome, crate::call::CallError>) -> Self {
+    pub(crate) fn from_run_result(result: Result<CallOutcome, crate::call::CallError>) -> Self {
         match result {
             Ok(o) => Self {
                 cause: map_cause(o.termination),
@@ -1829,7 +1831,7 @@ fn record_prepare_outcome(elapsed: std::time::Duration, ok: bool) {
 /// `siphon_ai_calls_total` counter label. Mirrors
 /// [`CdrTerminationCause`]'s snake_case serialization so dashboards
 /// can correlate the two without re-mapping.
-fn termination_label(cause: CdrTerminationCause) -> &'static str {
+pub(crate) fn termination_label(cause: CdrTerminationCause) -> &'static str {
     match cause {
         CdrTerminationCause::ServerHangup => "server_hangup",
         CdrTerminationCause::LocalShutdown => "local_shutdown",

--- a/crates/core/src/outbound_service.rs
+++ b/crates/core/src/outbound_service.rs
@@ -7,26 +7,40 @@
 //! `POST /admin/v1/calls` endpoint drives it.
 //!
 //! The originate call returns immediately with the bridge `call_id` (202) —
-//! the call proceeds on a spawned task. Its progress (ringing / answered /
-//! failed) surfaces via webhooks + the CDR in chunk 5. The concurrency permit
-//! from the guard is held for the spawned task's lifetime, so it's released
+//! the call proceeds on a spawned task. Its progress surfaces out-of-band:
+//! an `outbound_initiated` webhook when the INVITE goes out, then exactly one
+//! of `outbound_answered` (followed by a `call_end` webhook + a CDR when the
+//! bridge finishes) or `outbound_failed` (terminal — failed calls get the
+//! webhook + the `siphon_ai_outbound_calls_total` metric, no CDR, mirroring
+//! inbound where CDRs cover bridged calls only). The concurrency permit from
+//! the guard is held for the spawned task's lifetime, so it's released
 //! exactly when the call ends.
 
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use chrono::{DateTime, Utc};
 use forge_core::{CallId, ParticipantId};
 use sip_core::SipUri;
 use siphon_ai_bridge::{BridgeConfig, CallId as BridgeCallId};
+use siphon_ai_cdr::{
+    AudioInfo as CdrAudioInfo, CdrRecord, CdrSinkHandle, Direction as CdrDirection,
+    TerminationInfo as CdrTerminationInfo, CDR_VERSION,
+};
 use siphon_ai_media_glue::{OutboundOfferRequest, TapOptions};
 use siphon_ai_telemetry::{
     OriginateRejection, OriginateRequest, OutboundOriginateHandle, OUTBOUND_CALLS_ACTIVE,
     OUTBOUND_CALLS_TOTAL,
 };
+use siphon_ai_webhooks::{
+    CallEndEvent, OutboundAnsweredEvent, OutboundFailedEvent, OutboundInitiatedEvent, WebhookEvent,
+    WebhookSinkHandle, WEBHOOK_VERSION,
+};
 use tracing::{info, warn};
 
 use crate::acceptor::{
-    barge_in_to_tap_action, build_outbound_start_msg, BridgeDefaults, CallIdFactory,
+    barge_in_to_tap_action, build_outbound_start_msg, termination_label, BridgeDefaults,
+    CallIdFactory, CallTerminationView,
 };
 use crate::call::{CallController, CallControllerConfig};
 use crate::outbound::{
@@ -52,6 +66,8 @@ pub struct OutboundService {
     guard: OutboundGuard,
     defaults: BridgeDefaults,
     call_id_factory: CallIdFactory,
+    cdr_sink: CdrSinkHandle,
+    webhook_sink: WebhookSinkHandle,
 }
 
 impl OutboundService {
@@ -60,12 +76,16 @@ impl OutboundService {
         guard: OutboundGuard,
         defaults: BridgeDefaults,
         call_id_factory: CallIdFactory,
+        cdr_sink: CdrSinkHandle,
+        webhook_sink: WebhookSinkHandle,
     ) -> Self {
         Self {
             gateways,
             guard,
             defaults,
             call_id_factory,
+            cdr_sink,
+            webhook_sink,
         }
     }
 }
@@ -123,19 +143,53 @@ impl OutboundOriginateHandle for OutboundService {
         };
         let from = req.from.clone().unwrap_or_else(|| gw.from.clone());
         let to = req.to.clone();
+        let gateway = req.gateway.clone();
         let originator = Arc::clone(&gw.originator);
+        let cdr_sink = Arc::clone(&self.cdr_sink);
+        let webhook_sink = Arc::clone(&self.webhook_sink);
 
-        info!(call_id = %bridge_id_str, gateway = %req.gateway, "originating outbound call");
+        info!(call_id = %bridge_id_str, gateway = %gateway, "originating outbound call");
         let log_id = bridge_id_str.clone();
         tokio::spawn(async move {
             let _permit = permit; // held until the call ends, then released
             metrics::gauge!(OUTBOUND_CALLS_ACTIVE).increment(1.0);
+            let started_at = Utc::now();
+            webhook_sink
+                .emit(WebhookEvent::OutboundInitiated(OutboundInitiatedEvent {
+                    version: WEBHOOK_VERSION,
+                    call_id: log_id.clone(),
+                    timestamp: started_at,
+                    to: to.clone(),
+                    gateway: gateway.clone(),
+                }))
+                .await;
             let result = originator.place(target, offer_req, tap).await;
-            metrics::counter!(OUTBOUND_CALLS_TOTAL, "result" => outbound_result_label(&result))
-                .increment(1);
+            let result_label = outbound_result_label(&result);
+            metrics::counter!(OUTBOUND_CALLS_TOTAL, "result" => result_label).increment(1);
             match result {
-                Ok(call) => run_call(originator, call, bridge_id, bridge, from, to).await,
-                Err(e) => warn!(call_id = %log_id, error = %e, "outbound call did not connect"),
+                Ok(call) => {
+                    let ctx = OutboundCallContext {
+                        bridge_id,
+                        started_at,
+                        from,
+                        to,
+                        gateway,
+                        cdr_sink,
+                        webhook_sink,
+                    };
+                    run_call(originator, call, bridge, ctx).await;
+                }
+                Err(e) => {
+                    warn!(call_id = %log_id, error = %e, "outbound call did not connect");
+                    webhook_sink
+                        .emit(WebhookEvent::OutboundFailed(OutboundFailedEvent {
+                            version: WEBHOOK_VERSION,
+                            call_id: log_id,
+                            timestamp: Utc::now(),
+                            cause: result_label.to_string(),
+                        }))
+                        .await;
+                }
             }
             metrics::gauge!(OUTBOUND_CALLS_ACTIVE).decrement(1.0);
         });
@@ -162,15 +216,31 @@ fn outbound_result_label(result: &Result<OutboundCall, OutboundError>) -> &'stat
     }
 }
 
-/// Run an answered outbound call's audio bridge to completion, then tear it
-/// down (BYE the dialog + stop the media session).
+/// Everything the answered-call path needs at CDR/webhook-emission time
+/// beyond the call itself — the outbound counterpart of the acceptor's
+/// `CallStart` snapshot.
+struct OutboundCallContext {
+    bridge_id: BridgeCallId,
+    /// When `place()` started (= the `outbound_initiated` timestamp), so
+    /// the CDR's `duration_ms` covers ring time too; answer time is on
+    /// the `outbound_answered` webhook.
+    started_at: DateTime<Utc>,
+    from: String,
+    to: String,
+    /// `[[gateway]].name` — fills the CDR `route` field for outbound.
+    gateway: String,
+    cdr_sink: CdrSinkHandle,
+    webhook_sink: WebhookSinkHandle,
+}
+
+/// Run an answered outbound call's audio bridge to completion, tear it
+/// down (BYE the dialog + stop the media session), then emit the CDR and
+/// the `call_end` webhook.
 async fn run_call(
     originator: Arc<OutboundOriginator>,
     call: OutboundCall,
-    bridge_id: BridgeCallId,
     bridge: BridgeConfig,
-    from: String,
-    to: String,
+    ctx: OutboundCallContext,
 ) {
     let OutboundCall {
         accepted,
@@ -179,15 +249,29 @@ async fn run_call(
         call_id,
     } = call;
     let sip_call_id = dialog.id().call_id().to_string();
+    ctx.webhook_sink
+        .emit(WebhookEvent::OutboundAnswered(OutboundAnsweredEvent {
+            version: WEBHOOK_VERSION,
+            call_id: ctx.bridge_id.as_str().to_string(),
+            sip_call_id: sip_call_id.clone(),
+            timestamp: Utc::now(),
+        }))
+        .await;
+    let audio = CdrAudioInfo {
+        codec: accepted.answer.negotiated_codec.encoding_name().to_string(),
+        payload_type: accepted.answer.negotiated_payload_type,
+        sample_rate: accepted.answer.negotiated_audio_sample_rate,
+    };
+    let ws_url = bridge.ws_url.clone();
     let start = build_outbound_start_msg(
-        bridge_id.clone(),
-        &from,
-        &to,
+        ctx.bridge_id.clone(),
+        &ctx.from,
+        &ctx.to,
         &sip_call_id,
         &accepted.answer,
     );
     let cfg = CallControllerConfig {
-        call_id: bridge_id,
+        call_id: ctx.bridge_id.clone(),
         bridge,
         start,
         media_tap: accepted.tap,
@@ -195,7 +279,8 @@ async fn run_call(
         recording: None,
     };
     let (controller, _handle) = CallController::new(cfg);
-    match controller.run().await {
+    let run_result = controller.run().await;
+    match &run_result {
         Ok(o) => {
             info!(sip_call_id = %sip_call_id, termination = ?o.termination, "outbound call ended")
         }
@@ -205,11 +290,115 @@ async fn run_call(
     originator.hangup(&dialog).await;
     originator.stop_session(&call_id).await;
     drop(call_handle); // stop keepalives / session-timer tasks
+
+    let view = CallTerminationView::from_run_result(run_result);
+    let ended_at = Utc::now();
+    let record = build_outbound_record(&ctx, &sip_call_id, audio, &ws_url, ended_at, &view);
+    let end_event = WebhookEvent::CallEnd(CallEndEvent {
+        version: WEBHOOK_VERSION,
+        call_id: ctx.bridge_id.as_str().to_string(),
+        sip_call_id,
+        timestamp: ended_at,
+        from: ctx.from.clone(),
+        to: ctx.to.clone(),
+        route: ctx.gateway.clone(),
+        ws_url,
+        duration_ms: record.duration_ms,
+        termination_cause: termination_label(view.cause).to_string(),
+    });
+    ctx.cdr_sink.emit(record).await;
+    ctx.webhook_sink.emit(end_event).await;
+}
+
+/// Assemble the CDR for an answered outbound call — the outbound
+/// counterpart of the acceptor's `CallStart::into_record`. Failed calls
+/// don't get a CDR (the `outbound_failed` webhook + metric cover them),
+/// mirroring inbound where CDRs cover bridged calls only.
+fn build_outbound_record(
+    ctx: &OutboundCallContext,
+    sip_call_id: &str,
+    audio: CdrAudioInfo,
+    ws_url: &str,
+    ended_at: DateTime<Utc>,
+    view: &CallTerminationView,
+) -> CdrRecord {
+    let duration_ms = (ended_at - ctx.started_at).num_milliseconds().max(0) as u64;
+    CdrRecord {
+        version: CDR_VERSION,
+        call_id: ctx.bridge_id.as_str().to_string(),
+        sip_call_id: sip_call_id.to_string(),
+        started_at: ctx.started_at,
+        ended_at,
+        duration_ms,
+        from: ctx.from.clone(),
+        to: ctx.to.clone(),
+        direction: CdrDirection::Outbound,
+        route: ctx.gateway.clone(),
+        ws_url: ws_url.to_string(),
+        audio,
+        termination: CdrTerminationInfo {
+            cause: view.cause,
+            bridge_disconnect: view.bridge_detail.clone(),
+            tap_disconnect: view.tap_detail.clone(),
+        },
+        // STIR/SHAKEN verstat is an inbound-verification concern; recording
+        // isn't wired for outbound calls in this release (controller runs
+        // with `recording: None`).
+        verstat_attest: None,
+        verstat_passed: None,
+        recording_id: None,
+        recording_path: None,
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::TimeZone;
+    use siphon_ai_cdr::TerminationCause as CdrTerminationCause;
+
+    #[test]
+    fn outbound_record_carries_direction_gateway_and_termination() {
+        let ctx = OutboundCallContext {
+            bridge_id: BridgeCallId::new("siphon-9b2c"),
+            started_at: Utc.with_ymd_and_hms(2026, 6, 9, 10, 0, 0).unwrap(),
+            from: "sip:bot@siphon.example.com".into(),
+            to: "+13125550000".into(),
+            gateway: "twilio_main".into(),
+            cdr_sink: Arc::new(siphon_ai_cdr::NullSink),
+            webhook_sink: Arc::new(siphon_ai_webhooks::NullSink),
+        };
+        let view = CallTerminationView {
+            cause: CdrTerminationCause::ServerHangup,
+            bridge_detail: "stop_sent".into(),
+            tap_detail: "controller_hung_up".into(),
+            recording: None,
+        };
+        let audio = CdrAudioInfo {
+            codec: "PCMU".into(),
+            payload_type: 0,
+            sample_rate: 8000,
+        };
+        let ended_at = Utc.with_ymd_and_hms(2026, 6, 9, 10, 0, 42).unwrap();
+        let record = build_outbound_record(
+            &ctx,
+            "xyz-789@siphon",
+            audio,
+            "wss://agent.example.com/bridge",
+            ended_at,
+            &view,
+        );
+        assert_eq!(record.version, CDR_VERSION);
+        assert_eq!(record.direction, CdrDirection::Outbound);
+        assert_eq!(record.call_id, "siphon-9b2c");
+        assert_eq!(record.sip_call_id, "xyz-789@siphon");
+        assert_eq!(record.route, "twilio_main");
+        assert_eq!(record.duration_ms, 42_000);
+        assert_eq!(record.termination.cause, CdrTerminationCause::ServerHangup);
+        assert_eq!(record.termination.bridge_disconnect, "stop_sent");
+        assert_eq!(record.verstat_attest, None);
+        assert_eq!(record.recording_id, None);
+    }
 
     #[test]
     fn result_labels_map_failure_outcomes() {

--- a/crates/webhooks/src/event.rs
+++ b/crates/webhooks/src/event.rs
@@ -50,6 +50,23 @@ pub enum WebhookEvent {
     /// `failed → registered`. Ops integrations subscribe to this
     /// to alert when an upstream PBX deregisters us.
     RegistrationStateChanged(RegistrationStateChangedEvent),
+
+    /// Fired when an outbound call (`POST /admin/v1/calls`) is
+    /// admitted and the INVITE is about to be sent. Exactly one of
+    /// `OutboundAnswered` or `OutboundFailed` follows with the same
+    /// `call_id`.
+    OutboundInitiated(OutboundInitiatedEvent),
+
+    /// Fired when the callee answers an outbound call (2xx received,
+    /// media bound, WS bridge starting). A `CallEnd` with the same
+    /// `call_id` follows when the call ends — answered outbound calls
+    /// share the inbound end-of-call shape (and get a CDR).
+    OutboundAnswered(OutboundAnsweredEvent),
+
+    /// Fired when an outbound call ends without being answered —
+    /// busy / declined / no-answer / rejected / unreachable / setup
+    /// failure. Terminal: no `CallEnd` (and no CDR) follows.
+    OutboundFailed(OutboundFailedEvent),
 }
 
 impl WebhookEvent {
@@ -61,6 +78,9 @@ impl WebhookEvent {
             WebhookEvent::CallStart(_) => "call_start",
             WebhookEvent::CallEnd(_) => "call_end",
             WebhookEvent::RegistrationStateChanged(_) => "registration_state_changed",
+            WebhookEvent::OutboundInitiated(_) => "outbound_initiated",
+            WebhookEvent::OutboundAnswered(_) => "outbound_answered",
+            WebhookEvent::OutboundFailed(_) => "outbound_failed",
         }
     }
 
@@ -72,6 +92,9 @@ impl WebhookEvent {
             WebhookEvent::CallStart(e) => Some(&e.call_id),
             WebhookEvent::CallEnd(e) => Some(&e.call_id),
             WebhookEvent::RegistrationStateChanged(_) => None,
+            WebhookEvent::OutboundInitiated(e) => Some(&e.call_id),
+            WebhookEvent::OutboundAnswered(e) => Some(&e.call_id),
+            WebhookEvent::OutboundFailed(e) => Some(&e.call_id),
         }
     }
 }
@@ -144,6 +167,53 @@ pub struct RegistrationStateChangedEvent {
     pub expires_at: Option<DateTime<Utc>>,
 }
 
+/// An outbound call was admitted and is being placed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OutboundInitiatedEvent {
+    /// Schema version. Bumped per CLAUDE.md §7.9.
+    pub version: u32,
+    /// SiphonAI bridge call id — the one `POST /admin/v1/calls`
+    /// returned, shared by the follow-up answered/failed/end events.
+    pub call_id: String,
+    /// When the INVITE was dispatched (UTC).
+    pub timestamp: DateTime<Utc>,
+    /// Destination as given in the originate request (user part —
+    /// the gateway supplies host/port).
+    pub to: String,
+    /// `[[gateway]].name` the call is placed through.
+    pub gateway: String,
+}
+
+/// The callee answered an outbound call.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OutboundAnsweredEvent {
+    pub version: u32,
+    /// Bridge call id, pairing with `OutboundInitiated`.
+    pub call_id: String,
+    /// SIP `Call-ID` of the established dialog — correlates with
+    /// HEP/Homer captures.
+    pub sip_call_id: String,
+    /// When the 2xx answer was processed (UTC).
+    pub timestamp: DateTime<Utc>,
+}
+
+/// An outbound call ended without an answer. Terminal for its
+/// `call_id` — no `CallEnd` or CDR follows.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OutboundFailedEvent {
+    pub version: u32,
+    /// Bridge call id, pairing with `OutboundInitiated`.
+    pub call_id: String,
+    /// When the failure was observed (UTC).
+    pub timestamp: DateTime<Utc>,
+    /// Why the call didn't connect, mirroring the
+    /// `siphon_ai_outbound_calls_total{result}` metric labels so
+    /// dashboards correlate without a re-mapping table: `busy` /
+    /// `declined` / `no_answer` / `rejected` / `unreachable` /
+    /// `failed`.
+    pub cause: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -176,6 +246,57 @@ mod tests {
             duration_ms: 42_000,
             termination_cause: "server_hangup".into(),
         })
+    }
+
+    fn sample_outbound() -> [WebhookEvent; 3] {
+        let ts = Utc.with_ymd_and_hms(2026, 6, 9, 10, 0, 0).unwrap();
+        [
+            WebhookEvent::OutboundInitiated(OutboundInitiatedEvent {
+                version: WEBHOOK_VERSION,
+                call_id: "siphon-9b2c".into(),
+                timestamp: ts,
+                to: "+13125550000".into(),
+                gateway: "twilio_main".into(),
+            }),
+            WebhookEvent::OutboundAnswered(OutboundAnsweredEvent {
+                version: WEBHOOK_VERSION,
+                call_id: "siphon-9b2c".into(),
+                sip_call_id: "xyz-789@siphon".into(),
+                timestamp: ts,
+            }),
+            WebhookEvent::OutboundFailed(OutboundFailedEvent {
+                version: WEBHOOK_VERSION,
+                call_id: "siphon-9b2c".into(),
+                timestamp: ts,
+                cause: "busy".into(),
+            }),
+        ]
+    }
+
+    #[test]
+    fn outbound_events_round_trip_through_json() {
+        for event in sample_outbound() {
+            let s = serde_json::to_string(&event).unwrap();
+            let parsed: WebhookEvent = serde_json::from_str(&s).unwrap();
+            assert_eq!(event, parsed);
+        }
+    }
+
+    #[test]
+    fn outbound_type_strs_match_wire_discriminators() {
+        let expected = ["outbound_initiated", "outbound_answered", "outbound_failed"];
+        for (event, want) in sample_outbound().iter().zip(expected) {
+            assert_eq!(event.type_str(), want);
+            let v: Value = serde_json::to_value(event).unwrap();
+            assert_eq!(v["type"], json!(want));
+        }
+    }
+
+    #[test]
+    fn outbound_events_are_call_scoped() {
+        for event in sample_outbound() {
+            assert_eq!(event.call_id(), Some("siphon-9b2c"));
+        }
     }
 
     #[test]

--- a/crates/webhooks/src/lib.rs
+++ b/crates/webhooks/src/lib.rs
@@ -24,7 +24,8 @@ pub mod http;
 pub mod sink;
 
 pub use event::{
-    CallEndEvent, CallStartEvent, RegistrationStateChangedEvent, WebhookEvent, WEBHOOK_VERSION,
+    CallEndEvent, CallStartEvent, OutboundAnsweredEvent, OutboundFailedEvent,
+    OutboundInitiatedEvent, RegistrationStateChangedEvent, WebhookEvent, WEBHOOK_VERSION,
 };
 pub use http::{HttpSink, HttpSinkConfig};
 pub use sink::{FilteredSink, NullSink, WebhookSink, WebhookSinkHandle};

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -465,7 +465,7 @@ regardless of sub-block state. Adding fields to the CDR schema bumps the
 | `enabled`     | bool     | `false`                | |
 | `url`         | URL      | required if on         | POST target. |
 | `auth_header` | string   | unset                  | Sent verbatim. `${VAR}` expansion works. |
-| `events`      | string[] | all                    | Allowlist. Valid today: `"call_start"`, `"call_end"`, `"registration_state_changed"`. |
+| `events`      | string[] | all                    | Allowlist. Valid today: `"call_start"`, `"call_end"`, `"registration_state_changed"`, `"outbound_initiated"`, `"outbound_answered"`, `"outbound_failed"`. |
 | `retry_max`   | integer  | `3`                    | |
 | `timeout_ms`  | integer  | `5000`                 | |
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -336,8 +336,10 @@ curl -X POST http://localhost:9091/admin/v1/calls -d '{
 
 Responses: `202` (accepted — placing), `404` (unknown gateway), `400` (bad
 target / no ws_url / invalid JSON), `503` (`max_concurrent` reached), `429`
-(rate limited), `501` (outbound disabled). The call's progress (ringing /
-answered / failed) is reported via webhooks + the CDR (chunk 5).
+(rate limited), `501` (outbound disabled). The call's progress arrives
+out-of-band via lifecycle webhooks: `outbound_initiated`, then exactly one
+of `outbound_answered` (followed by `call_end` + a CDR when the call
+finishes) or `outbound_failed` (see [Lifecycle webhooks](#lifecycle-webhooks)).
 
 Example: bump bridge logging to debug for an incident, then revert.
 
@@ -407,6 +409,20 @@ Two optional recording fields appear when the call was recorded (added in
   recording `failed` (it points at where the file would be); cross-check
   with the `siphon_ai_recordings_total` metric for the outcome.
 
+Outbound originated calls (0.6.0, `POST /admin/v1/calls`) produce the same
+record with `direction: "outbound"` — the schema stays at version 1 (the
+field was reserved for this since v1). Two outbound-specific readings:
+
+- `route` carries the `[[gateway]]` name the call was placed through, not
+  a `[[route]]` name.
+- `started_at` is when the INVITE went out, so `duration_ms` includes ring
+  time; the answer instant is on the `outbound_answered` webhook.
+
+Only *answered* outbound calls get a CDR — calls that end busy / declined /
+unanswered / unreachable are covered by the `outbound_failed` webhook and
+the `siphon_ai_outbound_calls_total{result}` metric, mirroring inbound
+where CDRs cover bridged calls only.
+
 The webhook sink delivers the same JSON to `[cdr.webhook].url` with
 `Content-Type: application/json`. Retries on non-2xx up to
 `[cdr.webhook].retry_max` times with exponential backoff.
@@ -419,11 +435,30 @@ CDR webhook. Event types:
 | `type`                          | When                                             |
 |---------------------------------|--------------------------------------------------|
 | `call_start`                    | After 200 OK has gone out on an accepted INVITE. |
-| `call_end`                      | After the controller exits and the CDR record is built. |
+| `call_end`                      | After the controller exits and the CDR record is built (inbound *and* answered outbound calls). |
 | `registration_state_changed`    | Each `[[register]]` state transition (`pending` → `registered`, `registered` → `failed`, etc.). |
+| `outbound_initiated`            | An originated call (`POST /admin/v1/calls`) was admitted and its INVITE is going out. |
+| `outbound_answered`             | The callee answered (2xx) and the WS bridge is starting. |
+| `outbound_failed`               | The originated call ended without an answer. Terminal — no `call_end`/CDR follows. |
 
 Each delivery is a single JSON object with `version`, `timestamp` (ISO 8601), `type`,
 and per-event fields documented in `crates/webhooks/src/event.rs`.
+
+An outbound call emits `outbound_initiated`, then exactly one of
+`outbound_answered` or `outbound_failed`, all sharing the `call_id` that
+`POST /admin/v1/calls` returned. Answered calls finish with a `call_end`
+(same shape as inbound; `route` = gateway name). `outbound_failed.cause`
+mirrors the `siphon_ai_outbound_calls_total{result}` metric labels:
+`busy` / `declined` / `no_answer` / `rejected` / `unreachable` / `failed`.
+
+```json
+{ "type": "outbound_initiated", "version": 1, "call_id": "siphon-…",
+  "timestamp": "2026-06-09T10:00:00Z", "to": "+15558675309", "gateway": "twilio" }
+{ "type": "outbound_answered", "version": 1, "call_id": "siphon-…",
+  "sip_call_id": "f81d4fae…@10.0.0.5", "timestamp": "2026-06-09T10:00:06Z" }
+{ "type": "outbound_failed", "version": 1, "call_id": "siphon-…",
+  "timestamp": "2026-06-09T10:00:30Z", "cause": "no_answer" }
+```
 
 ## HEP / Homer
 


### PR DESCRIPTION
Chunk 5b of the 0.6.0 outbound-origination plan (`docs/DEV_PLAN_0.6.0.md`) — the second half of chunk 5 (observability), after the metrics in #146. Outbound calls placed via `POST /admin/v1/calls` now report progress and outcome out-of-band.

### CDR — `direction: "outbound"` (schema stays v1)
- `Direction` gains `Outbound` — additive per plan §9.4 (the field was reserved for exactly this since v1), so `CDR_VERSION` stays 1.
- Answered outbound calls get a CDR assembled in `outbound_service::run_call`:
  - `route` = the `[[gateway]]` name (documented on the field and in DEPLOY.md);
  - `started_at` = INVITE dispatch, so `duration_ms` includes ring time — the answer instant is on the `outbound_answered` webhook;
  - termination reuses the acceptor's `CallTerminationView` outcome→cause mapping (made `pub(crate)` instead of replicating it);
  - `verstat_*` / `recording_*` stay `None` (inbound-verification concern / outbound recording not wired this release).
- **Failed calls get no CDR** — the `outbound_failed` webhook + `siphon_ai_outbound_calls_total{result}` metric cover them, mirroring inbound where CDRs cover bridged calls only.

### Webhooks — three new event types (additive, `WEBHOOK_VERSION` stays 1)
| type | when | payload extras |
|---|---|---|
| `outbound_initiated` | call admitted, INVITE going out | `to`, `gateway` |
| `outbound_answered` | 2xx received, bridge starting | `sip_call_id` |
| `outbound_failed` | ended without answer (terminal) | `cause` |

`outbound_failed.cause` mirrors the metric's `result` labels (`busy`/`declined`/`no_answer`/`rejected`/`unreachable`/`failed`) so dashboards correlate without a re-mapping table. Answered calls finish with the existing `call_end` shape (`route` = gateway name). Exactly one of answered/failed follows each initiated, all sharing the `call_id` the originate endpoint returned.

### Wiring
`OutboundService` now holds `CdrSinkHandle` + `WebhookSinkHandle`; the daemon clones both (cheap `Arc`s) before the acceptor consumes them. Emission points: initiated at spawn start, failed on `place()` error, answered + CDR + `call_end` in `run_call`.

### Tests / docs
- Serialization round-trips + wire-discriminator + `call_id()` pins for the new events; `direction: "outbound"` additivity test; `build_outbound_record` unit test.
- `cargo fmt` + `clippy -D warnings` + full workspace test suite green (596 tests).
- DEPLOY.md (webhook table, payload examples, outbound CDR notes), CONFIG.md (`events` allowlist), per CLAUDE.md §7.7/§7.9.

Next: chunk 6 — `docs/OUTBOUND.md`, SIPp UAS answer-path scenario, version bump 0.5.0→0.6.0, release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)