### PR TITLE
feat(docs,test-harness): OUTBOUND.md + SIPp answer-path + release 0.6.0 (chunk 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-09
+
+Theme: **outbound call origination.** SiphonAI inverts its inbound-only
+model — `POST /admin/v1/calls` places a SIP call through a configured
+gateway and bridges the answered call to a WS server over the same
+protocol v1 session inbound calls use. **Off by default** (fail-closed on
+`[outbound].max_concurrent = 0`) — a 0.5.0 deployment upgrades with zero
+behaviour change. The WS protocol stays at `version: "1"` (the new
+`start.direction` field is additive) and the CDR schema stays at version 1
+(`direction` was reserved for outbound since v1).
+
+### Added
+
+- **Outbound origination** — `[outbound]` (`max_concurrent`,
+  `rate_limit_per_sec`) + `[[gateway]]` blocks: standalone trunks
+  (`proxy` / `from` / optional digest `auth_username` + `auth_password`)
+  or `register = "<name>"` to dial through an existing `[[register]]`,
+  inheriting its server, credentials, and AOR. Validated at config load.
+  See `docs/OUTBOUND.md`.
+- **Originate API** — `POST /admin/v1/calls` `{to, gateway, ws_url?,
+  from?}` → `202 {call_id}`. **No built-in auth by design** (reverse-proxy
+  posture, plan §9.5): bind the admin API private and front it yourself.
+  The cap + rate limit are the native toll-fraud guardrails; the
+  `503`/`429` rejections are fail-closed.
+- **WS protocol** — `start.direction: "inbound" | "outbound"` (additive;
+  servers that ignore it keep working). Outbound sessions start at answer
+  and carry the dialed `to` and the caller-ID `from`.
+- **Call-progress webhooks** — `outbound_initiated` `{to, gateway}`,
+  `outbound_answered` `{sip_call_id}`, terminal `outbound_failed`
+  `{cause}`; answered calls finish with the existing `call_end`. `cause`
+  mirrors the metric's `result` labels.
+- **CDR** — `direction: "outbound"` for answered originated calls;
+  `route` carries the gateway name. Unanswered calls get no CDR (webhook +
+  metric cover them), mirroring inbound where CDRs cover bridged calls.
+- **Metrics** — `siphon_ai_outbound_calls_total{result="answered"|"busy"|
+  "declined"|"no_answer"|"rejected"|"unreachable"|"failed"}` and the
+  `siphon_ai_outbound_calls_active` gauge.
+- **SIPp coverage** — `outbound_uas_answer.xml` + an always-on roles-
+  inverted regression phase (SIPp answers SiphonAI's INVITE; pass requires
+  the full INVITE → ACK → BYE flow *and* the answered-counter reading 1),
+  driven by a new `--auto-hangup-after-ms` test-harness knob on the echo
+  WS example server.
+- **`docs/OUTBOUND.md`** — the outbound guide (enabling, originate API,
+  the toll-fraud security posture, lifecycle, observability, testing
+  without spending money, limitations).
+
+### Notes
+
+- Outbound calls **spend money**. The security model is deliberate:
+  no native API auth, so the documented posture (private bind +
+  authenticating reverse proxy + `max_concurrent` + `rate_limit_per_sec`
+  + trunk-side destination allowlists) is mandatory reading —
+  `docs/OUTBOUND.md` §3.
+- Not in 0.6.0: early media (WS session starts at answer), attended
+  transfer (the 0.6.1 fast-follow), outbound recording, outbound
+  STIR/SHAKEN signing, built-in AMD (the WS server's job, by design).
+
 ## [0.5.0] - 2026-06-08
 
 Theme: **call recording.** Each call's audio can be captured to a stereo WAV
@@ -584,7 +641,8 @@ the WebSocket server's job.
 - Reference WebSocket servers in `examples/`: echo (Python / Node),
   an OpenAI Realtime bridge, and a Deepgram + LLM voice bot.
 
-[Unreleased]: https://github.com/thevoiceguy/siphon-ai/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/thevoiceguy/siphon-ai/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/thevoiceguy/siphon-ai/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/thevoiceguy/siphon-ai/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/thevoiceguy/siphon-ai/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/thevoiceguy/siphon-ai/compare/v0.3.2...v0.4.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2899,7 +2899,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "base64",
  "bytes",
@@ -2920,7 +2920,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2937,7 +2937,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "regex",
  "serde",
@@ -2954,7 +2954,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2993,7 +2993,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -3008,7 +3008,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3030,7 +3030,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "thiserror 1.0.69",
  "tokio",
@@ -3039,7 +3039,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "regex",
  "serde",
@@ -3050,7 +3050,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3059,7 +3059,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3082,7 +3082,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -3100,7 +3100,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3121,7 +3121,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -42,6 +42,22 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
+**v0.6.0** — sixth release. Theme: **outbound call origination.** SiphonAI
+now **places** calls, not just answers them: `POST /admin/v1/calls` dials a
+destination through a configured `[[gateway]]` (a standalone trunk, or
+dialing through an existing `[[register]]`) and bridges the answered call
+to a WS server over the same protocol v1 session — `start.direction:
+"outbound"` is the only wire difference (additive). Progress arrives via
+new `outbound_initiated` / `outbound_answered` / `outbound_failed`
+webhooks, a `direction: "outbound"` CDR, and a
+`siphon_ai_outbound_calls_total{result}` metric. **Off by default**
+(fail-closed on `max_concurrent = 0`) and **toll-fraud-aware by design**:
+the originate API has no native auth — the documented posture is a private
+bind + authenticating reverse proxy, with the concurrency cap + rate limit
+as native guardrails. See [`docs/OUTBOUND.md`](docs/OUTBOUND.md). Attended
+transfer is the 0.6.1 fast-follow. Full notes:
+[`CHANGELOG.md`](CHANGELOG.md).
+
 **v0.5.0** — fifth release. Theme: **call recording.** Each call's audio can
 be captured to a stereo WAV (caller left, bot/WS right) for compliance and
 QA — `[recording].mode` = `off` (default) / `always` / `on_demand`, with a

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -274,7 +274,8 @@ request_uri_user = "9000"
 
 SiphonAI can **place** calls (not just answer them) and bridge them to a WS
 server on answer. Outbound is **disabled by default** and fail-closed: it
-turns on only when `[outbound].max_concurrent` is a positive number.
+turns on only when `[outbound].max_concurrent` is a positive number. Full
+guide (originate API, lifecycle, toll-fraud posture): `docs/OUTBOUND.md`.
 
 ```toml
 [outbound]

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -313,7 +313,7 @@ the listener on a private network.
 ### `POST /admin/v1/calls` — outbound origination
 
 Requires `[outbound].max_concurrent > 0` and at least one `[[gateway]]` (see
-`docs/CONFIG.md`). **This endpoint places billable calls and has no built-in
+`docs/CONFIG.md`; full guide: `docs/OUTBOUND.md`). **This endpoint places billable calls and has no built-in
 auth** — restrict access to it (bind to a private network / front with an
 authenticating reverse proxy). The `max_concurrent` cap + `rate_limit_per_sec`
 are the native guardrails.

--- a/docs/OUTBOUND.md
+++ b/docs/OUTBOUND.md
@@ -1,0 +1,186 @@
+# Outbound Call Origination
+
+SiphonAI can **place** calls, not just answer them (0.6.0). An HTTP request
+names a destination and a gateway; SiphonAI sends the INVITE, and when the
+callee answers it bridges the call's audio to your WebSocket server over the
+same protocol inbound calls use. Callbacks, reminders, notifications,
+outbound bots — same WS server, inverted call direction.
+
+```
+POST /admin/v1/calls ──► SiphonAI ──INVITE──► gateway/trunk ──► callee
+                            │                                     │
+                            ◄────────────── 200 OK (answer) ──────┘
+                            │
+                            └──WebSocket──► your WS server (same protocol v1)
+```
+
+**Outbound calls spend money.** Read [§3](#3-security--toll-fraud) before
+exposing anything.
+
+## 1. Enabling
+
+Outbound is **off by default** and fail-closed: it activates only when
+`[outbound].max_concurrent` is a positive number and at least one
+`[[gateway]]` is configured. See `docs/CONFIG.md` (`[outbound]` +
+`[[gateway]]`) for every field; the short version:
+
+```toml
+[outbound]
+max_concurrent     = 20      # 0 (default) = outbound disabled
+rate_limit_per_sec = 5       # optional new-calls/sec ceiling
+
+# A standalone trunk (static / IP-auth or digest):
+[[gateway]]
+name          = "twilio"
+proxy         = "siptrunk.example.com:5060"
+from          = "sip:+13125551234@siptrunk.example.com"
+auth_username = "ACxxxx"                # optional digest
+auth_password = "${TWILIO_TRUNK_SECRET}"
+
+# Or dial through an existing [[register]] (reuse server + credentials):
+[[gateway]]
+name     = "pbx-out"
+register = "pbx"
+
+[observability]
+enabled     = true
+http_listen = "127.0.0.1:9091"   # the originate endpoint lives here
+```
+
+The originate endpoint is part of the admin API, so `[observability]` must
+be on. Gateway config is validated at startup — bad `proxy`, unknown
+`register` reference, or half-set credentials fail loud.
+
+## 2. Placing a call
+
+```sh
+curl -X POST http://localhost:9091/admin/v1/calls -d '{
+  "to": "+15558675309",
+  "gateway": "twilio",
+  "ws_url": "wss://my-bot.example/outbound"
+}'
+# → 202 {"call_id":"siphon-…"}
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `to` | yes | Destination (E.164 / SIP user). Becomes the Request-URI user at the gateway's proxy. |
+| `gateway` | yes | A `[[gateway]]` name. `404` if unknown. |
+| `ws_url` | no | WS server for this call. Falls back to `[bridge].ws_url`; `400` if neither is set. |
+| `from` | no | Caller-ID override (full `sip:` URI). Falls back to the gateway's `from`. |
+
+`202` means *admitted and dialing*, not answered — the HTTP exchange ends
+there, and everything after arrives out-of-band (see [§4](#4-call-lifecycle)).
+Other responses: `404` unknown gateway, `400` bad target / no ws_url /
+invalid JSON, `503` at `max_concurrent`, `429` rate-limited, `501` outbound
+disabled.
+
+Digest auth (401/407 challenges from the trunk) is answered automatically
+with the gateway's credentials; there's nothing per-call to do.
+
+## 3. Security — toll fraud
+
+This is the first SiphonAI feature where a compromised or misconfigured
+deployment **directly costs money**: anyone who can reach the originate
+endpoint can place calls billed to your trunk. Premium-rate fraud burns
+thousands of dollars in hours, so treat the endpoint like a payment API.
+
+**The originate API has no built-in authentication** (a deliberate 0.6.0
+decision — see `docs/DEV_PLAN_0.6.0.md` §9.5). The intended posture:
+
+1. **Bind the admin API to localhost or a private network**
+   (`http_listen = "127.0.0.1:9091"`, the documented default posture) and
+   front it with an authenticating reverse proxy (nginx + OIDC/mTLS/basic
+   auth) if anything non-local needs it. Never expose :9091 raw to the
+   internet.
+2. **Set a realistic `max_concurrent`.** It's the blast-radius cap; 20
+   concurrent premium-rate calls is a very different incident than 2000.
+3. **Set `rate_limit_per_sec`.** A dialer bug or a stolen `curl` loop hits
+   the token bucket instead of your trunk.
+4. **Use trunk-side allowlists too.** Most providers can restrict
+   destinations (countries, premium ranges) per trunk — defense in depth
+   that survives a SiphonAI misconfiguration.
+5. **Watch `siphon_ai_outbound_calls_total`.** An unexpected slope on that
+   counter is the earliest fraud signal you'll get; alert on it.
+
+## 4. Call lifecycle
+
+Progress is reported via lifecycle webhooks (`[webhooks]`, see
+`docs/DEPLOY.md`), all carrying the `call_id` the originate request
+returned:
+
+```
+outbound_initiated ──► outbound_answered ──► call_end   (+ CDR)
+        │
+        └────────────► outbound_failed                  (terminal, no CDR)
+```
+
+- **`outbound_initiated`** `{to, gateway}` — admitted, INVITE going out.
+- **`outbound_answered`** `{sip_call_id}` — callee sent 2xx; media is bound
+  and the WS bridge is connecting.
+- **`outbound_failed`** `{cause}` — ended without answer: `busy` /
+  `declined` / `no_answer` / `rejected` / `unreachable` / `failed` (same
+  strings as the metric labels).
+- **`call_end`** — same shape as inbound; `route` carries the gateway name.
+
+Answered calls also produce a CDR with `direction: "outbound"` (schema
+stays v1; `route` = gateway name, `started_at` = INVITE dispatch so
+`duration_ms` includes ring time). Unanswered calls get **no CDR** — the
+`outbound_failed` webhook + metric cover them, mirroring inbound where CDRs
+cover bridged calls only.
+
+### What your WS server sees
+
+The same protocol v1 session as inbound, with `start.direction:
+"outbound"` (additive — servers that ignore it keep working). `from` is the
+caller-ID the call was placed with, `to` the dialed destination. The
+`start` arrives **after answer** — by the time your server gets it, a human
+(or their voicemail) is already listening, so speak first: an outbound bot
+should send audio immediately, not wait for caller speech like an inbound
+greeting flow might. Everything else — audio frames, barge-in, DTMF,
+`hangup`, transfer — behaves identically to inbound. See
+`docs/PROTOCOL.md`.
+
+## 5. Observability
+
+- **Metrics** — `siphon_ai_outbound_calls_total{result}` (`answered`,
+  `busy`, `declined`, `no_answer`, `rejected`, `unreachable`, `failed`) and
+  the `siphon_ai_outbound_calls_active` gauge (admitted but not yet
+  settled). Bridged-call mechanics land in the same per-call metrics
+  inbound calls use.
+- **CDR** — `direction: "outbound"`, see [§4](#4-call-lifecycle) and
+  `docs/DEPLOY.md` (CDR consumers).
+- **Webhooks** — the three `outbound_*` events + `call_end`, payloads in
+  `docs/DEPLOY.md` (lifecycle webhooks).
+- **Logs** — `originating outbound call` / `outbound call answered` /
+  `outbound call ended` at `info`, all with `call_id` in the span.
+- **HEP/Homer** — the outbound INVITE/BYE transactions ship via the same
+  siphon-rs HEP emission as inbound; correlate by the SIP Call-ID from
+  `outbound_answered.sip_call_id` or the CDR.
+
+## 6. Testing without spending money
+
+The SIPp regression suite has an always-on outbound phase
+(`test-harness/sipp-scenarios/outbound_uas_answer.xml`): SIPp plays the
+callee, a throwaway daemon dials it through a loopback gateway, and the
+echo WS server ends the call. The same trick works interactively — point a
+`[[gateway]]` at any lab UAS (`proxy = "127.0.0.1:5080"`) and originate
+against it; nothing leaves the machine.
+
+## 7. Limitations (v0.6.0)
+
+- **No early media** — audio before the 200 OK (ringback injected by the
+  far end, IVR pre-answer prompts) is not bridged; the WS session starts at
+  answer. Planned as a stretch follow-up.
+- **No mid-call progress webhook for ringing** — `outbound_initiated` fires
+  at INVITE, the next signal is answered/failed. (180 Ringing is visible in
+  HEP/Homer if you need it.)
+- **Attended transfer** (consultation leg as an outbound call) is the 0.6.1
+  fast-follow.
+- **Recording** is not wired for outbound calls in this release.
+- **No STIR/SHAKEN signing** — SiphonAI verifies inbound `Identity` headers
+  but does not sign outbound INVITEs; attestation for your calls is the
+  trunk provider's job.
+- **AMD (answering-machine detection)** is not built in — your WS server
+  hears the answered audio and can run its own detection (that's the
+  provider-neutral hook; see CLAUDE.md §4.1).

--- a/examples/echo-ws-server-python/server.py
+++ b/examples/echo-ws-server-python/server.py
@@ -59,6 +59,10 @@ class Options:
     # silent on the control channel by default (see file docstring).
     auto_transfer_target: str | None
     auto_transfer_delay_ms: int
+    # Test-harness knob: after `start`, wait this long and then send a
+    # `hangup`. Lets the outbound SIPp scenario end the call from the
+    # WS side (the callee just waits for our BYE). None = disabled.
+    auto_hangup_after_ms: int | None
 
 
 # ─── HTTP-side concerns: auth + subprotocol ─────────────────────────────────
@@ -183,6 +187,19 @@ async def handle(connection: ServerConnection, opts: Options) -> None:
                         )
                     )
 
+                if opts.auto_hangup_after_ms is not None and call_id:
+                    # Test-harness behaviour: end the call from the WS
+                    # side after a beat. Used by the outbound SIPp
+                    # scenario, where SIPp (the callee) answers and then
+                    # waits for SiphonAI's BYE.
+                    asyncio.create_task(
+                        _send_after(
+                            connection,
+                            opts.auto_hangup_after_ms,
+                            {"type": "hangup", "call_id": call_id},
+                        )
+                    )
+
             elif mtype == "stop":
                 LOG.info("stop call_id=%s reason=%s", call_id, msg.get("reason"))
                 # SiphonAI closes the connection right after `stop`; we
@@ -281,6 +298,17 @@ def parse_args(argv: list[str] | None = None) -> Options:
         help="ms to wait after `start` before emitting the transfer (default: 200)",
     )
     p.add_argument(
+        "--auto-hangup-after-ms",
+        type=int,
+        default=None,
+        metavar="MS",
+        help=(
+            "test-harness only: after `start`, emit a `hangup` after "
+            "this many ms. See test-harness/sipp-scenarios/"
+            "outbound_uas_answer.xml."
+        ),
+    )
+    p.add_argument(
         "--log-level",
         default="INFO",
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
@@ -299,6 +327,7 @@ def parse_args(argv: list[str] | None = None) -> Options:
         log_level=args.log_level,
         auto_transfer_target=args.auto_transfer_target,
         auto_transfer_delay_ms=args.auto_transfer_delay_ms,
+        auto_hangup_after_ms=args.auto_hangup_after_ms,
     )
 
 

--- a/test-harness/sipp-scenarios/README.md
+++ b/test-harness/sipp-scenarios/README.md
@@ -2,7 +2,8 @@
 
 End-to-end SIP scenarios driven by [SIPp](https://github.com/SIPp/sipp).
 SIPp plays the role of the **caller (UAC)**; SiphonAI is the UAS under
-test. The point of these scenarios is to validate signaling
+test (except `outbound_uas_answer.xml`, where the roles invert: SiphonAI
+dials and SIPp answers). The point of these scenarios is to validate signaling
 correctness end-to-end: parse → route → media setup → SIP final →
 in-dialog handling → teardown. Audio quality is out of scope here
 (see `docs/DEV_PLAN.md` §10.3).
@@ -49,12 +50,21 @@ sipp -sf basic_call_then_bye.xml -m 1 -p 5070 -s 1000 127.0.0.1:5060
 | `stir_shaken_no_identity_428.xml`   | STIR/SHAKEN `require_identity`: INVITE with no `Identity` header → 428 Use Identity Header (stir_shaken phase) |
 | `stir_shaken_attestation_403.xml`   | STIR/SHAKEN gate: `Identity` present but unverifiable (unreachable `x5u`) below `min_attestation = "A"` → 403 Forbidden (stir_shaken phase) |
 | `stir_shaken_attestation_pass.xml`  | STIR/SHAKEN happy path: a fully-verifiable `Identity` (fresh PASSporT, real x5u fetch, chain to the test anchor) → **200 admitted** (stir_shaken phase). Templated — `__IDENTITY__` is substituted at run time; does not run standalone. |
+| `outbound_uas_answer.xml`           | 0.6.0 outbound answer path, roles inverted: SiphonAI dials via `POST /admin/v1/calls`, SIPp answers (180 → 200 + SDP), bridge runs, SiphonAI BYEs (outbound phase) |
 
 `run-all.sh` also has an always-on **recording** auxiliary phase: it starts
 a daemon with `[recording].mode = "always"` writing to a temp dir, runs one
 `basic_call_then_bye.xml` call through the echo WS bridge, then asserts the
 written file is a valid stereo PCM16 WAV with audio in it (via Python's
 `wave`). It reuses `basic_call_then_bye.xml` — no dedicated scenario file.
+
+`run-all.sh` also has an always-on **outbound** auxiliary phase — the
+roles-inverted scenario above. It starts a fresh daemon with `[outbound]`
+enabled and a `[[gateway]]` pointing at SIPp's port, a dedicated echo-ws
+instance with `--auto-hangup-after-ms 1500` (so the WS side ends the call),
+backgrounds SIPp as the callee, then POSTs `/admin/v1/calls`. Pass = SIPp
+completed INVITE → ACK → BYE **and** the daemon's
+`siphon_ai_outbound_calls_total{result="answered"}` metric reads 1.
 
 The `stir_shaken_*` scenarios run in `run-all.sh`'s always-on
 **stir_shaken** auxiliary phase. It builds + runs the

--- a/test-harness/sipp-scenarios/outbound_uas_answer.xml
+++ b/test-harness/sipp-scenarios/outbound_uas_answer.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  outbound_uas_answer — roles inverted: SIPp acts as the CALLEE (UAS);
+  SiphonAI is the UAC, placing the call via `POST /admin/v1/calls`
+  through a `[[gateway]]` that points at SIPp's listen port.
+
+  Validates the 0.6.0 outbound answer path end-to-end over real SIP:
+  INVITE (with SDP offer) → 180 → 200 (SDP answer) → ACK, then the
+  WS bridge runs (the harness echo server auto-hangs-up after a
+  beat), and SiphonAI tears the dialog down with BYE → 200.
+
+  Run via run-all.sh's outbound auxiliary phase — the scenario alone
+  does nothing until the runner POSTs the originate request.
+-->
+<scenario name="outbound_uas_answer">
+  <recv request="INVITE" rtd="true"/>
+
+  <send>
+<![CDATA[
+SIP/2.0 180 Ringing
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="200"/>
+
+  <send retrans="500">
+<![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=sipp 53655765 2353687637 IN IP4 [local_ip]
+s=-
+c=IN IP4 [local_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+]]>
+  </send>
+
+  <recv request="ACK" rtd="true"/>
+
+  <!-- The call is up; SiphonAI's bridge connects to the echo WS
+       server, which emits `hangup` after ~1.5s (the runner starts it
+       with the auto-hangup-after-ms flag). SiphonAI then BYEs us. -->
+  <recv request="BYE" rtd="true"/>
+
+  <send>
+<![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+</scenario>

--- a/test-harness/sipp-scenarios/run-all.sh
+++ b/test-harness/sipp-scenarios/run-all.sh
@@ -329,6 +329,101 @@ fi
 rec_cleanup
 trap - EXIT
 
+# ─── Always-on auxiliary phase: outbound origination ──────────────
+# Roles inverted: SIPp is the CALLEE (UAS), SiphonAI the UAC. A fresh
+# daemon comes up with `[outbound]` enabled and a `[[gateway]]`
+# pointing at SIPp's port; the runner POSTs /admin/v1/calls, SIPp
+# answers (180 → 200 + SDP), the WS bridge runs against a dedicated
+# echo-ws instance that auto-emits `hangup` after ~1.5s, and SiphonAI
+# BYEs the dialog. This is the live SIP answer-path test for 0.6.0
+# (everything below the originate endpoint ran only against unit
+# tests until now). Needs its own echo-ws because the auto-hangup
+# knob is incompatible with the long-lived calls other phases expect.
+echo
+echo "─── auxiliary phase: outbound ─────────────────────────"
+OB_WS_PORT=8767
+OB_ADMIN_PORT=9091
+OB_WS_LOG=$(mktemp -t echo-ws-ob.XXXXXX.log)
+OB_DAEMON_LOG=$(mktemp -t siphon-ai-ob.XXXXXX.log)
+OB_CONFIG=$(mktemp -t siphon-ai-ob.XXXXXX.toml)
+cat >"$OB_CONFIG" <<EOF
+[node]
+id = "siphon-ai-sipp-ob"
+[sip]
+listen = "127.0.0.1:$DAEMON_PORT"
+[media]
+codecs = ["pcmu"]
+[bridge]
+ws_url = "ws://127.0.0.1:$OB_WS_PORT/"
+[observability]
+enabled = true
+http_listen = "127.0.0.1:$OB_ADMIN_PORT"
+[outbound]
+max_concurrent = 2
+[[gateway]]
+name = "sipp"
+proxy = "127.0.0.1:$SIPP_PORT"
+from = "sip:harness@127.0.0.1"
+[[route]]
+name = "default"
+[route.match]
+any = true
+EOF
+
+# Dedicated echo-ws with the auto-hangup harness knob. Prefer the
+# venv the CI workflow preps (same as the transfer phase); fall back
+# to system python3 for local runs with `websockets` installed.
+OB_PYTHON="$REPO_ROOT/examples/echo-ws-server-python/.venv/bin/python"
+[[ -x "$OB_PYTHON" ]] || OB_PYTHON=python3
+"$OB_PYTHON" "$REPO_ROOT/examples/echo-ws-server-python/server.py" \
+    --bind "127.0.0.1:$OB_WS_PORT" \
+    --auto-hangup-after-ms 1500 \
+    >"$OB_WS_LOG" 2>&1 &
+OB_WS_PID=$!
+
+RUST_LOG=siphon_ai=info "$DAEMON_BIN" --config "$OB_CONFIG" \
+    >"$OB_DAEMON_LOG" 2>&1 &
+OB_DAEMON_PID=$!
+ob_cleanup() {
+    kill "$OB_WS_PID" "$OB_DAEMON_PID" 2>/dev/null || true
+    wait "$OB_WS_PID" "$OB_DAEMON_PID" 2>/dev/null || true
+}
+trap ob_cleanup EXIT
+sleep 1.2
+
+total=$((total + 1))
+echo "─── outbound_uas_answer ──────────────────────────────"
+ob_ok=0
+# SIPp listens as the callee; no remote target needed until we make
+# it ring. -bg would detach past our PID bookkeeping, so plain &.
+sipp -sf "$SCRIPT_DIR/outbound_uas_answer.xml" \
+    -m 1 -timeout 15s -trace_err -p "$SIPP_PORT" >/dev/null 2>&1 &
+OB_SIPP_PID=$!
+sleep 0.3
+
+# Place the call. 202 + a call_id means admitted; the rest plays out
+# between the daemon, SIPp, and the echo-ws hangup.
+ob_resp=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST "http://127.0.0.1:$OB_ADMIN_PORT/admin/v1/calls" \
+    -d '{"to": "7001", "gateway": "sipp"}')
+if [[ "$ob_resp" == "202" ]] && wait "$OB_SIPP_PID"; then
+    # SIPp saw INVITE → ACK → BYE. Cross-check the daemon agrees the
+    # call was ANSWERED (metric from chunk 5a).
+    if curl -s "http://127.0.0.1:$OB_ADMIN_PORT/metrics" \
+        | grep -q 'siphon_ai_outbound_calls_total{result="answered"} 1'; then
+        ob_ok=1
+    fi
+fi
+if (( ob_ok )); then
+    echo "  OK"
+else
+    echo "  FAIL (originate=$ob_resp; daemon: $OB_DAEMON_LOG; ws: $OB_WS_LOG)"
+    failures=$((failures + 1))
+fi
+
+ob_cleanup
+trap - EXIT
+
 # ─── Optional third phase: blind_transfer ─────────────────────────
 # Needs a WS server that proactively emits BridgeIn::Transfer. The
 # runner stops the daemon, brings up an echo-ws that auto-emits


### PR DESCRIPTION
The final chunk of the 0.6.0 outbound-origination plan (`docs/DEV_PLAN_0.6.0.md`) — docs, the live SIP answer-path test deferred since chunk 2, and the release bump. After this merges, `main` is `v0.6.0` and gets tagged.

### `docs/OUTBOUND.md` — the outbound guide
Enabling (`[outbound]` + `[[gateway]]`, both forms), the originate API, **the toll-fraud security posture** (§3 — the DoD item: no native auth by design per plan §9.5, so private bind + authenticating reverse proxy + `max_concurrent` + `rate_limit_per_sec` + trunk-side allowlists + metric alerting are spelled out as mandatory), the webhook/CDR lifecycle, what the WS server sees (`start.direction`, sessions begin at answer — speak first), observability, testing against a loopback gateway, and v0.6.0 limitations (no early media, attended transfer = 0.6.1, no outbound recording/signing, AMD is the WS server's job). Cross-linked from CONFIG.md and DEPLOY.md.

### SIPp — the live answer-path test (deferred since chunk 2)
- `outbound_uas_answer.xml`: roles inverted — SIPp is the **callee** (UAS). INVITE → 180 → 200+SDP → ACK → (bridge runs) → BYE → 200.
- New always-on **outbound** auxiliary phase in `run-all.sh`: fresh daemon with `[outbound]` enabled and a `[[gateway]]` at SIPp's port, a dedicated echo-ws instance with the new `--auto-hangup-after-ms` knob (so the WS side ends the call), then `POST /admin/v1/calls`. Pass requires SIPp completing the full flow **and** `siphon_ai_outbound_calls_total{result="answered"}` reading 1 — so the daemon's view is asserted, not just SIPp's.
- `examples/echo-ws-server-python`: `--auto-hangup-after-ms` test-harness knob (mirrors the existing `--auto-transfer-target` precedent).

Validated locally: **all 12 scenarios pass** (6 core + session_progress + 3 STIR/SHAKEN + recording + outbound).

### Release
- Workspace version `0.5.0` → `0.6.0` (single bump, crates inherit).
- CHANGELOG `[0.6.0]` entry covering chunks 1–6 (gateways, originate API, protocol `start.direction`, webhooks, CDR, metrics, SIPp coverage) + the toll-fraud note; compare links updated.
- README status blurb.

Everything is off by default — a 0.5.0 deployment upgrades with zero behaviour change; protocol stays `version: "1"` and the CDR schema stays at v1.

After merge: tag + GitHub release `v0.6.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)