### PR TITLE
feat(core): ConsultRegistry — attended-transfer consult lookup (0.6.1 chunk 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2971,6 +2971,7 @@ dependencies = [
  "serde_json",
  "sip-core",
  "sip-dialog",
+ "sip-parse",
  "sip-transaction",
  "sip-uac",
  "sip-uas",

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -75,8 +75,8 @@ use siphon_ai_config::{
     ObservabilityConfig, SipConfig, SipTlsConfig, SipTransport, WebhooksConfig,
 };
 use siphon_ai_core::{
-    default_call_id_factory, BridgingAcceptor, CallRegistry, OutboundGateway, OutboundGuard,
-    OutboundOriginator, OutboundService, StaticCredentials,
+    default_call_id_factory, BridgingAcceptor, CallRegistry, ConsultRegistry, OutboundGateway,
+    OutboundGuard, OutboundOriginator, OutboundService, StaticCredentials,
 };
 use siphon_ai_media_glue::MediaSetup;
 use siphon_ai_sip_glue::{
@@ -492,6 +492,10 @@ impl Runtime {
                 );
             }
             let guard = OutboundGuard::new(outbound.max_concurrent, outbound.rate_limit_per_sec);
+            // Attended-transfer consult lookup (DEV_PLAN_0.6.1 §2.1).
+            // Answered outbound calls register here; the transfer task
+            // wiring that reads it lands in 0.6.1 chunk 2.
+            let consult_registry = ConsultRegistry::new();
             let service = OutboundService::new(
                 gateways,
                 guard,
@@ -499,6 +503,7 @@ impl Runtime {
                 default_call_id_factory(),
                 outbound_cdr_sink,
                 outbound_webhook_sink,
+                consult_registry,
             );
             info!(
                 gateways = outbound.gateways.len(),

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -55,6 +55,7 @@ forge-rtp.workspace    = true
 
 [dev-dependencies]
 bytes.workspace                       = true
+sip-parse.workspace                   = true
 tokio-tungstenite.workspace           = true
 futures.workspace                     = true
 serde_json.workspace                  = true

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -28,5 +28,5 @@ pub use outbound::{
     OutboundPermit, OutboundRejection, StaticCredentials,
 };
 pub use outbound_service::{OutboundGateway, OutboundService};
-pub use registry::{CallEntry, CallRegistry};
+pub use registry::{CallEntry, CallRegistry, ConsultRegistry};
 pub use transfer::{TransferContext, TransferOutcome};

--- a/crates/core/src/outbound_service.rs
+++ b/crates/core/src/outbound_service.rs
@@ -47,6 +47,7 @@ use crate::outbound::{
     NotAnsweredCause, OutboundCall, OutboundError, OutboundGuard, OutboundOriginator,
     OutboundRejection,
 };
+use crate::registry::ConsultRegistry;
 
 /// One configured outbound gateway, ready to dial. Built by the daemon from a
 /// compiled `[[gateway]]` (the `siphon-ai-config::Gateway`) plus a per-gateway
@@ -68,9 +69,14 @@ pub struct OutboundService {
     call_id_factory: CallIdFactory,
     cdr_sink: CdrSinkHandle,
     webhook_sink: WebhookSinkHandle,
+    /// Attended-transfer lookup (DEV_PLAN_0.6.1 §2.1): answered calls
+    /// register their dialog snapshot here so another call's transfer
+    /// task can build a REFER-with-Replaces against this leg.
+    consult_registry: ConsultRegistry,
 }
 
 impl OutboundService {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         gateways: HashMap<String, OutboundGateway>,
         guard: OutboundGuard,
@@ -78,6 +84,7 @@ impl OutboundService {
         call_id_factory: CallIdFactory,
         cdr_sink: CdrSinkHandle,
         webhook_sink: WebhookSinkHandle,
+        consult_registry: ConsultRegistry,
     ) -> Self {
         Self {
             gateways,
@@ -86,6 +93,7 @@ impl OutboundService {
             call_id_factory,
             cdr_sink,
             webhook_sink,
+            consult_registry,
         }
     }
 }
@@ -147,6 +155,7 @@ impl OutboundOriginateHandle for OutboundService {
         let originator = Arc::clone(&gw.originator);
         let cdr_sink = Arc::clone(&self.cdr_sink);
         let webhook_sink = Arc::clone(&self.webhook_sink);
+        let consult_registry = self.consult_registry.clone();
 
         info!(call_id = %bridge_id_str, gateway = %gateway, "originating outbound call");
         let log_id = bridge_id_str.clone();
@@ -176,6 +185,7 @@ impl OutboundOriginateHandle for OutboundService {
                         gateway,
                         cdr_sink,
                         webhook_sink,
+                        consult_registry,
                     };
                     run_call(originator, call, bridge, ctx).await;
                 }
@@ -231,6 +241,9 @@ struct OutboundCallContext {
     gateway: String,
     cdr_sink: CdrSinkHandle,
     webhook_sink: WebhookSinkHandle,
+    /// Register/deregister this leg as an attended-transfer consult
+    /// target for the call's lifetime.
+    consult_registry: ConsultRegistry,
 }
 
 /// Run an answered outbound call's audio bridge to completion, tear it
@@ -249,6 +262,11 @@ async fn run_call(
         call_id,
     } = call;
     let sip_call_id = dialog.id().call_id().to_string();
+    // Answered → this leg is a valid attended-transfer consult target
+    // until it ends. Snapshot is enough: the transfer task only reads
+    // the dialog's id and remote target (DEV_PLAN_0.6.1 §2.1).
+    ctx.consult_registry
+        .insert(ctx.bridge_id.as_str(), dialog.clone());
     ctx.webhook_sink
         .emit(WebhookEvent::OutboundAnswered(OutboundAnsweredEvent {
             version: WEBHOOK_VERSION,
@@ -286,7 +304,9 @@ async fn run_call(
         }
         Err(e) => warn!(sip_call_id = %sip_call_id, error = %e, "outbound controller error"),
     }
-    // The controller's done — BYE the dialog and release the media session.
+    // The controller's done — this leg is no longer a consult target;
+    // then BYE the dialog and release the media session.
+    ctx.consult_registry.remove(ctx.bridge_id.as_str());
     originator.hangup(&dialog).await;
     originator.stop_session(&call_id).await;
     drop(call_handle); // stop keepalives / session-timer tasks
@@ -367,6 +387,7 @@ mod tests {
             gateway: "twilio_main".into(),
             cdr_sink: Arc::new(siphon_ai_cdr::NullSink),
             webhook_sink: Arc::new(siphon_ai_webhooks::NullSink),
+            consult_registry: ConsultRegistry::new(),
         };
         let view = CallTerminationView {
             cause: CdrTerminationCause::ServerHangup,

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -39,6 +39,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use parking_lot::RwLock;
+use sip_dialog::Dialog;
 use siphon_ai_sip_glue::DialogTerminator;
 use tracing::{debug, warn};
 
@@ -161,6 +162,80 @@ impl CallRegistry {
     /// unspecified. Intended for admin / debug introspection.
     pub fn snapshot_call_ids(&self) -> Vec<String> {
         self.inner.read().keys().cloned().collect()
+    }
+}
+
+/// Process-wide map from a bridge `call_id` to that outbound call's
+/// established SIP dialog — the consult-leg lookup for attended
+/// transfer (DEV_PLAN_0.6.1 §2.1).
+///
+/// `BridgeIn::Transfer { replaces_call_id }` runs on call A's
+/// transfer task but needs the *consult* call's dialog identifiers
+/// (Call-ID + tags, for the `Replaces=` parameter) and its remote
+/// target (the Refer-To URI). Both are fixed once the outbound leg
+/// is answered, so the registry stores a snapshot [`Dialog`] clone
+/// taken at answer time — not a live handle into the other call's
+/// task. That keeps this within CLAUDE.md §4.4's spirit the same way
+/// [`CallRegistry`] is: immutable-after-insert data, exact-id
+/// lookup, no enumeration of or reach into running calls. CSeq
+/// divergence on the snapshot is irrelevant — REFER is sent on call
+/// A's dialog; the consult dialog is only *read* for its id/target.
+///
+/// Insert happens in `outbound_service::run_call` once the call is
+/// answered; removal on that task's way out. Lookup happens at most
+/// once per attended-transfer attempt. Never touches the audio path.
+#[derive(Debug, Clone, Default)]
+pub struct ConsultRegistry {
+    inner: Arc<RwLock<HashMap<String, Dialog>>>,
+}
+
+impl ConsultRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Number of currently-registered consultable calls. For tests
+    /// and debug introspection.
+    pub fn len(&self) -> usize {
+        self.inner.read().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.read().is_empty()
+    }
+
+    /// Register an answered outbound call's dialog snapshot under
+    /// its bridge `call_id`. A collision means the caller reused a
+    /// bridge id (a bug — ids come from `CallIdFactory`); the
+    /// previous snapshot is replaced with a warning, matching
+    /// [`CallRegistry::insert`] semantics.
+    pub fn insert(&self, bridge_call_id: impl Into<String>, dialog: Dialog) {
+        let key = bridge_call_id.into();
+        let mut guard = self.inner.write();
+        if guard.insert(key.clone(), dialog).is_some() {
+            warn!(
+                call_id = %key,
+                "consult registry insert collided with existing entry; previous dialog dropped"
+            );
+        } else {
+            debug!(call_id = %key, "registered consultable outbound call");
+        }
+    }
+
+    /// Snapshot of the dialog for `bridge_call_id`, if that outbound
+    /// call is still up. Returns a clone — the caller (the transfer
+    /// task) only reads `id()` and `remote_target()` from it.
+    pub fn lookup(&self, bridge_call_id: &str) -> Option<Dialog> {
+        self.inner.read().get(bridge_call_id).cloned()
+    }
+
+    /// Drop the entry on the outbound call's way out. Removing an
+    /// unknown id is a no-op (teardown paths may race; last one
+    /// wins harmlessly).
+    pub fn remove(&self, bridge_call_id: &str) {
+        if self.inner.write().remove(bridge_call_id).is_some() {
+            debug!(call_id = %bridge_call_id, "deregistered consultable outbound call");
+        }
     }
 }
 
@@ -375,5 +450,98 @@ mod tests {
     fn terminate_from_bye_unknown_returns_false() {
         let reg = CallRegistry::new();
         assert!(!reg.terminate_from_bye("never-seen@pbx"));
+    }
+
+    /// Build a real UAC-side `Dialog` the way the outbound path does:
+    /// from an INVITE we sent and the 200 OK that answered it. Keeps
+    /// the ConsultRegistry tests honest about what a snapshot carries
+    /// (id + tags + remote target from the answer's Contact).
+    fn consult_dialog(call_id: &str, local_tag: &str, remote_tag: &str) -> Dialog {
+        let invite = format!(
+            "INVITE sip:agent@pbx.example.com SIP/2.0\r\n\
+             Via: SIP/2.0/UDP siphon.example.com;branch=z9hG4bK-test\r\n\
+             From: <sip:bot@siphon.example.com>;tag={local_tag}\r\n\
+             To: <sip:agent@pbx.example.com>\r\n\
+             Call-ID: {call_id}\r\n\
+             CSeq: 1 INVITE\r\n\
+             Contact: <sip:bot@siphon.example.com:5070>\r\n\
+             Content-Length: 0\r\n\r\n"
+        );
+        let ok = format!(
+            "SIP/2.0 200 OK\r\n\
+             Via: SIP/2.0/UDP siphon.example.com;branch=z9hG4bK-test\r\n\
+             From: <sip:bot@siphon.example.com>;tag={local_tag}\r\n\
+             To: <sip:agent@pbx.example.com>;tag={remote_tag}\r\n\
+             Call-ID: {call_id}\r\n\
+             CSeq: 1 INVITE\r\n\
+             Contact: <sip:agent@10.0.0.5:5080>\r\n\
+             Content-Length: 0\r\n\r\n"
+        );
+        let req = sip_parse::parse_request(&bytes::Bytes::from(invite)).expect("parse INVITE");
+        let resp = sip_parse::parse_response(&bytes::Bytes::from(ok)).expect("parse 200");
+        Dialog::new_uac(
+            &req,
+            &resp,
+            sip_core::SipUri::parse("sip:bot@siphon.example.com").unwrap(),
+            sip_core::SipUri::parse("sip:agent@pbx.example.com").unwrap(),
+        )
+        .expect("dialog from 200")
+    }
+
+    #[test]
+    fn consult_insert_lookup_remove_round_trip() {
+        let reg = ConsultRegistry::new();
+        assert!(reg.is_empty());
+
+        reg.insert("siphon-C", consult_dialog("abc@siphon", "ltag", "rtag"));
+        assert_eq!(reg.len(), 1);
+
+        // The snapshot carries exactly what the attended-transfer
+        // task reads: the Replaces identifiers and the Refer-To URI.
+        let dialog = reg.lookup("siphon-C").expect("present");
+        assert_eq!(dialog.id().call_id(), "abc@siphon");
+        assert_eq!(dialog.id().local_tag(), "ltag");
+        assert_eq!(dialog.id().remote_tag(), "rtag");
+        assert_eq!(dialog.remote_target().as_str(), "sip:agent@10.0.0.5:5080");
+
+        reg.remove("siphon-C");
+        assert!(reg.is_empty());
+        assert!(reg.lookup("siphon-C").is_none());
+        // Double-remove is a harmless no-op (teardown paths may race).
+        reg.remove("siphon-C");
+    }
+
+    #[test]
+    fn consult_lookup_unknown_returns_none() {
+        let reg = ConsultRegistry::new();
+        reg.insert("siphon-C", consult_dialog("abc@siphon", "l", "r"));
+        assert!(reg.lookup("never-seen").is_none());
+    }
+
+    #[test]
+    fn consult_duplicate_insert_replaces() {
+        // A bridge-id collision is a CallIdFactory bug, but the
+        // registry must stay coherent: last insert wins.
+        let reg = ConsultRegistry::new();
+        reg.insert("siphon-C", consult_dialog("first@siphon", "l1", "r1"));
+        reg.insert("siphon-C", consult_dialog("second@siphon", "l2", "r2"));
+        assert_eq!(reg.len(), 1);
+        assert_eq!(
+            reg.lookup("siphon-C").unwrap().id().call_id(),
+            "second@siphon"
+        );
+    }
+
+    #[test]
+    fn consult_cloned_registry_shares_state() {
+        // Same shared-Arc invariant as CallRegistry: the outbound
+        // service's clone and the transfer task's clone must see one
+        // map.
+        let a = ConsultRegistry::new();
+        let b = a.clone();
+        a.insert("siphon-C", consult_dialog("abc@siphon", "l", "r"));
+        assert!(b.lookup("siphon-C").is_some());
+        b.remove("siphon-C");
+        assert!(a.is_empty());
     }
 }


### PR DESCRIPTION
Chunk 1 of the 0.6.1 attended-transfer plan (`docs/DEV_PLAN_0.6.1.md` §2.1/§5, merged in #149) — the one new cross-call touch, landed first and inert so the feature chunk (#2) is a pure consumer.

### What
`ConsultRegistry`: a process-wide map from a bridge `call_id` to that **answered outbound call's** SIP dialog snapshot. Attended transfer (chunk 2) runs on call A's transfer task but needs the consult leg's dialog identifiers (Call-ID + tags for the `Replaces=` parameter) and its remote target (the Refer-To URI default) — both fixed at answer time.

### CLAUDE.md §4.4 argument
Same shape that makes `CallRegistry` acceptable: an immutable-after-insert snapshot (not a live handle into the other call's task), exact-id lookup only, no enumeration, insert/remove at setup/teardown, never on the audio path. CSeq divergence on the snapshot is irrelevant — the REFER is sent on call A's dialog; the consult dialog is only *read*.

### Wiring
- `outbound_service::run_call` inserts at answer (next to the `outbound_answered` webhook) and removes on its way out, before BYE/teardown.
- The daemon constructs the registry in the `[outbound]` branch; the transfer-task wiring that *reads* it is chunk 2.

### Tests
Unit tests build a real UAC dialog from a parsed INVITE + 200 OK (`sip-parse` added as a **dev**-dependency — same pinned upstream repo) and pin that the snapshot carries exactly what the transfer task will read: `id().{call_id, local_tag, remote_tag}` and `remote_target()`. Plus collision-replace, unknown-lookup, double-remove no-op, and shared-Arc clone semantics, mirroring the `CallRegistry` test suite.

No behavior change for existing calls; blind transfer untouched. Workspace green: clippy `-D warnings`, full test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)