### PR TITLE
feat(core): transfer on outbound legs — DialogSource (0.6.1 chunk 3)

### DIFF
--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -96,7 +96,7 @@ use crate::call::{
 };
 use crate::registry::CallRegistry;
 use crate::registry::ConsultRegistry;
-use crate::transfer::TransferContext;
+use crate::transfer::{DialogSource, TransferContext};
 
 /// Daemon-wide bridge & media defaults. Routes' `[route.bridge]`
 /// and `[route.media]` blocks override individual fields.
@@ -2991,9 +2991,11 @@ impl BridgingAcceptor {
         );
 
         let transfer = self.transfer.get().map(|installed| TransferContext {
-            sip_call_id: sip_call_id.clone(),
             uac: Arc::clone(&installed.uac),
-            dialog_manager: Arc::clone(&installed.dialog_manager),
+            source: DialogSource::Managed {
+                sip_call_id: sip_call_id.clone(),
+                dialog_manager: Arc::clone(&installed.dialog_manager),
+            },
             consult_registry: installed.consult_registry.clone(),
         });
 

--- a/crates/core/src/call.rs
+++ b/crates/core/src/call.rs
@@ -907,15 +907,12 @@ async fn run_transfer_inner(
         Err(msg) => return TransferOutcome::LocalError(msg),
     };
 
-    // The UAS owns the canonical dialog; we operate on a clone so the
-    // local CSeq the REFER consumes doesn't race the next inbound
-    // request on the same dialog. CLAUDE.md §4.4: per-call state is
+    // The leg's owner keeps the canonical dialog; we operate on a
+    // clone so the local CSeq the REFER consumes doesn't race other
+    // requests on the same dialog. CLAUDE.md §4.4: per-call state is
     // not shared across tasks — this is the per-task copy.
-    let Some(mut dialog) = ctx.dialog_manager.find_by_call_id(&ctx.sip_call_id) else {
-        return TransferOutcome::LocalError(format!(
-            "no dialog for sip_call_id {:?}",
-            ctx.sip_call_id
-        ));
+    let Some(mut dialog) = ctx.source.resolve() else {
+        return TransferOutcome::LocalError("dialog for this call is gone".to_string());
     };
 
     let (refer_to, consult) = match &plan {
@@ -935,8 +932,12 @@ async fn run_transfer_inner(
                 // Attended: the consult leg is NOT hung up here — the
                 // transferee's INVITE-with-Replaces takes it over, and
                 // its own teardown path runs when that leg ends.
-                if let Err(e) = ctx.uac.bye(&dialog).await {
-                    warn!(error = %e, "post-REFER BYE failed (dialog may linger)");
+                // Outbound legs skip the BYE too: their run_call
+                // teardown sends it when the controller exits.
+                if ctx.source.bye_after_refer() {
+                    if let Err(e) = ctx.uac.bye(&dialog).await {
+                        warn!(error = %e, "post-REFER BYE failed (dialog may linger)");
+                    }
                 }
                 TransferOutcome::Accepted
             } else {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -29,4 +29,4 @@ pub use outbound::{
 };
 pub use outbound_service::{OutboundGateway, OutboundService};
 pub use registry::{CallEntry, CallRegistry, ConsultRegistry};
-pub use transfer::{TransferContext, TransferOutcome};
+pub use transfer::{DialogSource, TransferContext, TransferOutcome};

--- a/crates/core/src/outbound.rs
+++ b/crates/core/src/outbound.rs
@@ -98,6 +98,14 @@ impl OutboundOriginator {
         Self { media, uac }
     }
 
+    /// This gateway's UAC. The outbound leg's transfer context sends
+    /// its in-dialog REFER through this (not the daemon-wide transfer
+    /// UAC) so the gateway's digest credentials answer any 401/407
+    /// challenge on the REFER (DEV_PLAN_0.6.1 §2.4).
+    pub fn uac(&self) -> Arc<IntegratedUAC> {
+        Arc::clone(&self.uac)
+    }
+
     /// Place an outbound call to `target`: allocate media + an SDP offer,
     /// send the INVITE, await the final response, and on a 2xx bind the
     /// peer's answer. On any non-answer the partially-built session is

--- a/crates/core/src/outbound_service.rs
+++ b/crates/core/src/outbound_service.rs
@@ -48,6 +48,7 @@ use crate::outbound::{
     OutboundRejection,
 };
 use crate::registry::ConsultRegistry;
+use crate::transfer::{DialogSource, TransferContext};
 
 /// One configured outbound gateway, ready to dial. Built by the daemon from a
 /// compiled `[[gateway]]` (the `siphon-ai-config::Gateway`) plus a per-gateway
@@ -288,12 +289,23 @@ async fn run_call(
         &sip_call_id,
         &accepted.answer,
     );
+    // Outbound legs are transferable too (DEV_PLAN_0.6.1 §2.4): the
+    // bot can consult an agent and hand this callee off. The REFER
+    // goes through this gateway's own UAC (digest credentials), on
+    // the dialog we hold directly — each gateway UAC keeps a private
+    // DialogManager, so the shared lookup the inbound path uses
+    // can't see this dialog.
+    let transfer = TransferContext {
+        uac: originator.uac(),
+        source: DialogSource::Direct(Box::new(dialog.clone())),
+        consult_registry: ctx.consult_registry.clone(),
+    };
     let cfg = CallControllerConfig {
         call_id: ctx.bridge_id.clone(),
         bridge,
         start,
         media_tap: accepted.tap,
-        transfer: None,
+        transfer: Some(transfer),
         recording: None,
     };
     let (controller, _handle) = CallController::new(cfg);

--- a/crates/core/src/transfer.rs
+++ b/crates/core/src/transfer.rs
@@ -36,27 +36,76 @@ use sip_uac::integrated::IntegratedUAC;
 
 use crate::registry::ConsultRegistry;
 
-/// Everything the controller needs to fire a REFER on the dialog
-/// established by the inbound INVITE.
+/// Where the REFER's dialog comes from — the inbound and outbound
+/// legs hold their dialogs differently (DEV_PLAN_0.6.1 §2.4).
+#[derive(Clone)]
+pub enum DialogSource {
+    /// Inbound leg: the UAS owns the canonical dialog; resolve a
+    /// per-task clone from the shared [`DialogManager`] by SIP
+    /// Call-ID at REFER time.
+    Managed {
+        sip_call_id: String,
+        dialog_manager: Arc<DialogManager>,
+    },
+    /// Outbound leg: the originate path holds the confirmed dialog
+    /// directly (each gateway UAC has its own private DialogManager,
+    /// so the shared one can't resolve it). Snapshot taken at answer;
+    /// the CSeq-divergence note below applies the same way.
+    Direct(Box<Dialog>),
+}
+
+impl DialogSource {
+    /// Per-task dialog clone for the REFER. `None` = the dialog is
+    /// gone (inbound leg already torn down) → `LocalError`.
+    pub(crate) fn resolve(&self) -> Option<Dialog> {
+        match self {
+            DialogSource::Managed {
+                sip_call_id,
+                dialog_manager,
+            } => dialog_manager.find_by_call_id(sip_call_id),
+            DialogSource::Direct(dialog) => Some(*dialog.clone()),
+        }
+    }
+
+    /// Whether the transfer task should BYE the leg itself after a
+    /// 202 ("REFER + BYE", RFC 5589 §6.1). True for inbound legs.
+    /// False for outbound legs — their `run_call` teardown already
+    /// sends the BYE when the controller exits, and a second one
+    /// here would just draw a 481 from the peer.
+    pub(crate) fn bye_after_refer(&self) -> bool {
+        matches!(self, DialogSource::Managed { .. })
+    }
+
+    /// The leg's SIP Call-ID, for logging.
+    fn sip_call_id(&self) -> &str {
+        match self {
+            DialogSource::Managed { sip_call_id, .. } => sip_call_id,
+            DialogSource::Direct(dialog) => dialog.id().call_id(),
+        }
+    }
+}
+
+/// Everything the controller needs to fire a REFER on this call's
+/// dialog — inbound (resolved via the shared [`DialogManager`]) or
+/// outbound (held directly, sent through the gateway's own UAC so
+/// its digest credentials answer any challenge).
 ///
-/// One [`TransferContext`] per call: it pins this call's SIP Call-ID
-/// so the per-call dialog lookup is local to the controller, not a
-/// process-wide search. `uac` and `dialog_manager` are `Arc` clones
-/// of the daemon-wide pair installed at startup; `consult_registry`
-/// is the daemon-wide consult-leg lookup for attended transfer
-/// (empty unless `[outbound]` calls are live).
+/// One [`TransferContext`] per call: the dialog source pins this
+/// call's leg, so the lookup is local to the controller, not a
+/// process-wide search. `consult_registry` is the daemon-wide
+/// consult-leg lookup for attended transfer (empty unless
+/// `[outbound]` calls are live).
 #[derive(Clone)]
 pub struct TransferContext {
-    pub sip_call_id: String,
     pub uac: Arc<IntegratedUAC>,
-    pub dialog_manager: Arc<DialogManager>,
+    pub source: DialogSource,
     pub consult_registry: ConsultRegistry,
 }
 
 impl std::fmt::Debug for TransferContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TransferContext")
-            .field("sip_call_id", &self.sip_call_id)
+            .field("sip_call_id", &self.source.sip_call_id())
             .finish_non_exhaustive()
     }
 }
@@ -209,6 +258,30 @@ mod tests {
         // the Replaces identifiers are the point of attended mode.
         let err = plan_refer(&reg, Some("sip:agent@example.com"), Some("siphon-gone")).unwrap_err();
         assert!(err.contains("siphon-gone"), "got: {err}");
+    }
+
+    #[test]
+    fn direct_source_resolves_the_held_dialog_and_skips_bye() {
+        // Outbound legs: the dialog is held directly; run_call's
+        // teardown owns the BYE, so the transfer task must not send
+        // a second one.
+        let src = DialogSource::Direct(Box::new(consult_dialog("out@siphon", "l", "r")));
+        let dialog = src.resolve().expect("direct always resolves");
+        assert_eq!(dialog.id().call_id(), "out@siphon");
+        assert!(!src.bye_after_refer());
+    }
+
+    #[test]
+    fn managed_source_misses_when_dialog_is_gone_and_byes() {
+        // Inbound legs: resolution goes through the shared manager;
+        // an empty manager (call torn down) is a clean miss. The
+        // post-REFER BYE stays on (RFC 5589 §6.1 pattern).
+        let src = DialogSource::Managed {
+            sip_call_id: "gone@pbx".into(),
+            dialog_manager: Arc::new(DialogManager::new()),
+        };
+        assert!(src.resolve().is_none());
+        assert!(src.bye_after_refer());
     }
 
     #[test]


### PR DESCRIPTION
Chunk 3 of the 0.6.1 plan (`docs/DEV_PLAN_0.6.1.md` §2.4, decision §9.3 locked) — outbound calls become transferable, blind and attended. This is the headline outbound-bot flow: bot dials a customer (0.6.0), customer asks for a human, bot consults an agent (#151) and completes the transfer — the REFER lands on the **customer** leg.

### The chunk-time verification (plan §7 risk, settled)
Each gateway `IntegratedUAC` constructs its **own private `DialogManager`** (`UserAgentClient::new` → fresh manager; the builder can't inject one). Outbound dialogs therefore never appear in the shared UAS manager the inbound transfer path resolves through — `find_by_call_id` would always miss. So this lands the plan's dialog-direct variant:

- `TransferContext.{sip_call_id, dialog_manager}` → `source: DialogSource`:
  - `Managed { sip_call_id, dialog_manager }` — inbound legs, resolve-at-REFER-time (unchanged behavior);
  - `Direct(Box<Dialog>)` — outbound legs, the confirmed dialog the originate path already holds.
- Per-leg policy rides on the source: `Direct` legs **skip the post-202 BYE** — `run_call`'s teardown already BYEs when the controller exits, and a second BYE would just draw a 481.
- The outbound context uses the **gateway's own UAC** (new `OutboundOriginator::uac()` accessor), not the credential-less daemon transfer UAC — so the trunk's digest credentials answer any 401/407 challenge on the REFER.

### Validation
- `DialogSource` unit tests (direct resolves + skips BYE; managed misses cleanly + keeps BYE).
- Workspace green (clippy `-D warnings`, all tests).
- SIPp locally: **13/13** including `blind_transfer` (inbound regression) and `outbound_uas_answer`.

Next: chunk 4 — docs polish, the live attended-transfer SIPp scenario, version bump, release v0.6.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)