### PR TITLE
feat(test-harness,docs): attended SIPp scenario + double-BYE fix + release 0.6.1 (chunk 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-06-10
+
+Theme: **attended transfer** — the 0.6.0 fast-follow. The bot consults a
+human before handing the caller off: SiphonAI places the consult leg as a
+plain 0.6.0 outbound call (its own WS session), and completion is one
+REFER-with-Replaces on the original call. The WS protocol stays at
+`version: "1"` (one additive field) and the CDR schema is unchanged.
+
+### Added
+
+- **Attended transfer** — `transfer.replaces_call_id` names an answered
+  outbound call (the consult leg, placed via `POST /admin/v1/calls` and
+  identified by the `call_id` that endpoint returned). SiphonAI sends a
+  REFER whose `Refer-To` embeds a `Replaces` built from the consult
+  dialog, so the transferee connects directly to the consulted party
+  (RFC 5589 §7). `target` becomes optional — the default Refer-To is the
+  consult dialog's remote target (its 200 OK Contact); send `target` only
+  to override the reachable URI. The consult leg is **not** torn down at
+  REFER time (the transferee's INVITE-with-Replaces takes it over); to
+  cancel a consultation, just hang up the consult call. Unknown / not-yet-
+  answered / already-ended `replaces_call_id` → `error
+  { code: "transfer_failed" }` and the call continues. `docs/PROTOCOL.md`
+  §4.4.
+- **Outbound legs are transferable** (blind or attended) — an outbound
+  bot can hand its callee off the same way. The REFER goes out through
+  the gateway's own UAC, so its digest credentials answer any 401/407
+  challenge on the REFER.
+- **Metric** — `siphon_ai_transfers_total{mode="blind"|"attended",
+  result="accepted"|"rejected"|"local_error"}`; also back-fills blind
+  transfers, which were previously unmetered.
+- **SIPp coverage** — `attended_transfer_a.xml` + an always-on
+  three-party regression phase (SIPp on both far ends: inbound transferee
+  + consult callee; pass requires the REFER's `Refer-To` to carry
+  `Replaces=` *and* the metric reading attended/accepted), driven by a
+  new `--auto-transfer-replaces` test-harness knob on the echo WS
+  example server.
+
+### Fixed
+
+- **Duplicate BYE after an accepted transfer** on inbound legs: the
+  transfer task sends the post-REFER BYE ("REFER + BYE", RFC 5589 §6.1),
+  but the acceptor's cleanup task then sent a *second* BYE from a fresh
+  CSeq space — a protocol violation that strict peers reject. Affected
+  blind transfer too (latent since 0.2.0; exposed by the new attended
+  SIPp scenario's stricter tail).
+
 ## [0.6.0] - 2026-06-09
 
 Theme: **outbound call origination.** SiphonAI inverts its inbound-only
@@ -641,7 +687,8 @@ the WebSocket server's job.
 - Reference WebSocket servers in `examples/`: echo (Python / Node),
   an OpenAI Realtime bridge, and a Deepgram + LLM voice bot.
 
-[Unreleased]: https://github.com/thevoiceguy/siphon-ai/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/thevoiceguy/siphon-ai/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/thevoiceguy/siphon-ai/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/thevoiceguy/siphon-ai/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/thevoiceguy/siphon-ai/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/thevoiceguy/siphon-ai/compare/v0.4.0...v0.4.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2899,7 +2899,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "base64",
  "bytes",
@@ -2920,7 +2920,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2937,7 +2937,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "regex",
  "serde",
@@ -2954,7 +2954,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2994,7 +2994,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -3009,7 +3009,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3031,7 +3031,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "thiserror 1.0.69",
  "tokio",
@@ -3040,7 +3040,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "regex",
  "serde",
@@ -3051,7 +3051,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3060,7 +3060,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3083,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "base64",
  "rcgen",
@@ -3101,7 +3101,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3122,7 +3122,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -42,20 +42,20 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**v0.6.0** — sixth release. Theme: **outbound call origination.** SiphonAI
-now **places** calls, not just answers them: `POST /admin/v1/calls` dials a
-destination through a configured `[[gateway]]` (a standalone trunk, or
-dialing through an existing `[[register]]`) and bridges the answered call
-to a WS server over the same protocol v1 session — `start.direction:
-"outbound"` is the only wire difference (additive). Progress arrives via
-new `outbound_initiated` / `outbound_answered` / `outbound_failed`
-webhooks, a `direction: "outbound"` CDR, and a
-`siphon_ai_outbound_calls_total{result}` metric. **Off by default**
-(fail-closed on `max_concurrent = 0`) and **toll-fraud-aware by design**:
-the originate API has no native auth — the documented posture is a private
-bind + authenticating reverse proxy, with the concurrency cap + rate limit
-as native guardrails. See [`docs/OUTBOUND.md`](docs/OUTBOUND.md). Attended
-transfer is the 0.6.1 fast-follow. Full notes:
+**v0.6.1** — seventh release. Theme: **attended transfer.** The bot
+consults a human before handing the caller off: SiphonAI places the
+consult leg as a plain 0.6.0 outbound call (`POST /admin/v1/calls`, its
+own WS session), and the WS server completes the handoff with one
+additive protocol field — `transfer { replaces_call_id }` — which becomes
+a REFER-with-Replaces on the original call (RFC 5589), connecting the two
+humans directly. The `Refer-To` is derived from the consult dialog
+(explicit `target` overrides), outbound legs are transferable too, and
+both transfer modes now emit `siphon_ai_transfers_total{mode,result}`.
+Builds on 0.6.0's outbound origination: gateways, the originate API, the
+toll-fraud posture (private bind + reverse proxy + cap + rate limit), and
+`start.direction` are unchanged — see
+[`docs/OUTBOUND.md`](docs/OUTBOUND.md) and
+[`docs/PROTOCOL.md`](docs/PROTOCOL.md) §4.4. Full notes:
 [`CHANGELOG.md`](CHANGELOG.md).
 
 **v0.5.0** — fifth release. Theme: **call recording.** Each call's audio can

--- a/crates/core/src/call.rs
+++ b/crates/core/src/call.rs
@@ -630,6 +630,22 @@ impl CallController {
                     match outcome {
                         TransferOutcome::Accepted => {
                             info!(call_id = %call_id, "REFER accepted; tearing down call");
+                            // On inbound legs the transfer task has
+                            // already sent the post-REFER BYE ("REFER
+                            // + BYE"); flag the handle so the
+                            // acceptor's cleanup doesn't owe the peer
+                            // a second one (it would go out with a
+                            // fresh CSeq space, which strict peers
+                            // reject). Outbound legs stay unmarked —
+                            // their run_call teardown still sends the
+                            // BYE. If the task's BYE failed we skip
+                            // the cleanup BYE anyway: it would reuse
+                            // the same UAC and fail the same way, and
+                            // the task already warned that the dialog
+                            // may linger.
+                            if transfer.as_ref().is_some_and(|t| t.source.bye_after_refer()) {
+                                handle.mark_remote_bye();
+                            }
                             termination = CallTermination::LocalShutdown;
                             let _ = control_out_tx
                                 .send(OutgoingEvent::Stop { reason: StopReason::Transfer })

--- a/docs/OUTBOUND.md
+++ b/docs/OUTBOUND.md
@@ -141,6 +141,22 @@ greeting flow might. Everything else — audio frames, barge-in, DTMF,
 `hangup`, transfer — behaves identically to inbound. See
 `docs/PROTOCOL.md`.
 
+### Consult legs — attended transfer (0.6.1)
+
+An outbound call doubles as the **consult leg** of an attended transfer:
+place it with `POST /admin/v1/calls`, let the bot talk to the consulted
+party over that call's own WS session, then send
+`transfer { replaces_call_id: "<the consult call_id>" }` on the *original*
+call's session. SiphonAI REFERs the original peer with a `Refer-To` that
+embeds a `Replaces` built from the consult dialog, so the two humans
+connect directly and both SiphonAI legs end. The consult call must be
+**answered** when the transfer fires, and SiphonAI does not tear it down at
+REFER time — the transferee's INVITE-with-Replaces takes it over. Field
+semantics, target derivation/override, and error cases are in
+`docs/PROTOCOL.md` §4.4. Outbound legs are themselves transferable too
+(blind or attended), so an outbound bot can hand its callee off the same
+way.
+
 ## 5. Observability
 
 - **Metrics** — `siphon_ai_outbound_calls_total{result}` (`answered`,
@@ -167,7 +183,7 @@ echo WS server ends the call. The same trick works interactively — point a
 `[[gateway]]` at any lab UAS (`proxy = "127.0.0.1:5080"`) and originate
 against it; nothing leaves the machine.
 
-## 7. Limitations (v0.6.0)
+## 7. Limitations (v0.6.1)
 
 - **No early media** — audio before the 200 OK (ringback injected by the
   far end, IVR pre-answer prompts) is not bridged; the WS session starts at
@@ -175,8 +191,6 @@ against it; nothing leaves the machine.
 - **No mid-call progress webhook for ringing** — `outbound_initiated` fires
   at INVITE, the next signal is answered/failed. (180 Ringing is visible in
   HEP/Homer if you need it.)
-- **Attended transfer** (consultation leg as an outbound call) is the 0.6.1
-  fast-follow.
 - **Recording** is not wired for outbound calls in this release.
 - **No STIR/SHAKEN signing** — SiphonAI verifies inbound `Identity` headers
   but does not sign outbound INVITEs; attestation for your calls is the

--- a/examples/echo-ws-server-python/server.py
+++ b/examples/echo-ws-server-python/server.py
@@ -63,6 +63,10 @@ class Options:
     # `hangup`. Lets the outbound SIPp scenario end the call from the
     # WS side (the callee just waits for our BYE). None = disabled.
     auto_hangup_after_ms: int | None
+    # Test-harness knob: after `start`, send an ATTENDED transfer
+    # naming this consult call id (`replaces_call_id`). Reuses
+    # auto_transfer_delay_ms for the pause. None = disabled.
+    auto_transfer_replaces: str | None
 
 
 # ─── HTTP-side concerns: auth + subprotocol ─────────────────────────────────
@@ -187,6 +191,24 @@ async def handle(connection: ServerConnection, opts: Options) -> None:
                         )
                     )
 
+                if opts.auto_transfer_replaces and call_id:
+                    # Test-harness behaviour: complete an attended
+                    # transfer against a consult call the harness
+                    # placed via POST /admin/v1/calls. No `target` —
+                    # SiphonAI derives the Refer-To from the consult
+                    # dialog's Contact (PROTOCOL.md §4.4).
+                    asyncio.create_task(
+                        _send_after(
+                            connection,
+                            opts.auto_transfer_delay_ms,
+                            {
+                                "type": "transfer",
+                                "call_id": call_id,
+                                "replaces_call_id": opts.auto_transfer_replaces,
+                            },
+                        )
+                    )
+
                 if opts.auto_hangup_after_ms is not None and call_id:
                     # Test-harness behaviour: end the call from the WS
                     # side after a beat. Used by the outbound SIPp
@@ -298,6 +320,17 @@ def parse_args(argv: list[str] | None = None) -> Options:
         help="ms to wait after `start` before emitting the transfer (default: 200)",
     )
     p.add_argument(
+        "--auto-transfer-replaces",
+        default=None,
+        metavar="CALL_ID",
+        help=(
+            "test-harness only: after `start`, emit an attended "
+            "`transfer` with this replaces_call_id (the consult "
+            "call's bridge id). Uses --auto-transfer-delay-ms. See "
+            "test-harness/sipp-scenarios/attended_transfer_a.xml."
+        ),
+    )
+    p.add_argument(
         "--auto-hangup-after-ms",
         type=int,
         default=None,
@@ -328,6 +361,7 @@ def parse_args(argv: list[str] | None = None) -> Options:
         auto_transfer_target=args.auto_transfer_target,
         auto_transfer_delay_ms=args.auto_transfer_delay_ms,
         auto_hangup_after_ms=args.auto_hangup_after_ms,
+        auto_transfer_replaces=args.auto_transfer_replaces,
     )
 
 

--- a/test-harness/sipp-scenarios/attended_transfer_a.xml
+++ b/test-harness/sipp-scenarios/attended_transfer_a.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  attended_transfer_a — SIPp is the CALLER (leg A, the transferee);
+  SiphonAI answers and bridges to an echo-ws started with the
+  auto-transfer-replaces knob. Meanwhile the harness has placed a
+  consult call (leg C) via POST /admin/v1/calls to a second SIPp
+  running outbound_uas_answer.xml.
+
+  Validates the 0.6.1 attended-transfer completion on the wire: after
+  the WS server sends `transfer { replaces_call_id }`, SiphonAI sends
+  us a REFER whose Refer-To carries a `Replaces=` parameter built
+  from the consult dialog (asserted below with check_it) — then the
+  "REFER + BYE" pattern tears our leg down.
+
+  Run via run-all.sh's attended_transfer auxiliary phase; standalone
+  it would wait forever for the REFER.
+-->
+<scenario name="attended_transfer_a">
+  <send>
+<![CDATA[
+INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+Max-Forwards: 70
+From: <sip:sipp@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:sipp@[local_ip]:[local_port]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=user1 53655765 2353687637 IN IP4 [local_ip]
+s=-
+c=IN IP4 [local_ip]
+t=0 0
+m=audio 9000 RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+]]>
+  </send>
+
+  <recv response="100" optional="true"/>
+  <recv response="180" optional="true"/>
+  <recv response="183" optional="true"/>
+
+  <recv response="200" rtd="true"/>
+
+  <send>
+<![CDATA[
+ACK sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]-ack
+Max-Forwards: 70
+From: <sip:sipp@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- The bridge is up; the echo-ws sends the attended `transfer`
+       after its delay. SiphonAI then REFERs us. check_it fails the
+       call if the Refer-To lacks an embedded Replaces parameter —
+       i.e. if a blind REFER snuck through instead of attended. -->
+  <recv request="REFER" rtd="true">
+    <action>
+      <ereg regexp="Refer-To:.*Replaces=" search_in="msg" check_it="true" assign_to="dummy"/>
+    </action>
+  </recv>
+
+  <send>
+<![CDATA[
+SIP/2.0 202 Accepted
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- Inbound legs keep the "REFER + BYE" pattern (RFC 5589 §6.1):
+       SiphonAI BYEs us right after the 202. -->
+  <recv request="BYE" rtd="true"/>
+
+  <send>
+<![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- Reference the assigned var so SIPp doesn't warn about it. -->
+  <nop>
+    <action>
+      <log message="refer-to with replaces seen: [$dummy]"/>
+    </action>
+  </nop>
+</scenario>

--- a/test-harness/sipp-scenarios/run-all.sh
+++ b/test-harness/sipp-scenarios/run-all.sh
@@ -424,6 +424,136 @@ fi
 ob_cleanup
 trap - EXIT
 
+# ─── Always-on auxiliary phase: attended transfer ─────────────────
+# The full 0.6.1 three-party flow with SIPp on both far ends:
+#   * leg A  — SIPp UAC calls in (the transferee); its echo-ws is
+#     started with --auto-transfer-replaces so the WS side completes
+#     the attended transfer shortly after the bridge comes up.
+#   * leg C  — a consult call the harness places via the originate
+#     API to a second SIPp running outbound_uas_answer.xml; its own
+#     echo-ws auto-hangs-up later (the consult leg must outlive the
+#     REFER — SiphonAI does NOT tear it down at transfer time).
+# Pass = leg A saw a REFER whose Refer-To embeds a Replaces built
+# from the consult dialog (check_it in the scenario) + the metric
+# reads attended/accepted.
+echo
+echo "─── auxiliary phase: attended_transfer ────────────────"
+AT_CONSULT_PORT=5081
+AT_ADMIN_PORT=9091
+AT_A_WS_PORT=8768
+AT_C_WS_PORT=8769
+AT_A_WS_LOG=$(mktemp -t echo-ws-at-a.XXXXXX.log)
+AT_C_WS_LOG=$(mktemp -t echo-ws-at-c.XXXXXX.log)
+AT_DAEMON_LOG=$(mktemp -t siphon-ai-at.XXXXXX.log)
+AT_CONFIG=$(mktemp -t siphon-ai-at.XXXXXX.toml)
+cat >"$AT_CONFIG" <<EOF
+[node]
+id = "siphon-ai-sipp-at"
+[sip]
+listen = "127.0.0.1:$DAEMON_PORT"
+[media]
+codecs = ["pcmu"]
+[bridge]
+ws_url = "ws://127.0.0.1:$AT_A_WS_PORT/"
+[observability]
+enabled = true
+http_listen = "127.0.0.1:$AT_ADMIN_PORT"
+[outbound]
+max_concurrent = 2
+[[gateway]]
+name = "sipp"
+proxy = "127.0.0.1:$AT_CONSULT_PORT"
+from = "sip:harness@127.0.0.1"
+[[route]]
+name = "default"
+[route.match]
+any = true
+EOF
+
+AT_PYTHON="$REPO_ROOT/examples/echo-ws-server-python/.venv/bin/python"
+[[ -x "$AT_PYTHON" ]] || AT_PYTHON=python3
+
+# Consult-leg echo-ws: hang the consult call up well AFTER the
+# transfer completes, so its dialog is still live when the REFER's
+# Replaces references it.
+"$AT_PYTHON" "$REPO_ROOT/examples/echo-ws-server-python/server.py" \
+    --bind "127.0.0.1:$AT_C_WS_PORT" \
+    --auto-hangup-after-ms 6000 \
+    >"$AT_C_WS_LOG" 2>&1 &
+AT_C_WS_PID=$!
+
+RUST_LOG=siphon_ai=info "$DAEMON_BIN" --config "$AT_CONFIG" \
+    >"$AT_DAEMON_LOG" 2>&1 &
+AT_DAEMON_PID=$!
+AT_A_WS_PID=""
+AT_C_SIPP_PID=""
+# Kill the consult-side sipp too: on a failed run it never sees its
+# BYE and -timeout won't reap a call still in progress, so it would
+# squat on $AT_CONSULT_PORT past the end of the script.
+at_cleanup() {
+    kill "$AT_C_WS_PID" "$AT_DAEMON_PID" $AT_A_WS_PID $AT_C_SIPP_PID 2>/dev/null || true
+    wait "$AT_C_WS_PID" "$AT_DAEMON_PID" $AT_A_WS_PID $AT_C_SIPP_PID 2>/dev/null || true
+}
+trap at_cleanup EXIT
+sleep 1.2
+
+total=$((total + 1))
+echo "─── attended_transfer ────────────────────────────────"
+at_ok=0
+# Consult callee first, then originate leg C through the gateway.
+sipp -sf "$SCRIPT_DIR/outbound_uas_answer.xml" \
+    -m 1 -timeout 20s -trace_err -p "$AT_CONSULT_PORT" >/dev/null 2>&1 &
+AT_C_SIPP_PID=$!
+sleep 0.3
+at_consult_id=$(curl -s -X POST "http://127.0.0.1:$AT_ADMIN_PORT/admin/v1/calls" \
+    -d "{\"to\": \"agent\", \"gateway\": \"sipp\", \"ws_url\": \"ws://127.0.0.1:$AT_C_WS_PORT/\"}" \
+    | sed -n 's/.*"call_id":"\([^"]*\)".*/\1/p')
+
+# Wait for the consult leg to be ANSWERED (registered as a consult
+# target) before leg A's transfer can reference it.
+at_answered=0
+for _ in $(seq 1 20); do
+    if curl -s "http://127.0.0.1:$AT_ADMIN_PORT/metrics" \
+        | grep -q 'siphon_ai_outbound_calls_total{result="answered"} 1'; then
+        at_answered=1; break
+    fi
+    sleep 0.2
+done
+
+if [[ -n "$at_consult_id" ]] && (( at_answered )); then
+    # Leg A's echo-ws completes the attended transfer once bridged.
+    "$AT_PYTHON" "$REPO_ROOT/examples/echo-ws-server-python/server.py" \
+        --bind "127.0.0.1:$AT_A_WS_PORT" \
+        --auto-transfer-replaces "$at_consult_id" \
+        --auto-transfer-delay-ms 300 \
+        >"$AT_A_WS_LOG" 2>&1 &
+    AT_A_WS_PID=$!
+    sleep 0.5
+
+    if sipp -sf "$SCRIPT_DIR/attended_transfer_a.xml" \
+            -m 1 -timeout 15s -trace_err -p "$SIPP_PORT" -s 1000 \
+            "127.0.0.1:$DAEMON_PORT" >/dev/null 2>&1 \
+        && wait "$AT_C_SIPP_PID"; then
+        # Both far ends are happy; cross-check the daemon's view.
+        if curl -s "http://127.0.0.1:$AT_ADMIN_PORT/metrics" \
+            | grep 'siphon_ai_transfers_total' \
+            | grep 'mode="attended"' \
+            | grep -q 'result="accepted"'; then
+            at_ok=1
+        fi
+    fi
+fi
+if (( at_ok )); then
+    echo "  OK"
+else
+    echo "  FAIL (consult_id=$at_consult_id answered=$at_answered;" \
+         "daemon: $AT_DAEMON_LOG; ws A: $AT_A_WS_LOG; ws C: $AT_C_WS_LOG)"
+    failures=$((failures + 1))
+fi
+
+at_cleanup
+trap - EXIT
+
 # ─── Optional third phase: blind_transfer ─────────────────────────
 # Needs a WS server that proactively emits BridgeIn::Transfer. The
 # runner stops the daemon, brings up an echo-ws that auto-emits


### PR DESCRIPTION
## Summary

Final chunk of the 0.6.1 attended-transfer theme (plan #149; chunks 1–3 = #150/#151/#152). Ships the live SIPp coverage, a real bug fix the new scenario exposed, the docs polish, and the 0.6.0 → 0.6.1 release bump.

### SIPp: attended transfer, three-party, always-on
- `attended_transfer_a.xml` — SIPp is the inbound transferee; asserts (via `check_it`) that the REFER's `Refer-To` embeds a `Replaces=` parameter, then plays out the REFER + BYE tail.
- New always-on phase in `run-all.sh`: a second SIPp is the consult callee, dialed through a loopback `[[gateway]]` via `POST /admin/v1/calls`; leg A's echo-ws completes the transfer with the new `--auto-transfer-replaces` knob (Python echo server). Pass additionally requires `siphon_ai_transfers_total{mode="attended",result="accepted"}` = 1.
- Phase cleanup reaps the consult-side sipp — it outlives `-timeout` when its call never completes, and a stray instance squats on the port for subsequent runs.

### Fix: duplicate BYE after an accepted transfer (inbound legs)
The transfer task sends the post-REFER BYE ("REFER + BYE", RFC 5589 §6.1) — and then the acceptor's cleanup task sent a **second** BYE from a fresh CSeq space (observed on the wire: `CSeq: 2 BYE` followed by `CSeq: 1 BYE`), a protocol violation that strict peers reject. Latent since blind transfer (0.2.0); the existing `blind_transfer.xml` never caught it because its scenario exits before the second BYE lands. `TransferOutcome::Accepted` now marks the call handle (`mark_remote_bye`, whose documented semantics already cover "BYE leg implicitly completed") so cleanup knows no BYE is owed. Outbound legs are unaffected — their `run_call` teardown still owns the BYE.

### Docs + release
- `OUTBOUND.md`: consult-leg section under §4 (cross-links PROTOCOL.md §4.4), stale "attended transfer is the 0.6.1 fast-follow" limitation removed, heading bumped to v0.6.1.
- README status blurb → v0.6.1.
- CHANGELOG `[0.6.1]`, workspace version 0.6.0 → 0.6.1.

After squash-merge: tag `v0.6.1` + GitHub release.

## Validation
- Full SIPp suite **14/14** including the new attended phase and the `blind_transfer.xml` regression (`./run-all.sh --with-transfer`).
- `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all --check` — all green.
- Wire-level verification: message trace shows exactly one BYE to the transferee after the 202, and the consult leg stays up at REFER time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)