### PR TITLE
fix(sip): TLS Contact advertised the UDP listener's port — in-dialog ACK/BYE lost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **TLS trunks: in-dialog ACK/BYE were lost (silent-tail recordings, wrong CDR cause).**
+  When the daemon ran both a UDP and a TLS listener (`[sip].transports = ["udp", "tls"]`),
+  the `Contact` on responses advertised the UDP listener's port with `transport=tls`
+  (e.g. `<sip:siphon@<ip>:5060;transport=tls>`) regardless of which listener received
+  the INVITE. A secure trunk (e.g. Twilio over TLS) honoured that Contact and dialed
+  TLS to the UDP port, where nothing listens — so the caller's ACK and BYE never
+  arrived and the call only ended when the RTP inactivity watchdog fired ~60 s later.
+  Symptoms: call recordings padded with a ~60 s silent tail, CDR `cause = tap_ended`
+  instead of a clean hangup, and `outbound BYE failed` warnings. Fixed upstream in
+  siphon-rs (the auto-filled Contact port now follows the listener that received the
+  request); this release threads the receiving listener's local address through the
+  packet pump (`TransportContext::with_local_addr`) and bumps the siphon-rs pin.
+  UDP-only deployments were never affected and their Contacts are unchanged.
+
 - **SIPp suite portability to dual-stack hosts** (`test-harness/
   sipp-scenarios/run-all.sh`): sipp invocations now pin `-i 127.0.0.1`.
   Without it, sipp's `[local_ip]` can expand to `::1`, so UAS scenarios

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2633,7 +2633,7 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 [[package]]
 name = "sip-auth"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3dd5fbfc6631#3dd5fbfc663169795650c42ba25277da5601d2a8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3#a8782e307dbab91f3718a3187f87544a6573f4f2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2656,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "sip-core"
 version = "0.7.6"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3dd5fbfc6631#3dd5fbfc663169795650c42ba25277da5601d2a8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3#a8782e307dbab91f3718a3187f87544a6573f4f2"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2669,7 +2669,7 @@ dependencies = [
 [[package]]
 name = "sip-dialog"
 version = "0.3.3"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3dd5fbfc6631#3dd5fbfc663169795650c42ba25277da5601d2a8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3#a8782e307dbab91f3718a3187f87544a6573f4f2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2687,7 +2687,7 @@ dependencies = [
 [[package]]
 name = "sip-dns"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3dd5fbfc6631#3dd5fbfc663169795650c42ba25277da5601d2a8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3#a8782e307dbab91f3718a3187f87544a6573f4f2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2701,7 +2701,7 @@ dependencies = [
 [[package]]
 name = "sip-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3dd5fbfc6631#3dd5fbfc663169795650c42ba25277da5601d2a8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3#a8782e307dbab91f3718a3187f87544a6573f4f2"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -2712,7 +2712,7 @@ dependencies = [
 [[package]]
 name = "sip-identity"
 version = "0.1.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3dd5fbfc6631#3dd5fbfc663169795650c42ba25277da5601d2a8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3#a8782e307dbab91f3718a3187f87544a6573f4f2"
 dependencies = [
  "base64",
  "ring",
@@ -2725,7 +2725,7 @@ dependencies = [
 [[package]]
 name = "sip-observe"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3dd5fbfc6631#3dd5fbfc663169795650c42ba25277da5601d2a8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3#a8782e307dbab91f3718a3187f87544a6573f4f2"
 dependencies = [
  "once_cell",
  "tracing",
@@ -2734,7 +2734,7 @@ dependencies = [
 [[package]]
 name = "sip-parse"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3dd5fbfc6631#3dd5fbfc663169795650c42ba25277da5601d2a8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3#a8782e307dbab91f3718a3187f87544a6573f4f2"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2748,7 +2748,7 @@ dependencies = [
 [[package]]
 name = "sip-ratelimit"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3dd5fbfc6631#3dd5fbfc663169795650c42ba25277da5601d2a8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3#a8782e307dbab91f3718a3187f87544a6573f4f2"
 dependencies = [
  "dashmap 5.5.3",
  "parking_lot",
@@ -2759,7 +2759,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3dd5fbfc6631#3dd5fbfc663169795650c42ba25277da5601d2a8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3#a8782e307dbab91f3718a3187f87544a6573f4f2"
 dependencies = [
  "nom",
  "smol_str",
@@ -2777,7 +2777,7 @@ dependencies = [
 [[package]]
 name = "sip-transaction"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3dd5fbfc6631#3dd5fbfc663169795650c42ba25277da5601d2a8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3#a8782e307dbab91f3718a3187f87544a6573f4f2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2796,7 +2796,7 @@ dependencies = [
 [[package]]
 name = "sip-transport"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3dd5fbfc6631#3dd5fbfc663169795650c42ba25277da5601d2a8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3#a8782e307dbab91f3718a3187f87544a6573f4f2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2816,7 +2816,7 @@ dependencies = [
 [[package]]
 name = "sip-uac"
 version = "0.4.2"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3dd5fbfc6631#3dd5fbfc663169795650c42ba25277da5601d2a8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3#a8782e307dbab91f3718a3187f87544a6573f4f2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2829,7 +2829,7 @@ dependencies = [
  "sip-dialog",
  "sip-dns",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=3dd5fbfc6631)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -2841,7 +2841,7 @@ dependencies = [
 [[package]]
 name = "sip-uas"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3dd5fbfc6631#3dd5fbfc663169795650c42ba25277da5601d2a8"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3#a8782e307dbab91f3718a3187f87544a6573f4f2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2851,7 +2851,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=3dd5fbfc6631)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3)",
  "sip-transaction",
  "sip-transport",
  "smol_str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,19 +108,19 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 # main branch and replace the rev hashes here (see CLAUDE.md §7.5).
 
 # siphon-rs — RFC 3261 SIP stack
-sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3dd5fbfc6631" }
-sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3dd5fbfc6631" }
-sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3dd5fbfc6631", features = ["tls"] }
-sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3dd5fbfc6631" }
-sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3dd5fbfc6631" }
-sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3dd5fbfc6631" }
-sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3dd5fbfc6631" }
-sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3dd5fbfc6631" }
-sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3dd5fbfc6631" }
-sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3dd5fbfc6631" }
+sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a8782e3" }
+sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a8782e3" }
+sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a8782e3", features = ["tls"] }
+sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a8782e3" }
+sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a8782e3" }
+sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a8782e3" }
+sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a8782e3" }
+sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a8782e3" }
+sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a8782e3" }
+sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a8782e3" }
 # sip-identity — STIR/SHAKEN Identity-header parsing + PASSporT verification
 # (ES256 + X.509 chain validation). Consumed by the stir-shaken verifier crate.
-sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3dd5fbfc6631" }
+sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a8782e3" }
 
 # forge-media — RTP / codecs / SDP / DTMF / engine.
 #

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -1298,6 +1298,12 @@ async fn handle_packet(
     // the same inbound socket instead of opening a fresh outbound
     // connection (or, for TLS, failing outright because the
     // dispatcher has no way to originate one).
+    // Capture the receiving listener's local address before
+    // `into_parts` consumes the packet — it lets the UAS build a
+    // Contact on the same port the request arrived on (so a TLS
+    // request on :5061 advertises `:5061;transport=tls`, not the
+    // UDP listener's port).
+    let local = packet.local();
     let (transport, peer, payload, stream) = packet.into_parts();
 
     let Some(request) = parse_request(&payload) else {
@@ -1316,7 +1322,7 @@ async fn handle_packet(
     };
 
     let tx_kind = map_transport_kind(transport);
-    let ctx = TransportContext::new(tx_kind, peer, stream);
+    let ctx = TransportContext::new(tx_kind, peer, stream).with_local_addr(local);
 
     if request.method().as_str() == "ACK" {
         // ACK doesn't open a server transaction; just notify the


### PR DESCRIPTION
## Problem

With dual transports (`[sip].transports = ["udp", "tls"]`), responses to requests received on the **TLS** listener carried a Contact built from the **UDP** listener's port, e.g. `<sip:siphon@<ip>:5060;transport=tls>`. A secure trunk (Twilio over TLS) honours that Contact and dials TLS to the UDP port, where nothing listens — so the caller's in-dialog ACK and BYE never arrive and the call only ends when the RTP inactivity watchdog fires ~60 s later.

Symptoms in production: recordings padded with a ~60 s silent tail, CDR `cause = tap_ended` instead of a clean hangup, and `outbound BYE failed` warnings.

## Fix

- Bump siphon-rs pin `3dd5fbf` → `a8782e3` (upstream `fix(transport,uas): Contact port follows receiving listener`).
- Thread the receiving listener's local address through the packet pump via `TransportContext::with_local_addr` (bins/siphon-ai/src/runtime.rs) so the UAS builds the Contact on the port the request actually arrived on.
- CHANGELOG entry.

UDP-only deployments were never affected; their Contacts are unchanged.

## Verification

- `cargo test --workspace`, clippy `-D warnings`, fmt — clean
- SIPp regression suite: **14/14** (incl. attended + blind transfer)
- HEP-collector-stub tests: pass
- Manual dual-listener check (UDP :5070 + TLS :5071):
  - INVITE over TLS → Contact `<sip:siphon@127.0.0.1:5071;transport=tls>` on 100 and 200; in-dialog BYE on the same TLS connection → **200 OK** (previously lost)
  - INVITE over UDP → Contact `<sip:siphon@127.0.0.1:5070;transport=udp>`; BYE → 200 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)