### PR TITLE
fix(core): daemon-initiated BYE on TLS dialogs — reuse the inbound connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **TLS trunks: daemon-initiated BYE never reached the peer (caller heard dead air
+  after the bot hung up).** The companion to the Contact-port fix below, in the other
+  direction. When the WS server ended the call (`hangup`), or a session timer / admin
+  force-hangup drove teardown, the cleanup BYE was sent via `IntegratedUAC::bye`,
+  which resolves the dialog's remote target and builds a fresh transport context —
+  but the dispatcher is inbound-only and refuses to open a new TCP/TLS connection,
+  so the BYE died with `outbound BYE failed … transport error` and the peer held the
+  call until its own timeout. The acceptor now captures the inbound connection's
+  writer channel at INVITE time (`DialogFlow`) and sends the cleanup BYE through
+  `IntegratedUAC::bye_via_flow` over that same connection (RFC 5626 flow semantics).
+  UDP dialogs keep the existing path. Known remaining gap: REFER (transfer) on a
+  TCP/TLS dialog still fails the same way — `send_refer` has no flow-reuse variant
+  upstream yet; transfers on TLS trunks will return `transfer_failed` to the WS
+  server until that lands.
+
 - **TLS trunks: in-dialog ACK/BYE were lost (silent-tail recordings, wrong CDR cause).**
   When the daemon ran both a UDP and a TLS listener (`[sip].transports = ["udp", "tls"]`),
   the `Contact` on responses advertised the UDP listener's port with `transport=tls`

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -39,6 +39,10 @@ sip-dialog.workspace      = true
 sip-uac.workspace         = true
 sip-uas.workspace         = true
 sip-transaction.workspace = true
+# `DialogFlow` carries the inbound connection's writer channel,
+# whose payload type (`bytes::Bytes`) is part of sip-transaction's
+# `TransportContext` API.
+bytes.workspace           = true
 
 # Upstream — forge for constructing CallId/ParticipantId in the acceptor;
 # media-glue owns the session/bridge logic so we only need the type stubs.
@@ -54,7 +58,6 @@ forge-sdp.workspace    = true
 forge-rtp.workspace    = true
 
 [dev-dependencies]
-bytes.workspace                       = true
 sip-parse.workspace                   = true
 tokio-tungstenite.workspace           = true
 futures.workspace                     = true

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -59,6 +59,7 @@ use parking_lot::RwLock;
 use sip_core::{Request, Response};
 use sip_dialog::session_timer_manager::{SessionTimerEvent, SessionTimerManager};
 use sip_dialog::{DialogId, DialogManager};
+use sip_transaction::{TransportContext, TransportKind};
 use sip_uac::integrated::IntegratedUAC;
 use sip_uas::integrated::{AcceptInviteAsyncOutcome, IntegratedUAS};
 use sip_uas::{NegotiatedSessionTimer, SessionTimerPolicy, UserAgentServer};
@@ -1478,6 +1479,39 @@ struct InstalledTransfer {
 pub struct AcceptedSession {
     pub dialog: sip_dialog::Dialog,
     pub timer: Option<NegotiatedSessionTimer>,
+    /// The inbound connection this dialog arrived on, when the
+    /// transport is connection-oriented. See [`DialogFlow`].
+    pub flow: Option<DialogFlow>,
+}
+
+/// The inbound connection a TCP/TLS dialog rides on: the
+/// per-connection writer channel plus the peer's source address.
+/// Captured at INVITE time because daemon-initiated in-dialog
+/// requests (the cleanup BYE) must reuse the established connection
+/// — the dispatcher is inbound-only and cannot originate a TCP/TLS
+/// connection, and resolving the peer's Contact would dial a fresh
+/// one even if it could (RFC 5626 flow semantics: in-dialog requests
+/// to a connection-oriented peer follow the existing flow). `None`
+/// for datagram transports, where the dispatcher can always send.
+#[derive(Clone)]
+pub struct DialogFlow {
+    pub stream: tokio::sync::mpsc::Sender<bytes::Bytes>,
+    pub peer: std::net::SocketAddr,
+}
+
+impl DialogFlow {
+    /// Capture the flow from the transport context the INVITE
+    /// arrived on. `None` for datagram transports or when the
+    /// listener didn't attach a writer channel.
+    pub fn from_transport(ctx: &TransportContext) -> Option<Self> {
+        match ctx.transport() {
+            TransportKind::Tcp | TransportKind::Tls => ctx.stream().map(|s| DialogFlow {
+                stream: s.clone(),
+                peer: ctx.peer(),
+            }),
+            _ => None,
+        }
+    }
 }
 
 /// Carried into the post-controller cleanup task. Same Arc'd UAC +
@@ -1487,6 +1521,11 @@ pub struct AcceptedSession {
 struct TeardownContext {
     uac: Arc<IntegratedUAC>,
     dialog_manager: Arc<DialogManager>,
+    /// `Some` on TCP/TLS dialogs: the BYE goes out via
+    /// [`IntegratedUAC::bye_via_flow`] over the inbound connection
+    /// instead of a DNS-resolved fresh one the dispatcher would
+    /// refuse to open.
+    flow: Option<DialogFlow>,
 }
 
 /// Send an outbound BYE on the confirmed dialog for `sip_call_id`,
@@ -1515,17 +1554,27 @@ async fn send_outbound_bye(
         );
         return;
     };
-    match ctx.uac.bye(&dialog).await {
+    let sent = match &ctx.flow {
+        Some(flow) => {
+            ctx.uac
+                .bye_via_flow(&dialog, flow.stream.clone(), flow.peer)
+                .await
+        }
+        None => ctx.uac.bye(&dialog).await,
+    };
+    match sent {
         Ok(resp) => debug!(
             call_id = %bridge_call_id,
             sip_call_id = %sip_call_id,
             status = resp.code(),
+            reused_inbound_connection = ctx.flow.is_some(),
             "outbound BYE sent"
         ),
         Err(e) => warn!(
             call_id = %bridge_call_id,
             sip_call_id = %sip_call_id,
             error = %e,
+            reused_inbound_connection = ctx.flow.is_some(),
             "outbound BYE failed; SIP dialog may linger"
         ),
     }
@@ -2471,6 +2520,7 @@ impl CallAcceptor for BridgingAcceptor {
                     Some(AcceptedSession {
                         dialog,
                         timer: session_timer,
+                        flow: DialogFlow::from_transport(call.transport),
                     }),
                 );
                 Ok(())
@@ -2564,10 +2614,12 @@ impl BridgingAcceptor {
         // events from the manager and looks the handle up in
         // `dialog_handles` to drive teardown. Stopping the timer is
         // the cleanup task's job below.
+        let dialog_flow = accepted.as_ref().and_then(|a| a.flow.clone());
         let session_timer_key = match accepted.as_ref() {
             Some(AcceptedSession {
                 dialog,
                 timer: Some(timer),
+                ..
             }) => {
                 let id = dialog.id().clone();
                 self.dialog_handles
@@ -2638,6 +2690,7 @@ impl BridgingAcceptor {
         let teardown = self.transfer.get().map(|t| TeardownContext {
             uac: Arc::clone(&t.uac),
             dialog_manager: Arc::clone(&t.dialog_manager),
+            flow: dialog_flow,
         });
         let session_timer_manager = Arc::clone(&self.session_timer_manager);
         let dialog_handles = Arc::clone(&self.dialog_handles);
@@ -3052,6 +3105,42 @@ mod tests {
     use sip_core::{Headers as SipHeaders, Method, Request, RequestLine, SipUri};
     use siphon_ai_media_glue::{AnswerOutcome, Codec};
     use siphon_ai_routes::load_from_toml;
+
+    mod dialog_flow {
+        use super::super::{DialogFlow, TransportContext, TransportKind};
+
+        fn peer() -> std::net::SocketAddr {
+            "192.0.2.10:42000".parse().unwrap()
+        }
+
+        #[test]
+        fn udp_yields_no_flow() {
+            let (tx, _rx) = tokio::sync::mpsc::channel(1);
+            let ctx = TransportContext::new(TransportKind::Udp, peer(), Some(tx));
+            assert!(DialogFlow::from_transport(&ctx).is_none());
+        }
+
+        #[test]
+        fn tls_with_stream_captures_flow() {
+            let (tx, _rx) = tokio::sync::mpsc::channel(1);
+            let ctx = TransportContext::new(TransportKind::Tls, peer(), Some(tx));
+            let flow = DialogFlow::from_transport(&ctx).expect("flow");
+            assert_eq!(flow.peer, peer());
+        }
+
+        #[test]
+        fn tcp_with_stream_captures_flow() {
+            let (tx, _rx) = tokio::sync::mpsc::channel(1);
+            let ctx = TransportContext::new(TransportKind::Tcp, peer(), Some(tx));
+            assert!(DialogFlow::from_transport(&ctx).is_some());
+        }
+
+        #[test]
+        fn tls_without_stream_yields_no_flow() {
+            let ctx = TransportContext::new(TransportKind::Tls, peer(), None);
+            assert!(DialogFlow::from_transport(&ctx).is_none());
+        }
+    }
 
     fn invite_with(content_type: Option<&str>, body: &str) -> Request {
         let uri = SipUri::parse("sip:5000@siphon.example.com").expect("uri");


### PR DESCRIPTION
## Problem

Companion to #156, in the other direction. #156 fixed the caller's in-dialog ACK/BYE reaching **us** over TLS. This fixes **our** BYE reaching the caller.

When the WS server ends the call (`hangup` — the normal ending for a voice-agent conversation), or session-timer expiry / admin force-hangup drives teardown, the cleanup BYE went through `IntegratedUAC::bye`, which resolves the dialog's remote target and builds a fresh transport context. But `MultiTransportDispatcher` is inbound-only and refuses to originate a TCP/TLS connection, so on TLS dialogs the BYE died:

```
WARN siphon_ai_core::acceptor: outbound BYE failed; SIP dialog may linger
     error=Transaction terminated: transport error
```

The peer (e.g. Twilio) held the call until its own timeout — the caller heard dead air after the bot hung up.

## Fix

- New `DialogFlow` in `crates/core/src/acceptor.rs`: the inbound connection's writer channel + peer address, captured from the INVITE's `TransportContext` at accept time (`None` for UDP).
- Threaded via `AcceptedSession` → `TeardownContext`; the cleanup BYE uses `IntegratedUAC::bye_via_flow` over the original connection (RFC 5626 flow semantics) when a flow exists, plain `bye()` otherwise.
- BYE outcome logs gain a `reused_inbound_connection` field.
- `bytes` promoted from dev-dependency to dependency in core (the writer channel's payload type is part of sip-transaction's API).

## Known remaining gap (documented in CHANGELOG)

REFER on a TCP/TLS dialog fails the same way — upstream `send_refer` has no flow-reuse variant. Transfers on TLS trunks return `transfer_failed` to the WS server until a `send_refer_via_flow` lands in siphon-rs. Also worth folding into that upstream PR: `bye_via_flow` fills the request's `Via` with the UDP listener's address (cosmetic — responses ride the connection regardless).

## Verification

- `cargo test --workspace`, clippy `-D warnings`, fmt — clean
- New unit tests: `DialogFlow::from_transport` (UDP→None, TLS/TCP+stream→Some, TLS w/o stream→None)
- SIPp regression suite: **14/14** (UDP behavior unchanged)
- HEP-collector-stub tests: pass
- Live dual-listener check: TLS call + echo-ws `--auto-hangup-after-ms 2000` → caller **receives BYE on the same TLS connection**, daemon logs `outbound BYE sent status=200 reused_inbound_connection=true`. Before the fix: no BYE on the wire, transport error in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)