### PR TITLE
chore(deps): re-pin siphon-rs to main after upstream #56 merged

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2633,7 +2633,7 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 [[package]]
 name = "sip-auth"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3#a8782e307dbab91f3718a3187f87544a6573f4f2"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a#b9183f53998a0a3f8a30826a9efe7291464a9d83"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2656,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "sip-core"
 version = "0.7.6"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3#a8782e307dbab91f3718a3187f87544a6573f4f2"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a#b9183f53998a0a3f8a30826a9efe7291464a9d83"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2669,7 +2669,7 @@ dependencies = [
 [[package]]
 name = "sip-dialog"
 version = "0.3.3"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3#a8782e307dbab91f3718a3187f87544a6573f4f2"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a#b9183f53998a0a3f8a30826a9efe7291464a9d83"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2687,7 +2687,7 @@ dependencies = [
 [[package]]
 name = "sip-dns"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3#a8782e307dbab91f3718a3187f87544a6573f4f2"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a#b9183f53998a0a3f8a30826a9efe7291464a9d83"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2701,7 +2701,7 @@ dependencies = [
 [[package]]
 name = "sip-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3#a8782e307dbab91f3718a3187f87544a6573f4f2"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a#b9183f53998a0a3f8a30826a9efe7291464a9d83"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -2712,7 +2712,7 @@ dependencies = [
 [[package]]
 name = "sip-identity"
 version = "0.1.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3#a8782e307dbab91f3718a3187f87544a6573f4f2"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a#b9183f53998a0a3f8a30826a9efe7291464a9d83"
 dependencies = [
  "base64",
  "ring",
@@ -2725,7 +2725,7 @@ dependencies = [
 [[package]]
 name = "sip-observe"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3#a8782e307dbab91f3718a3187f87544a6573f4f2"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a#b9183f53998a0a3f8a30826a9efe7291464a9d83"
 dependencies = [
  "once_cell",
  "tracing",
@@ -2734,7 +2734,7 @@ dependencies = [
 [[package]]
 name = "sip-parse"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3#a8782e307dbab91f3718a3187f87544a6573f4f2"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a#b9183f53998a0a3f8a30826a9efe7291464a9d83"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2748,7 +2748,7 @@ dependencies = [
 [[package]]
 name = "sip-ratelimit"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3#a8782e307dbab91f3718a3187f87544a6573f4f2"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a#b9183f53998a0a3f8a30826a9efe7291464a9d83"
 dependencies = [
  "dashmap 5.5.3",
  "parking_lot",
@@ -2759,7 +2759,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3#a8782e307dbab91f3718a3187f87544a6573f4f2"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a#b9183f53998a0a3f8a30826a9efe7291464a9d83"
 dependencies = [
  "nom",
  "smol_str",
@@ -2777,7 +2777,7 @@ dependencies = [
 [[package]]
 name = "sip-transaction"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3#a8782e307dbab91f3718a3187f87544a6573f4f2"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a#b9183f53998a0a3f8a30826a9efe7291464a9d83"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2796,7 +2796,7 @@ dependencies = [
 [[package]]
 name = "sip-transport"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3#a8782e307dbab91f3718a3187f87544a6573f4f2"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a#b9183f53998a0a3f8a30826a9efe7291464a9d83"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2816,7 +2816,7 @@ dependencies = [
 [[package]]
 name = "sip-uac"
 version = "0.4.2"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3#a8782e307dbab91f3718a3187f87544a6573f4f2"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a#b9183f53998a0a3f8a30826a9efe7291464a9d83"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2829,7 +2829,7 @@ dependencies = [
  "sip-dialog",
  "sip-dns",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -2841,7 +2841,7 @@ dependencies = [
 [[package]]
 name = "sip-uas"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3#a8782e307dbab91f3718a3187f87544a6573f4f2"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a#b9183f53998a0a3f8a30826a9efe7291464a9d83"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2851,7 +2851,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=a8782e3)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a)",
  "sip-transaction",
  "sip-transport",
  "smol_str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,19 +108,19 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 # main branch and replace the rev hashes here (see CLAUDE.md §7.5).
 
 # siphon-rs — RFC 3261 SIP stack
-sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a8782e3" }
-sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a8782e3" }
-sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a8782e3", features = ["tls"] }
-sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a8782e3" }
-sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a8782e3" }
-sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a8782e3" }
-sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a8782e3" }
-sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a8782e3" }
-sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a8782e3" }
-sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a8782e3" }
+sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9183f53998a" }
+sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9183f53998a" }
+sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9183f53998a", features = ["tls"] }
+sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9183f53998a" }
+sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9183f53998a" }
+sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9183f53998a" }
+sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9183f53998a" }
+sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9183f53998a" }
+sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9183f53998a" }
+sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9183f53998a" }
 # sip-identity — STIR/SHAKEN Identity-header parsing + PASSporT verification
 # (ES256 + X.509 chain validation). Consumed by the stir-shaken verifier crate.
-sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "a8782e3" }
+sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9183f53998a" }
 
 # forge-media — RTP / codecs / SDP / DTMF / engine.
 #


### PR DESCRIPTION
Upstream siphon-rs #56 (the Contact-port fix we pinned in #156) was squash-merged to main as `b9183f53998a`, and the PR branch was deleted — leaving our pinned `a8782e3` on an unreferenced commit that GitHub may eventually GC, which would break fresh `cargo fetch`es.

This moves all 11 siphon-rs rev pins to the main-branch commit. The trees are identical (`fa1875c7d700` on both sides), so it's a pointer move with zero code change.

Verified per CLAUDE.md §7.5 regardless: workspace tests, SIPp suite 14/14, HEP-collector-stub tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)