### PR TITLE
fix(core): transfers on TCP/TLS trunks — REFER reuses the inbound connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **TLS trunks: call transfer (REFER) failed with `transfer_failed` (#159).** The known
+  gap left by the cleanup-BYE fix below: a `transfer` requested by the WS server on a
+  call that arrived over TCP/TLS died with `send_refer: … transport error`, because
+  upstream `send_refer` resolves the dialog's remote target and dials a fresh
+  connection the inbound-only dispatcher refuses to open (and the peer's Contact names
+  an ephemeral source port nothing listens on anyway). The transfer task now reuses the
+  inbound connection captured at INVITE time: `TransferContext` carries the same
+  `DialogFlow` that `TeardownContext` got in the BYE fix (attached in `run_call`, once
+  the accepted session's transport is known), and `run_transfer_inner` sends both the
+  REFER and the post-REFER BYE through the new upstream `send_refer_via_flow` /
+  `bye_via_flow` (siphon-rs#58). `DialogFlow` additionally captures the receiving
+  listener's local address so the auto-filled `Via` on flow-routed requests advertises
+  the TLS listener's port instead of the UDP listener's (the cosmetic nit observed in
+  the #157 verification). UDP dialogs and outbound (gateway-originated) legs keep the
+  existing resolve-and-send path. Pin bumped to siphon-rs `db45e42251c3`, which also
+  changes the `*_via_flow` call convention to the new `Flow` struct.
+
 - **TLS trunks: daemon-initiated BYE never reached the peer (caller heard dead air
   after the bot hung up).** The companion to the Contact-port fix below, in the other
   direction. When the WS server ended the call (`hangup`), or a session timer / admin

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2633,7 +2633,7 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 [[package]]
 name = "sip-auth"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a#b9183f53998a0a3f8a30826a9efe7291464a9d83"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=db45e42251c3#db45e42251c3dbac2d8b4a2b7632d06f87fc31ff"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2656,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "sip-core"
 version = "0.7.6"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a#b9183f53998a0a3f8a30826a9efe7291464a9d83"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=db45e42251c3#db45e42251c3dbac2d8b4a2b7632d06f87fc31ff"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2669,7 +2669,7 @@ dependencies = [
 [[package]]
 name = "sip-dialog"
 version = "0.3.3"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a#b9183f53998a0a3f8a30826a9efe7291464a9d83"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=db45e42251c3#db45e42251c3dbac2d8b4a2b7632d06f87fc31ff"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2687,7 +2687,7 @@ dependencies = [
 [[package]]
 name = "sip-dns"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a#b9183f53998a0a3f8a30826a9efe7291464a9d83"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=db45e42251c3#db45e42251c3dbac2d8b4a2b7632d06f87fc31ff"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2701,7 +2701,7 @@ dependencies = [
 [[package]]
 name = "sip-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a#b9183f53998a0a3f8a30826a9efe7291464a9d83"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=db45e42251c3#db45e42251c3dbac2d8b4a2b7632d06f87fc31ff"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -2712,7 +2712,7 @@ dependencies = [
 [[package]]
 name = "sip-identity"
 version = "0.1.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a#b9183f53998a0a3f8a30826a9efe7291464a9d83"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=db45e42251c3#db45e42251c3dbac2d8b4a2b7632d06f87fc31ff"
 dependencies = [
  "base64",
  "ring",
@@ -2725,7 +2725,7 @@ dependencies = [
 [[package]]
 name = "sip-observe"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a#b9183f53998a0a3f8a30826a9efe7291464a9d83"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=db45e42251c3#db45e42251c3dbac2d8b4a2b7632d06f87fc31ff"
 dependencies = [
  "once_cell",
  "tracing",
@@ -2734,7 +2734,7 @@ dependencies = [
 [[package]]
 name = "sip-parse"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a#b9183f53998a0a3f8a30826a9efe7291464a9d83"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=db45e42251c3#db45e42251c3dbac2d8b4a2b7632d06f87fc31ff"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2748,7 +2748,7 @@ dependencies = [
 [[package]]
 name = "sip-ratelimit"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a#b9183f53998a0a3f8a30826a9efe7291464a9d83"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=db45e42251c3#db45e42251c3dbac2d8b4a2b7632d06f87fc31ff"
 dependencies = [
  "dashmap 5.5.3",
  "parking_lot",
@@ -2759,7 +2759,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a#b9183f53998a0a3f8a30826a9efe7291464a9d83"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=db45e42251c3#db45e42251c3dbac2d8b4a2b7632d06f87fc31ff"
 dependencies = [
  "nom",
  "smol_str",
@@ -2777,7 +2777,7 @@ dependencies = [
 [[package]]
 name = "sip-transaction"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a#b9183f53998a0a3f8a30826a9efe7291464a9d83"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=db45e42251c3#db45e42251c3dbac2d8b4a2b7632d06f87fc31ff"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2796,7 +2796,7 @@ dependencies = [
 [[package]]
 name = "sip-transport"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a#b9183f53998a0a3f8a30826a9efe7291464a9d83"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=db45e42251c3#db45e42251c3dbac2d8b4a2b7632d06f87fc31ff"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2816,7 +2816,7 @@ dependencies = [
 [[package]]
 name = "sip-uac"
 version = "0.4.2"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a#b9183f53998a0a3f8a30826a9efe7291464a9d83"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=db45e42251c3#db45e42251c3dbac2d8b4a2b7632d06f87fc31ff"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2829,7 +2829,7 @@ dependencies = [
  "sip-dialog",
  "sip-dns",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=db45e42251c3)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -2841,7 +2841,7 @@ dependencies = [
 [[package]]
 name = "sip-uas"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a#b9183f53998a0a3f8a30826a9efe7291464a9d83"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=db45e42251c3#db45e42251c3dbac2d8b4a2b7632d06f87fc31ff"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2851,7 +2851,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=b9183f53998a)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=db45e42251c3)",
  "sip-transaction",
  "sip-transport",
  "smol_str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,19 +108,19 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 # main branch and replace the rev hashes here (see CLAUDE.md §7.5).
 
 # siphon-rs — RFC 3261 SIP stack
-sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9183f53998a" }
-sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9183f53998a" }
-sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9183f53998a", features = ["tls"] }
-sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9183f53998a" }
-sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9183f53998a" }
-sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9183f53998a" }
-sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9183f53998a" }
-sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9183f53998a" }
-sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9183f53998a" }
-sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9183f53998a" }
+sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "db45e42251c3" }
+sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "db45e42251c3" }
+sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "db45e42251c3", features = ["tls"] }
+sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "db45e42251c3" }
+sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "db45e42251c3" }
+sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "db45e42251c3" }
+sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "db45e42251c3" }
+sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "db45e42251c3" }
+sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "db45e42251c3" }
+sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "db45e42251c3" }
 # sip-identity — STIR/SHAKEN Identity-header parsing + PASSporT verification
 # (ES256 + X.509 chain validation). Consumed by the stir-shaken verifier crate.
-sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9183f53998a" }
+sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "db45e42251c3" }
 
 # forge-media — RTP / codecs / SDP / DTMF / engine.
 #

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -1497,6 +1497,11 @@ pub struct AcceptedSession {
 pub struct DialogFlow {
     pub stream: tokio::sync::mpsc::Sender<bytes::Bytes>,
     pub peer: std::net::SocketAddr,
+    /// Local address of the listener that owns the connection
+    /// (threaded through `TransportContext` since siphon-rs#56).
+    /// Upstream uses it so the auto-filled `Via` advertises the
+    /// listener's port rather than the default listener's.
+    pub local: Option<std::net::SocketAddr>,
 }
 
 impl DialogFlow {
@@ -1508,8 +1513,18 @@ impl DialogFlow {
             TransportKind::Tcp | TransportKind::Tls => ctx.stream().map(|s| DialogFlow {
                 stream: s.clone(),
                 peer: ctx.peer(),
+                local: ctx.local_addr(),
             }),
             _ => None,
+        }
+    }
+
+    /// The upstream representation, for the `*_via_flow` UAC methods.
+    pub fn to_uac_flow(&self) -> sip_uac::integrated::Flow {
+        let flow = sip_uac::integrated::Flow::new(self.stream.clone(), self.peer);
+        match self.local {
+            Some(local) => flow.with_local_addr(local),
+            None => flow,
         }
     }
 }
@@ -1555,11 +1570,7 @@ async fn send_outbound_bye(
         return;
     };
     let sent = match &ctx.flow {
-        Some(flow) => {
-            ctx.uac
-                .bye_via_flow(&dialog, flow.stream.clone(), flow.peer)
-                .await
-        }
+        Some(flow) => ctx.uac.bye_via_flow(&dialog, flow.to_uac_flow()).await,
         None => ctx.uac.bye(&dialog).await,
     };
     match sent {
@@ -2674,7 +2685,11 @@ impl BridgingAcceptor {
         let bridge_call_id = prepared.bridge_call_id.clone();
         let forge_call_id = prepared.forge_call_id.clone();
         let sip_call_id = prepared.sip_call_id;
-        let controller = prepared.controller;
+        let mut controller = prepared.controller;
+        // prepare_call built the TransferContext before the INVITE's
+        // transport was known; give the REFER path the same inbound
+        // connection the cleanup BYE uses (TCP/TLS dialogs only).
+        controller.attach_transfer_flow(dialog_flow.clone());
         let media = Arc::clone(&self.media);
         let registry = self.registry.clone();
         let cdr_sink = Arc::clone(&self.cdr_sink);
@@ -3050,6 +3065,9 @@ impl BridgingAcceptor {
                 dialog_manager: Arc::clone(&installed.dialog_manager),
             },
             consult_registry: installed.consult_registry.clone(),
+            // The INVITE's transport context isn't threaded down to
+            // prepare; run_call attaches the accepted session's flow.
+            flow: None,
         });
 
         // Recording setup. The matched route's `[route.recording].mode`
@@ -3126,6 +3144,19 @@ mod tests {
             let ctx = TransportContext::new(TransportKind::Tls, peer(), Some(tx));
             let flow = DialogFlow::from_transport(&ctx).expect("flow");
             assert_eq!(flow.peer, peer());
+            // No listener address on the context → none captured;
+            // upstream then falls back to the configured Via port.
+            assert_eq!(flow.local, None);
+        }
+
+        #[test]
+        fn flow_captures_listener_local_addr_for_via() {
+            let listener: std::net::SocketAddr = "0.0.0.0:5061".parse().unwrap();
+            let (tx, _rx) = tokio::sync::mpsc::channel(1);
+            let ctx = TransportContext::new(TransportKind::Tls, peer(), Some(tx))
+                .with_local_addr(Some(listener));
+            let flow = DialogFlow::from_transport(&ctx).expect("flow");
+            assert_eq!(flow.local, Some(listener));
         }
 
         #[test]

--- a/crates/core/src/call.rs
+++ b/crates/core/src/call.rs
@@ -317,6 +317,18 @@ impl CallController {
         )
     }
 
+    /// Attach the inbound connection this call's dialog rides on to
+    /// the transfer context, so a REFER reuses it instead of dialing
+    /// the peer's Contact (TCP/TLS dialogs; see issue #159). Called
+    /// by `run_call` after accept, when the flow is known — the
+    /// `TransferContext` itself is built earlier, in `prepare_call`.
+    /// No-op when transfer isn't installed or `flow` is `None`.
+    pub fn attach_transfer_flow(&mut self, flow: Option<crate::acceptor::DialogFlow>) {
+        if let Some(transfer) = self.cfg.transfer.as_mut() {
+            transfer.flow = flow;
+        }
+    }
+
     pub fn handle(&self) -> &CallHandle {
         &self.handle
     }
@@ -936,9 +948,26 @@ async fn run_transfer_inner(
         ReferPlan::Attended { refer_to, consult } => (refer_to, Some(consult.as_ref())),
     };
 
-    match ctx.uac.send_refer(&mut dialog, refer_to, consult).await {
+    // TCP/TLS dialogs: the REFER must ride the inbound connection —
+    // the dispatcher is inbound-only and the peer's Contact names an
+    // ephemeral source port nothing listens on (issue #159, same
+    // reasoning as the cleanup BYE in #157).
+    let sent = match &ctx.flow {
+        Some(flow) => {
+            ctx.uac
+                .send_refer_via_flow(&mut dialog, refer_to, consult, flow.to_uac_flow())
+                .await
+        }
+        None => ctx.uac.send_refer(&mut dialog, refer_to, consult).await,
+    };
+    match sent {
         Ok((response, _subscription)) => {
             let status = response.code();
+            debug!(
+                status,
+                reused_inbound_connection = ctx.flow.is_some(),
+                "REFER sent"
+            );
             if (200..300).contains(&status) {
                 // RFC 5589 allows either pattern (BYE-after-202 vs.
                 // staying in-dialog to consume NOTIFYs); v1 ships the
@@ -951,7 +980,11 @@ async fn run_transfer_inner(
                 // Outbound legs skip the BYE too: their run_call
                 // teardown sends it when the controller exits.
                 if ctx.source.bye_after_refer() {
-                    if let Err(e) = ctx.uac.bye(&dialog).await {
+                    let bye_sent = match &ctx.flow {
+                        Some(flow) => ctx.uac.bye_via_flow(&dialog, flow.to_uac_flow()).await,
+                        None => ctx.uac.bye(&dialog).await,
+                    };
+                    if let Err(e) = bye_sent {
                         warn!(error = %e, "post-REFER BYE failed (dialog may linger)");
                     }
                 }

--- a/crates/core/src/outbound_service.rs
+++ b/crates/core/src/outbound_service.rs
@@ -299,6 +299,9 @@ async fn run_call(
         uac: originator.uac(),
         source: DialogSource::Direct(Box::new(dialog.clone())),
         consult_registry: ctx.consult_registry.clone(),
+        // Outbound legs dialed out themselves, so the gateway UAC's
+        // dispatcher can reach the peer without flow reuse.
+        flow: None,
     };
     let cfg = CallControllerConfig {
         call_id: ctx.bridge_id.clone(),

--- a/crates/core/src/transfer.rs
+++ b/crates/core/src/transfer.rs
@@ -34,6 +34,7 @@ use sip_core::SipUri;
 use sip_dialog::{Dialog, DialogManager};
 use sip_uac::integrated::IntegratedUAC;
 
+use crate::acceptor::DialogFlow;
 use crate::registry::ConsultRegistry;
 
 /// Where the REFER's dialog comes from — the inbound and outbound
@@ -100,6 +101,16 @@ pub struct TransferContext {
     pub uac: Arc<IntegratedUAC>,
     pub source: DialogSource,
     pub consult_registry: ConsultRegistry,
+    /// `Some` when this call's dialog arrived over TCP/TLS: the REFER
+    /// (and the post-REFER BYE) must reuse the inbound connection via
+    /// the `*_via_flow` UAC methods — the dispatcher is inbound-only
+    /// and the peer's Contact names an ephemeral port nothing listens
+    /// on. Same plumbing as `TeardownContext.flow` (#157). Attached
+    /// post-prepare in `run_call`, where the accepted session's flow
+    /// is known; `None` on datagram transports and outbound legs
+    /// (their gateway UAC dialed out itself, so its dispatcher can
+    /// reach the peer).
+    pub flow: Option<DialogFlow>,
 }
 
 impl std::fmt::Debug for TransferContext {


### PR DESCRIPTION
Closes #159.

## Problem

The known gap left by #157: a `transfer` requested by the WS server on a call that arrived over TCP/TLS failed with `transfer_failed` (`send_refer: … transport error`). Upstream `send_refer` resolves the dialog's remote target and builds a fresh transport context with no stream — our `MultiTransportDispatcher` is inbound-only and refuses to originate a TCP/TLS connection, and the peer's Contact names an ephemeral source port nothing listens on anyway. Production impact: transfer on the Twilio TLS trunk.

## Change

- **Pin bump** to siphon-rs `db45e42251c3` — picks up upstream #58 (`send_refer_via_flow` + the new `Flow` struct + the Via-port fix).
- **`TransferContext` carries the `DialogFlow`** that `TeardownContext` got in #157. `prepare_call` still builds the context before the INVITE's transport is known (its public signature is untouched — several integration tests drive it directly), so `run_call` attaches the accepted session's flow post-prepare via the new `CallController::attach_transfer_flow`. `None` on UDP dialogs and on outbound (gateway-originated) legs, which keep the resolve-and-send path.
- **`run_transfer_inner` sends both the REFER and the post-REFER BYE through the flow** (`send_refer_via_flow` / `bye_via_flow`) when present, with a `reused_inbound_connection` field on the debug log, mirroring the BYE path.
- **`DialogFlow` gains the receiving listener's local address** (`ctx.local_addr()`, available since siphon-rs#56) and a `to_uac_flow()` conversion. Upstream uses it so the auto-filled `Via` on flow-routed requests advertises the TLS listener's port instead of the UDP listener's — the cosmetic `Via: SIP/2.0/TLS <ip>:5070` nit observed during the #157 verification.
- The existing `bye_via_flow` call site in `send_outbound_bye` updated to the new `Flow` convention.

## Verification

- `cargo test --workspace` green (46 test binaries, 0 failures); clippy `-D warnings` clean.
- SIPp suite **14/14**, including the UDP blind-transfer and attended-transfer phases (unchanged behaviour).
- TLS repro on a dual-listener daemon (UDP 5070 + TLS 5071, echo-ws `--auto-transfer-target`): TLS INVITE client observes the **REFER arriving on the same inbound TLS connection** with `Via: SIP/2.0/TLS 127.0.0.1:5071` and a correct `Refer-To`, answers 202, then receives the **post-REFER BYE on the same connection** too. Daemon log: `REFER sent status=202 reused_inbound_connection=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)