### PR TITLE
feat(core): outbound dialing over TCP/TLS gateways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Outbound dialing over TCP/TLS (`[[gateway]].transport`).** The transport
+  dispatcher was inbound-only: any request needing a fresh TCP/TLS connection
+  (an originated INVITE to a TLS trunk, a REGISTER to a TLS registrar) died
+  with `outbound … without an existing stream is not supported in v1`. The
+  dispatcher now owns client connection pools (`sip-transport`'s
+  `ConnectionPool`/`TlsPool`, the pattern proven in siphond): outbound TCP/TLS
+  with no established stream dials out through the pool, reuses the connection
+  on subsequent requests, and the pool's reader feeds responses back into the
+  same inbound packet pipeline the listeners use. TLS verifies the peer against
+  the bundled webpki (Mozilla CA) roots — sufficient for public trunks like
+  Twilio — plus an optional `[sip.tls_client].extra_ca` PEM bundle for
+  private-CA deployments and self-signed test rigs (path validated at load).
+  SNI is the gateway's proxy host, threaded through the existing
+  `TransportContext::server_name`.
+  * `[[gateway]]` gains `transport = "udp" | "tcp" | "tls"` (default udp).
+    Non-UDP appends `;transport=…` to the Request-URI so RFC 3263 resolution
+    selects the right transport; `tls` flips the default proxy port to 5061.
+    With `register` set the transport is inherited from the register block and
+    an explicit `transport` is rejected at load. `[[register]]` blocks with
+    `transport = "tls"` — documented since 0.3.0 but broken by the same
+    dispatcher gap — now actually go out over TLS.
+  * Note: media on outbound legs is still plain RTP. Trunks that require SRTP
+    (e.g. Twilio secure trunking) need the follow-up SDES change before
+    outbound calls carry audio — this change is signaling-transport only.
+
 ### Fixed
 
 - **TLS trunks: call transfer (REFER) failed with `transfer_failed` (#159).** The known

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2874,6 +2874,7 @@ dependencies = [
  "forge-rtp",
  "metrics 0.23.1",
  "rustls",
+ "rustls-pemfile",
  "sip-core",
  "sip-dns",
  "sip-parse",
@@ -2895,6 +2896,7 @@ dependencies = [
  "tokio-rustls",
  "tracing",
  "tracing-subscriber",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]

--- a/bins/siphon-ai/Cargo.toml
+++ b/bins/siphon-ai/Cargo.toml
@@ -62,6 +62,12 @@ tokio-rustls.workspace = true
 # graph (they do, transitively).
 rustls = { version = "0.23", features = ["aws_lc_rs"] }
 
+# Client-side TLS verification roots for outgoing connections
+# (gateways / registrations with transport = "tls"). Both already
+# in the dependency tree transitively.
+webpki-roots = "1"
+rustls-pemfile = "2"
+
 # SIGHUP cert reload state (W5): the daemon holds an
 # `Arc<ArcSwap<ServerConfig>>` shared between the listener accept
 # loop and the SIGHUP handler. `arc-swap` rides in transitively via

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -62,8 +62,10 @@ use sip_transaction::{
     TransactionManager, TransportContext, TransportDispatcher, TransportKind as TxTransportKind,
 };
 use sip_transport::{
-    load_rustls_server_config, run_tcp, run_tls_with_swappable_config, run_udp, send_stream,
-    send_udp, InboundPacket, TransportKind as TpTransportKind,
+    load_rustls_server_config,
+    pool::{ConnectionPool, TlsClientConfig, TlsPool},
+    run_tcp, run_tls_with_swappable_config, run_udp, send_stream, send_udp, InboundPacket,
+    TransportKind as TpTransportKind,
 };
 use sip_uac::integrated::IntegratedUAC;
 use sip_uas::integrated::{IntegratedUAS, UasRequestHandler};
@@ -316,8 +318,23 @@ impl Runtime {
                 .await
                 .with_context(|| format!("bind UDP {}", sip.listen_addr))?,
         );
-        let dispatcher: Arc<dyn TransportDispatcher> =
-            Arc::new(MultiTransportDispatcher::new(Arc::clone(&udp_socket)));
+        // Client-side connection pools for OUTBOUND TCP/TLS — what lets
+        // a gateway or registration with `transport = "tcp"|"tls"`
+        // actually dial out. Responses arriving on these client
+        // connections are fed back into the inbound packet pipeline in
+        // spawn_listeners (set_inbound_tx). Inbound dialogs are
+        // unaffected: their requests/responses keep riding the
+        // per-connection writer the listener attached.
+        let tcp_client_pool = Arc::new(ConnectionPool::new());
+        let tls_client_pool = Arc::new(TlsPool::new());
+        let tls_client_config = build_tls_client_config(sip.tls_client_extra_ca.as_deref())
+            .with_context(|| "build client TLS verification roots")?;
+        let dispatcher: Arc<dyn TransportDispatcher> = Arc::new(MultiTransportDispatcher::new(
+            Arc::clone(&udp_socket),
+            Arc::clone(&tcp_client_pool),
+            Arc::clone(&tls_client_pool),
+            tls_client_config,
+        ));
         let transaction_mgr = Arc::new(TransactionManager::new(Arc::clone(&dispatcher)));
 
         // System DNS resolver, shared by every per-[[register]] UAC
@@ -462,7 +479,10 @@ impl Runtime {
             Arc::clone(&transaction_mgr),
             Arc::clone(&uas),
             tls_server_config,
-        );
+            &tcp_client_pool,
+            &tls_client_pool,
+        )
+        .await;
 
         // ─── Outbound origination service (0.6.0) ──────────────────
         // One authenticated UAC + originator per `[[gateway]]`, then the
@@ -496,6 +516,7 @@ impl Runtime {
                         originator,
                         proxy_host: gw.proxy_host.clone(),
                         proxy_port: gw.proxy_port,
+                        transport_uri_param: gw.transport.uri_param(),
                         from: gw.from.clone(),
                     },
                 );
@@ -831,6 +852,40 @@ impl siphon_ai_sip_glue::TrunkAllowlist for ConfigTrunkAllowlist {
 }
 
 /// Load the TLS server config (cert + key) from disk paths in
+/// Verification roots for OUTGOING TLS connections: the bundled
+/// webpki (Mozilla CA) roots — sufficient for public trunks like
+/// Twilio — plus the operator's `[sip.tls_client].extra_ca` PEM
+/// bundle for private-CA deployments and self-signed test rigs.
+/// Failure is fatal at startup, same contract as the server side.
+fn build_tls_client_config(extra_ca: Option<&std::path::Path>) -> Result<Arc<TlsClientConfig>> {
+    let mut roots = tokio_rustls::rustls::RootCertStore::empty();
+    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    if let Some(path) = extra_ca {
+        let pem = std::fs::read(path)
+            .with_context(|| format!("read [sip.tls_client].extra_ca {}", path.display()))?;
+        let mut added = 0usize;
+        for cert in rustls_pemfile::certs(&mut pem.as_slice()) {
+            let cert = cert.with_context(|| format!("parse certificate in {}", path.display()))?;
+            roots
+                .add(cert)
+                .with_context(|| format!("add CA root from {}", path.display()))?;
+            added += 1;
+        }
+        if added == 0 {
+            return Err(anyhow!(
+                "[sip.tls_client].extra_ca {} contains no certificates",
+                path.display()
+            ));
+        }
+        info!(path = %path.display(), added, "client TLS extra CA roots loaded");
+    }
+    Ok(Arc::new(
+        tokio_rustls::rustls::ClientConfig::builder()
+            .with_root_certificates(roots)
+            .with_no_client_auth(),
+    ))
+}
+
 /// `[sip.tls]`. Failure here is fatal — operators who set
 /// `transports = ["tls"]` expect SIPS to actually work, not to
 /// silently degrade to cleartext.
@@ -1194,16 +1249,26 @@ fn sip_public_addr(node: &NodeConfig, sip: &SipConfig) -> Option<SocketAddr> {
     candidate.parse().ok()
 }
 
-fn spawn_listeners(
+#[allow(clippy::too_many_arguments)]
+async fn spawn_listeners(
     sip: &SipConfig,
     udp_socket: Arc<UdpSocket>,
     udp_bound_addr: SocketAddr,
     transaction_mgr: Arc<TransactionManager>,
     uas: Arc<IntegratedUAS>,
     tls_server_config: Option<Arc<arc_swap::ArcSwap<tokio_rustls::rustls::ServerConfig>>>,
+    tcp_client_pool: &ConnectionPool,
+    tls_client_pool: &TlsPool,
 ) -> Vec<JoinHandle<()>> {
     let mut handles = Vec::new();
     let (packet_tx, packet_rx) = mpsc::channel::<InboundPacket>(1024);
+
+    // Route responses arriving on OUTBOUND client connections (the
+    // dispatcher's TCP/TLS pools) into the same packet pipeline the
+    // listeners feed. Without this the pool opens a connection, sends
+    // the request, and silently drops everything the peer sends back.
+    tcp_client_pool.set_inbound_tx(packet_tx.clone()).await;
+    tls_client_pool.set_inbound_tx(packet_tx.clone()).await;
 
     let want_udp = sip.transports.contains(&SipTransport::Udp);
     let want_tcp = sip.transports.contains(&SipTransport::Tcp);
@@ -1371,17 +1436,33 @@ fn map_transport_kind(kind: TpTransportKind) -> TxTransportKind {
 // response payload through that channel back to the peer over the
 // established socket.
 //
-// Outbound TCP/TLS connect (without a `stream` already set in
-// ctx) is what UAC mode would need — for v1 we error out cleanly
-// rather than silently falling back to UDP.
+// Outbound TCP/TLS connect (no `stream` in ctx) goes through the
+// client pools: `ConnectionPool` / `TlsPool` open (or reuse) a
+// connection to the peer, and their reader tasks feed responses
+// back into the inbound packet pipeline (`set_inbound_tx` in
+// `spawn_listeners`). This is what `[[gateway]]` / `[[register]]`
+// blocks with `transport = "tcp"|"tls"` ride.
 
 struct MultiTransportDispatcher {
     udp_socket: Arc<UdpSocket>,
+    tcp_client_pool: Arc<ConnectionPool>,
+    tls_client_pool: Arc<TlsPool>,
+    tls_client_config: Arc<TlsClientConfig>,
 }
 
 impl MultiTransportDispatcher {
-    fn new(udp_socket: Arc<UdpSocket>) -> Self {
-        Self { udp_socket }
+    fn new(
+        udp_socket: Arc<UdpSocket>,
+        tcp_client_pool: Arc<ConnectionPool>,
+        tls_client_pool: Arc<TlsPool>,
+        tls_client_config: Arc<TlsClientConfig>,
+    ) -> Self {
+        Self {
+            udp_socket,
+            tcp_client_pool,
+            tls_client_pool,
+            tls_client_config,
+        }
     }
 }
 
@@ -1393,6 +1474,9 @@ impl TransportDispatcher for MultiTransportDispatcher {
                 .await
                 .with_context(|| format!("send_udp to {}", ctx.peer())),
             TxTransportKind::Tcp | TxTransportKind::Tls => match ctx.stream() {
+                // Established connection (inbound dialog, or a pooled
+                // client connection threaded back through a flow) —
+                // reply over it.
                 Some(writer) => {
                     let target = match ctx.transport() {
                         TxTransportKind::Tcp => sip_transport::TransportKind::Tcp,
@@ -1403,12 +1487,40 @@ impl TransportDispatcher for MultiTransportDispatcher {
                         .await
                         .with_context(|| format!("send_stream to {}", ctx.peer()))
                 }
-                None => Err(anyhow!(
-                    "outbound {:?} without an existing stream is not supported in v1 \
-                     (peer={}); inbound-only UAS",
-                    ctx.transport(),
-                    ctx.peer()
-                )),
+                // No connection yet — originate one via the client
+                // pools (gateway INVITE, REGISTER to a TLS registrar).
+                None => match ctx.transport() {
+                    TxTransportKind::Tcp => self
+                        .tcp_client_pool
+                        .send_tcp(ctx.peer(), payload)
+                        .await
+                        .with_context(|| format!("outbound TCP connect to {}", ctx.peer())),
+                    TxTransportKind::Tls => {
+                        // SNI: the UAC threads the DNS target's host
+                        // into the ctx; the IP fallback only fires for
+                        // literal-IP targets, where certificate
+                        // verification needs an IP SAN anyway.
+                        let server_name = ctx
+                            .server_name()
+                            .map(String::from)
+                            .unwrap_or_else(|| ctx.peer().ip().to_string());
+                        self.tls_client_pool
+                            .send_tls(
+                                ctx.peer(),
+                                server_name.clone(),
+                                Arc::clone(&self.tls_client_config),
+                                payload,
+                            )
+                            .await
+                            .with_context(|| {
+                                format!(
+                                    "outbound TLS connect to {} (sni={server_name})",
+                                    ctx.peer()
+                                )
+                            })
+                    }
+                    _ => unreachable!(),
+                },
             },
             other => Err(anyhow!(
                 "transport {other:?} is not enabled in this build (peer={})",

--- a/bins/siphon-ai/tests/startup.rs
+++ b/bins/siphon-ai/tests/startup.rs
@@ -21,6 +21,21 @@ use tokio::sync::oneshot;
 
 const FIXTURE: &str = include_str!("fixtures/local-dev.toml");
 
+/// Install rustls's process-wide crypto provider exactly once.
+/// `main()` does this in the daemon path; tests don't run `main`,
+/// and `Runtime::build` unconditionally constructs the client TLS
+/// verification roots (for outbound `transport = "tls"`), so every
+/// test that builds a runtime needs this first (or rustls panics
+/// with "Could not automatically determine the process-level
+/// CryptoProvider").
+fn install_crypto_provider() {
+    use std::sync::Once;
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    });
+}
+
 /// Test env source. Random port allocation lives at the OS layer
 /// (the daemon binds via `UdpSocket::bind`) so we just pin a
 /// `127.0.0.1:0` listen and let the kernel pick a free port.
@@ -43,6 +58,7 @@ impl EnvSource for MapEnv {
 
 #[tokio::test]
 async fn runtime_starts_and_shuts_down_cleanly() {
+    install_crypto_provider();
     let env = MapEnv::new([
         ("TEST_SIP_LISTEN", "127.0.0.1:0"),
         ("TEST_RTP_MIN", "40000"),
@@ -108,6 +124,7 @@ any = true
 
 #[tokio::test]
 async fn runtime_with_udp_and_tcp_transports_binds_both() {
+    install_crypto_provider();
     // The TCP listener uses the same host:port pair as UDP — but
     // UDP and TCP are different namespaces in the kernel, so the
     // "busy" check only enforces uniqueness within a transport.
@@ -197,6 +214,7 @@ any = true
 
 #[tokio::test]
 async fn registrations_seed_into_manager_on_startup() {
+    install_crypto_provider();
     let env = MapEnv::new([
         ("TEST_SIP_LISTEN", "127.0.0.1:0"),
         ("TEST_RTP_MIN", "40600"),
@@ -248,6 +266,7 @@ async fn registrations_seed_into_manager_on_startup() {
 
 #[tokio::test]
 async fn build_fails_when_listen_port_is_busy() {
+    install_crypto_provider();
     // Bind a placeholder UDP socket on an ephemeral port, then ask
     // the runtime to bind the same one — the second bind must
     // surface as a startup error, not a silent succeed-and-overlap.
@@ -317,6 +336,7 @@ any = true
 
 #[tokio::test]
 async fn runtime_with_hep_enabled_binds_and_drains_worker_on_shutdown() {
+    install_crypto_provider();
     // Bind a UDP socket to stand in for Homer; we don't actually
     // need to receive anything for this smoke — the test asserts the
     // daemon brings up the HEP plumbing without failing the build,

--- a/crates/config/src/compile.rs
+++ b/crates/config/src/compile.rs
@@ -99,6 +99,10 @@ pub struct Gateway {
     pub name: String,
     pub proxy_host: String,
     pub proxy_port: u16,
+    /// Transport for calls placed through this trunk. Non-UDP adds a
+    /// `;transport=` URI parameter so the UAC's RFC 3263 resolution
+    /// selects the right transport (and, for TLS, the right SNI).
+    pub transport: SipTransport,
     /// Default caller-ID `sip:` URI.
     pub from: String,
     pub credentials: Option<GatewayCredentials>,
@@ -106,11 +110,14 @@ pub struct Gateway {
 
 impl Gateway {
     /// The Request-URI for dialing `destination` through this gateway —
-    /// `sip:<destination>@<proxy_host>:<proxy_port>`.
+    /// `sip:<destination>@<proxy_host>:<proxy_port>[;transport=…]`.
     pub fn request_uri(&self, destination: &str) -> String {
         format!(
-            "sip:{}@{}:{}",
-            destination, self.proxy_host, self.proxy_port
+            "sip:{}@{}:{}{}",
+            destination,
+            self.proxy_host,
+            self.proxy_port,
+            self.transport.uri_param()
         )
     }
 }
@@ -363,6 +370,10 @@ pub struct SipConfig {
     /// transports list. `None` when TLS isn't enabled. Daemon
     /// loads cert/key from these paths at startup.
     pub tls: Option<SipTlsConfig>,
+    /// `[sip.tls_client].extra_ca` — optional PEM bundle appended to
+    /// the webpki roots when verifying OUTGOING TLS connections
+    /// (gateways / registrations with `transport = "tls"`).
+    pub tls_client_extra_ca: Option<PathBuf>,
     /// RFC 4028 Min-SE for the UAS (`[sip].min_session_expires_secs`).
     /// Defaults to 90 (RFC minimum).
     pub min_session_expires: Duration,
@@ -384,6 +395,19 @@ pub enum SipTransport {
     Udp,
     Tcp,
     Tls,
+}
+
+impl SipTransport {
+    /// The `;transport=` URI parameter for a Request-URI using this
+    /// transport. Empty for UDP — the RFC 3263 default; emitting it
+    /// explicitly would only churn byte-identical configs.
+    pub fn uri_param(&self) -> &'static str {
+        match self {
+            SipTransport::Udp => "",
+            SipTransport::Tcp => ";transport=tcp",
+            SipTransport::Tls => ";transport=tls",
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -533,6 +557,18 @@ pub enum CompileError {
 
     #[error("[[gateway]] {name:?} has `auth_username` without `auth_password` (or vice versa)")]
     GatewayIncompleteAuth { name: String },
+
+    #[error("[[gateway]] {name:?} transport {transport:?} is not one of udp, tcp, tls")]
+    GatewayUnknownTransport { name: String, transport: String },
+
+    #[error("[sip.tls_client].extra_ca {0:?} does not exist or is not a file")]
+    TlsClientExtraCaMissing(String),
+
+    #[error(
+        "[[gateway]] {name:?} sets both `register` and `transport`; \
+         the transport is inherited from the register block"
+    )]
+    GatewayTransportWithRegister { name: String },
 
     #[error("[media].rtp_port_range {min}-{max} is invalid (min must be < max and even)")]
     BadRtpPortRange { min: u16, max: u16 },
@@ -762,6 +798,20 @@ fn compile_sip(raw: RawSip) -> Result<SipConfig, CompileError> {
     let tls_enabled = transports.contains(&SipTransport::Tls);
     let tls = compile_sip_tls(raw.tls, tls_enabled, &listen_addr)?;
 
+    // Client-side roots are independent of the TLS *listener* — a
+    // UDP-only daemon can still dial a TLS trunk. Validate the path
+    // at load per CLAUDE.md §4.6 (fail loud at startup).
+    let tls_client_extra_ca = match raw.tls_client.extra_ca {
+        None => None,
+        Some(p) => {
+            let path = PathBuf::from(&p);
+            if !path.is_file() {
+                return Err(CompileError::TlsClientExtraCaMissing(p));
+            }
+            Some(path)
+        }
+    };
+
     let call_progress = compile_call_progress(raw.call_progress)?;
 
     // RFC 4028: 90 s is the floor (Min-SE). An operator setting
@@ -781,6 +831,7 @@ fn compile_sip(raw: RawSip) -> Result<SipConfig, CompileError> {
         user_agent: raw.user_agent,
         contact: raw.contact,
         tls,
+        tls_client_extra_ca,
         call_progress,
         min_session_expires,
         preferred_session_expires,
@@ -1031,7 +1082,14 @@ fn compile_outbound(
         }
 
         let gw = if let Some(reg_name) = g.register.as_deref().filter(|s| !s.is_empty()) {
-            // Register reuse — inherit server + credentials + AOR.
+            // Register reuse — inherit server + credentials + AOR +
+            // transport. An explicit `transport` here is a conflict,
+            // not an override: fail loud per CLAUDE.md §4.6.
+            if g.transport.is_some() {
+                return Err(CompileError::GatewayTransportWithRegister {
+                    name: g.name.clone(),
+                });
+            }
             let reg = registrations
                 .iter()
                 .find(|r| r.name == reg_name)
@@ -1049,6 +1107,7 @@ fn compile_outbound(
                 name: g.name.clone(),
                 proxy_host: reg.server_host.clone(),
                 proxy_port: reg.server_addr.port(),
+                transport: reg.transport,
                 from,
                 credentials: Some(GatewayCredentials {
                     username: reg.auth_username.clone(),
@@ -1065,13 +1124,32 @@ fn compile_outbound(
                 .ok_or_else(|| CompileError::GatewayNeedsProxyOrRegister {
                     name: g.name.clone(),
                 })?;
-            let (proxy_host, proxy_port) =
-                parse_register_server(proxy, None, 5060).map_err(|err| {
-                    CompileError::GatewayBadProxy {
+            let transport = match g
+                .transport
+                .as_deref()
+                .unwrap_or("udp")
+                .to_ascii_lowercase()
+                .as_str()
+            {
+                "udp" => SipTransport::Udp,
+                "tcp" => SipTransport::Tcp,
+                "tls" => SipTransport::Tls,
+                other => {
+                    return Err(CompileError::GatewayUnknownTransport {
                         name: g.name.clone(),
-                        proxy: proxy.to_string(),
-                        err,
-                    }
+                        transport: other.to_string(),
+                    })
+                }
+            };
+            let default_port = match transport {
+                SipTransport::Tls => 5061,
+                _ => 5060,
+            };
+            let (proxy_host, proxy_port) = parse_register_server(proxy, None, default_port)
+                .map_err(|err| CompileError::GatewayBadProxy {
+                    name: g.name.clone(),
+                    proxy: proxy.to_string(),
+                    err,
                 })?;
             let from = g.from.clone().filter(|s| !s.is_empty()).ok_or_else(|| {
                 CompileError::GatewayFromRequired {
@@ -1098,6 +1176,7 @@ fn compile_outbound(
                 name: g.name.clone(),
                 proxy_host,
                 proxy_port,
+                transport,
                 from,
                 credentials,
             }

--- a/crates/config/src/raw.rs
+++ b/crates/config/src/raw.rs
@@ -118,6 +118,12 @@ pub struct RawSip {
     /// for UDP-only deployments.
     #[serde(default)]
     pub tls: RawSipTls,
+    /// Client-side TLS sub-block — verification roots for OUTGOING
+    /// TLS connections (gateways / registrations with
+    /// `transport = "tls"`). Independent of `[sip.tls]`, which is
+    /// the server side. Unset = the bundled webpki roots only.
+    #[serde(default)]
+    pub tls_client: RawSipTlsClient,
     /// Call-progress sub-block — how the UAS responds to inbound
     /// INVITEs before the 2xx. Unset = `mode = "instant_answer"`
     /// (v0.1.0 behaviour).
@@ -168,6 +174,17 @@ pub struct RawSipTls {
     /// PEM-encoded private key (path on disk). Required.
     #[serde(default)]
     pub key: Option<String>,
+}
+
+/// `[sip.tls_client]` — verification roots for outgoing TLS.
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawSipTlsClient {
+    /// Path to a PEM bundle appended to the bundled webpki roots —
+    /// for trunks fronted by a private CA, and for test rigs with
+    /// self-signed certs.
+    #[serde(default)]
+    pub extra_ca: Option<String>,
 }
 
 fn default_transports() -> Vec<String> {
@@ -295,6 +312,14 @@ pub struct RawGateway {
     /// `host` or `host:port` of the trunk. Required unless `register` is set.
     #[serde(default)]
     pub proxy: Option<String>,
+    /// `udp` (default) | `tcp` | `tls` — transport for calls placed
+    /// through this trunk. With `tls`, the default proxy port becomes
+    /// 5061 and the daemon verifies the trunk's certificate against
+    /// its client TLS roots (webpki + `[sip.tls_client].extra_ca`).
+    /// Must be unset when `register` is set — the transport is
+    /// inherited from the register block.
+    #[serde(default)]
+    pub transport: Option<String>,
     /// Default caller-ID — a full `sip:` URI. Required for standalone
     /// trunks; defaults to the register AOR when `register` is set.
     #[serde(default)]

--- a/crates/config/tests/load.rs
+++ b/crates/config/tests/load.rs
@@ -1645,3 +1645,185 @@ ws_url = "wss://x/y"
     let err = load_from_str_with_env(toml, &env).unwrap_err();
     assert!(err.to_string().contains("public_address"));
 }
+
+// ─── [[gateway]] transport selection (outbound TLS, PR #163) ──────
+
+#[test]
+fn gateway_transport_tls_defaults_port_5061_and_adds_uri_param() {
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[bridge]
+ws_url = "wss://x/y"
+
+[outbound]
+max_concurrent = 2
+
+[[gateway]]
+name = "twilio"
+proxy = "siphon.pstn.twilio.com"
+transport = "tls"
+from = "sip:+15551230000@siphon.pstn.twilio.com"
+"#;
+    let cfg = load_from_str_with_env(toml, &env).unwrap();
+    let gw = cfg.outbound.gateway("twilio").expect("gateway compiled");
+    assert_eq!(gw.transport, SipTransport::Tls);
+    // TLS flips the default proxy port to 5061 (SIPS standard).
+    assert_eq!(gw.proxy_port, 5061);
+    assert_eq!(
+        gw.request_uri("+15183217034"),
+        "sip:+15183217034@siphon.pstn.twilio.com:5061;transport=tls"
+    );
+}
+
+#[test]
+fn gateway_transport_defaults_to_udp_with_no_uri_param() {
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[bridge]
+ws_url = "wss://x/y"
+
+[outbound]
+max_concurrent = 2
+
+[[gateway]]
+name = "pbx"
+proxy = "10.0.0.5"
+from = "sip:bot@10.0.0.5"
+"#;
+    let cfg = load_from_str_with_env(toml, &env).unwrap();
+    let gw = cfg.outbound.gateway("pbx").expect("gateway compiled");
+    assert_eq!(gw.transport, SipTransport::Udp);
+    assert_eq!(gw.proxy_port, 5060);
+    // UDP is the RFC 3263 default; no param churn on existing configs.
+    assert_eq!(gw.request_uri("7001"), "sip:7001@10.0.0.5:5060");
+}
+
+#[test]
+fn gateway_unknown_transport_is_rejected() {
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[bridge]
+ws_url = "wss://x/y"
+
+[[gateway]]
+name = "bad"
+proxy = "10.0.0.5"
+transport = "sctp"
+from = "sip:bot@10.0.0.5"
+"#;
+    let err = load_from_str_with_env(toml, &env).unwrap_err();
+    assert!(err.to_string().contains("sctp"), "got: {err}");
+}
+
+#[test]
+fn gateway_transport_conflicts_with_register_reuse() {
+    // With `register` set the transport is inherited; an explicit
+    // `transport` is a conflict, not an override.
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[bridge]
+ws_url = "wss://x/y"
+
+[[register]]
+name = "pbx-main"
+server = "10.0.0.5"
+transport = "tls"
+username = "bot"
+password = "hunter2"
+
+[[gateway]]
+name = "via-pbx"
+register = "pbx-main"
+transport = "udp"
+"#;
+    let err = load_from_str_with_env(toml, &env).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("inherited from the register block"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn gateway_register_reuse_inherits_transport() {
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[bridge]
+ws_url = "wss://x/y"
+
+[[register]]
+name = "pbx-main"
+server = "10.0.0.5"
+transport = "tls"
+username = "bot"
+password = "hunter2"
+
+[[gateway]]
+name = "via-pbx"
+register = "pbx-main"
+"#;
+    let cfg = load_from_str_with_env(toml, &env).unwrap();
+    let gw = cfg.outbound.gateway("via-pbx").expect("gateway compiled");
+    assert_eq!(gw.transport, SipTransport::Tls);
+    assert_eq!(gw.proxy_port, 5061);
+    assert!(gw.request_uri("100").ends_with(";transport=tls"));
+}
+
+// ─── [sip.tls_client] — outgoing TLS verification roots ───────────
+
+#[test]
+fn tls_client_extra_ca_missing_file_is_rejected_at_load() {
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[sip.tls_client]
+extra_ca = "/nonexistent/ca.pem"
+
+[bridge]
+ws_url = "wss://x/y"
+"#;
+    let err = load_from_str_with_env(toml, &env).unwrap_err();
+    assert!(err.to_string().contains("extra_ca"), "got: {err}");
+}
+
+#[test]
+fn tls_client_extra_ca_existing_file_compiles() {
+    let env = MapEnv::new([]);
+    let dir = std::env::temp_dir().join(format!("siphon-ai-ca-test-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let ca = dir.join("ca.pem");
+    std::fs::write(&ca, "not validated at compile time, only at startup").unwrap();
+    let toml = format!(
+        r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[sip.tls_client]
+extra_ca = "{}"
+
+[bridge]
+ws_url = "wss://x/y"
+"#,
+        ca.display()
+    );
+    let cfg = load_from_str_with_env(&toml, &env).unwrap();
+    assert_eq!(cfg.sip.tls_client_extra_ca.as_deref(), Some(ca.as_path()));
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/core/src/outbound_service.rs
+++ b/crates/core/src/outbound_service.rs
@@ -58,6 +58,10 @@ pub struct OutboundGateway {
     pub originator: Arc<OutboundOriginator>,
     pub proxy_host: String,
     pub proxy_port: u16,
+    /// `;transport=…` Request-URI parameter for this trunk, empty
+    /// for UDP (config's `SipTransport::uri_param()` — kept as a
+    /// plain string for the same no-config-dep reason as above).
+    pub transport_uri_param: &'static str,
     /// Default caller-ID `sip:` URI for calls through this gateway.
     pub from: String,
 }
@@ -114,7 +118,10 @@ impl OutboundOriginateHandle for OutboundService {
             .filter(|s| !s.is_empty())
             .ok_or(OriginateRejection::NoWsUrl)?;
 
-        let target_str = format!("sip:{}@{}:{}", req.to, gw.proxy_host, gw.proxy_port);
+        let target_str = format!(
+            "sip:{}@{}:{}{}",
+            req.to, gw.proxy_host, gw.proxy_port, gw.transport_uri_param
+        );
         let target = SipUri::parse(&target_str)
             .map_err(|e| OriginateRejection::BadTarget(format!("{target_str}: {e}")))?;
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -51,12 +51,20 @@ before TOML parsing. Unset variables without a default fail the load.
 | `cert`   | path        | required when TLS on | PEM cert chain on disk. |
 | `key`    | path        | required when TLS on | PEM private key on disk. |
 
-> **Inbound UAS + outbound UAC for REGISTER.** SiphonAI terminates
-> inbound TLS for SIP signaling at this listener (v0.1.0). Outbound
-> TLS is supported for the UAC's `[[register]]` path as of 0.3.0 —
-> registrations with `transport = "tls"` actually go out over TLS
-> (see [`docs/REGISTRATION.md`](REGISTRATION.md)). Outbound TLS for
-> originated INVITEs is post-v1 per CLAUDE.md §8.
+> **Server side only.** `[sip.tls]` is the inbound listener's
+> cert/key. *Outgoing* TLS connections — `[[gateway]]` and
+> `[[register]]` blocks with `transport = "tls"` — verify the peer
+> against the client roots below and need no `[sip.tls]` at all: a
+> UDP-only daemon can still dial a TLS trunk.
+
+### `[sip.tls_client]` (0.7.0+)
+
+| Field      | Type | Default | Notes |
+|------------|------|---------|-------|
+| `extra_ca` | path | unset   | PEM bundle appended to the built-in webpki (Mozilla CA) roots when verifying outgoing TLS. For trunks fronted by a private CA and for test rigs with self-signed certs. Public trunks (e.g. Twilio) verify against the built-in roots without this. |
+
+The path is checked at config load; an unreadable or empty bundle
+fails at startup, not at first dial-out.
 
 ### `[sip.call_progress]`
 
@@ -302,7 +310,8 @@ register = "pbx"            # name of a [[register]] block
 | `max_concurrent` | `[outbound]` | Max simultaneous outbound calls. `0` (default) disables outbound entirely. This + `rate_limit_per_sec` are the **native guardrails** — the originate API itself has no built-in auth (it's fronted by a reverse proxy / trusted network), so **you must restrict access to that endpoint and set a sane cap** to avoid toll fraud. |
 | `rate_limit_per_sec` | `[outbound]` | Optional ceiling on *new* outbound calls per second (token bucket, burst = the rate). `0`/unset = no rate limit. |
 | `name` | `[[gateway]]` | Unique gateway name; the originate request names one. |
-| `proxy` | `[[gateway]]` | `host` or `host:port` of the trunk (resolved per RFC 3263 at INVITE time). Required unless `register` is set. |
+| `proxy` | `[[gateway]]` | `host` or `host:port` of the trunk (resolved per RFC 3263 at INVITE time). Required unless `register` is set. Default port: 5060, or 5061 when `transport = "tls"`. |
+| `transport` | `[[gateway]]` | `"udp"` (default) \| `"tcp"` \| `"tls"`. Non-UDP dials out through the daemon's client connection pools; TLS verifies the trunk's cert against the webpki roots + `[sip.tls_client].extra_ca` and uses the proxy host as SNI. Must be unset when `register` is set — the transport is inherited from the register block. |
 | `from` | `[[gateway]]` | Default caller-ID — a full `sip:`/`sips:` URI. Required for standalone trunks; defaults to the register AOR when `register` is set. |
 | `register` | `[[gateway]]` | Name of a `[[register]]` to dial through, inheriting its server address, digest credentials, and AOR. |
 | `auth_username` / `auth_password` | `[[gateway]]` | Digest credentials for a standalone trunk (both or neither). Answered on any 401/407 challenge the trunk sends. |


### PR DESCRIPTION
## What

The transport dispatcher was inbound-only: any request needing a fresh TCP/TLS connection — an originated INVITE to a TLS trunk, or a REGISTER to a TLS registrar — died with `outbound … without an existing stream is not supported in v1`. This wires the dispatcher to client connection pools so outbound TCP/TLS actually dials.

The dispatcher now owns `sip-transport`'s `ConnectionPool`/`TlsPool` (the pattern proven in siphond): outbound TCP/TLS with no established stream dials through the pool, reuses the connection on later requests, and the pool's reader task feeds responses back into the same inbound packet pipeline the listeners use (`set_inbound_tx`). Inbound dialogs are unaffected — they keep riding the per-connection writer the listener attached.

TLS verifies the peer against the bundled webpki (Mozilla CA) roots — sufficient for public trunks like Twilio — plus an optional `[sip.tls_client].extra_ca` PEM bundle for private-CA deployments and self-signed test rigs (path validated at load). SNI is the gateway's proxy host, threaded through the existing `TransportContext::server_name`.

## Config

- `[[gateway]]` gains `transport = "udp" | "tcp" | "tls"` (default `udp`). Non-UDP appends `;transport=…` to the Request-URI so RFC 3263 resolution selects the right transport; `tls` flips the default proxy port to 5061. With `register` set, the transport is inherited from the register block and an explicit `transport` is rejected at load.
- `[[register]]` blocks with `transport = "tls"` — documented since 0.3.0 but broken by the same dispatcher gap — now actually go out over TLS.
- `[sip.tls_client].extra_ca` — optional PEM bundle appended to the webpki roots. A UDP-only daemon (no `[sip.tls]` listener) can still dial a TLS trunk.

## Scope

Media on outbound legs is still plain RTP. Trunks requiring SRTP (e.g. Twilio secure trunking) need the follow-up SDES change before outbound calls carry audio — **this change is signaling-transport only.**

## Testing

- `cargo test --workspace`, `cargo clippy --all-targets -D warnings`, `cargo fmt --check` — all clean. `startup.rs` tests now install the rustls `CryptoProvider` (`Runtime::build` unconditionally constructs the client TLS roots).
- SIPp regression suite **14/14** (`run-all-local.sh --with-transfer`).
- Live local rig: a UDP-only daemon dials a CA-verified TLS UAS — INVITE carries `;transport=tls`, 200/ACK and the WS media bridge establish over one pooled outbound TLS connection (`outbound call answered and media bridged code=200`).
- Not yet exercised against the live Twilio TLS trunk (needs outbound origination enabled in prod config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)