### PR TITLE
chore(release): 0.6.2 — TLS trunk hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.6.2] - 2026-06-12
+
+Theme: **TLS trunk hardening** — the fixes found by running v0.6.1 against a
+production TLS trunk (Twilio secure trunking), plus the dispatcher growing
+outbound TCP/TLS so gateways and registrations can dial secure trunks, not
+just answer them. Everything new is off by default; the WS protocol stays at
+`version: "1"` and the CDR schema is unchanged. A 0.6.1 deployment upgrades
+with zero config changes.
 
 ### Added
 
@@ -33,6 +40,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * Note: media on outbound legs is still plain RTP. Trunks that require SRTP
     (e.g. Twilio secure trunking) need the follow-up SDES change before
     outbound calls carry audio — this change is signaling-transport only.
+
+- **Deepgram/LLM example bot: human-handoff transfer triggers**
+  (`examples/deepgram-llm-bot-node/`). With `BOT_TRANSFER_TARGET` (a SIP URI)
+  set, the bot hands the caller off via the protocol's `transfer` frame
+  (PROTOCOL.md §4.4) through two routes sharing one announce-then-REFER path:
+  a deterministic keyword fast-path over final utterances
+  (`BOT_TRANSFER_PHRASE`, e.g. "transfer me" / "speak to a human"), and a
+  `transfer_call` tool offered to the LLM so natural phrasings the regex
+  misses still trigger the handoff. The tool only signals intent — the
+  destination is always `BOT_TRANSFER_TARGET`; the model never chooses a URI.
+  Example-only; no daemon changes.
 
 ### Fixed
 
@@ -63,10 +81,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   call until its own timeout. The acceptor now captures the inbound connection's
   writer channel at INVITE time (`DialogFlow`) and sends the cleanup BYE through
   `IntegratedUAC::bye_via_flow` over that same connection (RFC 5626 flow semantics).
-  UDP dialogs keep the existing path. Known remaining gap: REFER (transfer) on a
-  TCP/TLS dialog still fails the same way — `send_refer` has no flow-reuse variant
-  upstream yet; transfers on TLS trunks will return `transfer_failed` to the WS
-  server until that lands.
+  UDP dialogs keep the existing path. (The matching REFER gap this fix left open
+  is also closed in this release — see the transfer entry above.)
 
 - **TLS trunks: in-dialog ACK/BYE were lost (silent-tail recordings, wrong CDR cause).**
   When the daemon ran both a UDP and a TLS listener (`[sip].transports = ["udp", "tls"]`),
@@ -772,7 +788,7 @@ the WebSocket server's job.
 - Reference WebSocket servers in `examples/`: echo (Python / Node),
   an OpenAI Realtime bridge, and a Deepgram + LLM voice bot.
 
-[Unreleased]: https://github.com/thevoiceguy/siphon-ai/compare/v0.6.1...HEAD
+[0.6.2]: https://github.com/thevoiceguy/siphon-ai/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/thevoiceguy/siphon-ai/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/thevoiceguy/siphon-ai/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/thevoiceguy/siphon-ai/compare/v0.4.1...v0.5.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2901,7 +2901,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "base64",
  "bytes",
@@ -2922,7 +2922,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2939,7 +2939,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "regex",
  "serde",
@@ -2956,7 +2956,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2996,7 +2996,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -3011,7 +3011,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3033,7 +3033,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "thiserror 1.0.69",
  "tokio",
@@ -3042,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "regex",
  "serde",
@@ -3053,7 +3053,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -3062,7 +3062,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3085,7 +3085,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "base64",
  "rcgen",
@@ -3103,7 +3103,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3124,7 +3124,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
+**v0.6.2** — patch release. Theme: **TLS trunk hardening.** Fixes found by
+running v0.6.1 against a production TLS trunk: the `Contact` on dual-listener
+daemons advertised the UDP port for TLS dialogs (losing in-dialog ACK/BYE —
+~60 s silent-tail recordings, wrong CDR cause), and daemon-initiated BYE and
+REFER on TCP/TLS dialogs dialed fresh connections nothing answered — both now
+reuse the inbound connection (RFC 5626 flow semantics). The transport
+dispatcher also grows **outbound TCP/TLS**: `[[gateway]]` / `[[register]]`
+blocks with `transport = "tcp" | "tls"` dial out through client connection
+pools, verifying peers against the bundled webpki roots plus an optional
+`[sip.tls_client].extra_ca` (signaling only — SRTP media is a follow-up). The
+Deepgram/LLM example bot gains human-handoff transfer triggers (keyword
+fast-path + a `transfer_call` LLM tool). Protocol stays `version: "1"`; CDR
+schema unchanged; a 0.6.1 deployment upgrades with zero config changes. Full
+notes: [`CHANGELOG.md`](CHANGELOG.md).
+
 **v0.6.1** — seventh release. Theme: **attended transfer.** The bot
 consults a human before handing the caller off: SiphonAI places the
 consult leg as a plain 0.6.0 outbound call (`POST /admin/v1/calls`, its

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -57,7 +57,7 @@ before TOML parsing. Unset variables without a default fail the load.
 > against the client roots below and need no `[sip.tls]` at all: a
 > UDP-only daemon can still dial a TLS trunk.
 
-### `[sip.tls_client]` (0.7.0+)
+### `[sip.tls_client]` (0.6.2+)
 
 | Field      | Type | Default | Notes |
 |------------|------|---------|-------|


### PR DESCRIPTION
## Summary

Cuts the **v0.6.2** release: CHANGELOG `[Unreleased]` → `[0.6.2] - 2026-06-12`, workspace version `0.6.1` → `0.6.2` (+ Cargo.lock), README status blurb.

The release ships the TLS-transport arc already on main (#155–#163):

- **Fixed — TLS trunks:** per-listener `Contact` port (#156), daemon-initiated BYE (#157) and REFER/transfer (#160) now reuse the inbound connection. These are production-impacting on v0.6.1 (lost ACK/BYE, ~60 s silent-tail recordings, `cause=tap_ended` CDRs, `transfer_failed`).
- **Added:** outbound TCP/TLS dialing — client connection pools in the dispatcher, `[[gateway]].transport`, `[sip.tls_client].extra_ca` (#163, off by default); Deepgram/LLM bot human-handoff transfer triggers (#161/#162).
- **Harness:** SIPp suite dual-stack portability (#155).

## Release-prep edits beyond the cutover

- `docs/CONFIG.md`: `[sip.tls_client]` label **"(0.7.0+)" → "(0.6.2+)"** — it ships now; 0.7.0 stays reserved for conferencing + park (DEV_PLAN_0.7.0.md).
- CHANGELOG: the #157 entry's "known remaining gap: REFER…" note now points at the #160 fix in the same release instead of reading as still open.
- CHANGELOG: back-filled an Added entry for the Deepgram bot transfer triggers (#161/#162 had none).

Semver note: `[[gateway]].transport` / `[sip.tls_client]` are additive features riding in a patch release — both off by default, zero config changes for 0.6.1 deployments; flagged in the changelog as Added.

## Validation

- `cargo test --workspace` — green
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- Full SIPp suite **14/14** including `--with-transfer`, run against the identical code at e6fca24

## After merge

Tag `v0.6.2` on the merge commit (matching prior releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)