### PR TITLE
feat(bridge,core,media-glue): conference WS protocol surface (0.7.0 chunk 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     the rest of forge-media). Deliberately **not** `forge-conference` — its
     DTMF-IVR/PIN/host-control layer is out of scope per §9.4.
 
+- **Conference WS protocol surface (0.7.0 chunk 2 of 5).** The WS server can
+  now drive conferencing for its own call (self-scoped, §9.2); the protocol
+  version stays `"1"` (all additions are new messages / a new error code).
+  * Server → SiphonAI: `conference_join { room_id }` (creates the room if
+    absent, subject to caps) and `conference_leave`. `docs/PROTOCOL.md` §4.8.
+  * SiphonAI → server: `conference_joined { room_id, participants }`,
+    `conference_left { room_id, reason }` (`reason` = `left` |
+    `room_closed`), and the fan-out events `participant_joined` /
+    `participant_left { room_id, participant_call_id }` to every *other*
+    member when the room's composition changes. `docs/PROTOCOL.md` §3.12.
+  * New `error` code `conference_failed` — a refused join (disabled, cap
+    reached, sample-rate mismatch, already joined); the call continues on its
+    direct pair.
+  * Wired into both inbound (`BridgingAcceptor::with_conference`) and
+    outbound (`OutboundService::with_conference`) calls; the daemon builds
+    one shared `ConferenceRegistry` from `[conference]` when enabled. The
+    async join runs off the controller's control loop (spawned, like REFER).
+  * Reference echo server (`examples/echo-ws-server-python`) gains
+    `--auto-conference-join ROOM` and logs the new events — the harness hook
+    for the chunk-5 two-caller SIPp scenario.
+
 ## [0.6.2] - 2026-06-12
 
 Theme: **TLS trunk hardening** — the fixes found by running v0.6.1 against a

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -77,8 +77,9 @@ use siphon_ai_config::{
     ObservabilityConfig, SipConfig, SipTlsConfig, SipTransport, WebhooksConfig,
 };
 use siphon_ai_core::{
-    default_call_id_factory, BridgingAcceptor, CallRegistry, ConsultRegistry, OutboundGateway,
-    OutboundGuard, OutboundOriginator, OutboundService, StaticCredentials,
+    default_call_id_factory, BridgingAcceptor, CallRegistry, ConferenceLimits, ConferenceRegistry,
+    ConsultRegistry, OutboundGateway, OutboundGuard, OutboundOriginator, OutboundService,
+    StaticCredentials,
 };
 use siphon_ai_media_glue::MediaSetup;
 use siphon_ai_sip_glue::{
@@ -149,10 +150,7 @@ impl Runtime {
             security,
             recording,
             outbound,
-            // [conference] is compiled + validated since 0.7.0 chunk 1,
-            // but nothing drives joins until the WS protocol surface
-            // (chunk 2) wires a ConferenceRegistry in here.
-            conference: _,
+            conference,
             cdr,
             observability,
             webhooks,
@@ -265,19 +263,37 @@ impl Runtime {
         let outbound_cdr_sink = Arc::clone(&cdr_sink);
         let outbound_webhook_sink = Arc::clone(&webhook_sink);
 
-        let acceptor = Arc::new(
-            BridgingAcceptor::new(media_setup, bridge_defaults, registry.clone())
-                .with_cdr_sink(cdr_sink)
-                .with_webhook_sink(webhook_sink)
-                .with_session_timer_policy(session_timer_policy)
-                .with_call_progress(sip.call_progress)
-                .with_verifier(verifier)
-                .with_security_policy(security_policy)
-                // Share the same HEP worker the SIP/RTCP/CDR emitters use so
-                // the verstat chunk lands on the same Homer call view.
-                .with_hep_telemetry(hep_telemetry.clone())
-                .with_recording(recording),
-        );
+        // Conference registry (0.7.0). Built once and shared (Clone) by
+        // the inbound acceptor and the outbound service so a bot on
+        // either kind of call can `conference_join`. `None` when
+        // `[conference].enabled = false` (the default) — no registry is
+        // allocated and joins are rejected with `conference_failed`.
+        let conference_registry = if conference.enabled {
+            Some(ConferenceRegistry::new(ConferenceLimits {
+                enabled: true,
+                max_rooms: conference.max_rooms,
+                max_participants_per_room: conference.max_participants_per_room,
+                join_tones: conference.join_tones,
+            }))
+        } else {
+            None
+        };
+
+        let mut acceptor_builder = BridgingAcceptor::new(media_setup, bridge_defaults, registry.clone())
+            .with_cdr_sink(cdr_sink)
+            .with_webhook_sink(webhook_sink)
+            .with_session_timer_policy(session_timer_policy)
+            .with_call_progress(sip.call_progress)
+            .with_verifier(verifier)
+            .with_security_policy(security_policy)
+            // Share the same HEP worker the SIP/RTCP/CDR emitters use so
+            // the verstat chunk lands on the same Homer call view.
+            .with_hep_telemetry(hep_telemetry.clone())
+            .with_recording(recording);
+        if let Some(reg) = &conference_registry {
+            acceptor_builder = acceptor_builder.with_conference(reg.clone());
+        }
+        let acceptor = Arc::new(acceptor_builder);
 
         // ─── Registration manager ──────────────────────────────────
         // Seed the manager up-front so a /metrics scrape during the
@@ -526,7 +542,7 @@ impl Runtime {
                 );
             }
             let guard = OutboundGuard::new(outbound.max_concurrent, outbound.rate_limit_per_sec);
-            let service = OutboundService::new(
+            let mut service = OutboundService::new(
                 gateways,
                 guard,
                 outbound_bridge_defaults,
@@ -535,6 +551,11 @@ impl Runtime {
                 outbound_webhook_sink,
                 consult_registry.clone(),
             );
+            // Outbound bots can join conferences too (§9.1 — a room is
+            // composed of any active calls). Share the same registry.
+            if let Some(reg) = &conference_registry {
+                service = service.with_conference(reg.clone());
+            }
             info!(
                 gateways = outbound.gateways.len(),
                 max_concurrent = outbound.max_concurrent,

--- a/crates/bridge/src/conn.rs
+++ b/crates/bridge/src/conn.rs
@@ -54,7 +54,8 @@ use tokio_tungstenite::{connect_async_with_config, MaybeTlsStream, WebSocketStre
 use tracing::{debug, info, instrument, warn};
 
 use crate::protocol::{
-    BridgeIn, BridgeOut, CallId, DtmfMethod, ErrorCode, Seq, StartMsg, StopReason, WS_SUBPROTOCOL,
+    BridgeIn, BridgeOut, CallId, ConferenceLeftReason, DtmfMethod, ErrorCode, Seq, StartMsg,
+    StopReason, WS_SUBPROTOCOL,
 };
 
 /// Maximum size of any single text frame, per PROTOCOL.md §2.1.
@@ -193,6 +194,27 @@ pub enum OutgoingEvent {
     RecordingFailed {
         recording_id: String,
         reason: String,
+    },
+    /// This call joined a conference room → [`BridgeOut::ConferenceJoined`].
+    /// The conn stamps `call_id` + `seq`.
+    ConferenceJoined {
+        room_id: String,
+        participants: usize,
+    },
+    /// This call left a conference room → [`BridgeOut::ConferenceLeft`].
+    ConferenceLeft {
+        room_id: String,
+        reason: ConferenceLeftReason,
+    },
+    /// Another call joined this call's room → [`BridgeOut::ParticipantJoined`].
+    ParticipantJoined {
+        room_id: String,
+        participant_call_id: String,
+    },
+    /// Another call left this call's room → [`BridgeOut::ParticipantLeft`].
+    ParticipantLeft {
+        room_id: String,
+        participant_call_id: String,
     },
 }
 
@@ -591,6 +613,39 @@ fn build_bridge_out(event: OutgoingEvent, call_id: CallId, seq: Seq) -> BridgeOu
             recording_id,
             reason,
         },
+        OutgoingEvent::ConferenceJoined {
+            room_id,
+            participants,
+        } => BridgeOut::ConferenceJoined {
+            call_id,
+            seq,
+            room_id,
+            participants,
+        },
+        OutgoingEvent::ConferenceLeft { room_id, reason } => BridgeOut::ConferenceLeft {
+            call_id,
+            seq,
+            room_id,
+            reason,
+        },
+        OutgoingEvent::ParticipantJoined {
+            room_id,
+            participant_call_id,
+        } => BridgeOut::ParticipantJoined {
+            call_id,
+            seq,
+            room_id,
+            participant_call_id,
+        },
+        OutgoingEvent::ParticipantLeft {
+            room_id,
+            participant_call_id,
+        } => BridgeOut::ParticipantLeft {
+            call_id,
+            seq,
+            room_id,
+            participant_call_id,
+        },
     }
 }
 
@@ -607,6 +662,8 @@ fn bridge_in_call_id(msg: &BridgeIn) -> &str {
         BridgeIn::StopRecording { call_id } => call_id.as_str(),
         BridgeIn::PauseRecording { call_id } => call_id.as_str(),
         BridgeIn::ResumeRecording { call_id } => call_id.as_str(),
+        BridgeIn::ConferenceJoin { call_id, .. } => call_id.as_str(),
+        BridgeIn::ConferenceLeave { call_id } => call_id.as_str(),
     }
 }
 

--- a/crates/bridge/src/lib.rs
+++ b/crates/bridge/src/lib.rs
@@ -17,6 +17,7 @@ pub use conn::{
     DisconnectReason, OutgoingEvent,
 };
 pub use protocol::{
-    AudioEncoding, AudioFormat, BridgeIn, BridgeOut, CallId, Direction, DtmfMethod, ErrorCode,
-    HangupCause, Seq, SipMeta, StartMsg, StopReason, PROTOCOL_VERSION, WS_SUBPROTOCOL,
+    AudioEncoding, AudioFormat, BridgeIn, BridgeOut, CallId, ConferenceLeftReason, Direction,
+    DtmfMethod, ErrorCode, HangupCause, Seq, SipMeta, StartMsg, StopReason, PROTOCOL_VERSION,
+    WS_SUBPROTOCOL,
 };

--- a/crates/bridge/src/protocol.rs
+++ b/crates/bridge/src/protocol.rs
@@ -188,6 +188,53 @@ pub enum BridgeOut {
         reason: String,
     },
 
+    /// This call successfully joined a conference room, in response to
+    /// the server's [`BridgeIn::ConferenceJoin`] (0.7.0). The call's
+    /// audio is now mixed into the room; the bot hears the room minus
+    /// its own playout. `participants` is the member-call count at the
+    /// moment of joining (this call included) — a snapshot; subsequent
+    /// changes arrive as [`BridgeOut::ParticipantJoined`] /
+    /// [`BridgeOut::ParticipantLeft`].
+    ConferenceJoined {
+        call_id: CallId,
+        seq: Seq,
+        room_id: String,
+        participants: usize,
+    },
+
+    /// This call left a conference room — either because the server
+    /// sent [`BridgeIn::ConferenceLeave`] (`reason = "left"`) or
+    /// because the room ended underneath it (`reason = "room_closed"`,
+    /// e.g. an operator force-ended the room). The direct caller↔WS
+    /// audio pair is restored; the call continues. Added in 0.7.0.
+    ConferenceLeft {
+        call_id: CallId,
+        seq: Seq,
+        room_id: String,
+        reason: ConferenceLeftReason,
+    },
+
+    /// ANOTHER call joined the room this call is in (0.7.0; fan-out to
+    /// every other member). `participant_call_id` is the bridge
+    /// `call_id` of the call that joined — distinct from the envelope
+    /// `call_id`, which is always this receiving session's own call.
+    ParticipantJoined {
+        call_id: CallId,
+        seq: Seq,
+        room_id: String,
+        participant_call_id: String,
+    },
+
+    /// ANOTHER call left the room this call is in (0.7.0). See
+    /// [`BridgeOut::ParticipantJoined`] for the `participant_call_id`
+    /// vs `call_id` distinction.
+    ParticipantLeft {
+        call_id: CallId,
+        seq: Seq,
+        room_id: String,
+        participant_call_id: String,
+    },
+
     /// Last message SiphonAI sends. Followed by a clean WS close (1000).
     Stop {
         call_id: CallId,
@@ -346,6 +393,17 @@ pub enum StopReason {
     Error,
 }
 
+/// Why a [`BridgeOut::ConferenceLeft`] fired.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConferenceLeftReason {
+    /// The server asked to leave via [`BridgeIn::ConferenceLeave`].
+    Left,
+    /// The room ended underneath this call (e.g. operator force-end,
+    /// or the room task stopped). The call reverts to its direct pair.
+    RoomClosed,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ErrorCode {
@@ -355,6 +413,11 @@ pub enum ErrorCode {
     ProtocolError,
     ServerTooSlow,
     TransferFailed,
+    /// A [`BridgeIn::ConferenceJoin`] was refused (conferencing
+    /// disabled, room/participant cap reached, sample-rate mismatch,
+    /// or already joined). The call continues on its direct pair.
+    /// Added in 0.7.0.
+    ConferenceFailed,
     Internal,
 }
 
@@ -451,6 +514,29 @@ pub enum BridgeIn {
 
     /// Resume recording after a [`BridgeIn::PauseRecording`].
     ResumeRecording { call_id: CallId },
+
+    /// Join this call into a conference room (0.7.0, §2.1). Creates
+    /// the room if it doesn't exist yet (subject to
+    /// `[conference]` caps). Self-scoped: a session may only join its
+    /// OWN call — cross-call composition (adding another participant)
+    /// is the admin API's job (§9.2). SiphonAI replies with
+    /// [`BridgeOut::ConferenceJoined`] or
+    /// [`BridgeOut::Error`]`{ code: "conference_failed" }`. While
+    /// joined, the bot hears the room mix minus its own playout and
+    /// speaks into the room.
+    ConferenceJoin {
+        call_id: CallId,
+        /// Operator-meaningful room name; calls naming the same
+        /// `room_id` share a room. The room locks to the first
+        /// joiner's sample rate.
+        room_id: String,
+    },
+
+    /// Leave the conference room this call is in (0.7.0). No-op if the
+    /// call isn't in a room. SiphonAI replies with
+    /// [`BridgeOut::ConferenceLeft`]`{ reason: "left" }` and restores
+    /// the direct caller↔WS audio pair.
+    ConferenceLeave { call_id: CallId },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -975,6 +1061,95 @@ mod tests {
             panic!("expected RecordingFailed");
         };
         assert_eq!(reason, "disk full");
+    }
+
+    // ─── Conference (0.7.0) ─────────────────────────────────────────────
+
+    #[test]
+    fn bridge_in_conference_join() {
+        let raw = r#"{ "type": "conference_join", "call_id": "siphon-a", "room_id": "support-7" }"#;
+        let msg: BridgeIn = assert_round_trip(raw);
+        let BridgeIn::ConferenceJoin { call_id, room_id } = msg else {
+            panic!("expected ConferenceJoin");
+        };
+        assert_eq!(call_id.as_str(), "siphon-a");
+        assert_eq!(room_id, "support-7");
+    }
+
+    #[test]
+    fn bridge_in_conference_leave() {
+        let raw = r#"{ "type": "conference_leave", "call_id": "siphon-a" }"#;
+        let msg: BridgeIn = assert_round_trip(raw);
+        assert!(matches!(msg, BridgeIn::ConferenceLeave { .. }));
+    }
+
+    #[test]
+    fn bridge_out_conference_joined() {
+        let raw = r#"{ "type": "conference_joined", "call_id": "siphon-a", "seq": 4, "room_id": "support-7", "participants": 2 }"#;
+        let msg: BridgeOut = assert_round_trip(raw);
+        let BridgeOut::ConferenceJoined {
+            room_id,
+            participants,
+            ..
+        } = msg
+        else {
+            panic!("expected ConferenceJoined");
+        };
+        assert_eq!(room_id, "support-7");
+        assert_eq!(participants, 2);
+    }
+
+    #[test]
+    fn bridge_out_conference_left_reasons() {
+        let left: BridgeOut = assert_round_trip(
+            r#"{ "type": "conference_left", "call_id": "siphon-a", "seq": 9, "room_id": "support-7", "reason": "left" }"#,
+        );
+        assert!(matches!(
+            left,
+            BridgeOut::ConferenceLeft {
+                reason: ConferenceLeftReason::Left,
+                ..
+            }
+        ));
+        let closed: BridgeOut = assert_round_trip(
+            r#"{ "type": "conference_left", "call_id": "siphon-a", "seq": 9, "room_id": "support-7", "reason": "room_closed" }"#,
+        );
+        assert!(matches!(
+            closed,
+            BridgeOut::ConferenceLeft {
+                reason: ConferenceLeftReason::RoomClosed,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn bridge_out_participant_joined_left() {
+        let joined: BridgeOut = assert_round_trip(
+            r#"{ "type": "participant_joined", "call_id": "siphon-a", "seq": 5, "room_id": "support-7", "participant_call_id": "siphon-b" }"#,
+        );
+        let BridgeOut::ParticipantJoined {
+            participant_call_id,
+            ..
+        } = joined
+        else {
+            panic!("expected ParticipantJoined");
+        };
+        assert_eq!(participant_call_id, "siphon-b");
+        let left: BridgeOut = assert_round_trip(
+            r#"{ "type": "participant_left", "call_id": "siphon-a", "seq": 6, "room_id": "support-7", "participant_call_id": "siphon-b" }"#,
+        );
+        assert!(matches!(left, BridgeOut::ParticipantLeft { .. }));
+    }
+
+    #[test]
+    fn bridge_out_error_conference_failed() {
+        let raw = r#"{ "type": "error", "call_id": "siphon-a", "seq": 3, "code": "conference_failed", "message": "room is full (8 calls)" }"#;
+        let msg: BridgeOut = assert_round_trip(raw);
+        let BridgeOut::Error { code, .. } = msg else {
+            panic!("expected Error");
+        };
+        assert_eq!(code, ErrorCode::ConferenceFailed);
     }
 
     // ─── Negative cases ─────────────────────────────────────────────────

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -95,6 +95,7 @@ use uuid::Uuid;
 use crate::call::{
     CallController, CallControllerConfig, CallOutcome, CallTermination, RecordingSummary,
 };
+use crate::conference::ConferenceRegistry;
 use crate::registry::CallRegistry;
 use crate::registry::ConsultRegistry;
 use crate::transfer::{DialogSource, TransferContext};
@@ -1458,6 +1459,11 @@ pub struct BridgingAcceptor {
     /// Recording policy. Default is `Off` (no recording). When `Always`,
     /// every accepted call gets a per-call WAV writer.
     recording: RecordingConfig,
+    /// Conference registry (0.7.0). `Some` when `[conference].enabled`;
+    /// every accepted call's controller gets a clone so the WS server
+    /// can `conference_join`. `None` → conferencing off, and joins are
+    /// rejected with `conference_failed`. Cheap to clone (Arc inside).
+    conference: Option<ConferenceRegistry>,
 }
 
 /// Daemon-wide REFER plumbing (shared across every accepted call).
@@ -1672,6 +1678,7 @@ impl BridgingAcceptor {
             security: AcceptSecurityPolicy::default(),
             hep: None,
             recording: RecordingConfig::default(),
+            conference: None,
         }
     }
 
@@ -1783,6 +1790,15 @@ impl BridgingAcceptor {
     /// accepted call.
     pub fn with_recording(mut self, recording: RecordingConfig) -> Self {
         self.recording = recording;
+        self
+    }
+
+    /// Install the conference registry (0.7.0). The daemon builds one
+    /// from `[conference]` and shares it here; every accepted call's
+    /// controller gets a clone so the WS server can `conference_join`.
+    /// Left unset → conferencing is off and joins are rejected.
+    pub fn with_conference(mut self, conference: ConferenceRegistry) -> Self {
+        self.conference = Some(conference);
         self
     }
 
@@ -3100,6 +3116,7 @@ impl BridgingAcceptor {
             media_tap: tap,
             transfer,
             recording,
+            conference: self.conference.clone(),
         };
         let (controller, handle) = CallController::new(cfg);
 

--- a/crates/core/src/call.rs
+++ b/crates/core/src/call.rs
@@ -63,7 +63,9 @@ use siphon_ai_bridge::{
     connect_and_run, BridgeChannels, BridgeConfig, BridgeError, BridgeIn, CallId, DisconnectReason,
     ErrorCode, OutgoingEvent, StartMsg, StopReason,
 };
-use siphon_ai_media_glue::{MediaTap, MediaTapError, TapCommand, TapDisconnect};
+use siphon_ai_media_glue::{MediaTap, MediaTapError, RoomMembership, TapCommand, TapDisconnect};
+
+use crate::conference::{ConferenceError, ConferenceRegistry};
 use siphon_ai_recording::{
     RecControl, RecEvent, RecFrame, RecordingError, RecordingSetup, RecordingStats, RecordingWriter,
 };
@@ -118,6 +120,12 @@ pub struct CallControllerConfig {
     /// task, forks both audio legs to it via the tap, and finalizes the WAV
     /// at teardown. `None` → no recording.
     pub recording: Option<RecordingSetup>,
+
+    /// Conference registry (0.7.0). `Some` when `[conference].enabled`;
+    /// the controller routes `BridgeIn::ConferenceJoin` through it. `None`
+    /// → conferencing off, and a join request is answered with
+    /// `error { code: "conference_failed" }`. Cheap to clone (Arc inside).
+    pub conference: Option<ConferenceRegistry>,
 }
 
 /// Where in its life a call is. State transitions are logged at
@@ -351,7 +359,13 @@ impl CallController {
             media_tap,
             transfer,
             recording,
+            conference,
         } = cfg;
+
+        // Captured before `media_tap` moves into its task — a room
+        // locks to its first joiner's negotiated rate, and a join is
+        // rejected at any other rate (no resampling in 0.7.0).
+        let call_sample_rate = media_tap.sample_rate();
 
         log_state(&call_id, CallState::Initializing);
 
@@ -376,6 +390,13 @@ impl CallController {
         // back-pressure simple if a second BridgeIn::Transfer arrives
         // while the first is still in flight.
         let (transfer_result_tx, mut transfer_result_rx) = mpsc::channel::<TransferOutcome>(1);
+        // conference join task → controller: the outcome of an async
+        // `ConferenceRegistry::join`. Spawned (like REFER) so the
+        // round-trip to the room task never blocks the control loop.
+        // Cap a few deep so back-to-back joins (e.g. room-switch)
+        // don't drop a result.
+        let (conf_join_tx, mut conf_join_rx) =
+            mpsc::channel::<Result<RoomMembership, ConferenceError>>(4);
 
         let channels = BridgeChannels {
             audio_out_rx: caller_audio_rx,
@@ -558,6 +579,52 @@ impl CallController {
                         Some(BridgeIn::ResumeRecording { call_id: cid }) => {
                             route_rec_control(&rec_ctrl_tx, RecControl::Resume, "ResumeRecording", &cid);
                         }
+                        Some(BridgeIn::ConferenceJoin { call_id: cid, room_id }) => {
+                            // Async join (round-trips to the room task)
+                            // is spawned so the control loop never
+                            // blocks — same reasoning as REFER. The
+                            // task reports back on `conf_join_rx`,
+                            // which forwards the membership to the tap
+                            // (or emits `conference_failed`).
+                            match &conference {
+                                Some(registry) => {
+                                    debug!(ws_call_id = %cid, %room_id, "spawning conference join");
+                                    let registry = registry.clone();
+                                    let tx = conf_join_tx.clone();
+                                    let join_call_id = call_id.as_str().to_string();
+                                    tokio::spawn(async move {
+                                        let outcome = registry
+                                            .join(&room_id, &join_call_id, call_sample_rate)
+                                            .await;
+                                        let _ = tx.try_send(outcome);
+                                    });
+                                }
+                                None => {
+                                    warn!(
+                                        ws_call_id = %cid,
+                                        %room_id,
+                                        "ConferenceJoin received but conferencing is disabled; rejecting"
+                                    );
+                                    let _ = control_out_tx
+                                        .send(OutgoingEvent::Error {
+                                            code: ErrorCode::ConferenceFailed,
+                                            message: "conferencing is disabled on this daemon"
+                                                .to_string(),
+                                        })
+                                        .await;
+                                }
+                            }
+                        }
+                        Some(BridgeIn::ConferenceLeave { call_id: cid }) => {
+                            // The tap drops its RoomSender (→ the room
+                            // removes this call) and emits
+                            // `conference_left`. No registry round-trip
+                            // needed: leave is drop-driven (chunk 1).
+                            debug!(ws_call_id = %cid, "forwarding ConferenceLeave to tap");
+                            if let Err(e) = tap_cmd_tx.try_send(TapCommand::LeaveRoom) {
+                                warn!(error = %e, "tap command channel full or closed; dropping ConferenceLeave");
+                            }
+                        }
                         Some(BridgeIn::Mark { call_id: cid, name }) => {
                             debug!(ws_call_id = %cid, %name, "forwarding Mark to tap");
                             // Mark is a notification request — the
@@ -684,6 +751,51 @@ impl CallController {
                                 .send(OutgoingEvent::Error {
                                     code: ErrorCode::TransferFailed,
                                     message: format!("{status} {reason}"),
+                                })
+                                .await;
+                        }
+                    }
+                }
+
+                // Outcome of an async conference join. On success the
+                // membership is handed to the tap (which re-plumbs the
+                // audio and emits `conference_joined`); on failure the
+                // server gets `error { code: "conference_failed" }`
+                // and the call continues on its direct pair.
+                Some(outcome) = conf_join_rx.recv() => {
+                    match outcome {
+                        Ok(membership) => {
+                            let room_id = membership.room_id().to_string();
+                            if let Err(e) =
+                                tap_cmd_tx.try_send(TapCommand::JoinRoom { membership })
+                            {
+                                // The tap command channel is full or
+                                // gone — we can't re-plumb, and the
+                                // membership drops here (its RoomSender
+                                // Drop leaves the room cleanly). Tell
+                                // the server the join didn't take.
+                                warn!(
+                                    call_id = %call_id,
+                                    %room_id,
+                                    error = %e,
+                                    "tap command channel full or closed; conference join aborted"
+                                );
+                                let _ = control_out_tx
+                                    .send(OutgoingEvent::Error {
+                                        code: ErrorCode::ConferenceFailed,
+                                        message: "tap unavailable for conference join".to_string(),
+                                    })
+                                    .await;
+                            } else {
+                                info!(call_id = %call_id, %room_id, "joined conference room");
+                            }
+                        }
+                        Err(e) => {
+                            warn!(call_id = %call_id, error = %e, "conference join rejected");
+                            let _ = control_out_tx
+                                .send(OutgoingEvent::Error {
+                                    code: ErrorCode::ConferenceFailed,
+                                    message: e.to_string(),
                                 })
                                 .await;
                         }

--- a/crates/core/src/outbound_service.rs
+++ b/crates/core/src/outbound_service.rs
@@ -43,6 +43,7 @@ use crate::acceptor::{
     CallIdFactory, CallTerminationView,
 };
 use crate::call::{CallController, CallControllerConfig};
+use crate::conference::ConferenceRegistry;
 use crate::outbound::{
     NotAnsweredCause, OutboundCall, OutboundError, OutboundGuard, OutboundOriginator,
     OutboundRejection,
@@ -78,6 +79,9 @@ pub struct OutboundService {
     /// register their dialog snapshot here so another call's transfer
     /// task can build a REFER-with-Replaces against this leg.
     consult_registry: ConsultRegistry,
+    /// Conference registry (0.7.0). `Some` when `[conference].enabled`;
+    /// an outbound bot can `conference_join` just like an inbound one.
+    conference: Option<ConferenceRegistry>,
 }
 
 impl OutboundService {
@@ -99,7 +103,16 @@ impl OutboundService {
             cdr_sink,
             webhook_sink,
             consult_registry,
+            conference: None,
         }
+    }
+
+    /// Share the daemon's conference registry so outbound calls can
+    /// join rooms over the WS protocol. Unset → outbound joins are
+    /// rejected with `conference_failed`, same as inbound.
+    pub fn with_conference(mut self, conference: ConferenceRegistry) -> Self {
+        self.conference = Some(conference);
+        self
     }
 }
 
@@ -164,6 +177,7 @@ impl OutboundOriginateHandle for OutboundService {
         let cdr_sink = Arc::clone(&self.cdr_sink);
         let webhook_sink = Arc::clone(&self.webhook_sink);
         let consult_registry = self.consult_registry.clone();
+        let conference = self.conference.clone();
 
         info!(call_id = %bridge_id_str, gateway = %gateway, "originating outbound call");
         let log_id = bridge_id_str.clone();
@@ -194,6 +208,7 @@ impl OutboundOriginateHandle for OutboundService {
                         cdr_sink,
                         webhook_sink,
                         consult_registry,
+                        conference,
                     };
                     run_call(originator, call, bridge, ctx).await;
                 }
@@ -252,6 +267,9 @@ struct OutboundCallContext {
     /// Register/deregister this leg as an attended-transfer consult
     /// target for the call's lifetime.
     consult_registry: ConsultRegistry,
+    /// Conference registry, shared with the controller so an outbound
+    /// bot can `conference_join`. `None` when conferencing is off.
+    conference: Option<ConferenceRegistry>,
 }
 
 /// Run an answered outbound call's audio bridge to completion, tear it
@@ -317,6 +335,7 @@ async fn run_call(
         media_tap: accepted.tap,
         transfer: Some(transfer),
         recording: None,
+        conference: ctx.conference.clone(),
     };
     let (controller, _handle) = CallController::new(cfg);
     let run_result = controller.run().await;
@@ -410,6 +429,7 @@ mod tests {
             cdr_sink: Arc::new(siphon_ai_cdr::NullSink),
             webhook_sink: Arc::new(siphon_ai_webhooks::NullSink),
             consult_registry: ConsultRegistry::new(),
+            conference: None,
         };
         let view = CallTerminationView {
             cause: CdrTerminationCause::ServerHangup,

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -380,6 +380,7 @@ mod tests {
             media_tap: tap,
             transfer: None,
             recording: None,
+            conference: None,
         };
         let (controller, handle) = CallController::new(cfg);
         // Drop the controller without running it; the handle still

--- a/crates/core/tests/controller_lifecycle.rs
+++ b/crates/core/tests/controller_lifecycle.rs
@@ -22,7 +22,9 @@ use siphon_ai_bridge::{
     AudioEncoding, AudioFormat, BridgeConfig, CallId, Direction, DisconnectReason, SipMeta,
     StartMsg,
 };
-use siphon_ai_core::{CallController, CallControllerConfig, CallTermination};
+use siphon_ai_core::{
+    CallController, CallControllerConfig, CallTermination, ConferenceLimits, ConferenceRegistry,
+};
 use siphon_ai_media_glue::MediaTap;
 use tokio::net::TcpListener;
 use tokio_tungstenite::tungstenite::handshake::server::{
@@ -92,6 +94,14 @@ fn echo_subprotocol(
 }
 
 fn make_controller(port: u16, call_id: &str) -> (CallController, siphon_ai_core::CallHandle) {
+    make_controller_with_conference(port, call_id, None)
+}
+
+fn make_controller_with_conference(
+    port: u16,
+    call_id: &str,
+    conference: Option<ConferenceRegistry>,
+) -> (CallController, siphon_ai_core::CallHandle) {
     let manager = Arc::new(MediaBridgeManager::new());
     let tap = MediaTap::attach(
         &manager,
@@ -117,8 +127,19 @@ fn make_controller(port: u16, call_id: &str) -> (CallController, siphon_ai_core:
         media_tap: tap,
         transfer: None,
         recording: None,
+        conference,
     };
     CallController::new(cfg)
+}
+
+/// An enabled registry for the conference round-trip tests.
+fn enabled_conference() -> ConferenceRegistry {
+    ConferenceRegistry::new(ConferenceLimits {
+        enabled: true,
+        max_rooms: 8,
+        max_participants_per_room: 8,
+        join_tones: false,
+    })
 }
 
 #[tokio::test]
@@ -260,5 +281,110 @@ async fn transfer_without_uac_emits_error() {
     let outcome = controller.run().await.expect("run");
     // Server closed the WS after the error; controller's bridge
     // task is the first to exit.
+    assert_eq!(outcome.termination, CallTermination::BridgeEnded);
+}
+
+#[tokio::test]
+async fn conference_join_without_registry_emits_error() {
+    // Conferencing disabled (conference = None): a `conference_join`
+    // must surface as `error { code: conference_failed }`, not a
+    // silent drop. The call continues.
+    let port = one_shot_server(|mut ws| async move {
+        let _ = ws.next().await; // drain start
+        let join = serde_json::json!({
+            "type": "conference_join",
+            "call_id": "conf-1",
+            "room_id": "support-7"
+        });
+        ws.send(Message::Text(join.to_string())).await.unwrap();
+
+        let saw_error = loop {
+            match ws.next().await {
+                Some(Ok(Message::Text(t))) => {
+                    let v: Value = serde_json::from_str(&t).expect("json");
+                    if v["type"] == "error" {
+                        assert_eq!(v["code"], "conference_failed");
+                        break true;
+                    }
+                }
+                Some(Ok(Message::Binary(_))) => {}
+                _ => break false,
+            }
+        };
+        assert!(saw_error, "did not observe conference_failed error");
+        ws.close(None).await.ok();
+    })
+    .await;
+
+    let (controller, _handle) = make_controller_with_conference(port, "conf-1", None);
+    let outcome = controller.run().await.expect("run");
+    assert_eq!(outcome.termination, CallTermination::BridgeEnded);
+}
+
+#[tokio::test]
+async fn conference_join_then_leave_round_trip() {
+    // With an enabled registry: `conference_join` → `conference_joined`
+    // (participants = 1, this call alone in a fresh room), then
+    // `conference_leave` → `conference_left { reason: "left" }`.
+    let port = one_shot_server(|mut ws| async move {
+        let _ = ws.next().await; // drain start
+
+        ws.send(Message::Text(
+            serde_json::json!({
+                "type": "conference_join",
+                "call_id": "conf-2",
+                "room_id": "support-7"
+            })
+            .to_string(),
+        ))
+        .await
+        .unwrap();
+
+        // Wait for conference_joined.
+        let joined = loop {
+            match ws.next().await {
+                Some(Ok(Message::Text(t))) => {
+                    let v: Value = serde_json::from_str(&t).expect("json");
+                    if v["type"] == "conference_joined" {
+                        break v;
+                    }
+                    assert_ne!(v["type"], "error", "join failed: {v}");
+                }
+                Some(Ok(Message::Binary(_))) => {}
+                other => panic!("ws closed before conference_joined: {other:?}"),
+            }
+        };
+        assert_eq!(joined["room_id"], "support-7");
+        assert_eq!(joined["participants"], 1);
+
+        // Now leave.
+        ws.send(Message::Text(
+            serde_json::json!({ "type": "conference_leave", "call_id": "conf-2" }).to_string(),
+        ))
+        .await
+        .unwrap();
+
+        let left = loop {
+            match ws.next().await {
+                Some(Ok(Message::Text(t))) => {
+                    let v: Value = serde_json::from_str(&t).expect("json");
+                    if v["type"] == "conference_left" {
+                        break v;
+                    }
+                }
+                Some(Ok(Message::Binary(_))) => {}
+                other => panic!("ws closed before conference_left: {other:?}"),
+            }
+        };
+        assert_eq!(left["room_id"], "support-7");
+        assert_eq!(left["reason"], "left");
+
+        ws.close(None).await.ok();
+    })
+    .await;
+
+    let (controller, _handle) =
+        make_controller_with_conference(port, "conf-2", Some(enabled_conference()));
+    let outcome = controller.run().await.expect("run");
     assert_eq!(outcome.termination, CallTermination::BridgeEnded);
 }

--- a/crates/core/tests/hold_resume.rs
+++ b/crates/core/tests/hold_resume.rs
@@ -107,6 +107,7 @@ async fn push_bridge_event_emits_hold_and_resume_on_ws() {
         media_tap: tap,
         transfer: None,
         recording: None,
+        conference: None,
     };
     let (controller, handle) = CallController::new(cfg);
     let run = tokio::spawn(async move { controller.run().await });

--- a/crates/core/tests/registry_bye.rs
+++ b/crates/core/tests/registry_bye.rs
@@ -129,6 +129,7 @@ async fn dispatch_bye_wakes_running_controller_via_registry() {
         media_tap: tap,
         transfer: None,
         recording: None,
+        conference: None,
     };
     let (controller, handle) = CallController::new(cfg);
 
@@ -215,6 +216,7 @@ async fn bye_drives_wire_stop_with_caller_hangup_reason() {
         media_tap: tap,
         transfer: None,
         recording: None,
+        conference: None,
     };
     let (controller, handle) = CallController::new(cfg);
 

--- a/crates/media-glue/src/lib.rs
+++ b/crates/media-glue/src/lib.rs
@@ -14,7 +14,7 @@ pub mod sdp;
 pub mod setup;
 pub mod tap;
 
-pub use room::{spawn_room, RoomConfig, RoomHandle, RoomJoinError, RoomMembership};
+pub use room::{spawn_room, RoomConfig, RoomEvent, RoomHandle, RoomJoinError, RoomMembership};
 pub use sdp::{
     audio_remote_addr, build_answer, generate_offer, negotiate_answer, negotiate_offer_answer,
     parse_offer, AnswerOutcome, Codec, LocalCapabilities, MediaDirection, SdpError,

--- a/crates/media-glue/src/room.rs
+++ b/crates/media-glue/src/room.rs
@@ -70,6 +70,12 @@ const INPUT_CHANNEL_FRAMES: usize = 64;
 /// Control channel: small and bounded like every control channel.
 const CTRL_CHANNEL_CAPACITY: usize = 8;
 
+/// Per-member membership-change event channel (`RoomEvent` fan-out).
+/// Rare control-plane events (a join/leave is human-paced), delivered
+/// best-effort with `try_send` — a member that can't keep up loses a
+/// fan-out notification, never the room. 16 absorbs a burst of joins.
+const EVENT_CHANNEL_CAPACITY: usize = 16;
+
 /// How much audio a participant may buffer inside the mixer before
 /// the oldest samples are dropped. WS bots stream TTS faster than
 /// realtime; 30 s absorbs a long prompt queued at once. (8 calls ×
@@ -121,6 +127,19 @@ pub enum RoomJoinError {
     /// join). The registry retries once with a fresh room.
     #[error("room is gone")]
     RoomClosed,
+}
+
+/// A membership-change notification the room fans out to its OTHER
+/// members (never the call the change is about). The controller maps
+/// these onto the WS protocol's `participant_joined` /
+/// `participant_left` events (DEV_PLAN_0.7.0.md §2.2). Delivered over
+/// the per-member [`RoomMembership::events_rx`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RoomEvent {
+    /// Another call joined the room.
+    ParticipantJoined { call_id: String },
+    /// Another call left the room (explicit leave, hang-up, or reap).
+    ParticipantLeft { call_id: String },
 }
 
 /// Parameters a room is spawned with. The sample rate is the first
@@ -212,9 +231,9 @@ impl RoomHandle {
 }
 
 /// Everything a joined call holds: the send side (input channel +
-/// participant ids + leave-on-drop) and the two per-sink receivers.
-/// Handed to the call's tap via `TapCommand::JoinRoom`; split with
-/// [`Self::split`] inside the tap.
+/// participant ids + leave-on-drop), the two per-sink receivers, and
+/// the membership-change event stream. Handed to the call's tap via
+/// `TapCommand::JoinRoom`; split with [`Self::split`] inside the tap.
 #[derive(Debug)]
 pub struct RoomMembership {
     pub(crate) sender: RoomSender,
@@ -224,6 +243,15 @@ pub struct RoomMembership {
     /// Mix-minus-`ws` — what the bot hears (its own caller + the
     /// other calls), forwarded to the WS as caller audio.
     pub(crate) ws_out_rx: mpsc::Receiver<Vec<i16>>,
+    /// Membership-change fan-out for THIS member (someone else joined
+    /// or left). The tap maps these onto `participant_joined` /
+    /// `participant_left` WS events.
+    pub(crate) events_rx: mpsc::Receiver<RoomEvent>,
+    /// Member-call count at the moment this call joined (itself
+    /// included) — the `participants` field of the `conference_joined`
+    /// WS event. A point-in-time snapshot; live changes arrive as
+    /// `RoomEvent`s.
+    participants: usize,
 }
 
 impl RoomMembership {
@@ -231,19 +259,28 @@ impl RoomMembership {
         &self.sender.room_id
     }
 
-    /// Split into the send half and the two sink receivers (tap
-    /// keeps them in separate locals so its `select!` arms can
-    /// borrow them independently).
-    pub(crate) fn split(
-        self,
-    ) -> (
-        RoomSender,
-        mpsc::Receiver<Vec<i16>>,
-        mpsc::Receiver<Vec<i16>>,
-    ) {
-        (self.sender, self.sip_out_rx, self.ws_out_rx)
+    /// Member-call count at join time (this call included).
+    pub fn participants(&self) -> usize {
+        self.participants
+    }
+
+    /// Split into the send half, the two sink receivers, and the
+    /// event receiver (the tap keeps them in separate locals so its
+    /// `select!` arms can borrow each independently).
+    pub(crate) fn split(self) -> RoomMembershipParts {
+        (self.sender, self.sip_out_rx, self.ws_out_rx, self.events_rx)
     }
 }
+
+/// The pieces of a [`RoomMembership`] after [`RoomMembership::split`]:
+/// the send half, the SIP-out and WS-out sink receivers, and the
+/// membership-change event receiver.
+pub(crate) type RoomMembershipParts = (
+    RoomSender,
+    mpsc::Receiver<Vec<i16>>,
+    mpsc::Receiver<Vec<i16>>,
+    mpsc::Receiver<RoomEvent>,
+);
 
 /// The send half of a membership. Dropping it tells the room to
 /// remove the call (so every tap exit path — clean or not — leaves
@@ -310,12 +347,29 @@ struct Member {
     ws_id: String,
     sip_out_tx: mpsc::Sender<Vec<i16>>,
     ws_out_tx: mpsc::Sender<Vec<i16>>,
+    /// Fan-out sink: the room pushes `RoomEvent`s here when ANOTHER
+    /// call joins or leaves. The matching receiver rides on this
+    /// member's `RoomMembership`.
+    events_tx: mpsc::Sender<RoomEvent>,
 }
 
 impl Member {
     /// Both sink receivers dropped → the tap is gone; reap.
     fn is_abandoned(&self) -> bool {
         self.sip_out_tx.is_closed() && self.ws_out_tx.is_closed()
+    }
+}
+
+/// Fan a membership-change event out to every member except the one
+/// it's about (`exclude`). Best-effort `try_send`: a member whose
+/// event queue is full loses the notification but never blocks the
+/// room.
+fn fan_out(members: &HashMap<String, Member>, event: &RoomEvent, exclude: &str) {
+    for (id, member) in members.iter() {
+        if id == exclude {
+            continue;
+        }
+        let _ = member.events_tx.try_send(event.clone());
     }
 }
 
@@ -528,6 +582,7 @@ fn handle_join(
 
     let (sip_out_tx, sip_out_rx) = mpsc::channel(SINK_CHANNEL_FRAMES);
     let (ws_out_tx, ws_out_rx) = mpsc::channel(SINK_CHANNEL_FRAMES);
+    let (events_tx, events_rx) = mpsc::channel(EVENT_CHANNEL_CAPACITY);
     members.insert(
         call_id.clone(),
         Member {
@@ -535,13 +590,24 @@ fn handle_join(
             ws_id: ws_id.clone(),
             sip_out_tx,
             ws_out_tx,
+            events_tx,
         },
     );
+    let participants = members.len();
     info!(
         room_id = %cfg.room_id,
         %call_id,
-        calls = members.len(),
+        calls = participants,
         "call joined conference room"
+    );
+    // Tell everyone already in the room that this call arrived. The
+    // new member learns the room size from `participants` instead.
+    fan_out(
+        members,
+        &RoomEvent::ParticipantJoined {
+            call_id: call_id.clone(),
+        },
+        &call_id,
     );
 
     Ok(RoomMembership {
@@ -555,6 +621,8 @@ fn handle_join(
         },
         sip_out_rx,
         ws_out_rx,
+        events_rx,
+        participants,
     })
 }
 
@@ -576,6 +644,15 @@ fn remove_member(
         %call_id,
         calls = members.len(),
         "call left conference room"
+    );
+    // Tell the remaining members this call is gone. (`member` was
+    // already removed, so it won't notify itself.)
+    fan_out(
+        members,
+        &RoomEvent::ParticipantLeft {
+            call_id: call_id.to_string(),
+        },
+        call_id,
     );
     true
 }
@@ -715,8 +792,8 @@ mod tests {
         let handle = spawn_room(cfg("r1", 8000, 8, false));
         let a = handle.join("call-a", 8000).await.expect("join a");
         let b = handle.join("call-b", 8000).await.expect("join b");
-        let (a_send, mut a_sip_out, mut a_ws_out) = a.split();
-        let (b_send, mut b_sip_out, _b_ws_out) = b.split();
+        let (a_send, mut a_sip_out, mut a_ws_out, _a_events) = a.split();
+        let (b_send, mut b_sip_out, _b_ws_out, _b_events) = b.split();
 
         // Feed both SIP legs continuously so every tick has a full
         // frame from each (the WS sides stay silent — like real bots
@@ -787,7 +864,7 @@ mod tests {
     async fn explicit_leave_closes_sinks_and_last_leave_ends_room() {
         let handle = spawn_room(cfg("r5", 8000, 8, false));
         let a = handle.join("call-a", 8000).await.expect("join a");
-        let (a_send, mut a_sip_out, _a_ws_out) = a.split();
+        let (a_send, mut a_sip_out, _a_ws_out, _a_events) = a.split();
 
         handle.leave("call-a");
         // Sink closes when the room removes the member.
@@ -840,7 +917,7 @@ mod tests {
     async fn abandoned_member_reaped_by_tick_even_if_leave_is_lost() {
         let handle = spawn_room(cfg("r7", 8000, 8, false));
         let a = handle.join("call-a", 8000).await.expect("join a");
-        let (a_send, a_sip_out, a_ws_out) = a.split();
+        let (a_send, a_sip_out, a_ws_out, _a_events) = a.split();
         // Drop only the receivers and *forget* the sender's Drop by
         // leaking it — the per-tick is_closed() reap must still
         // remove the member and end the room.
@@ -862,7 +939,7 @@ mod tests {
         let handle = spawn_room(cfg("r8", 8000, 8, true));
         let a = handle.join("call-a", 8000).await.expect("join a");
         let b = handle.join("call-b", 8000).await.expect("join b");
-        let (_a_send, mut a_sip_out, _a_ws_out) = a.split();
+        let (_a_send, mut a_sip_out, _a_ws_out, _a_events) = a.split();
 
         // B's join chime reaches A with no participant ever sending
         // audio (the tone participant is the only contributor).
@@ -877,8 +954,8 @@ mod tests {
         let handle = spawn_room(cfg("r9", 8000, 8, false));
         let a = handle.join("call-a", 8000).await.expect("join a");
         let b = handle.join("call-b", 8000).await.expect("join b");
-        let (a_send, _a_sip_out, _a_ws_out) = a.split();
-        let (_b_send, mut b_sip_out, _b_ws_out) = b.split();
+        let (a_send, _a_sip_out, _a_ws_out, _a_events) = a.split();
+        let (_b_send, mut b_sip_out, _b_ws_out, _b_events) = b.split();
 
         // Queue ~2 s of bot-A audio, then clear it before (most of)
         // it can play out; B should go silent shortly after.

--- a/crates/media-glue/src/tap.rs
+++ b/crates/media-glue/src/tap.rs
@@ -60,7 +60,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use crate::idle::{IdleDetector, IdleEvent};
-use crate::room::{RoomMembership, RoomSender};
+use crate::room::{RoomEvent, RoomMembership, RoomSender};
 use crate::rtp_stats::RtpStatsTracker;
 
 use forge_core::{CallId, DtmfDetectionMethod, DtmfEventKind, EventBus, ForgeError, ForgeEvent};
@@ -70,7 +70,8 @@ use forge_engine::{
     PlayoutMode,
 };
 use siphon_ai_bridge::{
-    pack_pcm16_le, unpack_pcm16_le, AudioError, DtmfMethod, OutgoingEvent, Reframer,
+    pack_pcm16_le, unpack_pcm16_le, AudioError, ConferenceLeftReason, DtmfMethod, OutgoingEvent,
+    Reframer,
 };
 use siphon_ai_recording::RecFrame;
 use thiserror::Error;
@@ -449,6 +450,9 @@ impl MediaTap {
         let mut room_send: Option<RoomSender> = None;
         let mut room_sip_out: Option<mpsc::Receiver<Vec<i16>>> = None;
         let mut room_ws_out: Option<mpsc::Receiver<Vec<i16>>> = None;
+        // Membership-change fan-out from the room → `participant_joined`
+        // / `participant_left` WS events.
+        let mut room_events: Option<mpsc::Receiver<RoomEvent>> = None;
 
         // RTP watchdog. Pinned so we can reset the deadline in place
         // every time an inbound frame arrives. When the timeout is
@@ -637,10 +641,11 @@ impl MediaTap {
                 // restores it).
                 mixed = recv_opt(&mut room_sip_out), if room_sip_out.is_some() => {
                     let Some(samples) = mixed else {
-                        info!(call_id = %self.call_id, "room ended; reverting to direct bridge");
-                        room_send = None;
-                        room_sip_out = None;
-                        room_ws_out = None;
+                        revert_to_direct(
+                            &events_tx, &self.call_id,
+                            &mut room_send, &mut room_sip_out,
+                            &mut room_ws_out, &mut room_events,
+                        );
                         continue;
                     };
                     // Recording fork (right channel) in room mode:
@@ -677,15 +682,47 @@ impl MediaTap {
                 // "caller audio" the WS session hears.
                 mixed = recv_opt(&mut room_ws_out), if room_ws_out.is_some() => {
                     let Some(samples) = mixed else {
-                        info!(call_id = %self.call_id, "room ended; reverting to direct bridge");
-                        room_send = None;
-                        room_sip_out = None;
-                        room_ws_out = None;
+                        revert_to_direct(
+                            &events_tx, &self.call_id,
+                            &mut room_send, &mut room_sip_out,
+                            &mut room_ws_out, &mut room_events,
+                        );
                         continue;
                     };
                     if caller_audio_tx.send(pack_pcm16_le(&samples)).await.is_err() {
                         debug!("caller_audio_tx closed; ending tap");
                         return Ok(TapDisconnect::ControllerHungUp);
+                    }
+                }
+
+                // Room membership changes (another call joined/left
+                // this room) → `participant_joined` / `participant_left`
+                // WS events. Best-effort try_send like the other tap
+                // events.
+                room_evt = recv_opt(&mut room_events), if room_events.is_some() => {
+                    match room_evt {
+                        Some(RoomEvent::ParticipantJoined { call_id: who }) => {
+                            emit_room_event(
+                                &events_tx, &self.call_id, &room_send,
+                                |room_id| OutgoingEvent::ParticipantJoined {
+                                    room_id,
+                                    participant_call_id: who,
+                                },
+                            );
+                        }
+                        Some(RoomEvent::ParticipantLeft { call_id: who }) => {
+                            emit_room_event(
+                                &events_tx, &self.call_id, &room_send,
+                                |room_id| OutgoingEvent::ParticipantLeft {
+                                    room_id,
+                                    participant_call_id: who,
+                                },
+                            );
+                        }
+                        // Sender closed without the audio sinks closing
+                        // (shouldn't happen — they share the room task's
+                        // lifetime — but don't spin the arm if it does).
+                        None => room_events = None,
                     }
                 }
 
@@ -951,19 +988,50 @@ impl MediaTap {
                                     "tap re-plumbed into conference room"
                                 );
                             }
-                            let (send, sip_out, ws_out) = membership.split();
+                            let room_id = membership.room_id().to_string();
+                            let participants = membership.participants();
+                            let (send, sip_out, ws_out, events) = membership.split();
                             room_send = Some(send);
                             room_sip_out = Some(sip_out);
                             room_ws_out = Some(ws_out);
+                            room_events = Some(events);
+                            // The command response the WS server is
+                            // waiting on for its `conference_join`.
+                            if let Err(e) = events_tx.try_send(OutgoingEvent::ConferenceJoined {
+                                room_id,
+                                participants,
+                            }) {
+                                warn!(
+                                    call_id = %self.call_id,
+                                    error = %e,
+                                    "events_tx full or closed; dropping conference_joined"
+                                );
+                            }
                         }
                         TapCommand::LeaveRoom => {
-                            if room_send.take().is_some() {
+                            if let Some(send) = room_send.take() {
+                                let room_id = send.room_id().to_string();
+                                // Drop the sender first so the room sees
+                                // the leave before we announce it.
+                                drop(send);
                                 room_sip_out = None;
                                 room_ws_out = None;
+                                room_events = None;
                                 info!(
                                     call_id = %self.call_id,
+                                    %room_id,
                                     "left conference room; direct bridge restored"
                                 );
+                                if let Err(e) = events_tx.try_send(OutgoingEvent::ConferenceLeft {
+                                    room_id,
+                                    reason: ConferenceLeftReason::Left,
+                                }) {
+                                    warn!(
+                                        call_id = %self.call_id,
+                                        error = %e,
+                                        "events_tx full or closed; dropping conference_left"
+                                    );
+                                }
                             }
                         }
                     }
@@ -1039,6 +1107,52 @@ async fn recv_opt<T>(rx: &mut Option<mpsc::Receiver<T>>) -> Option<T> {
     match rx {
         Some(rx) => rx.recv().await,
         None => std::future::pending().await,
+    }
+}
+
+/// Tear down room routing and restore the direct caller↔WS pair,
+/// emitting `conference_left { room_closed }` first. Called when a
+/// room sink closes — i.e. the room ended underneath us (last member
+/// left, or an operator force-ended it). Idempotent on the already-
+/// reverted state (no `room_send` → nothing emitted, all cleared).
+fn revert_to_direct(
+    events_tx: &mpsc::Sender<OutgoingEvent>,
+    call_id: &CallId,
+    room_send: &mut Option<RoomSender>,
+    room_sip_out: &mut Option<mpsc::Receiver<Vec<i16>>>,
+    room_ws_out: &mut Option<mpsc::Receiver<Vec<i16>>>,
+    room_events: &mut Option<mpsc::Receiver<RoomEvent>>,
+) {
+    if let Some(send) = room_send.as_ref() {
+        let room_id = send.room_id().to_string();
+        info!(call_id = %call_id, %room_id, "room ended; reverting to direct bridge");
+        if let Err(e) = events_tx.try_send(OutgoingEvent::ConferenceLeft {
+            room_id,
+            reason: ConferenceLeftReason::RoomClosed,
+        }) {
+            warn!(call_id = %call_id, error = %e, "events_tx full or closed; dropping conference_left");
+        }
+    }
+    *room_send = None;
+    *room_sip_out = None;
+    *room_ws_out = None;
+    *room_events = None;
+}
+
+/// Emit a participant-change WS event, tagging it with the current
+/// room id. A `None` `room_send` (we left the room between the event
+/// arriving and being handled) drops it silently.
+fn emit_room_event(
+    events_tx: &mpsc::Sender<OutgoingEvent>,
+    call_id: &CallId,
+    room_send: &Option<RoomSender>,
+    build: impl FnOnce(String) -> OutgoingEvent,
+) {
+    let Some(send) = room_send.as_ref() else {
+        return;
+    };
+    if let Err(e) = events_tx.try_send(build(send.room_id().to_string())) {
+        warn!(call_id = %call_id, error = %e, "events_tx full or closed; dropping participant event");
     }
 }
 
@@ -1312,7 +1426,7 @@ mod tests {
         });
         let membership_a = room.join("call-a", 8000).await.expect("join a");
         let membership_b = room.join("call-b", 8000).await.expect("join b");
-        let (_b_send, mut b_sip_out, _b_ws_out) = membership_b.split();
+        let (_b_send, mut b_sip_out, _b_ws_out, _b_events) = membership_b.split();
 
         cmd_tx
             .send(TapCommand::JoinRoom {

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -326,6 +326,7 @@ then closes the WebSocket cleanly (close code 1000).
 | `protocol_error` | A WS message was malformed JSON, used an unknown `type`, or had a `call_id` that doesn't match the connection. |
 | `server_too_slow` | Server didn't begin sending audio within 5 s of `start`. |
 | `transfer_failed` | A REFER was attempted but the far end rejected it. |
+| `conference_failed` | A `conference_join` (§4.8) was refused: conferencing disabled, room or per-room cap reached, sample-rate mismatch, or already joined. The call continues on its direct pair. |
 | `internal` | SiphonAI internal error. The `message` field has details. |
 
 `error` is always followed by `stop` (with `reason: "error"`) and a
@@ -345,6 +346,41 @@ control on `on_demand`; `recording_stopped` on call end or `stop_recording`.
 
 `recording_id` identifies the recording (one per call in this release).
 Recording is best-effort — `recording_failed` never tears the call down.
+
+### 3.12 `conference_joined` / `conference_left` / `participant_joined` / `participant_left` — conference room events (0.7.0)
+
+Emitted for a call that has joined a conference room (§4.8). Additive —
+the protocol version stays `"1"`; a server that never sends
+`conference_join` never sees these.
+
+```json
+{ "type": "conference_joined",  "call_id": "...", "seq": 14, "room_id": "support-7", "participants": 2 }
+{ "type": "conference_left",    "call_id": "...", "seq": 40, "room_id": "support-7", "reason": "left" }
+{ "type": "participant_joined", "call_id": "...", "seq": 15, "room_id": "support-7", "participant_call_id": "siphon-b" }
+{ "type": "participant_left",   "call_id": "...", "seq": 38, "room_id": "support-7", "participant_call_id": "siphon-b" }
+```
+
+- **`conference_joined`** — the response to *this* session's
+  `conference_join`. `participants` is the member-call count at the
+  moment of joining (this call included); it's a snapshot — live
+  changes arrive as the events below.
+- **`conference_left`** — this call left the room. `reason` is `"left"`
+  (the server sent `conference_leave`) or `"room_closed"` (the room
+  ended underneath it — e.g. an operator force-ended it). Either way
+  the direct caller↔WS audio pair is restored and the call continues.
+- **`participant_joined` / `participant_left`** — fan-out: ANOTHER call
+  joined or left the room this call is in. `participant_call_id` is
+  that other call's bridge `call_id`, distinct from the envelope
+  `call_id`, which is always *your* call. These let a bot track who
+  else is in the room; cross-call control (adding/removing others) is
+  the admin API's job, not the WS surface (a session only acts on its
+  own call).
+
+While joined, every other event (`dtmf`, `speech_*`, `mark`, …) keeps
+flowing for this call's own leg. Audio frames are unchanged on the
+wire: SiphonAI sends the room mix (minus this call's own contribution)
+as the inbound binary frames, and the server's outbound audio is mixed
+into the room.
 
 ---
 
@@ -487,6 +523,45 @@ silenced (e.g. while the caller reads a card number) — and `resume_recording`
 continues. All are no-ops if recording isn't enabled for the call or the
 control is invalid for the current state. (With `mode = "always"` recording
 covers the whole call; these controls aren't needed.)
+
+### 4.8 `conference_join` / `conference_leave` — conference rooms (0.7.0)
+
+```json
+{ "type": "conference_join",  "call_id": "...", "room_id": "support-7" }
+{ "type": "conference_leave", "call_id": "..." }
+```
+
+Join this call into a named conference room, or leave the one it's in.
+Requires `[conference].enabled = true` on the daemon.
+
+- **`conference_join`** creates the room if it doesn't exist yet
+  (subject to `[conference].max_rooms` and
+  `max_participants_per_room`). On success SiphonAI replies
+  `conference_joined` (§3.12) and the call's audio is mixed into the
+  room: the bot hears the room **minus its own playout** and speaks
+  into it. On failure — conferencing off, a cap reached, a sample-rate
+  mismatch (a room locks to its first joiner's rate; no resampling in
+  0.7.0), or already in this room — SiphonAI replies
+  `error { code: "conference_failed" }` and the call continues
+  unchanged on its direct pair. Joining a second room moves the call
+  (it leaves the first).
+- **`conference_leave`** removes the call from its room and restores
+  the direct caller↔WS pair; SiphonAI replies
+  `conference_left { reason: "left" }`. A no-op (no reply) if the call
+  isn't in a room.
+
+**Self-scoped (§5.3):** these act only on the session's *own* call. A
+bot can put itself in or out of a room, but it cannot add or remove
+*another* participant — that's the admin API's job (operator control
+plane). A bot tracks the rest of the room via the `participant_joined`
+/ `participant_left` fan-out events.
+
+The room model: N calls share one mixed room, **every call keeps its
+own WS session** (there is no single "host" bot). For N member calls
+the room mixes 2N streams — each call's SIP caller and its bot — and
+hands each side the mix minus its own input. So a caller never hears
+themselves, a bot never hears its own playout, but a caller hears
+their own bot and a bot hears its own caller (STT keeps working).
 
 ---
 

--- a/examples/echo-ws-server-python/server.py
+++ b/examples/echo-ws-server-python/server.py
@@ -67,6 +67,11 @@ class Options:
     # naming this consult call id (`replaces_call_id`). Reuses
     # auto_transfer_delay_ms for the pause. None = disabled.
     auto_transfer_replaces: str | None
+    # Test-harness knob: after `start`, wait auto_transfer_delay_ms and
+    # then `conference_join` into this room. Lets two SIPp callers be
+    # mixed in one room without a human driving the control channel.
+    # None = disabled.
+    auto_conference_join: str | None
 
 
 # ─── HTTP-side concerns: auth + subprotocol ─────────────────────────────────
@@ -209,6 +214,22 @@ async def handle(connection: ServerConnection, opts: Options) -> None:
                         )
                     )
 
+                if opts.auto_conference_join and call_id:
+                    # Test-harness behaviour: join a conference room so
+                    # two SIPp callers land in the same mix. The delay
+                    # lets the SIP side reach ESTABLISHED first.
+                    asyncio.create_task(
+                        _send_after(
+                            connection,
+                            opts.auto_transfer_delay_ms,
+                            {
+                                "type": "conference_join",
+                                "call_id": call_id,
+                                "room_id": opts.auto_conference_join,
+                            },
+                        )
+                    )
+
                 if opts.auto_hangup_after_ms is not None and call_id:
                     # Test-harness behaviour: end the call from the WS
                     # side after a beat. Used by the outbound SIPp
@@ -236,6 +257,10 @@ async def handle(connection: ServerConnection, opts: Options) -> None:
                 "hold",
                 "resume",
                 "error",
+                "conference_joined",
+                "conference_left",
+                "participant_joined",
+                "participant_left",
             }:
                 LOG.info("%s: %s", mtype, _redact(msg))
 
@@ -342,6 +367,17 @@ def parse_args(argv: list[str] | None = None) -> Options:
         ),
     )
     p.add_argument(
+        "--auto-conference-join",
+        default=None,
+        metavar="ROOM",
+        help=(
+            "test-harness only: after `start`, emit a `conference_join` "
+            "into this room (uses --auto-transfer-delay-ms for the "
+            "pause). Two callers pointed at the same room get mixed — "
+            "the hook for the 0.7.0 two-caller conference SIPp scenario."
+        ),
+    )
+    p.add_argument(
         "--log-level",
         default="INFO",
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
@@ -362,6 +398,7 @@ def parse_args(argv: list[str] | None = None) -> Options:
         auto_transfer_delay_ms=args.auto_transfer_delay_ms,
         auto_hangup_after_ms=args.auto_hangup_after_ms,
         auto_transfer_replaces=args.auto_transfer_replaces,
+        auto_conference_join=args.auto_conference_join,
     )
 
 


### PR DESCRIPTION
## Summary

Chunk 2 of 5 for the 0.7.0 conferencing + park theme (`docs/DEV_PLAN_0.7.0.md` §2.2; decisions locked in #154, room core landed in #165). Wires the chunk-1 room to the WS protocol so a bot can join/leave a conference room **for its own call**. The protocol version stays `"1"` (every addition is a new message or a new error code), and a `[conference].enabled = false` deployment (the default) sees zero behaviour change.

## What's new

**Protocol (`crates/bridge`)**
- `BridgeIn`: `conference_join { room_id }`, `conference_leave`. Self-scoped per §9.2 — a session only acts on its own call; cross-call participant add/remove is the admin API's job (chunk 3).
- `BridgeOut`: `conference_joined { room_id, participants }`, `conference_left { room_id, reason }` (`reason` = `left` | `room_closed`), and the fan-out `participant_joined` / `participant_left { room_id, participant_call_id }` to every *other* member on a composition change.
- New `error` code `conference_failed` (disabled / cap reached / sample-rate mismatch / already joined → the call continues on its direct pair).

**Room fan-out (`media-glue/room.rs`)** — `RoomEvent` pushed to all *other* members on join/remove via a per-member event channel; `RoomMembership` now carries `events_rx` + a `participants` snapshot.

**Tap (`media-glue/tap.rs`)** — `JoinRoom` emits `conference_joined` and forwards room events as `participant_*`; `LeaveRoom` emits `conference_left{left}`; a closing room sink (room ended) emits `conference_left{room_closed}` and reverts to the direct pair. All via the existing best-effort `try_send` event path — no new hot-path cost.

**Controller (`core/call.rs`)** — `CallControllerConfig.conference: Option<ConferenceRegistry>`. `conference_join` spawns the async `registry.join` off the control loop (like REFER); success → `TapCommand::JoinRoom`, failure → `error{conference_failed}`. `conference_leave` → `TapCommand::LeaveRoom` (drop-driven; the room reaps).

**Wiring** — `BridgingAcceptor::with_conference` + `OutboundService::with_conference`; the daemon builds one shared `ConferenceRegistry` from `[conference]` when enabled and threads it to inbound and outbound calls alike (§9.1: a room is composed of any active calls).

**Harness + docs** — echo server gains `--auto-conference-join ROOM` and logs the new events (the hook for chunk 5's two-caller SIPp scenario); `docs/PROTOCOL.md` §3.12 (events) + §4.8 (commands) + the `conference_failed` row; CHANGELOG.

## Design note

`conference_joined` / `conference_left` and the `participant_*` fan-out are all emitted by the **tap**, because the tap already owns the join/leave/room-death state transitions (the room-ended detection is the sink-closed arm). The controller owns only the async join and the `conference_failed` rejection. This keeps room-lifecycle event emission colocated with the audio re-plumbing and forward-compatible with chunk 3's admin force-end (which closes a member's sinks → the tap emits `room_closed`).

## Tests

- Bridge round-trips for every new message + the new error code.
- Controller end-to-end over a real WS server: `conference_join` → `conference_joined` → `conference_leave` → `conference_left{left}`; and disabled-registry → `error{conference_failed}`.
- Chunk-1 room/tap tests updated for the new `split()` arity.

## Validation

- `cargo test --workspace` — 643 passed, 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- Full SIPp suite **14/14** incl. `--with-transfer` (regression: no behaviour change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)