### PR TITLE
feat: media-only call park + retrieve (0.7.0 chunk 4)

### DIFF
--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -74,12 +74,14 @@ use siphon_ai_cdr::{
 };
 use siphon_ai_config::{
     CdrConfig, CdrFileConfig, CdrWebhookConfig, Config, HepConfig, MediaConfig, NodeConfig,
-    ObservabilityConfig, SipConfig, SipTlsConfig, SipTransport, WebhooksConfig,
+    ObservabilityConfig, ParkTimeoutAction as ConfigParkTimeoutAction, SipConfig, SipTlsConfig,
+    SipTransport, WebhooksConfig,
 };
 use siphon_ai_core::{
     default_call_id_factory, BridgingAcceptor, CallControlRegistry, CallRegistry, ConferenceAdmin,
     ConferenceLimits, ConferenceRegistry, ConsultRegistry, OutboundGateway, OutboundGuard,
-    OutboundOriginator, OutboundService, StaticCredentials,
+    OutboundOriginator, OutboundService, ParkAdmin, ParkContext, ParkRegistry, ParkSettings,
+    ParkTimeoutAction as CoreParkTimeoutAction, StaticCredentials,
 };
 use siphon_ai_media_glue::MediaSetup;
 use siphon_ai_sip_glue::{
@@ -88,8 +90,8 @@ use siphon_ai_sip_glue::{
 };
 use siphon_ai_telemetry::{
     admin::{
-        AdminCallRegistry, AdminConference, AdminOutbound, AdminState, CallRegistryHandle,
-        RegistrationRow,
+        AdminCallRegistry, AdminConference, AdminOutbound, AdminPark, AdminState,
+        CallRegistryHandle, RegistrationRow,
     },
     install_recorder, HepTelemetry, HepTelemetryBuild, HepWorkerHandle, LogFilterHandle,
     ObservabilityServer, ReadinessFlag,
@@ -158,6 +160,7 @@ impl Runtime {
             observability,
             webhooks,
             hep,
+            park,
         } = config;
 
         // ─── Telemetry: install Prometheus recorder ─────────────────
@@ -291,6 +294,32 @@ impl Runtime {
         // Cheap and empty when conferencing is off.
         let control_registry = CallControlRegistry::new();
 
+        // Park context (0.7.0). Built once and shared (Clone) by the
+        // acceptor and the outbound service so any call — inbound or
+        // outbound — can be parked. `None` when `[park].enabled = false`
+        // (the default): no `ParkRegistry` is allocated and park requests
+        // are rejected. The `ParkRegistry` inside is also handed to the
+        // admin `ParkAdmin` so `GET /admin/v1/parked` and the cap share
+        // one table.
+        let park_context = if park.enabled {
+            let settings = ParkSettings {
+                moh_file: park.moh_file,
+                timeout: park.timeout,
+                timeout_action: match park.timeout_action {
+                    ConfigParkTimeoutAction::Hangup => CoreParkTimeoutAction::Hangup,
+                    ConfigParkTimeoutAction::Keep => CoreParkTimeoutAction::Keep,
+                },
+            };
+            Some(ParkContext {
+                settings,
+                registry: ParkRegistry::new(park.max_parked),
+                // call_parked / call_retrieved / park_timeout webhooks.
+                webhooks: Some(Arc::clone(&webhook_sink)),
+            })
+        } else {
+            None
+        };
+
         let mut acceptor_builder = BridgingAcceptor::new(media_setup, bridge_defaults, registry.clone())
             .with_cdr_sink(cdr_sink)
             .with_webhook_sink(Arc::clone(&webhook_sink))
@@ -305,6 +334,9 @@ impl Runtime {
             .with_control_registry(control_registry.clone());
         if let Some(reg) = &conference_registry {
             acceptor_builder = acceptor_builder.with_conference(reg.clone());
+        }
+        if let Some(ctx) = &park_context {
+            acceptor_builder = acceptor_builder.with_park(ctx.clone());
         }
         let acceptor = Arc::new(acceptor_builder);
 
@@ -570,6 +602,10 @@ impl Runtime {
             if let Some(reg) = &conference_registry {
                 service = service.with_conference(reg.clone());
             }
+            // Outbound bots can park/retrieve too (0.7.0).
+            if let Some(ctx) = &park_context {
+                service = service.with_park(ctx.clone());
+            }
             info!(
                 gateways = outbound.gateways.len(),
                 max_concurrent = outbound.max_concurrent,
@@ -606,6 +642,14 @@ impl Runtime {
             conference: conference_registry.as_ref().map(|reg| {
                 Arc::new(ConferenceAdmin::new(reg.clone(), control_registry.clone()))
                     as AdminConference
+            }),
+            // Park admin CRUD, only when park is on. Shares the same
+            // ParkRegistry the acceptor/outbound legs register into.
+            park: park_context.as_ref().map(|ctx| {
+                Arc::new(ParkAdmin::new(
+                    ctx.registry.clone(),
+                    control_registry.clone(),
+                )) as AdminPark
             }),
         };
         let observability_server = build_observability(

--- a/crates/bridge/src/conn.rs
+++ b/crates/bridge/src/conn.rs
@@ -664,6 +664,7 @@ fn bridge_in_call_id(msg: &BridgeIn) -> &str {
         BridgeIn::ResumeRecording { call_id } => call_id.as_str(),
         BridgeIn::ConferenceJoin { call_id, .. } => call_id.as_str(),
         BridgeIn::ConferenceLeave { call_id } => call_id.as_str(),
+        BridgeIn::Park { call_id, .. } => call_id.as_str(),
     }
 }
 

--- a/crates/bridge/src/protocol.rs
+++ b/crates/bridge/src/protocol.rs
@@ -297,6 +297,20 @@ pub struct StartMsg {
     /// `Box<T>` is serde-transparent — the wire JSON is identical.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub verstat: Option<Box<VerificationResult>>,
+    /// `true` when this `start` opens a *retrieve* session on a
+    /// previously-parked call (0.7.0, §2.4) — the WS server is picking
+    /// the call back up, not handling a fresh inbound one. `seq` still
+    /// restarts at 0 (a fresh session, no replay). Additive — omitted
+    /// (and `false`) on every non-retrieve `start`, so a pre-0.7.0
+    /// server sees the exact shape it always did.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub retrieved: bool,
+}
+
+/// serde `skip_serializing_if` helper — keep `retrieved: false` off the
+/// wire so the `start` shape is byte-identical for non-retrieve calls.
+fn is_false(b: &bool) -> bool {
+    !*b
 }
 
 /// SRTP details surfaced on [`StartMsg::srtp`].
@@ -390,6 +404,11 @@ pub enum StopReason {
     ServerHangup,
     Transfer,
     WsDisconnect,
+    /// The call was parked (0.7.0): the WS session is being detached but
+    /// the call stays alive (caller hears hold music). A later retrieve
+    /// opens a *fresh* WS session — this `stop` is the last message on
+    /// *this* session, not the end of the call.
+    Park,
     Error,
 }
 
@@ -418,6 +437,10 @@ pub enum ErrorCode {
     /// or already joined). The call continues on its direct pair.
     /// Added in 0.7.0.
     ConferenceFailed,
+    /// A [`BridgeIn::Park`] was refused (park disabled or
+    /// `[park].max_parked` reached). The call continues unparked.
+    /// Added in 0.7.0.
+    ParkFailed,
     Internal,
 }
 
@@ -514,6 +537,19 @@ pub enum BridgeIn {
 
     /// Resume recording after a [`BridgeIn::PauseRecording`].
     ResumeRecording { call_id: CallId },
+
+    /// Park this call (0.7.0, §2.4): detach the WS session and shelve
+    /// the call playing hold music, keeping the SIP dialog + RTP alive.
+    /// Self-scoped. SiphonAI replies `stop { reason: "park" }` and
+    /// closes this WS; the call is later retrieved (operator action)
+    /// onto a fresh WS session. `slot` is an optional human label for
+    /// the hold lot. Refused (`error { code: "park_failed" }`, call
+    /// continues) when park is disabled or `[park].max_parked` is hit.
+    Park {
+        call_id: CallId,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        slot: Option<String>,
+    },
 
     /// Join this call into a conference room (0.7.0, §2.1). Creates
     /// the room if it doesn't exist yet (subject to
@@ -1152,6 +1188,91 @@ mod tests {
         assert_eq!(code, ErrorCode::ConferenceFailed);
     }
 
+    // ─── Park (0.7.0) ────────────────────────────────────────────────────
+
+    #[test]
+    fn bridge_in_park_with_slot() {
+        let raw = r#"{ "type": "park", "call_id": "siphon-a", "slot": "lot-3" }"#;
+        let msg: BridgeIn = assert_round_trip(raw);
+        let BridgeIn::Park { slot, .. } = msg else {
+            panic!("expected Park");
+        };
+        assert_eq!(slot.as_deref(), Some("lot-3"));
+    }
+
+    #[test]
+    fn bridge_in_park_slot_optional() {
+        let raw = r#"{ "type": "park", "call_id": "siphon-a" }"#;
+        let msg: BridgeIn = assert_round_trip(raw);
+        assert!(matches!(msg, BridgeIn::Park { slot: None, .. }));
+    }
+
+    #[test]
+    fn stop_reason_park_round_trips() {
+        let raw = r#"{ "type": "stop", "call_id": "c", "seq": 9, "reason": "park" }"#;
+        let msg: BridgeOut = assert_round_trip(raw);
+        assert!(matches!(
+            msg,
+            BridgeOut::Stop {
+                reason: StopReason::Park,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn start_retrieved_omitted_when_false_present_when_true() {
+        // false ⇒ field absent (byte-identical to pre-0.7.0 start).
+        let start_false = StartMsg {
+            version: "1".into(),
+            call_id: CallId::new("c"),
+            seq: 0,
+            from: "+1".into(),
+            to: "5000".into(),
+            direction: Direction::Inbound,
+            audio: AudioFormat {
+                encoding: AudioEncoding::Pcm16le,
+                sample_rate: 8000,
+                channels: 1,
+                frame_ms: 20,
+            },
+            sip: SipMeta {
+                call_id: "x@y".into(),
+                headers: HashMap::new(),
+            },
+            srtp: None,
+            verstat: None,
+            retrieved: false,
+        };
+        let v = serde_json::to_value(&start_false).unwrap();
+        assert!(
+            v.get("retrieved").is_none(),
+            "retrieved must be absent when false"
+        );
+
+        // true ⇒ present.
+        let start_true = StartMsg {
+            retrieved: true,
+            ..start_false
+        };
+        let v = serde_json::to_value(&start_true).unwrap();
+        assert_eq!(v["retrieved"], serde_json::json!(true));
+        // And a retrieve-session start round-trips through BridgeOut.
+        let _ = assert_round_trip::<BridgeOut>(
+            &serde_json::to_string(&BridgeOut::Start(start_true)).unwrap(),
+        );
+    }
+
+    #[test]
+    fn bridge_out_error_park_failed() {
+        let raw = r#"{ "type": "error", "call_id": "c", "seq": 3, "code": "park_failed", "message": "max_parked reached" }"#;
+        let msg: BridgeOut = assert_round_trip(raw);
+        let BridgeOut::Error { code, .. } = msg else {
+            panic!("expected Error");
+        };
+        assert_eq!(code, ErrorCode::ParkFailed);
+    }
+
     // ─── Negative cases ─────────────────────────────────────────────────
 
     #[test]
@@ -1250,6 +1371,7 @@ mod tests {
             },
             srtp: None,
             verstat: None,
+            retrieved: false,
         });
         let v: Value = serde_json::to_value(&start).unwrap();
         let obj = v.as_object().unwrap();
@@ -1305,6 +1427,7 @@ mod tests {
                 },
                 srtp,
                 verstat: None,
+                retrieved: false,
             })
         };
 
@@ -1366,6 +1489,7 @@ mod tests {
                 },
                 srtp: None,
                 verstat: verstat.map(Box::new),
+                retrieved: false,
             })
         };
 

--- a/crates/bridge/tests/connection.rs
+++ b/crates/bridge/tests/connection.rs
@@ -221,6 +221,7 @@ fn fixture_start(call_id: &str) -> StartMsg {
         },
         srtp: None,
         verstat: None,
+        retrieved: false,
     }
 }
 

--- a/crates/cdr/src/file.rs
+++ b/crates/cdr/src/file.rs
@@ -174,6 +174,7 @@ mod tests {
             verstat_passed: None,
             recording_id: None,
             recording_path: None,
+            park: None,
         }
     }
 

--- a/crates/cdr/src/hep.rs
+++ b/crates/cdr/src/hep.rs
@@ -141,6 +141,7 @@ mod tests {
             verstat_passed: None,
             recording_id: None,
             recording_path: None,
+            park: None,
         }
     }
 

--- a/crates/cdr/src/lib.rs
+++ b/crates/cdr/src/lib.rs
@@ -31,6 +31,8 @@ pub mod webhook;
 
 pub use file::{FileSink, FileSinkError};
 pub use hep::HepCdrSink;
-pub use schema::{AudioInfo, CdrRecord, Direction, TerminationCause, TerminationInfo, CDR_VERSION};
+pub use schema::{
+    AudioInfo, CdrRecord, Direction, ParkInfo, TerminationCause, TerminationInfo, CDR_VERSION,
+};
 pub use sink::{CdrSink, CdrSinkHandle, MultiSink, NullSink};
 pub use webhook::{WebhookSink, WebhookSinkConfig};

--- a/crates/cdr/src/schema.rs
+++ b/crates/cdr/src/schema.rs
@@ -86,6 +86,21 @@ pub struct CdrRecord {
     /// Filesystem path of the recording, when one was written.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub recording_path: Option<String>,
+
+    /// Park summary (0.7.0), present when the call was parked at least
+    /// once. Omitted otherwise. Additive optional field → CDR schema
+    /// stays at version 1.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub park: Option<ParkInfo>,
+}
+
+/// Per-call park accounting on the CDR (0.7.0).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ParkInfo {
+    /// Number of park episodes over the call's lifetime.
+    pub count: u32,
+    /// Cumulative wall-time the call spent parked, in milliseconds.
+    pub total_ms: u64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -179,6 +194,7 @@ mod tests {
             verstat_passed: None,
             recording_id: None,
             recording_path: None,
+            park: None,
         }
     }
 

--- a/crates/cdr/src/sink.rs
+++ b/crates/cdr/src/sink.rs
@@ -120,6 +120,7 @@ mod tests {
             verstat_passed: None,
             recording_id: None,
             recording_path: None,
+            park: None,
         }
     }
 

--- a/crates/config/src/compile.rs
+++ b/crates/config/src/compile.rs
@@ -36,8 +36,8 @@ use tracing::warn;
 
 use crate::raw::{
     RawBridge, RawCdr, RawConference, RawConfig, RawGateway, RawHep, RawMedia, RawNode,
-    RawObservability, RawOutbound, RawRecording, RawRegister, RawSecurity, RawSip, RawSipTls,
-    RawWebhooks,
+    RawObservability, RawOutbound, RawPark, RawRecording, RawRegister, RawSecurity, RawSip,
+    RawSipTls, RawWebhooks,
 };
 
 /// Compiled, ready-to-pass daemon config.
@@ -66,6 +66,7 @@ pub struct Config {
     pub recording: siphon_ai_recording::RecordingConfig,
     pub outbound: OutboundConfig,
     pub conference: ConferenceConfig,
+    pub park: ParkConfig,
     pub cdr: CdrConfig,
     pub observability: ObservabilityConfig,
     pub webhooks: WebhooksConfig,
@@ -97,6 +98,45 @@ impl Default for ConferenceConfig {
             max_rooms: 16,
             max_participants_per_room: 8,
             join_tones: false,
+        }
+    }
+}
+
+/// What happens when a parked call hits `[park].timeout_secs`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParkTimeoutAction {
+    /// Tear the call down (the default).
+    Hangup,
+    /// Leave it parked; the operator must retrieve or hang up.
+    Keep,
+}
+
+/// Compiled `[park]` — media-only call park (0.7.0). Fail-closed:
+/// `enabled = false` (the default) refuses every park, so a 0.6.x
+/// deployment upgrades with zero behaviour change. The daemon maps this
+/// 1:1 onto `siphon-ai-core`'s `ParkLimits`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParkConfig {
+    pub enabled: bool,
+    /// Validated hold-music path (exists + decodes at load). `None` →
+    /// comfort noise. The native rate is resolved per-park; a call at a
+    /// different rate falls back to comfort noise (no resampling in v1).
+    pub moh_file: Option<PathBuf>,
+    /// Seconds before `timeout_action` fires. `None` = no timeout.
+    pub timeout: Option<Duration>,
+    pub timeout_action: ParkTimeoutAction,
+    /// Max simultaneously-parked calls across the daemon.
+    pub max_parked: usize,
+}
+
+impl Default for ParkConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            moh_file: None,
+            timeout: Some(Duration::from_secs(300)),
+            timeout_action: ParkTimeoutAction::Hangup,
+            max_parked: 32,
         }
     }
 }
@@ -608,6 +648,15 @@ pub enum CompileError {
         reason: &'static str,
     },
 
+    #[error("[park].max_parked must be >= 1")]
+    ParkBadMaxParked,
+
+    #[error("[park].timeout_action {0:?} is not one of \"hangup\", \"keep\"")]
+    ParkBadTimeoutAction(String),
+
+    #[error("[park].moh_file {0:?} does not exist or is not a file")]
+    ParkMohMissing(String),
+
     #[error("[media].rtp_port_range {min}-{max} is invalid (min must be < max and even)")]
     BadRtpPortRange { min: u16, max: u16 },
 
@@ -716,6 +765,7 @@ pub fn compile(raw: RawConfig) -> Result<Config, CompileError> {
     let recording = compile_recording(raw.recording)?;
     let outbound = compile_outbound(raw.outbound, raw.gateways, &registrations)?;
     let conference = compile_conference(raw.conference)?;
+    let park = compile_park(raw.park)?;
     let cdr = compile_cdr(raw.cdr)?;
     let observability = compile_observability(raw.observability)?;
     let webhooks = compile_webhooks(raw.webhooks)?;
@@ -807,6 +857,7 @@ pub fn compile(raw: RawConfig) -> Result<Config, CompileError> {
         recording,
         outbound,
         conference,
+        park,
         cdr,
         observability,
         webhooks,
@@ -1766,6 +1817,50 @@ fn compile_conference(raw: RawConference) -> Result<ConferenceConfig, CompileErr
         max_rooms: max_rooms as usize,
         max_participants_per_room: max_participants as usize,
         join_tones: raw.join_tones,
+    })
+}
+
+/// Compile `[park]` (0.7.0). Validation per CLAUDE.md §4.6 — fail loud
+/// at load: `timeout_action` is a known value, `max_parked >= 1`, and
+/// (when set + enabled) `moh_file` exists. Decodability is probed by the
+/// daemon at startup (config deliberately doesn't dep on the media
+/// stack — same split as `[sip.tls_client].extra_ca`).
+fn compile_park(raw: RawPark) -> Result<ParkConfig, CompileError> {
+    let defaults = ParkConfig::default();
+    let max_parked = raw.max_parked.unwrap_or(defaults.max_parked as u32);
+    if max_parked == 0 {
+        return Err(CompileError::ParkBadMaxParked);
+    }
+    let timeout_action = match raw.timeout_action.as_deref() {
+        None => defaults.timeout_action,
+        Some("hangup") => ParkTimeoutAction::Hangup,
+        Some("keep") => ParkTimeoutAction::Keep,
+        Some(other) => return Err(CompileError::ParkBadTimeoutAction(other.to_string())),
+    };
+    let timeout = match raw.timeout_secs {
+        None => defaults.timeout,
+        Some(0) => None,
+        Some(secs) => Some(Duration::from_secs(secs)),
+    };
+    // Existence check only when park is on — a disabled block shouldn't
+    // fail a boot over a stale path. (A moh_file on a disabled block is
+    // retained but unchecked; it's inert.)
+    let moh_file = match raw.moh_file.filter(|s| !s.is_empty()) {
+        None => None,
+        Some(p) => {
+            let path = PathBuf::from(&p);
+            if raw.enabled && !path.is_file() {
+                return Err(CompileError::ParkMohMissing(p));
+            }
+            Some(path)
+        }
+    };
+    Ok(ParkConfig {
+        enabled: raw.enabled,
+        moh_file,
+        timeout,
+        timeout_action,
+        max_parked: max_parked as usize,
     })
 }
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -36,14 +36,14 @@ use thiserror::Error;
 pub use compile::{
     compile, CdrConfig, CdrFileConfig, CdrWebhookConfig, CompileError, ConferenceConfig, Config,
     Gateway, GatewayCredentials, HepConfig, MediaConfig, NodeConfig, ObservabilityConfig,
-    OutboundConfig, RegisterConfig, SecurityConfig, SipConfig, SipTlsConfig, SipTransport,
-    TrunkCidr, TrunkCidrParseError, TrunkConfig, WebhooksConfig,
+    OutboundConfig, ParkConfig, ParkTimeoutAction, RegisterConfig, SecurityConfig, SipConfig,
+    SipTlsConfig, SipTransport, TrunkCidr, TrunkCidrParseError, TrunkConfig, WebhooksConfig,
 };
 pub use env::{expand, expand_cow, EnvError, EnvSource, ProcessEnv};
 pub use raw::{
     RawBridge, RawCdr, RawCdrFile, RawCdrWebhook, RawConference, RawConfig, RawGateway, RawHep,
-    RawMedia, RawNode, RawObservability, RawOutbound, RawRegister, RawSip, RawSipTls, RawTrunk,
-    RawWebhooks,
+    RawMedia, RawNode, RawObservability, RawOutbound, RawPark, RawRegister, RawSip, RawSipTls,
+    RawTrunk, RawWebhooks,
 };
 
 /// Top-level error type. Loaders surface this; consumers match on

--- a/crates/config/src/raw.rs
+++ b/crates/config/src/raw.rs
@@ -67,6 +67,10 @@ pub struct RawConfig {
     #[serde(default)]
     pub conference: RawConference,
 
+    /// `[park]` — media-only call park (0.7.0). Off by default.
+    #[serde(default)]
+    pub park: RawPark,
+
     #[serde(default)]
     pub cdr: RawCdr,
 
@@ -322,6 +326,30 @@ pub struct RawConference {
     /// Play a short chime into the room on join/leave. Default false.
     #[serde(default)]
     pub join_tones: bool,
+}
+
+/// `[park]` — media-only call park (0.7.0). Fail-closed like
+/// `[conference]`: with `enabled = false` (the default) park is refused
+/// and a 0.6.x deployment upgrades with zero behaviour change.
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawPark {
+    #[serde(default)]
+    pub enabled: bool,
+    /// Optional hold-music file (WAV/MP3/OGG/…). Looped while parked.
+    /// Unset → comfort noise. Existence + decodability checked at load.
+    #[serde(default)]
+    pub moh_file: Option<String>,
+    /// Seconds a call may stay parked before `timeout_action` fires.
+    /// Default 300. `0` disables the timeout (park indefinitely).
+    #[serde(default)]
+    pub timeout_secs: Option<u64>,
+    /// What happens at timeout: `"hangup"` (default) or `"keep"`.
+    #[serde(default)]
+    pub timeout_action: Option<String>,
+    /// Max simultaneously-parked calls across the daemon. Default 32.
+    #[serde(default)]
+    pub max_parked: Option<u32>,
 }
 
 /// `[[gateway]]` — one outbound trunk/provider (0.6.0). A gateway is the

--- a/crates/config/tests/load.rs
+++ b/crates/config/tests/load.rs
@@ -1931,3 +1931,118 @@ max_partcipants_per_room = 4
 "#;
     assert!(load_from_str_with_env(toml, &env).is_err());
 }
+
+// ─── [park] — media-only call park (0.7.0) ────────────────────────
+
+#[test]
+fn park_defaults_off() {
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[bridge]
+ws_url = "wss://x/y"
+"#;
+    let cfg = load_from_str_with_env(toml, &env).unwrap();
+    assert!(!cfg.park.enabled);
+    assert_eq!(cfg.park.max_parked, 32);
+    assert_eq!(cfg.park.timeout, Some(Duration::from_secs(300)));
+    assert!(cfg.park.moh_file.is_none());
+}
+
+#[test]
+fn park_block_compiles_with_overrides() {
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[bridge]
+ws_url = "wss://x/y"
+
+[park]
+enabled = true
+timeout_secs = 0
+timeout_action = "keep"
+max_parked = 4
+"#;
+    let cfg = load_from_str_with_env(toml, &env).unwrap();
+    assert!(cfg.park.enabled);
+    assert_eq!(cfg.park.timeout, None);
+    assert!(matches!(
+        cfg.park.timeout_action,
+        siphon_ai_config::ParkTimeoutAction::Keep
+    ));
+    assert_eq!(cfg.park.max_parked, 4);
+}
+
+#[test]
+fn park_bad_timeout_action_is_rejected() {
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[bridge]
+ws_url = "wss://x/y"
+
+[park]
+enabled = true
+timeout_action = "explode"
+"#;
+    let err = load_from_str_with_env(toml, &env).unwrap_err();
+    assert!(err.to_string().contains("timeout_action"), "got: {err}");
+}
+
+#[test]
+fn park_zero_max_parked_is_rejected() {
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[bridge]
+ws_url = "wss://x/y"
+
+[park]
+enabled = true
+max_parked = 0
+"#;
+    let err = load_from_str_with_env(toml, &env).unwrap_err();
+    assert!(err.to_string().contains("max_parked"), "got: {err}");
+}
+
+#[test]
+fn park_missing_moh_file_is_rejected_when_enabled() {
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[bridge]
+ws_url = "wss://x/y"
+
+[park]
+enabled = true
+moh_file = "/nonexistent/hold.wav"
+"#;
+    let err = load_from_str_with_env(toml, &env).unwrap_err();
+    assert!(err.to_string().contains("moh_file"), "got: {err}");
+}
+
+#[test]
+fn park_unknown_key_is_rejected() {
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[bridge]
+ws_url = "wss://x/y"
+
+[park]
+timeut_secs = 60
+"#;
+    assert!(load_from_str_with_env(toml, &env).is_err());
+}

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -96,6 +96,7 @@ use crate::call::{
     CallController, CallControllerConfig, CallOutcome, CallTermination, RecordingSummary,
 };
 use crate::conference::ConferenceRegistry;
+use crate::park::ParkContext;
 use crate::registry::CallControlRegistry;
 use crate::registry::CallRegistry;
 use crate::registry::ConsultRegistry;
@@ -1268,6 +1269,9 @@ pub fn build_start_msg(
         // wired (a later 0.4.0 chunk); the surface is in place now so the
         // WS shape is pinned before any code path produces a value.
         verstat,
+        // The acceptor only builds fresh inbound sessions; a retrieve
+        // session is built by the controller on park-retrieve.
+        retrieved: false,
     }
 }
 
@@ -1304,6 +1308,7 @@ pub fn build_outbound_start_msg(
         },
         srtp: None,
         verstat: None,
+        retrieved: false,
     }
 }
 
@@ -1469,6 +1474,10 @@ pub struct BridgingAcceptor {
     /// any active call (0.7.0). Populated for every accepted call,
     /// drained at teardown. Empty/unused when conferencing is off.
     control_registry: CallControlRegistry,
+    /// Park context (0.7.0). `Some` when `[park].enabled`; every
+    /// accepted call's controller gets a clone so a WS `park` (or admin
+    /// park) works. `None` → park off, requests rejected.
+    park: Option<ParkContext>,
 }
 
 /// Daemon-wide REFER plumbing (shared across every accepted call).
@@ -1685,6 +1694,7 @@ impl BridgingAcceptor {
             recording: RecordingConfig::default(),
             conference: None,
             control_registry: CallControlRegistry::new(),
+            park: None,
         }
     }
 
@@ -1817,6 +1827,14 @@ impl BridgingAcceptor {
         self
     }
 
+    /// Install the park context (0.7.0). The daemon builds it from
+    /// `[park]` + the shared `ParkRegistry`; every accepted call's
+    /// controller gets a clone. Left unset → park is off.
+    pub fn with_park(mut self, park: ParkContext) -> Self {
+        self.park = Some(park);
+        self
+    }
+
     /// The registry this acceptor populates. Cheap to clone — share
     /// it with the SIP-side BYE/CANCEL handler.
     pub fn registry(&self) -> &CallRegistry {
@@ -1887,6 +1905,10 @@ impl CallStart {
                 .recording
                 .as_ref()
                 .map(|r| r.path.display().to_string()),
+            park: outcome.park.map(|p| siphon_ai_cdr::ParkInfo {
+                count: p.count,
+                total_ms: p.total_ms,
+            }),
         }
     }
 }
@@ -1902,6 +1924,9 @@ pub(crate) struct CallTerminationView {
     /// Recording outcome, when the call was recorded. Feeds the CDR
     /// `recording_path` and the `siphon_ai_recordings_total` metric.
     pub(crate) recording: Option<RecordingSummary>,
+    /// Park accounting, when the call was parked at least once. Feeds
+    /// the CDR `park { count, total_ms }`.
+    pub(crate) park: Option<crate::call::ParkSummary>,
 }
 
 impl CallTerminationView {
@@ -1912,6 +1937,7 @@ impl CallTerminationView {
                 bridge_detail: bridge_detail(o.bridge),
                 tap_detail: tap_detail(o.tap),
                 recording: o.recording,
+                park: o.park,
             },
             Err(e) => Self {
                 // Treat a panic / join error as "bridge ended" —
@@ -1921,6 +1947,7 @@ impl CallTerminationView {
                 bridge_detail: format!("controller error: {e}"),
                 tap_detail: String::new(),
                 recording: None,
+                park: None,
             },
         }
     }
@@ -3143,6 +3170,7 @@ impl BridgingAcceptor {
             transfer,
             recording,
             conference: self.conference.clone(),
+            park: self.park.clone(),
         };
         let (controller, handle) = CallController::new(cfg);
 

--- a/crates/core/src/call.rs
+++ b/crates/core/src/call.rs
@@ -57,17 +57,26 @@
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use siphon_ai_bridge::{
     connect_and_run, BridgeChannels, BridgeConfig, BridgeError, BridgeIn, CallId, DisconnectReason,
     ErrorCode, OutgoingEvent, StartMsg, StopReason,
 };
-use siphon_ai_media_glue::{MediaTap, MediaTapError, RoomMembership, TapCommand, TapDisconnect};
+use siphon_ai_media_glue::{
+    MediaTap, MediaTapError, MohSource, RoomMembership, TapCommand, TapDisconnect,
+};
 
 use crate::conference::{ConferenceError, ConferenceRegistry};
+use crate::park::{ParkContext, ParkTimeoutAction};
+use chrono::Utc;
+use parking_lot::RwLock;
 use siphon_ai_recording::{
     RecControl, RecEvent, RecFrame, RecordingError, RecordingSetup, RecordingStats, RecordingWriter,
+};
+use siphon_ai_webhooks::{
+    CallParkedEvent, CallRetrievedEvent, ParkTimeoutEvent, WebhookEvent, WebhookSinkHandle,
+    WEBHOOK_VERSION,
 };
 use thiserror::Error;
 use tokio::sync::{mpsc, Notify};
@@ -75,7 +84,7 @@ use tokio::task::JoinHandle;
 use tracing::{debug, info, instrument, warn};
 
 use crate::transfer::{plan_refer, ReferPlan, TransferContext, TransferOutcome};
-use siphon_ai_telemetry::TRANSFERS_TOTAL;
+use siphon_ai_telemetry::{PARKED_CALLS_ACTIVE, PARKS_TOTAL, RETRIEVES_TOTAL, TRANSFERS_TOTAL};
 
 /// Bounded channel capacity for audio frames. 10 × 20 ms = 200 ms
 /// of audio; per CLAUDE.md §6.2 audio channels are bounded for
@@ -126,6 +135,13 @@ pub struct CallControllerConfig {
     /// → conferencing off, and a join request is answered with
     /// `error { code: "conference_failed" }`. Cheap to clone (Arc inside).
     pub conference: Option<ConferenceRegistry>,
+
+    /// Park context (0.7.0). `Some` when `[park].enabled`; the
+    /// controller honours `BridgeIn::Park` and admin park/retrieve.
+    /// `None` → park off, a park request answered with
+    /// `error { code: "park_failed" }`. Carries the MOH/timeout
+    /// settings + the daemon-wide `ParkRegistry`.
+    pub park: Option<ParkContext>,
 }
 
 /// Where in its life a call is. State transitions are logged at
@@ -178,6 +194,19 @@ pub struct CallOutcome {
     /// attempted). `None` when recording was off, or on-demand and never
     /// started. Feeds the CDR `recording_path` and the recordings metric.
     pub recording: Option<RecordingSummary>,
+    /// Park outcome, `Some` when the call was parked at least once.
+    /// Feeds the CDR `park { count, total_ms }`. `None` for a call that
+    /// was never parked (the field is omitted from the CDR then).
+    pub park: Option<ParkSummary>,
+}
+
+/// Per-call park outcome surfaced on [`CallOutcome`] → CDR.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParkSummary {
+    /// How many times this call was parked over its lifetime.
+    pub count: u32,
+    /// Cumulative wall-time the call spent parked, in milliseconds.
+    pub total_ms: u64,
 }
 
 /// Per-call recording outcome surfaced on [`CallOutcome`].
@@ -239,10 +268,16 @@ pub struct CallHandle {
     /// External-event push channel. The acceptor's `on_reinvite`
     /// uses this to surface mid-dialog state changes (currently
     /// `Hold` / `Resume`) to the WS bridge without going through
-    /// the controller's main select loop. Cloned from the same
-    /// sender the controller and tap push onto, so all three
-    /// producers feed one consumer (the bridge task).
-    bridge_events_tx: mpsc::Sender<OutgoingEvent>,
+    /// the controller's main select loop.
+    ///
+    /// Behind a `Mutex` so a **retrieve** (0.7.0 park) can swap it to
+    /// the fresh bridge's sender — the original bridge is gone after a
+    /// park, and `push_bridge_event` must reach whichever bridge is
+    /// current. This is control-plane only (re-INVITE events, rare),
+    /// never the per-frame audio path, so the lock doesn't violate
+    /// §4.3. `parking_lot::Mutex` (a core dep already) rather than a
+    /// new arc-swap dep.
+    bridge_events_tx: std::sync::Arc<RwLock<mpsc::Sender<OutgoingEvent>>>,
     /// Cross-call conference control (0.7.0). The admin API
     /// (`/admin/v1/conferences/:id/participants`) signals a call to
     /// join/leave a room *on its behalf* by pushing here — the
@@ -250,6 +285,10 @@ pub struct CallHandle {
     /// `conference_join`, so §4.4 holds (we signal the call; the
     /// controller mutates its own state). Bounded + `try_send`.
     conf_cmd_tx: mpsc::Sender<ConferenceCommand>,
+    /// Admin park/retrieve control (0.7.0). Same §4.4 stance as
+    /// `conf_cmd_tx`: the admin API signals; the controller acts on
+    /// its own state.
+    park_cmd_tx: mpsc::Sender<ParkCommand>,
 }
 
 /// A cross-call conference request pushed onto a [`CallHandle`] by the
@@ -264,18 +303,32 @@ pub enum ConferenceCommand {
     Leave,
 }
 
+/// An admin park/retrieve request pushed onto a [`CallHandle`] (0.7.0).
+/// WS-initiated park comes via `BridgeIn::Park` instead; retrieve is
+/// operator-only, so it has no WS variant.
+#[derive(Debug, Clone)]
+pub enum ParkCommand {
+    /// Park this call (optionally tagging a hold lot).
+    Park { slot: Option<String> },
+    /// Retrieve this call onto a fresh WS session (optionally
+    /// redirecting to a different `ws_url`).
+    Retrieve { ws_url: Option<String> },
+}
+
 impl CallHandle {
     fn new(
         call_id: CallId,
         bridge_events_tx: mpsc::Sender<OutgoingEvent>,
         conf_cmd_tx: mpsc::Sender<ConferenceCommand>,
+        park_cmd_tx: mpsc::Sender<ParkCommand>,
     ) -> Self {
         Self {
             notify: std::sync::Arc::new(Notify::new()),
             call_id,
             remote_bye: std::sync::Arc::new(AtomicBool::new(false)),
-            bridge_events_tx,
+            bridge_events_tx: std::sync::Arc::new(RwLock::new(bridge_events_tx)),
             conf_cmd_tx,
+            park_cmd_tx,
         }
     }
 
@@ -312,11 +365,49 @@ impl CallHandle {
     /// dispatch thread. Drop with a warn — re-INVITE events are
     /// informational and a missed Hold/Resume isn't fatal.
     pub fn push_bridge_event(&self, event: OutgoingEvent) {
-        if let Err(e) = self.bridge_events_tx.try_send(event) {
+        if let Err(e) = self.bridge_events_tx.read().try_send(event) {
             tracing::warn!(
                 call_id = %self.call_id,
                 error = %e,
                 "bridge_events_tx full or closed; dropping external event"
+            );
+        }
+    }
+
+    /// Swap the external-event sender to a retrieved call's fresh
+    /// bridge (0.7.0). Called by the controller during retrieve so
+    /// `push_bridge_event` reaches the new WS session.
+    fn swap_bridge_sender(&self, sender: mpsc::Sender<OutgoingEvent>) {
+        *self.bridge_events_tx.write() = sender;
+    }
+
+    /// A clone of the current external-event sender — the controller's
+    /// own send path, kept in sync with the swappable bridge.
+    fn bridge_sender(&self) -> mpsc::Sender<OutgoingEvent> {
+        self.bridge_events_tx.read().clone()
+    }
+
+    /// Ask this call to park (admin). The controller runs the same
+    /// path as a WS `park`. Best-effort `try_send`.
+    pub fn request_park(&self, slot: Option<String>) {
+        if let Err(e) = self.park_cmd_tx.try_send(ParkCommand::Park { slot }) {
+            tracing::warn!(
+                call_id = %self.call_id,
+                error = %e,
+                "park_cmd_tx full or closed; dropping park request"
+            );
+        }
+    }
+
+    /// Ask this call to retrieve onto a fresh WS session (admin),
+    /// optionally redirecting to `ws_url`. No-op at the controller if
+    /// the call isn't parked.
+    pub fn request_retrieve(&self, ws_url: Option<String>) {
+        if let Err(e) = self.park_cmd_tx.try_send(ParkCommand::Retrieve { ws_url }) {
+            tracing::warn!(
+                call_id = %self.call_id,
+                error = %e,
+                "park_cmd_tx full or closed; dropping retrieve request"
             );
         }
     }
@@ -363,6 +454,8 @@ pub struct CallController {
     /// Receiver for admin cross-call conference commands. Sender is on
     /// the handle. Consumed by `run()`.
     conf_cmd_rx: mpsc::Receiver<ConferenceCommand>,
+    /// Receiver for admin park/retrieve commands. Sender on the handle.
+    park_cmd_rx: mpsc::Receiver<ParkCommand>,
 }
 
 impl CallController {
@@ -373,13 +466,20 @@ impl CallController {
             mpsc::channel::<OutgoingEvent>(CONTROL_CHANNEL_CAPACITY);
         let (conf_cmd_tx, conf_cmd_rx) =
             mpsc::channel::<ConferenceCommand>(CONTROL_CHANNEL_CAPACITY);
-        let handle = CallHandle::new(cfg.call_id.clone(), control_out_tx, conf_cmd_tx);
+        let (park_cmd_tx, park_cmd_rx) = mpsc::channel::<ParkCommand>(CONTROL_CHANNEL_CAPACITY);
+        let handle = CallHandle::new(
+            cfg.call_id.clone(),
+            control_out_tx,
+            conf_cmd_tx,
+            park_cmd_tx,
+        );
         (
             Self {
                 cfg,
                 handle: handle.clone(),
                 control_out_rx,
                 conf_cmd_rx,
+                park_cmd_rx,
             },
             handle,
         )
@@ -412,6 +512,7 @@ impl CallController {
             handle,
             control_out_rx,
             mut conf_cmd_rx,
+            mut park_cmd_rx,
         } = self;
         let CallControllerConfig {
             call_id,
@@ -421,7 +522,14 @@ impl CallController {
             transfer,
             recording,
             conference,
+            park,
         } = cfg;
+
+        // Park needs to rebuild the WS bridge on retrieve from the
+        // original call facts + bridge config; clone them before the
+        // first bridge consumes the originals.
+        let start_template = start.clone();
+        let bridge_template = bridge.clone();
 
         // Captured before `media_tap` moves into its task — a room
         // locks to its first joiner's negotiated rate, and a join is
@@ -437,10 +545,11 @@ impl CallController {
         let (playout_audio_tx, playout_audio_rx) = mpsc::channel::<Vec<u8>>(AUDIO_CHANNEL_CAPACITY);
         // controller → bridge: outgoing events (Stop, Mark, …). The
         // sender lives on the CallHandle so external callers
-        // (acceptor's on_reinvite) can push too. The controller
-        // gets its own clone via the handle.
-        let control_out_tx = handle.bridge_events_tx.clone();
-        // bridge → controller: BridgeIn from server
+        // (acceptor's on_reinvite) can push too. `mut` because a
+        // retrieve (park) swaps it to the fresh bridge's sender.
+        let mut control_out_tx = handle.bridge_sender();
+        // bridge → controller: BridgeIn from server. `mut` so a
+        // retrieve can swap in the fresh bridge's receiver.
         let (control_in_tx, mut control_in_rx) =
             mpsc::channel::<BridgeIn>(CONTROL_CHANNEL_CAPACITY);
         // controller → tap: out-of-band commands the controller routes
@@ -537,6 +646,25 @@ impl CallController {
         // bridge_task arm. The flag flips to false on first None
         // and the arm becomes unselectable until we exit the loop.
         let mut control_open = true;
+
+        // ─── Park state (0.7.0 §2.4) ─────────────────────────────
+        // `parked` true between a park and its retrieve/teardown. While
+        // parked the tap plays MOH and the WS bridge is gone (its
+        // `bridge_task` completed) — so the bridge-end arm is guarded by
+        // `bridge_alive` and made non-terminal. Retrieve spawns a fresh
+        // bridge and flips both back.
+        let mut parked = false;
+        let mut bridge_alive = true;
+        // CDR `park { count, total_ms }` accounting.
+        let mut park_count: u32 = 0;
+        let mut park_total = Duration::ZERO;
+        let mut parked_since: Option<Instant> = None;
+        // Park timeout: a pinned far-future sleep, reset on park, only
+        // selected while `parked` AND a deadline is set (same pattern as
+        // the tap's RTP watchdog).
+        let park_timeout_sleep = tokio::time::sleep(Duration::from_secs(86_400));
+        tokio::pin!(park_timeout_sleep);
+        let mut park_deadline_armed = false;
 
         let shutdown = handle.notify.clone();
 
@@ -673,6 +801,13 @@ impl CallController {
                             if let Err(e) = tap_cmd_tx.try_send(TapCommand::LeaveRoom) {
                                 warn!(error = %e, "tap command channel full or closed; dropping ConferenceLeave");
                             }
+                        }
+                        Some(BridgeIn::Park { call_id: cid, slot }) => {
+                            // Funnel WS park through the same channel the
+                            // admin uses, so there's exactly one park
+                            // implementation (the park_cmd_rx arm).
+                            debug!(ws_call_id = %cid, ?slot, "WS park requested");
+                            handle.request_park(slot);
                         }
                         Some(BridgeIn::Mark { call_id: cid, name }) => {
                             debug!(ws_call_id = %cid, %name, "forwarding Mark to tap");
@@ -885,8 +1020,195 @@ impl CallController {
                     }
                 }
 
-                // Bridge sub-task ended.
-                res = &mut bridge_task => {
+                // Park / retrieve (admin, and WS park forwarded here).
+                Some(cmd) = park_cmd_rx.recv() => {
+                    match cmd {
+                        ParkCommand::Park { slot } => {
+                            if parked {
+                                debug!(call_id = %call_id, "park requested but already parked; ignoring");
+                            } else if let Some(park_ctx) = park.as_ref() {
+                                match park_ctx.registry.try_park(call_id.as_str(), slot.clone()) {
+                                    Ok(()) => {
+                                        let moh = MohSource::new(
+                                            park_ctx.settings.moh_file.as_deref(),
+                                            call_sample_rate,
+                                        );
+                                        if let Err(e) = tap_cmd_tx
+                                            .try_send(TapCommand::Park { moh: Box::new(moh) })
+                                        {
+                                            warn!(call_id = %call_id, error = %e,
+                                                "tap command channel full/closed; park aborted");
+                                            park_ctx.registry.remove(call_id.as_str());
+                                            let _ = control_out_tx.send(OutgoingEvent::Error {
+                                                code: ErrorCode::ParkFailed,
+                                                message: "tap unavailable for park".to_string(),
+                                            }).await;
+                                        } else {
+                                            // Detach the WS: the bridge sends
+                                            // `stop{park}` and closes. The
+                                            // bridge-end arm sees `parked` and
+                                            // stays alive.
+                                            let _ = control_out_tx
+                                                .send(OutgoingEvent::Stop { reason: StopReason::Park })
+                                                .await;
+                                            parked = true;
+                                            park_count += 1;
+                                            parked_since = Some(Instant::now());
+                                            if let Some(d) = park_ctx.settings.timeout {
+                                                park_timeout_sleep
+                                                    .as_mut()
+                                                    .reset(tokio::time::Instant::now() + d);
+                                                park_deadline_armed = true;
+                                            }
+                                            metrics::gauge!(PARKED_CALLS_ACTIVE).increment(1.0);
+                                            metrics::counter!(PARKS_TOTAL, "result" => "ok").increment(1);
+                                            info!(call_id = %call_id, ?slot, "call parked");
+                                            spawn_webhook(
+                                                &park_ctx.webhooks,
+                                                WebhookEvent::CallParked(CallParkedEvent {
+                                                    version: WEBHOOK_VERSION,
+                                                    call_id: call_id.as_str().to_string(),
+                                                    timestamp: Utc::now(),
+                                                    slot,
+                                                }),
+                                            );
+                                        }
+                                    }
+                                    Err(e) => {
+                                        warn!(call_id = %call_id, error = %e, "park rejected");
+                                        metrics::counter!(PARKS_TOTAL, "result" => "rejected").increment(1);
+                                        let _ = control_out_tx.send(OutgoingEvent::Error {
+                                            code: ErrorCode::ParkFailed,
+                                            message: e.to_string(),
+                                        }).await;
+                                    }
+                                }
+                            } else {
+                                warn!(call_id = %call_id, "park requested but park is disabled");
+                                let _ = control_out_tx.send(OutgoingEvent::Error {
+                                    code: ErrorCode::ParkFailed,
+                                    message: "park is disabled on this daemon".to_string(),
+                                }).await;
+                            }
+                        }
+                        ParkCommand::Retrieve { ws_url } => {
+                            if !parked {
+                                debug!(call_id = %call_id, "retrieve on a non-parked call; ignoring");
+                                metrics::counter!(RETRIEVES_TOTAL, "result" => "not_parked").increment(1);
+                            } else {
+                                // Account the parked span before flipping back.
+                                if let Some(since) = parked_since.take() {
+                                    park_total += since.elapsed();
+                                }
+                                // Fresh channels for the new bridge.
+                                let (n_caller_tx, n_caller_rx) =
+                                    mpsc::channel::<Vec<u8>>(AUDIO_CHANNEL_CAPACITY);
+                                let (n_playout_tx, n_playout_rx) =
+                                    mpsc::channel::<Vec<u8>>(AUDIO_CHANNEL_CAPACITY);
+                                let (n_ci_tx, n_ci_rx) =
+                                    mpsc::channel::<BridgeIn>(CONTROL_CHANNEL_CAPACITY);
+                                let (n_co_tx, n_co_rx) =
+                                    mpsc::channel::<OutgoingEvent>(CONTROL_CHANNEL_CAPACITY);
+                                // Fresh `start` from the preserved facts.
+                                let mut start2 = start_template.clone();
+                                start2.seq = 0;
+                                start2.retrieved = true;
+                                let ws = ws_url
+                                    .clone()
+                                    .filter(|s| !s.is_empty())
+                                    .unwrap_or_else(|| bridge_template.ws_url.clone());
+                                let bridge_cfg2 = BridgeConfig {
+                                    ws_url: ws.clone(),
+                                    ..bridge_template.clone()
+                                };
+                                bridge_task = tokio::spawn(connect_and_run(
+                                    bridge_cfg2,
+                                    start2,
+                                    BridgeChannels {
+                                        audio_out_rx: n_caller_rx,
+                                        control_out_rx: n_co_rx,
+                                        audio_in_tx: n_playout_tx,
+                                        control_in_tx: n_ci_tx,
+                                    },
+                                ));
+                                bridge_alive = true;
+                                control_in_rx = n_ci_rx;
+                                control_open = true;
+                                control_out_tx = n_co_tx.clone();
+                                handle.swap_bridge_sender(n_co_tx.clone());
+                                if let Err(e) = tap_cmd_tx.try_send(TapCommand::Unpark {
+                                    caller_audio_tx: n_caller_tx,
+                                    playout_audio_rx: n_playout_rx,
+                                    events_tx: n_co_tx,
+                                }) {
+                                    warn!(call_id = %call_id, error = %e,
+                                        "tap command channel full/closed; retrieve audio may not resume");
+                                }
+                                parked = false;
+                                park_deadline_armed = false;
+                                if let Some(pc) = park.as_ref() {
+                                    pc.registry.remove(call_id.as_str());
+                                }
+                                metrics::gauge!(PARKED_CALLS_ACTIVE).decrement(1.0);
+                                metrics::counter!(RETRIEVES_TOTAL, "result" => "ok").increment(1);
+                                info!(call_id = %call_id, ws_url = %ws, "call retrieved onto fresh WS session");
+                                if let Some(pc) = park.as_ref() {
+                                    spawn_webhook(
+                                        &pc.webhooks,
+                                        WebhookEvent::CallRetrieved(CallRetrievedEvent {
+                                            version: WEBHOOK_VERSION,
+                                            call_id: call_id.as_str().to_string(),
+                                            timestamp: Utc::now(),
+                                            ws_url: ws,
+                                        }),
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Park timeout. Armed on park; fires once. Selected only
+                // while parked with a live deadline.
+                _ = &mut park_timeout_sleep, if parked && park_deadline_armed => {
+                    park_deadline_armed = false;
+                    let action = park
+                        .as_ref()
+                        .map(|p| p.settings.timeout_action)
+                        .unwrap_or(ParkTimeoutAction::Hangup);
+                    info!(call_id = %call_id, ?action, "park timeout fired");
+                    if let Some(pc) = park.as_ref() {
+                        spawn_webhook(
+                            &pc.webhooks,
+                            WebhookEvent::ParkTimeout(ParkTimeoutEvent {
+                                version: WEBHOOK_VERSION,
+                                call_id: call_id.as_str().to_string(),
+                                timestamp: Utc::now(),
+                                action: match action {
+                                    ParkTimeoutAction::Hangup => "hangup".to_string(),
+                                    ParkTimeoutAction::Keep => "keep".to_string(),
+                                },
+                            }),
+                        );
+                    }
+                    match action {
+                        ParkTimeoutAction::Hangup => {
+                            termination = CallTermination::LocalShutdown;
+                            break;
+                        }
+                        ParkTimeoutAction::Keep => {
+                            // Stay parked; operator must retrieve or hang up.
+                        }
+                    }
+                }
+
+                // Bridge sub-task ended. Guarded by `bridge_alive` so a
+                // completed handle is never re-polled (it's reassigned on
+                // retrieve). A bridge ending *while parked* is the park's
+                // own `stop{park}` close — non-terminal; the call lives on
+                // MOH until retrieve / timeout / caller-BYE.
+                res = &mut bridge_task, if bridge_alive => {
+                    bridge_alive = false;
                     match res {
                         Ok(inner) => bridge_result = Some(inner),
                         Err(join_err) => {
@@ -894,8 +1216,12 @@ impl CallController {
                             return Err(CallError::TaskJoin(join_err));
                         }
                     }
-                    termination = CallTermination::BridgeEnded;
-                    break;
+                    if parked {
+                        debug!(call_id = %call_id, "WS bridge closed for park; call remains parked");
+                    } else {
+                        termination = CallTermination::BridgeEnded;
+                        break;
+                    }
                 }
 
                 // Tap sub-task ended.
@@ -939,6 +1265,24 @@ impl CallController {
         }
 
         log_state(&call_id, CallState::Terminating);
+
+        // ─── Park teardown ───────────────────────────────────────
+        // If we broke out while still parked (timeout-hangup, or a
+        // caller BYE during park), close the books on the parked span
+        // and free the registry slot + gauge.
+        if parked {
+            if let Some(since) = parked_since.take() {
+                park_total += since.elapsed();
+            }
+            if let Some(pc) = park.as_ref() {
+                pc.registry.remove(call_id.as_str());
+            }
+            metrics::gauge!(PARKED_CALLS_ACTIVE).decrement(1.0);
+        }
+        let park_summary = (park_count > 0).then_some(ParkSummary {
+            count: park_count,
+            total_ms: park_total.as_millis() as u64,
+        });
 
         // ─── Drain remaining sub-tasks with a budget ─────────────
         // The bridge needs to flush its `stop` send + WS close;
@@ -1053,12 +1397,24 @@ impl CallController {
             bridge: bridge_result,
             tap: tap_result,
             recording: recording_summary,
+            park: park_summary,
         })
     }
 }
 
 fn log_state(call_id: &CallId, state: CallState) {
     info!(call_id = %call_id, ?state, "call state");
+}
+
+/// Fire a lifecycle webhook off the control loop (best-effort, like the
+/// acceptor's call_start/end). `None` sink → no-op.
+fn spawn_webhook(sink: &Option<WebhookSinkHandle>, event: WebhookEvent) {
+    if let Some(sink) = sink {
+        let sink = sink.clone();
+        tokio::spawn(async move {
+            sink.emit(event).await;
+        });
+    }
 }
 
 /// Spawn the async conference join (round-trips to the room task) off

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -11,6 +11,8 @@ pub mod conference;
 pub mod conference_admin;
 pub mod outbound;
 pub mod outbound_service;
+pub mod park;
+pub mod park_admin;
 pub mod registry;
 pub mod transfer;
 
@@ -23,7 +25,7 @@ pub use acceptor::{
 };
 pub use call::{
     CallController, CallControllerConfig, CallError, CallHandle, CallOutcome, CallState,
-    CallTermination, ConferenceCommand,
+    CallTermination, ConferenceCommand, ParkCommand, ParkSummary,
 };
 pub use conference::{ConferenceError, ConferenceLimits, ConferenceRegistry, ConferenceSnapshot};
 pub use conference_admin::ConferenceAdmin;
@@ -32,5 +34,9 @@ pub use outbound::{
     OutboundPermit, OutboundRejection, StaticCredentials,
 };
 pub use outbound_service::{OutboundGateway, OutboundService};
+pub use park::{
+    ParkContext, ParkError, ParkRegistry, ParkSettings, ParkSnapshot, ParkTimeoutAction,
+};
+pub use park_admin::ParkAdmin;
 pub use registry::{CallControlRegistry, CallEntry, CallRegistry, ConsultRegistry};
 pub use transfer::{DialogSource, TransferContext, TransferOutcome};

--- a/crates/core/src/outbound_service.rs
+++ b/crates/core/src/outbound_service.rs
@@ -48,6 +48,7 @@ use crate::outbound::{
     NotAnsweredCause, OutboundCall, OutboundError, OutboundGuard, OutboundOriginator,
     OutboundRejection,
 };
+use crate::park::ParkContext;
 use crate::registry::{CallControlRegistry, ConsultRegistry};
 use crate::transfer::{DialogSource, TransferContext};
 
@@ -85,6 +86,9 @@ pub struct OutboundService {
     /// Bridge-id → handle table so the admin conference API can reach
     /// answered outbound calls too (§9.1). Shared with the acceptor.
     control_registry: CallControlRegistry,
+    /// Park context (0.7.0). `Some` when `[park].enabled`; outbound
+    /// bots can park/retrieve just like inbound calls.
+    park: Option<ParkContext>,
 }
 
 impl OutboundService {
@@ -108,6 +112,7 @@ impl OutboundService {
             consult_registry,
             conference: None,
             control_registry: CallControlRegistry::new(),
+            park: None,
         }
     }
 
@@ -123,6 +128,12 @@ impl OutboundService {
     /// conference API can reach answered outbound calls.
     pub fn with_control_registry(mut self, control_registry: CallControlRegistry) -> Self {
         self.control_registry = control_registry;
+        self
+    }
+
+    /// Share the park context so outbound bots can park/retrieve.
+    pub fn with_park(mut self, park: ParkContext) -> Self {
+        self.park = Some(park);
         self
     }
 }
@@ -190,6 +201,7 @@ impl OutboundOriginateHandle for OutboundService {
         let consult_registry = self.consult_registry.clone();
         let conference = self.conference.clone();
         let control_registry = self.control_registry.clone();
+        let park = self.park.clone();
 
         info!(call_id = %bridge_id_str, gateway = %gateway, "originating outbound call");
         let log_id = bridge_id_str.clone();
@@ -222,6 +234,7 @@ impl OutboundOriginateHandle for OutboundService {
                         consult_registry,
                         conference,
                         control_registry,
+                        park,
                     };
                     run_call(originator, call, bridge, ctx).await;
                 }
@@ -286,6 +299,9 @@ struct OutboundCallContext {
     /// Bridge-id handle table — this leg registers in it for its
     /// lifetime so the admin conference API can reach it.
     control_registry: CallControlRegistry,
+    /// Park context, shared with the controller so an outbound bot can
+    /// park/retrieve. `None` when park is off.
+    park: Option<ParkContext>,
 }
 
 /// Run an answered outbound call's audio bridge to completion, tear it
@@ -352,6 +368,7 @@ async fn run_call(
         transfer: Some(transfer),
         recording: None,
         conference: ctx.conference.clone(),
+        park: ctx.park.clone(),
     };
     let (controller, handle) = CallController::new(cfg);
     // Reachable by the admin conference API for this leg's lifetime.
@@ -428,6 +445,11 @@ fn build_outbound_record(
         verstat_passed: None,
         recording_id: None,
         recording_path: None,
+        // Outbound bots can park too (0.7.0); carry the accounting.
+        park: view.park.map(|p| siphon_ai_cdr::ParkInfo {
+            count: p.count,
+            total_ms: p.total_ms,
+        }),
     }
 }
 
@@ -450,12 +472,14 @@ mod tests {
             consult_registry: ConsultRegistry::new(),
             conference: None,
             control_registry: CallControlRegistry::new(),
+            park: None,
         };
         let view = CallTerminationView {
             cause: CdrTerminationCause::ServerHangup,
             bridge_detail: "stop_sent".into(),
             tap_detail: "controller_hung_up".into(),
             recording: None,
+            park: None,
         };
         let audio = CdrAudioInfo {
             codec: "PCMU".into(),

--- a/crates/core/src/park.rs
+++ b/crates/core/src/park.rs
@@ -1,0 +1,228 @@
+//! Call park — daemon-wide registry + per-call context (DEV_PLAN_0.7.0.md §2.4).
+//!
+//! Park is media-only: the WS session detaches, the caller hears hold
+//! music, and the SIP dialog + RTP stay up until the call is retrieved
+//! onto a fresh WS session (or times out / hangs up). The controller
+//! owns the lifecycle (see `call.rs`); this module provides:
+//!
+//! - [`ParkRegistry`] — `call_id → ParkedEntry` (slot + parked-at), the
+//!   §4.4-compliant table behind `GET /admin/v1/parked` and the
+//!   `max_parked` cap. Same shape as `ConferenceRegistry` /
+//!   `CallControlRegistry`: exact-id, insert on park, remove on
+//!   retrieve/teardown, no reach into call internals.
+//! - [`ParkContext`] — the per-call park config the controller needs
+//!   (MOH file, timeout policy) plus a clone of the registry. Mapped by
+//!   the daemon from `siphon-ai-config`'s `ParkConfig` (core doesn't dep
+//!   on config — same pattern as `ConferenceLimits`).
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use parking_lot::RwLock;
+use thiserror::Error;
+use tracing::{debug, warn};
+
+/// What happens when a parked call hits its timeout. Core mirror of
+/// `siphon-ai-config::ParkTimeoutAction`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParkTimeoutAction {
+    /// Tear the call down (the default).
+    Hangup,
+    /// Leave it parked; the operator must retrieve or hang up.
+    Keep,
+}
+
+/// Per-call park behaviour the controller applies on a park request.
+/// Cheap to clone (`PathBuf` + small scalars).
+#[derive(Debug, Clone)]
+pub struct ParkSettings {
+    /// Hold-music file (validated at load). `None` → comfort noise.
+    pub moh_file: Option<PathBuf>,
+    /// How long a call may stay parked. `None` = no timeout.
+    pub timeout: Option<Duration>,
+    pub timeout_action: ParkTimeoutAction,
+}
+
+/// Everything a [`CallController`](crate::CallController) needs to honour
+/// park requests: the per-call settings, a clone of the daemon-wide
+/// registry (for the cap + the admin list), and an optional webhook sink
+/// for `call_parked` / `call_retrieved` / `park_timeout`. `None` on the
+/// controller config means park is disabled for the call.
+#[derive(Clone)]
+pub struct ParkContext {
+    pub settings: ParkSettings,
+    pub registry: ParkRegistry,
+    pub webhooks: Option<siphon_ai_webhooks::WebhookSinkHandle>,
+}
+
+impl std::fmt::Debug for ParkContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ParkContext")
+            .field("settings", &self.settings)
+            .field("webhooks", &self.webhooks.is_some())
+            .finish()
+    }
+}
+
+/// Why a park was refused.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ParkError {
+    #[error("[park].max_parked reached ({max_parked})")]
+    AtCapacity { max_parked: usize },
+}
+
+/// One parked call's metadata.
+#[derive(Debug, Clone)]
+struct ParkedEntry {
+    slot: Option<String>,
+    parked_at: Instant,
+}
+
+/// A parked call in the `GET /admin/v1/parked` view.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParkSnapshot {
+    pub call_id: String,
+    pub slot: Option<String>,
+    /// Whole seconds the call has been parked.
+    pub parked_secs: u64,
+}
+
+/// Process-wide parked-call table. Cheap to clone (`Arc` inside).
+#[derive(Debug, Clone)]
+pub struct ParkRegistry {
+    max_parked: usize,
+    inner: Arc<RwLock<HashMap<String, ParkedEntry>>>,
+}
+
+impl ParkRegistry {
+    pub fn new(max_parked: usize) -> Self {
+        Self {
+            max_parked,
+            inner: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Register `call_id` as parked, enforcing `max_parked`. Called by
+    /// the controller when it enters the parked state.
+    pub fn try_park(&self, call_id: &str, slot: Option<String>) -> Result<(), ParkError> {
+        let mut guard = self.inner.write();
+        // A re-park of an already-parked id (shouldn't happen — the
+        // controller guards on its own `parked` flag) just refreshes
+        // the entry and doesn't count against the cap.
+        if !guard.contains_key(call_id) && guard.len() >= self.max_parked {
+            return Err(ParkError::AtCapacity {
+                max_parked: self.max_parked,
+            });
+        }
+        guard.insert(
+            call_id.to_string(),
+            ParkedEntry {
+                slot,
+                parked_at: Instant::now(),
+            },
+        );
+        debug!(call_id, parked = guard.len(), "call parked");
+        Ok(())
+    }
+
+    /// True if `call_id` is currently parked — the admin retrieve path
+    /// checks this before signalling the call.
+    pub fn is_parked(&self, call_id: &str) -> bool {
+        self.inner.read().contains_key(call_id)
+    }
+
+    /// Drop the entry on retrieve / teardown. Unknown id is a no-op
+    /// (teardown paths may race).
+    pub fn remove(&self, call_id: &str) {
+        if self.inner.write().remove(call_id).is_some() {
+            debug!(call_id, "call unparked");
+        } else {
+            // Not an error, but worth a trace-level note for races.
+            warn!(call_id, "park remove for an unknown call (already gone)");
+        }
+    }
+
+    /// Live parked count.
+    pub fn len(&self) -> usize {
+        self.inner.read().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.read().is_empty()
+    }
+
+    /// Snapshot for `GET /admin/v1/parked`. Sorted by `call_id`.
+    pub fn snapshot(&self) -> Vec<ParkSnapshot> {
+        let mut rows: Vec<ParkSnapshot> = self
+            .inner
+            .read()
+            .iter()
+            .map(|(id, e)| ParkSnapshot {
+                call_id: id.clone(),
+                slot: e.slot.clone(),
+                parked_secs: e.parked_at.elapsed().as_secs(),
+            })
+            .collect();
+        rows.sort_by(|a, b| a.call_id.cmp(&b.call_id));
+        rows
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn try_park_enforces_cap() {
+        let reg = ParkRegistry::new(2);
+        assert!(reg.try_park("a", None).is_ok());
+        assert!(reg.try_park("b", Some("lot-1".into())).is_ok());
+        assert_eq!(
+            reg.try_park("c", None).unwrap_err(),
+            ParkError::AtCapacity { max_parked: 2 }
+        );
+        assert_eq!(reg.len(), 2);
+    }
+
+    #[test]
+    fn re_park_same_id_does_not_count_against_cap() {
+        let reg = ParkRegistry::new(1);
+        assert!(reg.try_park("a", None).is_ok());
+        // Same id again — refresh, still under cap.
+        assert!(reg.try_park("a", Some("lot-2".into())).is_ok());
+        assert_eq!(reg.len(), 1);
+    }
+
+    #[test]
+    fn remove_frees_a_slot() {
+        let reg = ParkRegistry::new(1);
+        reg.try_park("a", None).unwrap();
+        assert!(reg.try_park("b", None).is_err());
+        reg.remove("a");
+        assert!(reg.try_park("b", None).is_ok());
+    }
+
+    #[test]
+    fn snapshot_lists_parked_calls_sorted() {
+        let reg = ParkRegistry::new(8);
+        reg.try_park("z", None).unwrap();
+        reg.try_park("a", Some("lot-3".into())).unwrap();
+        let snap = reg.snapshot();
+        assert_eq!(snap.len(), 2);
+        assert_eq!(snap[0].call_id, "a");
+        assert_eq!(snap[0].slot.as_deref(), Some("lot-3"));
+        assert_eq!(snap[1].call_id, "z");
+    }
+
+    #[test]
+    fn is_parked_tracks_membership() {
+        let reg = ParkRegistry::new(4);
+        assert!(!reg.is_parked("a"));
+        reg.try_park("a", None).unwrap();
+        assert!(reg.is_parked("a"));
+        reg.remove("a");
+        assert!(!reg.is_parked("a"));
+    }
+}

--- a/crates/core/src/park_admin.rs
+++ b/crates/core/src/park_admin.rs
@@ -1,0 +1,110 @@
+//! Admin park CRUD — the core-side impl of [`ParkAdminHandle`]
+//! (DEV_PLAN_0.7.0.md §2.4).
+//!
+//! Mirrors [`ConferenceAdmin`](crate::ConferenceAdmin): it ties the
+//! daemon-wide [`ParkRegistry`] (the parked-call list + cap) to the
+//! [`CallControlRegistry`] (resolve any active call by bridge id and
+//! signal it). `park` / `retrieve` are dispatch-and-return (202): the
+//! admin signals the call's [`CallHandle`](crate::CallHandle) and the
+//! call's own controller does the work (§4.4) — the outcome surfaces on
+//! the call's WS + the `call_parked` / `call_retrieved` webhooks.
+
+use siphon_ai_telemetry::{ParkAdminError, ParkAdminHandle, ParkedRow};
+
+use crate::park::ParkRegistry;
+use crate::registry::CallControlRegistry;
+
+/// Wires the park registry + the bridge-id call-control registry into
+/// the admin trait. Cheap to clone (both inner registries are
+/// `Arc`-backed).
+#[derive(Clone)]
+pub struct ParkAdmin {
+    park: ParkRegistry,
+    control: CallControlRegistry,
+}
+
+impl ParkAdmin {
+    pub fn new(park: ParkRegistry, control: CallControlRegistry) -> Self {
+        Self { park, control }
+    }
+}
+
+impl ParkAdminHandle for ParkAdmin {
+    fn list(&self) -> Vec<ParkedRow> {
+        self.park
+            .snapshot()
+            .into_iter()
+            .map(|s| ParkedRow {
+                call_id: s.call_id,
+                slot: s.slot,
+                parked_secs: s.parked_secs,
+            })
+            .collect()
+    }
+
+    fn park(&self, call_id: &str, slot: Option<String>) -> Result<(), ParkAdminError> {
+        // Resolve the target call and signal it to park. The cap is
+        // enforced inside the controller's park path (ParkRegistry::
+        // try_park); a refusal surfaces on the call's WS, not here. We
+        // only confirm the call exists.
+        match self.control.lookup(call_id) {
+            Some(handle) => {
+                handle.request_park(slot);
+                Ok(())
+            }
+            None => Err(ParkAdminError::UnknownCall(call_id.to_string())),
+        }
+    }
+
+    fn retrieve(&self, call_id: &str, ws_url: Option<String>) -> Result<(), ParkAdminError> {
+        // Resolve the call; reject if it isn't actually parked (a
+        // retrieve on a live call is operator error worth a 409, not a
+        // silent no-op).
+        let Some(handle) = self.control.lookup(call_id) else {
+            return Err(ParkAdminError::UnknownCall(call_id.to_string()));
+        };
+        if !self.park.is_parked(call_id) {
+            return Err(ParkAdminError::NotParked(call_id.to_string()));
+        }
+        handle.request_retrieve(ws_url);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn admin(max_parked: usize) -> ParkAdmin {
+        ParkAdmin::new(ParkRegistry::new(max_parked), CallControlRegistry::new())
+    }
+
+    #[test]
+    fn park_unknown_call_is_not_found() {
+        let a = admin(8);
+        assert_eq!(
+            a.park("ghost", None).unwrap_err(),
+            ParkAdminError::UnknownCall("ghost".into())
+        );
+    }
+
+    #[test]
+    fn retrieve_unknown_call_is_not_found() {
+        let a = admin(8);
+        assert_eq!(
+            a.retrieve("ghost", None).unwrap_err(),
+            ParkAdminError::UnknownCall("ghost".into())
+        );
+    }
+
+    #[test]
+    fn list_reflects_registry() {
+        let park = ParkRegistry::new(8);
+        park.try_park("siphon-a", Some("lot-1".into())).unwrap();
+        let a = ParkAdmin::new(park, CallControlRegistry::new());
+        let rows = a.list();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].call_id, "siphon-a");
+        assert_eq!(rows[0].slot.as_deref(), Some("lot-1"));
+    }
+}

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -436,11 +436,13 @@ mod tests {
                 },
                 srtp: None,
                 verstat: None,
+                retrieved: false,
             },
             media_tap: tap,
             transfer: None,
             recording: None,
             conference: None,
+            park: None,
         };
         let (controller, handle) = CallController::new(cfg);
         // Drop the controller without running it; the handle still

--- a/crates/core/tests/controller_lifecycle.rs
+++ b/crates/core/tests/controller_lifecycle.rs
@@ -24,6 +24,7 @@ use siphon_ai_bridge::{
 };
 use siphon_ai_core::{
     CallController, CallControllerConfig, CallTermination, ConferenceLimits, ConferenceRegistry,
+    ParkContext, ParkRegistry, ParkSettings, ParkTimeoutAction,
 };
 use siphon_ai_media_glue::MediaTap;
 use tokio::net::TcpListener;
@@ -55,6 +56,7 @@ fn start_msg(call_id: &str) -> StartMsg {
         },
         srtp: None,
         verstat: None,
+        retrieved: false,
     }
 }
 
@@ -94,13 +96,30 @@ fn echo_subprotocol(
 }
 
 fn make_controller(port: u16, call_id: &str) -> (CallController, siphon_ai_core::CallHandle) {
-    make_controller_with_conference(port, call_id, None)
+    make_controller_full(port, call_id, None, None)
 }
 
 fn make_controller_with_conference(
     port: u16,
     call_id: &str,
     conference: Option<ConferenceRegistry>,
+) -> (CallController, siphon_ai_core::CallHandle) {
+    make_controller_full(port, call_id, conference, None)
+}
+
+fn make_controller_with_park(
+    port: u16,
+    call_id: &str,
+    park: ParkContext,
+) -> (CallController, siphon_ai_core::CallHandle) {
+    make_controller_full(port, call_id, None, Some(park))
+}
+
+fn make_controller_full(
+    port: u16,
+    call_id: &str,
+    conference: Option<ConferenceRegistry>,
+    park: Option<ParkContext>,
 ) -> (CallController, siphon_ai_core::CallHandle) {
     let manager = Arc::new(MediaBridgeManager::new());
     let tap = MediaTap::attach(
@@ -128,8 +147,24 @@ fn make_controller_with_conference(
         transfer: None,
         recording: None,
         conference,
+        park,
     };
     CallController::new(cfg)
+}
+
+/// A park context for tests: an enabled registry, no MOH file (comfort
+/// noise — no fixture needed), no webhook sink, and a caller-supplied
+/// timeout policy.
+fn test_park_ctx(timeout: Option<Duration>, action: ParkTimeoutAction) -> ParkContext {
+    ParkContext {
+        settings: ParkSettings {
+            moh_file: None,
+            timeout,
+            timeout_action: action,
+        },
+        registry: ParkRegistry::new(8),
+        webhooks: None,
+    }
 }
 
 /// An enabled registry for the conference round-trip tests.
@@ -387,4 +422,136 @@ async fn conference_join_then_leave_round_trip() {
         make_controller_with_conference(port, "conf-2", Some(enabled_conference()));
     let outcome = controller.run().await.expect("run");
     assert_eq!(outcome.termination, CallTermination::BridgeEnded);
+}
+
+// ─── Park / retrieve (0.7.0) ─────────────────────────────────────────
+
+#[tokio::test]
+async fn park_then_retrieve_round_trip() {
+    // Park detaches the WS (the bridge sends `stop{park}` and closes)
+    // while the controller stays alive on MOH; retrieve opens a *fresh*
+    // WS that receives `start{retrieved:true}`. Two one-shot servers
+    // model the pre-park and post-retrieve sessions; the call ends
+    // normally when the retrieved session closes.
+    let (a_done_tx, a_done_rx) = tokio::sync::oneshot::channel::<bool>();
+    let port_a = one_shot_server(move |mut ws| async move {
+        let _ = ws.next().await; // drain start
+                                 // Read until the bridge closes the WS for the park; record
+                                 // whether we saw the `stop{park}` first.
+        let mut saw_park_stop = false;
+        while let Some(msg) = ws.next().await {
+            if let Ok(Message::Text(t)) = msg {
+                let v: Value = serde_json::from_str(&t).expect("json");
+                if v["type"] == "stop" && v["reason"] == "park" {
+                    saw_park_stop = true;
+                }
+            }
+        }
+        let _ = a_done_tx.send(saw_park_stop);
+    })
+    .await;
+
+    let (b_seen_tx, b_seen_rx) = tokio::sync::oneshot::channel::<bool>();
+    let port_b = one_shot_server(move |mut ws| async move {
+        // The retrieved session's `start` must carry `retrieved: true`.
+        let retrieved = match ws.next().await {
+            Some(Ok(Message::Text(t))) => {
+                let v: Value = serde_json::from_str(&t).expect("json");
+                assert_eq!(v["type"], "start");
+                v["retrieved"] == serde_json::json!(true)
+            }
+            other => panic!("retrieved session sent no start: {other:?}"),
+        };
+        let _ = b_seen_tx.send(retrieved);
+        ws.close(None).await.ok();
+    })
+    .await;
+
+    let (controller, handle) = make_controller_with_park(
+        port_a,
+        "park-1",
+        test_park_ctx(None, ParkTimeoutAction::Hangup),
+    );
+    let run = tokio::spawn(controller.run());
+
+    // Park, then wait until server A has actually seen the park stop +
+    // close before retrieving — deterministic ordering, no sleeps.
+    handle.request_park(Some("lot-1".into()));
+    assert!(
+        a_done_rx.await.expect("server A signalled"),
+        "pre-park session should have observed stop{{park}}"
+    );
+
+    handle.request_retrieve(Some(format!("ws://127.0.0.1:{port_b}/")));
+    assert!(
+        b_seen_rx.await.expect("server B signalled"),
+        "retrieved start must set retrieved=true"
+    );
+
+    let outcome = run.await.expect("join").expect("run");
+    assert_eq!(outcome.termination, CallTermination::BridgeEnded);
+    let park = outcome.park.expect("park summary present");
+    assert_eq!(park.count, 1, "one park episode");
+}
+
+#[tokio::test]
+async fn park_timeout_hangup_tears_down() {
+    // A parked call with `timeout_action = hangup` tears down when the
+    // deadline fires (no retrieve, no caller BYE) → `LocalShutdown`.
+    //
+    // Timing note: this harness has no real RTP feeding forge, so the
+    // tap's inbound stream ends on its own (`CallEnded`) ~tens of ms
+    // into a sustained park. We use a near-immediate deadline so the
+    // park-timeout arm — which precedes the tap arm in the controller's
+    // `biased` select — fires first, deterministically. A production
+    // call has continuous RTP, so the tap never ends mid-park and any
+    // real `timeout_secs` applies.
+    let port = one_shot_server(|mut ws| async move {
+        let _ = ws.next().await; // drain start
+        while ws.next().await.is_some() {} // until park closes the WS
+    })
+    .await;
+
+    let (controller, handle) = make_controller_with_park(
+        port,
+        "park-timeout",
+        test_park_ctx(Some(Duration::from_millis(1)), ParkTimeoutAction::Hangup),
+    );
+    let run = tokio::spawn(controller.run());
+
+    handle.request_park(None);
+
+    let outcome = run.await.expect("join").expect("run");
+    assert_eq!(outcome.termination, CallTermination::LocalShutdown);
+    assert_eq!(outcome.park.expect("park summary").count, 1);
+}
+
+#[tokio::test]
+async fn caller_bye_while_parked_tears_down() {
+    // A caller BYE (modelled as handle.shutdown()) while the call is
+    // parked tears it down cleanly, with the park episode still
+    // accounted on the outcome.
+    let (a_done_tx, a_done_rx) = tokio::sync::oneshot::channel::<()>();
+    let port = one_shot_server(move |mut ws| async move {
+        let _ = ws.next().await; // drain start
+        while ws.next().await.is_some() {} // until park closes the WS
+        let _ = a_done_tx.send(());
+    })
+    .await;
+
+    let (controller, handle) = make_controller_with_park(
+        port,
+        "park-bye",
+        test_park_ctx(None, ParkTimeoutAction::Hangup),
+    );
+    let run = tokio::spawn(controller.run());
+
+    handle.request_park(None);
+    a_done_rx.await.expect("park detached the WS");
+    // Now the SIP side hangs up while parked.
+    handle.shutdown();
+
+    let outcome = run.await.expect("join").expect("run");
+    assert_eq!(outcome.termination, CallTermination::LocalShutdown);
+    assert_eq!(outcome.park.expect("park summary").count, 1);
 }

--- a/crates/core/tests/hold_resume.rs
+++ b/crates/core/tests/hold_resume.rs
@@ -103,11 +103,13 @@ async fn push_bridge_event_emits_hold_and_resume_on_ws() {
             },
             srtp: None,
             verstat: None,
+            retrieved: false,
         },
         media_tap: tap,
         transfer: None,
         recording: None,
         conference: None,
+        park: None,
     };
     let (controller, handle) = CallController::new(cfg);
     let run = tokio::spawn(async move { controller.run().await });

--- a/crates/core/tests/registry_bye.rs
+++ b/crates/core/tests/registry_bye.rs
@@ -125,11 +125,13 @@ async fn dispatch_bye_wakes_running_controller_via_registry() {
             },
             srtp: None,
             verstat: None,
+            retrieved: false,
         },
         media_tap: tap,
         transfer: None,
         recording: None,
         conference: None,
+        park: None,
     };
     let (controller, handle) = CallController::new(cfg);
 
@@ -212,11 +214,13 @@ async fn bye_drives_wire_stop_with_caller_hangup_reason() {
             },
             srtp: None,
             verstat: None,
+            retrieved: false,
         },
         media_tap: tap,
         transfer: None,
         recording: None,
         conference: None,
+        park: None,
     };
     let (controller, handle) = CallController::new(cfg);
 

--- a/crates/media-glue/src/lib.rs
+++ b/crates/media-glue/src/lib.rs
@@ -8,12 +8,14 @@
 //! mandate, no `unwrap`/`panic`, no `std::sync::Mutex`, no blocking I/O.
 
 pub(crate) mod idle;
+pub mod moh;
 pub mod room;
 pub(crate) mod rtp_stats;
 pub mod sdp;
 pub mod setup;
 pub mod tap;
 
+pub use moh::MohSource;
 pub use room::{
     spawn_room, RoomConfig, RoomEvent, RoomHandle, RoomJoinError, RoomLifecycle, RoomMembership,
     RoomObserver,

--- a/crates/media-glue/src/moh.rs
+++ b/crates/media-glue/src/moh.rs
@@ -1,0 +1,163 @@
+//! Music-on-hold source for parked calls (DEV_PLAN_0.7.0.md §2.4).
+//!
+//! Built per-park at the call's negotiated rate. Produces an *infinite*
+//! 20 ms PCM16 stream so the tap's park loop never has to handle an
+//! end-of-stream:
+//!
+//! - `[park].moh_file` set **and** its native rate matches the call →
+//!   a looping [`forge_injection::FileSource`] (on end-of-file it
+//!   `reset()`s to the top and keeps going).
+//! - file unset / rate mismatch (forge has no resampler) / open error →
+//!   [`forge_injection::ToneGenerator::comfort_noise`] at the call's
+//!   rate. A rate mismatch logs once at `info` and falls back; it is
+//!   **not** a park failure (§4 of the design note).
+//!
+//! `next_frame` never errors and never panics — the looping + fallback
+//! guarantee a frame every time, so the parked caller always hears
+//! *something* (hold music, comfort noise, or — only on a truly broken
+//! decoder mid-loop — silence).
+
+use std::path::Path;
+
+use forge_injection::{AudioSource, FileSource, ToneGenerator};
+use tracing::{debug, info};
+
+/// Per-call hold-music generator. See the module docs.
+pub struct MohSource {
+    inner: Inner,
+    /// Samples per 20 ms frame at the call's rate (160 @ 8 k, 320 @ 16 k).
+    frame_samples: usize,
+    /// The call's rate — used to synthesize a silence frame on the
+    /// (should-never-happen) double-decode-failure path.
+    sample_rate: u32,
+}
+
+enum Inner {
+    /// Looping file playback.
+    File(FileSource),
+    /// Infinite comfort noise (or silence) — the fallback.
+    Tone(ToneGenerator),
+}
+
+impl MohSource {
+    /// Build the MOH source for a call at `sample_rate`. `moh_file`
+    /// `None` (or any load/rate problem) yields comfort noise.
+    pub fn new(moh_file: Option<&Path>, sample_rate: u32) -> Self {
+        let frame_samples = (sample_rate / 1000) as usize * 20;
+        let inner = match moh_file {
+            Some(path) => Self::open_file(path, sample_rate)
+                .unwrap_or_else(|| Inner::Tone(ToneGenerator::comfort_noise(sample_rate))),
+            None => Inner::Tone(ToneGenerator::comfort_noise(sample_rate)),
+        };
+        Self {
+            inner,
+            frame_samples,
+            sample_rate,
+        }
+    }
+
+    /// Try to open `path` as a looping source at `sample_rate`. `None`
+    /// on any failure (caller falls back to comfort noise) — forge has
+    /// no resampler, so a rate mismatch is a `None` here, by design.
+    fn open_file(path: &Path, sample_rate: u32) -> Option<Inner> {
+        match FileSource::open_trusted(path).and_then(|f| f.with_sample_rate(sample_rate)) {
+            Ok(f) => {
+                debug!(path = %path.display(), sample_rate, "MOH file opened");
+                Some(Inner::File(f))
+            }
+            Err(e) => {
+                info!(
+                    path = %path.display(),
+                    sample_rate,
+                    error = %e,
+                    "MOH file unusable at call rate; falling back to comfort noise"
+                );
+                None
+            }
+        }
+    }
+
+    /// One 20 ms PCM16 frame. Never errors: a file source loops at EOF,
+    /// the tone source is infinite, and the worst case is a silence
+    /// frame (a decoder that fails even after a reset).
+    pub fn next_frame(&mut self) -> Vec<i16> {
+        let n = self.frame_samples;
+        match &mut self.inner {
+            Inner::Tone(t) => t.read_frame(n).unwrap_or_else(|_| self.silence()),
+            Inner::File(f) => match f.read_frame(n) {
+                // A full frame mid-file.
+                Ok(frame) if frame.len() == n => frame,
+                // Short read or EOF → loop: reset and read a fresh
+                // frame from the top. (The brief boundary glitch is
+                // inaudible in hold music.)
+                _ => {
+                    if f.reset().is_err() {
+                        return self.silence();
+                    }
+                    f.read_frame(n).unwrap_or_else(|_| vec![0i16; n])
+                }
+            },
+        }
+    }
+
+    fn silence(&self) -> Vec<i16> {
+        vec![0i16; self.frame_samples]
+    }
+
+    /// The call rate this source produces at — used by the tap to
+    /// sanity-check it matches the forge session.
+    pub fn sample_rate(&self) -> u32 {
+        self.sample_rate
+    }
+}
+
+impl std::fmt::Debug for MohSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MohSource")
+            .field(
+                "kind",
+                &match self.inner {
+                    Inner::File(_) => "file",
+                    Inner::Tone(_) => "tone",
+                },
+            )
+            .field("sample_rate", &self.sample_rate)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn comfort_noise_when_no_file() {
+        let mut moh = MohSource::new(None, 8000);
+        let frame = moh.next_frame();
+        assert_eq!(frame.len(), 160);
+        // Comfort noise is non-silent.
+        assert!(frame.iter().any(|&s| s != 0));
+    }
+
+    #[test]
+    fn frame_size_tracks_rate() {
+        let mut moh16 = MohSource::new(None, 16000);
+        assert_eq!(moh16.next_frame().len(), 320);
+    }
+
+    #[test]
+    fn missing_file_falls_back_to_comfort_noise() {
+        let mut moh = MohSource::new(Some(Path::new("/nonexistent/x.wav")), 8000);
+        let frame = moh.next_frame();
+        assert_eq!(frame.len(), 160);
+        assert!(matches!(moh.inner, Inner::Tone(_)));
+    }
+
+    #[test]
+    fn produces_frames_indefinitely() {
+        let mut moh = MohSource::new(None, 8000);
+        for _ in 0..1000 {
+            assert_eq!(moh.next_frame().len(), 160);
+        }
+    }
+}

--- a/crates/media-glue/src/tap.rs
+++ b/crates/media-glue/src/tap.rs
@@ -192,6 +192,23 @@ pub enum TapCommand {
     /// Leave the current room and restore the direct caller↔WS
     /// pair. A no-op when not in a room.
     LeaveRoom,
+
+    /// Park the call (0.7.0 §2.4): stop using the WS-facing channels
+    /// and play `moh` into the caller leg on a 20 ms tick; drop inbound
+    /// caller frames (there's no WS to forward to). The forge media
+    /// session + RTP stay up. Pairs with [`TapCommand::Unpark`]. A
+    /// `Park` while in a room leaves the room first.
+    Park { moh: Box<crate::moh::MohSource> },
+
+    /// Retrieve a parked call: stop the MOH tick and swap the tap's
+    /// WS-facing endpoints to the fresh ones from the retrieve's new
+    /// bridge, resuming the direct caller↔WS pair. A no-op if not
+    /// parked.
+    Unpark {
+        caller_audio_tx: mpsc::Sender<Vec<u8>>,
+        playout_audio_rx: mpsc::Receiver<Vec<u8>>,
+        events_tx: mpsc::Sender<OutgoingEvent>,
+    },
 }
 
 /// How the tap reacts to forge-vad `SpeechStarted` events. Mirrors
@@ -435,6 +452,16 @@ impl MediaTap {
         events_tx: mpsc::Sender<OutgoingEvent>,
         mut commands_rx: mpsc::Receiver<TapCommand>,
     ) -> Result<TapDisconnect, MediaTapError> {
+        // The WS-facing endpoints are `mut` locals so a park→retrieve
+        // can swap them to a fresh bridge's channels (`TapCommand::Unpark`).
+        let mut caller_audio_tx = caller_audio_tx;
+        let mut events_tx = events_tx;
+        // Park state (0.7.0 §2.4). `Some(moh)` = the WS session is
+        // detached and the caller hears hold music on a 20 ms tick;
+        // caller audio is dropped. Installed by `TapCommand::Park`,
+        // cleared by `TapCommand::Unpark`.
+        let mut parked: Option<crate::moh::MohSource> = None;
+
         let mut reframer = Reframer::new(self.sample_rate)?;
         // Play-out estimation state for `TapCommand::Mark`.
         // Updated in the playout arm; read in the command arm.
@@ -486,14 +513,22 @@ impl MediaTap {
         rtp_stats_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         rtp_stats_tick.tick().await;
 
+        // MOH playout cadence — 20 ms, monotonic (CLAUDE §4.3), active
+        // only while parked. Same placeholder-interval pattern as the
+        // other optional ticks; the arm guard suppresses it otherwise.
+        let mut moh_tick = tokio::time::interval(Duration::from_millis(PLAYOUT_FRAME_MS));
+        moh_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        moh_tick.tick().await;
+
         loop {
             tokio::select! {
                 biased;
 
                 // Controller dropped the caller_audio_tx receiver →
                 // tear down immediately, even if no inbound frame is
-                // pending.
-                _ = caller_audio_tx.closed() => {
+                // pending. Suppressed while parked: the WS bridge (and
+                // thus this channel's receiver) is intentionally gone.
+                _ = caller_audio_tx.closed(), if parked.is_none() => {
                     debug!("caller_audio_tx receiver dropped; ending tap");
                     return Ok(TapDisconnect::ControllerHungUp);
                 }
@@ -513,7 +548,9 @@ impl MediaTap {
                 }
 
                 // Server → caller: bytes from the WS into forge's playout.
-                playout = playout_audio_rx.recv() => {
+                // Suppressed while parked — there's no WS, and the MOH
+                // tick owns playout instead.
+                playout = playout_audio_rx.recv(), if parked.is_none() => {
                     let Some(bytes) = playout else {
                         debug!("playout_audio_rx closed; ending tap");
                         return Ok(TapDisconnect::ControllerHungUp);
@@ -602,6 +639,21 @@ impl MediaTap {
                     }
                     reframer.push(&frame.samples);
                     while let Some(samples) = reframer.pop_frame() {
+                        // Parked: there's no WS to forward to. Keep
+                        // recording the caller's own voice (left
+                        // channel) but drop the frame otherwise — the
+                        // caller hears MOH (the moh_tick arm), not
+                        // themselves.
+                        if parked.is_some() {
+                            if let Some((rec, drops)) = &self.recording {
+                                if let Err(mpsc::error::TrySendError::Full(_)) =
+                                    rec.try_send(RecFrame::Caller(pack_pcm16_le(&samples)))
+                                {
+                                    drops.fetch_add(1, Ordering::Relaxed);
+                                }
+                            }
+                            continue;
+                        }
                         // In a room, caller frames feed the `sip`
                         // participant; the WS instead receives the
                         // room's mix-minus-`ws` sink (arm below).
@@ -1034,6 +1086,43 @@ impl MediaTap {
                                 }
                             }
                         }
+                        TapCommand::Park { moh } => {
+                            // Parking while in a room first leaves it
+                            // (drops the RoomSender → the room reaps us).
+                            if let Some(send) = room_send.take() {
+                                drop(send);
+                                room_sip_out = None;
+                                room_ws_out = None;
+                                room_events = None;
+                            }
+                            info!(
+                                call_id = %self.call_id,
+                                "tap parked; playing hold music, WS detached"
+                            );
+                            parked = Some(*moh);
+                            // Align the MOH cadence to now so the first
+                            // frame plays ~20 ms from here, not whenever
+                            // the free-running interval next ticks.
+                            moh_tick.reset();
+                        }
+                        TapCommand::Unpark {
+                            caller_audio_tx: new_caller_tx,
+                            playout_audio_rx: new_playout_rx,
+                            events_tx: new_events_tx,
+                        } => {
+                            if parked.take().is_some() {
+                                // Swap to the fresh bridge's channels.
+                                caller_audio_tx = new_caller_tx;
+                                playout_audio_rx = new_playout_rx;
+                                events_tx = new_events_tx;
+                                frames_sent_to_forge = 0;
+                                first_audio_pushed_at = None;
+                                info!(
+                                    call_id = %self.call_id,
+                                    "tap retrieved; direct bridge restored on fresh WS session"
+                                );
+                            }
+                        }
                     }
                 }
 
@@ -1093,6 +1182,34 @@ impl MediaTap {
                             error = %e,
                             "events_tx full or closed; dropping rtp_stats event"
                         );
+                    }
+                }
+
+                // MOH playout while parked: one hold-music frame per
+                // 20 ms into the caller leg. Active only when parked.
+                _ = moh_tick.tick(), if parked.is_some() => {
+                    if let Some(moh) = parked.as_mut() {
+                        let samples = moh.next_frame();
+                        // Recording right channel = what the caller
+                        // hears = the hold music.
+                        if let Some((rec, drops)) = &self.recording {
+                            if let Err(mpsc::error::TrySendError::Full(_)) =
+                                rec.try_send(RecFrame::Bot(pack_pcm16_le(&samples)))
+                            {
+                                drops.fetch_add(1, Ordering::Relaxed);
+                            }
+                        }
+                        let frame = OutboundMediaFrame {
+                            target: MediaTarget::A,
+                            sample_rate: self.sample_rate,
+                            samples,
+                            playback_id: None,
+                            mode: PlayoutMode::Append,
+                        };
+                        self.handle
+                            .send_audio(frame)
+                            .await
+                            .map_err(|e| MediaTapError::PlayoutFailed(e.to_string()))?;
                     }
                 }
             }

--- a/crates/telemetry/src/admin.rs
+++ b/crates/telemetry/src/admin.rs
@@ -20,6 +20,9 @@
 //! | DELETE | `/admin/v1/conferences/:id`   | Force-end a room (0.7.0)             |
 //! | POST   | `/admin/v1/conferences/:id/participants`           | Add a call to a room (0.7.0)  |
 //! | DELETE | `/admin/v1/conferences/:id/participants/:call_id`  | Remove a call (0.7.0)         |
+//! | GET    | `/admin/v1/parked`            | List parked calls (0.7.0)            |
+//! | POST   | `/admin/v1/calls/:id/park`    | Park a call (0.7.0)                  |
+//! | POST   | `/admin/v1/calls/:id/retrieve`| Retrieve a parked call (0.7.0)       |
 //!
 //! ## Threat model
 //!
@@ -65,6 +68,9 @@ pub struct AdminState {
     /// Conference admin handle (0.7.0). `None` when `[conference]` is
     /// disabled — the `/admin/v1/conferences` routes then return 501.
     pub conference: Option<AdminConference>,
+    /// Park admin handle (0.7.0). `None` when `[park]` is disabled —
+    /// the park/retrieve/parked routes then return 501.
+    pub park: Option<AdminPark>,
 }
 
 /// Minimal trait surface the admin endpoints need on the call
@@ -194,6 +200,55 @@ pub trait ConferenceAdminHandle: Send + Sync + 'static {
 /// Boxed handle the runtime installs into [`AdminState`].
 pub type AdminConference = Arc<dyn ConferenceAdminHandle>;
 
+/// One parked call in the `GET /admin/v1/parked` response.
+#[derive(Debug, Clone, Serialize)]
+pub struct ParkedRow {
+    pub call_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub slot: Option<String>,
+    pub parked_secs: u64,
+}
+
+/// `POST /admin/v1/calls/:id/park` body (all optional).
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ParkRequest {
+    #[serde(default)]
+    pub slot: Option<String>,
+}
+
+/// `POST /admin/v1/calls/:id/retrieve` body (all optional).
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct RetrieveRequest {
+    /// Redirect the retrieved session to a different WS server.
+    /// Defaults to the call's original `ws_url`.
+    #[serde(default)]
+    pub ws_url: Option<String>,
+}
+
+/// Why a park-admin op was refused.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParkAdminError {
+    /// Park is off (`[park].enabled = false`) → 501.
+    Disabled,
+    /// No active call with that bridge id → 404.
+    UnknownCall(String),
+    /// Retrieve named a call that isn't parked → 409.
+    NotParked(String),
+}
+
+/// The park admin entry point (0.7.0). Like the conference handle,
+/// `park`/`retrieve` are fire-and-forget: they signal the target call
+/// (which acts on its own state) and return `202`; the outcome surfaces
+/// on the call's WS + the `call_parked` / `call_retrieved` webhooks.
+pub trait ParkAdminHandle: Send + Sync + 'static {
+    fn list(&self) -> Vec<ParkedRow>;
+    fn park(&self, call_id: &str, slot: Option<String>) -> Result<(), ParkAdminError>;
+    fn retrieve(&self, call_id: &str, ws_url: Option<String>) -> Result<(), ParkAdminError>;
+}
+
+/// Boxed handle the runtime installs into [`AdminState`].
+pub type AdminPark = Arc<dyn ParkAdminHandle>;
+
 /// One row of the `GET /admin/registrations` response. Mirrors
 /// `sip_glue::RegistrationState` but defined here so telemetry
 /// doesn't depend on the upstream crate.
@@ -231,6 +286,29 @@ pub async fn dispatch(
         (&hyper::Method::POST, "/admin/v1/calls") => originate_call(state, &body),
         (&hyper::Method::GET, "/admin/v1/conferences") => list_conferences(state),
         (&hyper::Method::POST, "/admin/v1/conferences") => create_conference(state, &body),
+        (&hyper::Method::GET, "/admin/v1/parked") => list_parked(state),
+        (m, p)
+            if *m == hyper::Method::POST
+                && p.starts_with("/admin/v1/calls/")
+                && p.ends_with("/park") =>
+        {
+            let id = p
+                .strip_prefix("/admin/v1/calls/")
+                .and_then(|s| s.strip_suffix("/park"))
+                .unwrap_or("");
+            park_call(state, id, &body)
+        }
+        (m, p)
+            if *m == hyper::Method::POST
+                && p.starts_with("/admin/v1/calls/")
+                && p.ends_with("/retrieve") =>
+        {
+            let id = p
+                .strip_prefix("/admin/v1/calls/")
+                .and_then(|s| s.strip_suffix("/retrieve"))
+                .unwrap_or("");
+            retrieve_call(state, id, &body)
+        }
         (m, p)
             if m == hyper::Method::POST
                 && p.starts_with("/admin/calls/")
@@ -588,6 +666,94 @@ fn conference_error_response(e: ConferenceAdminError) -> Response<Full<Bytes>> {
         ConferenceAdminError::UnknownCall(c) => {
             (StatusCode::NOT_FOUND, format!("no active call: {c}"))
         }
+    };
+    json_response(status, &json!({ "error": msg }))
+}
+
+// ─── Park admin (0.7.0) ────────────────────────────────────────────
+
+fn list_parked(state: &AdminState) -> Response<Full<Bytes>> {
+    let Some(svc) = state.park.as_ref() else {
+        return park_disabled();
+    };
+    let parked = svc.list();
+    json_response(
+        StatusCode::OK,
+        &json!({ "count": parked.len(), "parked": parked }),
+    )
+}
+
+fn park_call(state: &AdminState, call_id: &str, body: &Bytes) -> Response<Full<Bytes>> {
+    let Some(svc) = state.park.as_ref() else {
+        return park_disabled();
+    };
+    if call_id.is_empty() {
+        return json_response(
+            StatusCode::BAD_REQUEST,
+            &json!({ "error": "empty call_id" }),
+        );
+    }
+    // Empty body allowed (slot optional).
+    let req: ParkRequest = if body.is_empty() {
+        ParkRequest::default()
+    } else {
+        match serde_json::from_slice(body) {
+            Ok(r) => r,
+            Err(e) => {
+                return json_response(
+                    StatusCode::BAD_REQUEST,
+                    &json!({ "error": format!("invalid park request: {e}") }),
+                )
+            }
+        }
+    };
+    match svc.park(call_id, req.slot) {
+        Ok(()) => json_response(StatusCode::ACCEPTED, &json!({ "call_id": call_id })),
+        Err(e) => park_error_response(e),
+    }
+}
+
+fn retrieve_call(state: &AdminState, call_id: &str, body: &Bytes) -> Response<Full<Bytes>> {
+    let Some(svc) = state.park.as_ref() else {
+        return park_disabled();
+    };
+    if call_id.is_empty() {
+        return json_response(
+            StatusCode::BAD_REQUEST,
+            &json!({ "error": "empty call_id" }),
+        );
+    }
+    let req: RetrieveRequest = if body.is_empty() {
+        RetrieveRequest::default()
+    } else {
+        match serde_json::from_slice(body) {
+            Ok(r) => r,
+            Err(e) => {
+                return json_response(
+                    StatusCode::BAD_REQUEST,
+                    &json!({ "error": format!("invalid retrieve request: {e}") }),
+                )
+            }
+        }
+    };
+    match svc.retrieve(call_id, req.ws_url) {
+        Ok(()) => json_response(StatusCode::ACCEPTED, &json!({ "call_id": call_id })),
+        Err(e) => park_error_response(e),
+    }
+}
+
+fn park_disabled() -> Response<Full<Bytes>> {
+    json_response(
+        StatusCode::NOT_IMPLEMENTED,
+        &json!({ "error": "park not enabled ([park].enabled = false)" }),
+    )
+}
+
+fn park_error_response(e: ParkAdminError) -> Response<Full<Bytes>> {
+    let (status, msg) = match e {
+        ParkAdminError::Disabled => return park_disabled(),
+        ParkAdminError::UnknownCall(c) => (StatusCode::NOT_FOUND, format!("no active call: {c}")),
+        ParkAdminError::NotParked(c) => (StatusCode::CONFLICT, format!("call is not parked: {c}")),
     };
     json_response(status, &json!({ "error": msg }))
 }
@@ -1056,6 +1222,164 @@ mod tests {
             "/admin/v1/conferences/r/participants/c/extra",
             "",
             &conf_state(StubConference::default()),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+
+    // ─── Park admin routes (0.7.0) ──────────────────────────────────
+
+    struct StubPark {
+        rows: Vec<ParkedRow>,
+        park: Result<(), ParkAdminError>,
+        retrieve: Result<(), ParkAdminError>,
+    }
+    impl Default for StubPark {
+        fn default() -> Self {
+            Self {
+                rows: vec![],
+                park: Ok(()),
+                retrieve: Ok(()),
+            }
+        }
+    }
+    impl ParkAdminHandle for StubPark {
+        fn list(&self) -> Vec<ParkedRow> {
+            self.rows.clone()
+        }
+        fn park(&self, _call_id: &str, _slot: Option<String>) -> Result<(), ParkAdminError> {
+            self.park.clone()
+        }
+        fn retrieve(&self, _call_id: &str, _ws_url: Option<String>) -> Result<(), ParkAdminError> {
+            self.retrieve.clone()
+        }
+    }
+
+    fn park_state(stub: StubPark) -> AdminState {
+        AdminState {
+            park: Some(Arc::new(stub) as AdminPark),
+            ..AdminState::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn parked_501_when_disabled() {
+        // All three routes return 501 with no park handle installed.
+        for (m, path) in [
+            (hyper::Method::GET, "/admin/v1/parked"),
+            (hyper::Method::POST, "/admin/v1/calls/c/park"),
+            (hyper::Method::POST, "/admin/v1/calls/c/retrieve"),
+        ] {
+            let (status, _) = conf(m, path, "", &empty_state()).await;
+            assert_eq!(status, StatusCode::NOT_IMPLEMENTED, "{path}");
+        }
+    }
+
+    #[tokio::test]
+    async fn list_parked_returns_rows() {
+        let stub = StubPark {
+            rows: vec![ParkedRow {
+                call_id: "siphon-a".into(),
+                slot: Some("lot-3".into()),
+                parked_secs: 42,
+            }],
+            ..Default::default()
+        };
+        let (status, body) = conf(
+            hyper::Method::GET,
+            "/admin/v1/parked",
+            "",
+            &park_state(stub),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["count"], 1);
+        assert_eq!(body["parked"][0]["call_id"], "siphon-a");
+        assert_eq!(body["parked"][0]["slot"], "lot-3");
+        assert_eq!(body["parked"][0]["parked_secs"], 42);
+    }
+
+    #[tokio::test]
+    async fn park_202_when_dispatched() {
+        let (status, body) = conf(
+            hyper::Method::POST,
+            "/admin/v1/calls/siphon-a/park",
+            r#"{"slot":"lot-1"}"#,
+            &park_state(StubPark::default()),
+        )
+        .await;
+        assert_eq!(status, StatusCode::ACCEPTED);
+        assert_eq!(body["call_id"], "siphon-a");
+    }
+
+    #[tokio::test]
+    async fn park_202_with_empty_body() {
+        // slot is optional — an empty body is a valid unlabeled park.
+        let (status, _) = conf(
+            hyper::Method::POST,
+            "/admin/v1/calls/siphon-a/park",
+            "",
+            &park_state(StubPark::default()),
+        )
+        .await;
+        assert_eq!(status, StatusCode::ACCEPTED);
+    }
+
+    #[tokio::test]
+    async fn park_404_unknown_call() {
+        let stub = StubPark {
+            park: Err(ParkAdminError::UnknownCall("ghost".into())),
+            ..Default::default()
+        };
+        let (status, _) = conf(
+            hyper::Method::POST,
+            "/admin/v1/calls/ghost/park",
+            "",
+            &park_state(stub),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn retrieve_202_when_dispatched() {
+        let (status, _) = conf(
+            hyper::Method::POST,
+            "/admin/v1/calls/siphon-a/retrieve",
+            r#"{"ws_url":"wss://bot.example/retrieve"}"#,
+            &park_state(StubPark::default()),
+        )
+        .await;
+        assert_eq!(status, StatusCode::ACCEPTED);
+    }
+
+    #[tokio::test]
+    async fn retrieve_409_when_not_parked() {
+        let stub = StubPark {
+            retrieve: Err(ParkAdminError::NotParked("siphon-a".into())),
+            ..Default::default()
+        };
+        let (status, _) = conf(
+            hyper::Method::POST,
+            "/admin/v1/calls/siphon-a/retrieve",
+            "",
+            &park_state(stub),
+        )
+        .await;
+        assert_eq!(status, StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn retrieve_404_unknown_call() {
+        let stub = StubPark {
+            retrieve: Err(ParkAdminError::UnknownCall("ghost".into())),
+            ..Default::default()
+        };
+        let (status, _) = conf(
+            hyper::Method::POST,
+            "/admin/v1/calls/ghost/retrieve",
+            "",
+            &park_state(stub),
         )
         .await;
         assert_eq!(status, StatusCode::NOT_FOUND);

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -27,10 +27,10 @@ pub mod metrics;
 pub mod readiness;
 
 pub use admin::{
-    AddParticipantRequest, AdminCallRegistry, AdminConference, AdminOutbound, AdminState,
-    CallRegistryHandle, ConferenceAdminError, ConferenceAdminHandle, ConferenceRow,
+    AddParticipantRequest, AdminCallRegistry, AdminConference, AdminOutbound, AdminPark,
+    AdminState, CallRegistryHandle, ConferenceAdminError, ConferenceAdminHandle, ConferenceRow,
     CreateConferenceRequest, OriginateRejection, OriginateRequest, OutboundOriginateHandle,
-    RegistrationRow,
+    ParkAdminError, ParkAdminHandle, ParkRequest, ParkedRow, RegistrationRow, RetrieveRequest,
 };
 pub use hep::{HepBuildError, HepTelemetry, HepTelemetryBuild, HepWorkerHandle};
 pub use http::ObservabilityServer;
@@ -41,9 +41,10 @@ pub use log_filter::{LogFilterError, LogFilterHandle};
 pub use metrics::{
     install_recorder, prometheus_builder, register_descriptions, InitError, CALLS_ACTIVE,
     CALLS_TOTAL, CALL_DURATION_BUCKETS, CALL_DURATION_SECONDS, INVITES_TOTAL,
-    OUTBOUND_CALLS_ACTIVE, OUTBOUND_CALLS_TOTAL, RECORDINGS_TOTAL, REGISTER_ATTEMPTS_TOTAL,
-    REGISTER_STATE, ROUTE_MATCH_TOTAL, SDP_NEGOTIATE_BUCKETS, SDP_NEGOTIATE_SECONDS,
-    TRANSFERS_TOTAL, VERSTAT_TOTAL, WS_CONNECT_BUCKETS, WS_CONNECT_SECONDS,
+    OUTBOUND_CALLS_ACTIVE, OUTBOUND_CALLS_TOTAL, PARKED_CALLS_ACTIVE, PARKS_TOTAL,
+    RECORDINGS_TOTAL, REGISTER_ATTEMPTS_TOTAL, REGISTER_STATE, RETRIEVES_TOTAL, ROUTE_MATCH_TOTAL,
+    SDP_NEGOTIATE_BUCKETS, SDP_NEGOTIATE_SECONDS, TRANSFERS_TOTAL, VERSTAT_TOTAL,
+    WS_CONNECT_BUCKETS, WS_CONNECT_SECONDS,
 };
 pub use metrics_exporter_prometheus::PrometheusHandle;
 pub use readiness::ReadinessFlag;

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -109,6 +109,16 @@ pub const CONFERENCE_JOINS_TOTAL: &str = "siphon_ai_conference_joins_total";
 /// sites in `siphon-ai-media-glue::room`.
 pub const ROOM_FRAMES_DROPPED_TOTAL: &str = "siphon_ai_room_frames_dropped_total";
 
+/// Calls parked (0.7.0). Labeled by `result`: `ok` / `rejected` (park
+/// disabled or `[park].max_parked` reached). Literal must match the
+/// call site in `siphon-ai-core::call`.
+pub const PARKS_TOTAL: &str = "siphon_ai_parks_total";
+
+/// Parked calls retrieved (0.7.0). Labeled by `result`: `ok` /
+/// `not_parked`. Literal must match the call site in
+/// `siphon-ai-core::call`.
+pub const RETRIEVES_TOTAL: &str = "siphon_ai_retrieves_total";
+
 // ─── Gauges ─────────────────────────────────────────────────────────
 
 /// Currently-active calls. Incremented when the controller spawns,
@@ -137,6 +147,10 @@ pub const CONFERENCES_ACTIVE: &str = "siphon_ai_conferences_active";
 /// contributes 2 (its SIP leg + its WS session) — two calls in one
 /// room read 4. Literal must match `siphon-ai-media-glue::room`.
 pub const CONFERENCE_PARTICIPANTS: &str = "siphon_ai_conference_participants";
+
+/// Currently-parked calls (0.7.0). Incremented on park, decremented on
+/// retrieve / teardown. Literal must match `siphon-ai-core::call`.
+pub const PARKED_CALLS_ACTIVE: &str = "siphon_ai_parked_calls_active";
 
 // ─── Histograms ─────────────────────────────────────────────────────
 
@@ -276,6 +290,11 @@ pub fn register_descriptions() {
         ROOM_FRAMES_DROPPED_TOTAL,
         "20 ms frames a conference room dropped instead of blocking, by stage (input, sink) and side (sip, ws)."
     );
+    describe_counter!(PARKS_TOTAL, "Calls parked, by result (ok, rejected).");
+    describe_counter!(
+        RETRIEVES_TOTAL,
+        "Parked calls retrieved, by result (ok, not_parked)."
+    );
     describe_gauge!(
         CALLS_ACTIVE,
         Unit::Count,
@@ -297,6 +316,7 @@ pub fn register_descriptions() {
         Unit::Count,
         "Mixer participants across all rooms (2 per member call: SIP leg + WS session)."
     );
+    describe_gauge!(PARKED_CALLS_ACTIVE, Unit::Count, "Currently-parked calls.");
     describe_histogram!(
         WS_CONNECT_SECONDS,
         Unit::Seconds,

--- a/crates/webhooks/src/event.rs
+++ b/crates/webhooks/src/event.rs
@@ -78,6 +78,19 @@ pub enum WebhookEvent {
     /// operator force-ended it (`DELETE /admin/v1/conferences/:id`).
     /// Pairs 1:1 with a `ConferenceCreated` for the same `room_id`.
     ConferenceEnded(ConferenceEndedEvent),
+
+    /// Fired when a call is parked (WS `park` or
+    /// `POST /admin/v1/calls/:id/park`) — the WS session detached and
+    /// the caller is on hold music (0.7.0).
+    CallParked(CallParkedEvent),
+
+    /// Fired when a parked call is retrieved onto a fresh WS session
+    /// (`POST /admin/v1/calls/:id/retrieve`).
+    CallRetrieved(CallRetrievedEvent),
+
+    /// Fired when a parked call hits `[park].timeout_secs`. `action` is
+    /// what happened next (`hangup` / `keep`).
+    ParkTimeout(ParkTimeoutEvent),
 }
 
 impl WebhookEvent {
@@ -94,6 +107,9 @@ impl WebhookEvent {
             WebhookEvent::OutboundFailed(_) => "outbound_failed",
             WebhookEvent::ConferenceCreated(_) => "conference_created",
             WebhookEvent::ConferenceEnded(_) => "conference_ended",
+            WebhookEvent::CallParked(_) => "call_parked",
+            WebhookEvent::CallRetrieved(_) => "call_retrieved",
+            WebhookEvent::ParkTimeout(_) => "park_timeout",
         }
     }
 
@@ -111,6 +127,9 @@ impl WebhookEvent {
             // Conference events are room-scoped, not call-scoped.
             WebhookEvent::ConferenceCreated(_) => None,
             WebhookEvent::ConferenceEnded(_) => None,
+            WebhookEvent::CallParked(e) => Some(&e.call_id),
+            WebhookEvent::CallRetrieved(e) => Some(&e.call_id),
+            WebhookEvent::ParkTimeout(e) => Some(&e.call_id),
         }
     }
 }
@@ -256,6 +275,40 @@ pub struct ConferenceEndedEvent {
     /// The most member calls in the room at any one time over its
     /// lifetime.
     pub peak_participants: usize,
+}
+
+/// A call was parked (0.7.0).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CallParkedEvent {
+    pub version: u32,
+    pub call_id: String,
+    /// When the call was parked (UTC).
+    pub timestamp: DateTime<Utc>,
+    /// Optional hold-lot label the parker supplied.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub slot: Option<String>,
+}
+
+/// A parked call was retrieved onto a fresh WS session (0.7.0).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CallRetrievedEvent {
+    pub version: u32,
+    pub call_id: String,
+    /// When the retrieve happened (UTC).
+    pub timestamp: DateTime<Utc>,
+    /// The WS URL the retrieved session connected to.
+    pub ws_url: String,
+}
+
+/// A parked call hit its timeout (0.7.0).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ParkTimeoutEvent {
+    pub version: u32,
+    pub call_id: String,
+    /// When the timeout fired (UTC).
+    pub timestamp: DateTime<Utc>,
+    /// What the daemon did: `"hangup"` or `"keep"`.
+    pub action: String,
 }
 
 #[cfg(test)]

--- a/crates/webhooks/src/lib.rs
+++ b/crates/webhooks/src/lib.rs
@@ -24,9 +24,9 @@ pub mod http;
 pub mod sink;
 
 pub use event::{
-    CallEndEvent, CallStartEvent, ConferenceCreatedEvent, ConferenceEndedEvent,
-    OutboundAnsweredEvent, OutboundFailedEvent, OutboundInitiatedEvent,
-    RegistrationStateChangedEvent, WebhookEvent, WEBHOOK_VERSION,
+    CallEndEvent, CallParkedEvent, CallRetrievedEvent, CallStartEvent, ConferenceCreatedEvent,
+    ConferenceEndedEvent, OutboundAnsweredEvent, OutboundFailedEvent, OutboundInitiatedEvent,
+    ParkTimeoutEvent, RegistrationStateChangedEvent, WebhookEvent, WEBHOOK_VERSION,
 };
 pub use http::{HttpSink, HttpSinkConfig};
 pub use sink::{FilteredSink, NullSink, WebhookSink, WebhookSinkHandle};

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -22,6 +22,7 @@ before TOML parsing. Unset variables without a default fail the load.
 [security]        # STIR/SHAKEN call-authentication policy (0.4.0)
 [security.stir_shaken]  # verification settings
 [conference]      # conference rooms (0.7.0); off by default
+[park]            # media-only call park (0.7.0); off by default
 [cdr]             # call detail records: file + webhook sinks
 [observability]   # /metrics, /health, /ready, /admin
 [webhooks]        # lifecycle events (call_start, call_end, …)
@@ -351,6 +352,36 @@ limitation). Rooms are created on first join and end when the last member
 leaves. Global only — no per-route overrides (rooms are a daemon-level
 facility, like outbound).
 
+## `[park]` — media-only call park (0.7.0)
+
+Park shelves a call **without** a WS session: the caller hears hold music,
+the SIP dialog and RTP stay up, and the call is later **retrieved** onto a
+*fresh* WS session (or times out / hangs up). Park is initiated by the WS
+server (`park`, see `docs/PROTOCOL.md` §4.9) or an operator
+(`POST /admin/v1/calls/:id/park`); retrieve is **operator-only**
+(`POST /admin/v1/calls/:id/retrieve`). This block only declares the
+daemon-level facility.
+
+```toml
+[park]
+enabled = false                       # fail-closed, like [conference]
+moh_file = "/etc/siphon-ai/moh.wav"   # optional; comfort noise if unset
+timeout_secs = 300                    # 0 = park indefinitely
+timeout_action = "hangup"             # "hangup" | "keep"
+max_parked = 32
+```
+
+| Field | Default | Notes |
+|---|---|---|
+| `enabled` | `false` | Off = every park refused (`error { code: "park_failed" }`). A 0.6.x config upgrades with zero behaviour change. |
+| `moh_file` | unset | Hold-music file looped while a call is parked. **Existence and decodability are checked at load** — a missing or garbage file fails startup loud. Unset → comfort noise. The file's native sample rate is resolved per-park; a call negotiated at a *different* rate falls back to comfort noise (no resampling in 0.7.0) — logged once, **not** a park failure. |
+| `timeout_secs` | `300` | How long a call may stay parked before `timeout_action` fires. `0` disables the timeout (park indefinitely). |
+| `timeout_action` | `"hangup"` | At timeout: `"hangup"` tears the call down; `"keep"` leaves it parked (the operator must retrieve or hang up). Any other value fails load. |
+| `max_parked` | `32` | Max simultaneously-parked calls across the daemon. Must be ≥ 1. A park beyond the cap is refused (`park_failed`); the call continues unparked. |
+
+Global only — no per-route overrides (park is a daemon-level facility, like
+conference and outbound). Applies to inbound **and** outbound calls.
+
 ## `[security]` — STIR/SHAKEN call authentication
 
 Verifies the RFC 8224 `Identity` header (RFC 8225 PASSporT, SHAKEN profile)
@@ -505,7 +536,7 @@ regardless of sub-block state. Adding fields to the CDR schema bumps the
 | `enabled`     | bool     | `false`                | |
 | `url`         | URL      | required if on         | POST target. |
 | `auth_header` | string   | unset                  | Sent verbatim. `${VAR}` expansion works. |
-| `events`      | string[] | all                    | Allowlist. Valid today: `"call_start"`, `"call_end"`, `"registration_state_changed"`, `"outbound_initiated"`, `"outbound_answered"`, `"outbound_failed"`, `"conference_created"`, `"conference_ended"`. |
+| `events`      | string[] | all                    | Allowlist. Valid today: `"call_start"`, `"call_end"`, `"registration_state_changed"`, `"outbound_initiated"`, `"outbound_answered"`, `"outbound_failed"`, `"conference_created"`, `"conference_ended"`, `"call_parked"`, `"call_retrieved"`, `"park_timeout"`. |
 | `retry_max`   | integer  | `3`                    | |
 | `timeout_ms`  | integer  | `5000`                 | |
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -314,6 +314,9 @@ the listener on a private network.
 | DELETE | `/admin/v1/conferences/:id`   | —               | **Force-end a room** (0.7.0). Every member reverts to its direct pair (`conference_left { room_closed }`). `404` if unknown. |
 | POST   | `/admin/v1/conferences/:id/participants`          | JSON | **Add a call to a room** (0.7.0). Body `{call_id}`; `202` (dispatched). |
 | DELETE | `/admin/v1/conferences/:id/participants/:call_id` | —    | **Remove a call from a room** (0.7.0). `202` (dispatched). |
+| GET    | `/admin/v1/parked`            | —               | **List parked calls** (0.7.0). `501` when `[park]` is disabled. |
+| POST   | `/admin/v1/calls/:id/park`    | JSON (opt.)     | **Park an active call** (0.7.0). Body `{slot?}`; `202` (dispatched). `404` if no active call has that id. `501` when `[park]` is disabled. |
+| POST   | `/admin/v1/calls/:id/retrieve`| JSON (opt.)     | **Retrieve a parked call** (0.7.0). Body `{ws_url?}`; `202` (dispatched). `404` unknown call, `409` if the call isn't parked. `501` when `[park]` is disabled. |
 
 ### `POST /admin/v1/calls` — outbound origination
 
@@ -388,6 +391,36 @@ curl -X PUT --data 'siphon_ai=info,siphon_ai_bridge=debug' \
 curl -X PUT --data "$prev" http://localhost:9091/admin/log
 ```
 
+### `/admin/v1/parked` — park admin (0.7.0)
+
+Requires `[park].enabled = true` (all routes `501` otherwise). Same no-auth
+posture as the other v1 admin routes — keep the listener private. Park
+shelves a call playing hold music with **no** WS session; see
+`docs/CONFIG.md` `[park]` and the WS protocol (`docs/PROTOCOL.md` §4.9).
+
+```sh
+# What's parked, and for how long
+curl -s http://localhost:9091/admin/v1/parked
+# → {"count":1,"parked":[{"call_id":"siphon-a","slot":"lot-3","parked_secs":42}]}
+
+# Park an active call (slot label optional)
+curl -X POST http://localhost:9091/admin/v1/calls/siphon-a/park \
+    -d '{"slot":"lot-3"}'        # → 202
+
+# Retrieve it onto a fresh WS session (ws_url optional — defaults to the
+# call's original bridge ws_url)
+curl -X POST http://localhost:9091/admin/v1/calls/siphon-a/retrieve \
+    -d '{"ws_url":"wss://my-bot.example/retrieve"}'   # → 202
+```
+
+`park`/`retrieve` return **`202` (dispatched)**: the daemon signals the
+target call and its own controller does the work — the outcome surfaces on
+the call's (old/new) WS session and the `call_parked` / `call_retrieved`
+webhooks, not in this HTTP response. A park refused by the `[park].max_parked`
+cap is **not** a `503` here — the cap is enforced in the call's controller and
+surfaces as `error { code: "park_failed" }` on its WS while the call continues
+unparked. `retrieve` is `409` when the named call exists but isn't parked.
+
 ## CDR consumers
 
 When `[cdr.file]` is enabled, the daemon appends one JSON record per ended
@@ -446,6 +479,14 @@ Two optional recording fields appear when the call was recorded (added in
   recording `failed` (it points at where the file would be); cross-check
   with the `siphon_ai_recordings_total` metric for the outcome.
 
+One optional park object appears when the call was parked at least once
+(added in 0.7.0; schema stays at version 1 — omitted when the call was
+never parked):
+
+- `park` — `{ "count": <episodes>, "total_ms": <cumulative parked ms> }`.
+  A call can park/retrieve repeatedly, so `count` is the number of park
+  episodes and `total_ms` is the summed parked wall-time across them.
+
 Outbound originated calls (0.6.0, `POST /admin/v1/calls`) produce the same
 record with `direction: "outbound"` — the schema stays at version 1 (the
 field was reserved for this since v1). Two outbound-specific readings:
@@ -479,6 +520,9 @@ CDR webhook. Event types:
 | `outbound_failed`               | The originated call ended without an answer. Terminal — no `call_end`/CDR follows. |
 | `conference_created`            | A conference room was created — first `conference_join` for a `room_id`, or an admin pre-create (0.7.0). Carries `room_id`, `sample_rate`. |
 | `conference_ended`              | A conference room ended — last member left, or an operator force-ended it (0.7.0). Carries `room_id`, `duration_ms`, `peak_participants`. Pairs 1:1 with `conference_created`. |
+| `call_parked`                   | A call was parked — WS `park` or `POST /admin/v1/calls/:id/park` (0.7.0). Carries `call_id` and the optional `slot` label. |
+| `call_retrieved`                | A parked call was retrieved onto a fresh WS session — `POST /admin/v1/calls/:id/retrieve` (0.7.0). Carries `call_id` and the `ws_url` the new session connected to. |
+| `park_timeout`                  | A parked call hit `[park].timeout_secs` (0.7.0). Carries `call_id` and `action` (`"hangup"` or `"keep"`, per `[park].timeout_action`). |
 
 Each delivery is a single JSON object with `version`, `timestamp` (ISO 8601), `type`,
 and per-event fields documented in `crates/webhooks/src/event.rs`.
@@ -497,6 +541,18 @@ mirrors the `siphon_ai_outbound_calls_total{result}` metric labels:
   "sip_call_id": "f81d4fae…@10.0.0.5", "timestamp": "2026-06-09T10:00:06Z" }
 { "type": "outbound_failed", "version": 1, "call_id": "siphon-…",
   "timestamp": "2026-06-09T10:00:30Z", "cause": "no_answer" }
+```
+
+A parked call emits `call_parked`, then (when retrieved) `call_retrieved`,
+or (on timeout) `park_timeout`. A call may park/retrieve repeatedly.
+
+```json
+{ "type": "call_parked", "version": 1, "call_id": "siphon-…",
+  "timestamp": "2026-06-14T10:00:00Z", "slot": "lot-3" }
+{ "type": "call_retrieved", "version": 1, "call_id": "siphon-…",
+  "timestamp": "2026-06-14T10:02:30Z", "ws_url": "wss://my-bot.example/retrieve" }
+{ "type": "park_timeout", "version": 1, "call_id": "siphon-…",
+  "timestamp": "2026-06-14T10:05:00Z", "action": "hangup" }
 ```
 
 ## HEP / Homer
@@ -545,6 +601,9 @@ on the metrics crate's defaults (CLAUDE.md §7.4).
 | `siphon_ai_conference_participants`     | gauge     | —                                     | Mixer participants across all rooms (0.7.0). Each member call contributes 2 — its SIP leg and its WS session; two calls in one room read 4. |
 | `siphon_ai_room_tick_lag_seconds`       | histogram | —                                     | How far past its 20 ms cadence a room's mix tick fired (0.7.0). Healthy rooms sit in the lowest bucket; sustained lag means the mixer (which allocates per tick upstream — DEV_PLAN_0.7.0.md §6) or the runtime is starved. Buckets 0.5 ms – 250 ms. |
 | `siphon_ai_room_frames_dropped_total`   | counter   | `stage=input\|sink`, `side=sip\|ws` | 20 ms frames a room dropped instead of blocking the audio path (0.7.0). `input` = the tap→room channel was full; `sink` = a member's output channel was full (stalled consumer). Healthy rooms sit at zero. |
+| `siphon_ai_parks_total`                 | counter   | `result=ok\|rejected`                 | Park requests (0.7.0). `rejected` = park disabled or `[park].max_parked` reached; the call continues unparked. |
+| `siphon_ai_retrieves_total`             | counter   | `result=ok\|not_parked`               | Retrieve requests (0.7.0). `not_parked` = a retrieve signalled a call that wasn't parked (ignored). |
+| `siphon_ai_parked_calls_active`         | gauge     | —                                     | Currently-parked calls (0.7.0). Incremented on park, decremented on retrieve or teardown. |
 | `forge_rtcp_*`                          | various   | per-call (forge-side)                 | RTP/RTCP quality. See forge-media's own metric inventory. |
 | `heplify_*`                             | various   | from the HEP collector                | Only visible if you scrape heplify too. |
 

--- a/docs/DESIGN_0.7.0_PARK.md
+++ b/docs/DESIGN_0.7.0_PARK.md
@@ -1,0 +1,330 @@
+# Design note — 0.7.0 chunk 4: Park + Retrieve
+
+> **Status: IMPLEMENTED.** The build followed this design; the locked
+> decisions (§12) all held. A handful of small deviations surfaced
+> during implementation — see §13. This note now documents what shipped.
+
+Implements DEV_PLAN_0.7.0.md §2.4 (park, media-only, §9.3). Park shelves
+a call without a WS session — the caller hears hold music, the SIP dialog
+and RTP stay up, and the call is later **retrieved** onto a *fresh* WS
+session. This is the one chunk that reworks the per-call controller
+lifecycle, so it gets a design pass.
+
+---
+
+## 1. What changes vs. what doesn't
+
+**Unchanged, durable across a park:** the SIP dialog, the forge media
+session + RTP, the `MediaTap` task (it keeps the forge `MediaBridgeHandle`
+alive — that's *why* the tap must persist), the `CallController` task, the
+call's entry in `CallRegistry` / `CallControlRegistry`, recording (a
+recording started before park keeps writing — see §9).
+
+**Detached on park, fresh on retrieve:** the WS `bridge` task and all four
+of its channels.
+
+**Out of scope (restating locked decisions):** no SIP re-INVITE/hold (the
+dialog stays `sendrecv` and we keep sending RTP — MOH needs it); retrieve
+is **operator-initiated only** (admin API), a *fresh* session (new `seq`
+from 0, `start.retrieved: true`, no replay) — explicitly **not** mid-call
+WS reconnect; no per-slot MOH.
+
+---
+
+## 2. Config — `[park]`
+
+```toml
+[park]
+enabled = false                      # fail-closed, like [conference]/[outbound]
+moh_file = "/etc/siphon-ai/moh.wav"  # optional; comfort noise if unset
+timeout_secs = 300                   # 0 = no timeout
+timeout_action = "hangup"            # "hangup" | "keep"
+max_parked = 32
+```
+
+Validated at load (`compile_park`): `timeout_action ∈ {hangup, keep}`;
+`max_parked ≥ 1`; if `moh_file` set, it must exist **and decode** (open it
+through `forge_injection::FileSource` once at startup and read one frame —
+fail loud on a missing/garbage file, per CLAUDE §4.6). The file's *native*
+sample rate is recorded but **not** required to match any call — see §4.
+
+`ParkConfig` (compiled) → mapped to core's `ParkLimits` (core doesn't dep
+on config, same pattern as `ConferenceLimits`).
+
+---
+
+## 3. WS protocol additions (version stays `"1"` — additive)
+
+- `BridgeIn::Park { call_id, slot: Option<String> }` — a WS server parks
+  its **own** call (self-scoped, §9.2). `slot` is an optional human label
+  for the lot.
+- `StopReason::Park` — the `stop` SiphonAI sends before closing the WS on
+  park. The server learns "you were parked, not hung up."
+- `StartMsg.retrieved: bool` (`#[serde(default)]`, skip-if-false) — `true`
+  on the `start` of a retrieve session so the new WS server knows it's
+  picking up a parked call, not a fresh inbound one.
+
+Retrieve has **no** WS-server-initiated message (operator-only). PROTOCOL.md
+§3/§4 updated in the same PR.
+
+---
+
+## 4. MOH source (media-glue)
+
+A small `MohSource` built **per park, at the call's negotiated rate**:
+
+- `moh_file` set **and** its native rate == the call's rate → looping
+  `FileSource` (`open_trusted`; on `EndOfFile`, `reset()` and continue —
+  forge exposes `reset()` = seek-to-zero).
+- otherwise (unset, rate mismatch — forge has no resampler — or open error)
+  → `ToneGenerator::comfort_noise(rate)` (infinite, any rate). A rate
+  mismatch logs once at `info` and falls back; it is **not** a park
+  failure.
+
+`MohSource::next_frame(samples)` returns one 20 ms PCM16 frame (`Vec<i16>`),
+never erroring (the looping/fallback guarantees an infinite stream).
+
+The startup `moh_file` check (decodability) catches gross misconfig early;
+the per-park rate decision is where fallback actually happens.
+
+---
+
+## 5. Tap changes (media-glue) — Park / Unpark modes
+
+The tap already multiplexes audio routing (direct pair ↔ room). Park adds a
+third mode, driven by two new `TapCommand`s:
+
+```rust
+TapCommand::Park   { moh: MohSource }
+TapCommand::Unpark { caller_audio_tx, playout_audio_rx, events_tx }
+```
+
+**On `Park`:** the tap stops using the WS-facing channels and switches to a
+20 ms `tokio::time::interval` (monotonic, §4.3 — same cadence the room
+uses) that pulls `moh.next_frame()` and pushes it to forge playout.
+Inbound caller frames are **dropped** (no WS to forward to). DTMF/VAD/etc.
+events are dropped too (no events sink). A `Park` while in a room first
+leaves the room (drops the `RoomSender`).
+
+**On `Unpark`:** the tap swaps its three WS-facing endpoints
+(`caller_audio_tx`, `playout_audio_rx`, `events_tx`) to the fresh ones the
+controller supplies (these become reassignable locals, like the room sink
+receivers are today), stops the MOH tick, and resumes the direct pair.
+
+The tap's `run()` already holds `playout_audio_rx` as `mut`; `caller_audio_tx`
+and `events_tx` become `mut` locals so they can be swapped. **No new
+allocations in steady state** — the MOH tick reuses the same per-frame
+budget as the room playout arm.
+
+`MediaTap` itself never ends on park — the tap task is the durable owner.
+
+---
+
+## 6. Controller lifecycle — the crux
+
+Today `CallController::run()` fuses `bridge_task` + `tap_task`: either one
+ending → `break` → teardown. Park makes **the tap durable and the bridge
+swappable**, with the controller persisting across the whole park episode.
+
+### 6.1 State
+
+Add a `parked: bool` (false initially). The select loop gains: a guard on
+the bridge-end arm, two new command sources (retrieve, park — see §6.4), a
+timeout arm, and a relay-free channel swap on retrieve.
+
+### 6.2 Park transition (from a `Park` request — WS or admin)
+
+1. Build `MohSource` at the call's rate (§4); `tap_cmd_tx.send(Park{moh})`.
+2. `control_out_tx.send(Stop { reason: Park })` → the current bridge sends
+   `stop{park}` to the WS and closes → `bridge_task` completes.
+3. Set `parked = true`. Register in `ParkRegistry` (§7). Bump
+   `siphon_ai_parked_calls_active`, `parks_total{result="ok"}`. Fire
+   `call_parked` webhook. Arm the timeout (§8).
+4. The **bridge-end arm is guarded** `if !parked` — so when `bridge_task`
+   completes for a park, the arm does **not** fire (no `break`). We capture
+   the prior `bridge_result` when we send the park Stop, before flipping
+   `parked`. (A completed `JoinHandle` must never be re-polled; the guard
+   guarantees it isn't until retrieve reassigns it.)
+
+### 6.3 Retrieve transition (admin only)
+
+Retrieve hands the controller a target `ws_url` (defaulting to the call's
+original bridge `ws_url`). The controller, **on its own task** (so the
+multi-RTT WS connect never blocks anything):
+
+1. Build **fresh** channels: `caller_audio` (tx→tap, rx→bridge),
+   `playout` (tx→bridge, rx→tap), `control_in` (tx→bridge, rx→controller),
+   `control_out` (tx→shared, rx→bridge).
+2. Build a fresh `StartMsg` from the **preserved call facts** (the
+   controller keeps a clone of the original `start` minus `seq`), with
+   `retrieved = true` and the (possibly new) `ws_url`.
+3. `bridge_task = tokio::spawn(connect_and_run(bridge_cfg, start, BridgeChannels{…}))`;
+   re-enable the bridge-end arm.
+4. Swap the controller's locals: `control_in_rx = ci_rx`,
+   `control_out_tx = co_tx`.
+5. `tap_cmd_tx.send(Unpark { caller_audio_tx, playout_audio_rx, events_tx: co_tx.clone() })`.
+6. `parked = false`. Deregister from `ParkRegistry`, disarm timeout. Bump
+   `retrieves_total{result="ok"}`, decrement `parked_calls_active`. Fire
+   `call_retrieved` webhook.
+
+### 6.4 Channel ownership — why this is clean
+
+The **one** shared piece is the handle's `bridge_events_tx` (cloned to the
+tap and used by the acceptor's `on_reinvite` for Hold/Resume). To let a
+fresh bridge receive events from all producers after retrieve, make it an
+`arc_swap::ArcSwap<mpsc::Sender<OutgoingEvent>>` on the `CallHandle` (arc-swap
+is already a workspace dep — the SIGHUP cert path uses it). `push_bridge_event`
+loads the current sender; retrieve stores the new one.
+
+**Crucially, `control_out_rx` stays owned by the bridge** (not relayed
+through the controller). So the existing teardown invariant is untouched:
+`control_out_tx.send(Stop).await; break;` still delivers `Stop` straight to
+the bridge. Retrieve only swaps *senders* (controller local + tap +
+handle's ArcSwap) and gives the new bridge a fresh *receiver*. No relay, no
+Stop-ordering hazard.
+
+### 6.5 Teardown while parked
+
+- **Caller BYE / CANCEL:** unchanged. The SIP layer calls
+  `CallRegistry::terminate*` → `handle.shutdown()` → the controller's
+  shutdown arm runs teardown. The `tap_task` also ends when forge RTP stops.
+  Either path is terminal; the parked-state cleanup (deregister, gauge
+  decrement, `parks_total` already counted) runs in the teardown tail.
+- **`max_parked` cap:** a park beyond the cap is refused —
+  `parks_total{result="rejected"}`, and (WS) an `error{code:"park_failed"}`;
+  the call continues unparked.
+- **Daemon shutdown:** the controller's existing shutdown path tears the
+  parked call down like any other.
+
+---
+
+## 7. `ParkRegistry` (core)
+
+`call_id → ParkedHandle`, same §4.4 shape as `ConferenceRegistry` /
+`CallControlRegistry`: exact-id, insert on park, remove on retrieve/teardown,
+no enumeration of call internals. `ParkedHandle` carries the optional
+`slot`, the `parked_at` instant (for `GET /parked` age + CDR), and the
+retrieve is driven through the existing `CallHandle` command channel (§6.3),
+not a separate one — `ParkRegistry` just records *that* a call is parked and
+its metadata for the admin list.
+
+Retrieve flow: admin → `ParkRegistry.lookup(call_id)` confirms it's parked →
+`CallControlRegistry.lookup(call_id)` → `handle.request_retrieve(ws_url)`
+(new `CallHandle` method, mirrors `request_conference_join`).
+
+Park via admin similarly: `handle.request_park(slot)`.
+
+`max_parked` is enforced in `ParkRegistry` (live count) at park time.
+
+---
+
+## 8. Timeout (core)
+
+On park, arm a deadline = `parked_at + timeout_secs` (skip if `0`). In the
+controller's select loop, a pinned `tokio::time::Sleep` arm, active only
+while `parked`:
+
+- fires → `park_timeout` webhook, then `timeout_action`:
+  - `hangup` → drive normal teardown (`handle.shutdown()` semantics).
+  - `keep` → stay parked, disarm (no repeat); operator must retrieve/hangup.
+
+**Races:** retrieve before timeout → `parked=false` disables the arm.
+Caller BYE before timeout → teardown disables it. The timer lives in the
+controller loop (single owner), so there's no cross-task race — the
+`parked` flag gates the arm.
+
+---
+
+## 9. Recording, CDR, metrics, webhooks
+
+- **Recording:** a recording in progress at park keeps writing — the tap
+  fork is unchanged; the parked span records the MOH the caller hears
+  (consistent with "what the caller heard"). No new recording control.
+- **CDR (additive, schema stays v1):** `park: { count, total_ms }` —
+  `count` = number of park episodes this call had, `total_ms` = cumulative
+  parked wall-time. Omitted when the call was never parked.
+- **Metrics:** `siphon_ai_parked_calls_active` (gauge),
+  `siphon_ai_parks_total{result=ok|rejected}`,
+  `siphon_ai_retrieves_total{result=ok|not_parked|failed}`.
+- **Webhooks:** `call_parked { call_id, slot? }`,
+  `call_retrieved { call_id, ws_url }`,
+  `park_timeout { call_id, action }`.
+
+---
+
+## 10. Admin API (telemetry) — `ParkAdminHandle`
+
+| Method | Path | Result |
+|---|---|---|
+| GET    | `/admin/v1/parked` | list parked calls (`call_id`, `slot`, `parked_secs`) |
+| POST   | `/admin/v1/calls/:call_id/park` `{slot?}` | `202` (dispatched) / `404` unknown call / `503` `max_parked` / `501` disabled |
+| POST   | `/admin/v1/calls/:call_id/retrieve` `{ws_url?}` | `202` / `404` unknown-or-not-parked / `501` disabled |
+
+`park`/`retrieve` are **`202` (dispatched)** — same pattern as conference
+add/remove: the admin signals the call via its `CallHandle`, the call's own
+controller does the work (§4.4), and the outcome surfaces on the (old/new)
+WS + webhooks. `GET /parked` reads `ParkRegistry`. Core impl `ParkAdmin`
+wires `ParkRegistry` + `CallControlRegistry`, mirroring `ConferenceAdmin`.
+
+---
+
+## 11. Test plan
+
+- **media-glue:** `MohSource` loops a short WAV fixture (rate match) and
+  falls back to comfort noise on rate mismatch / unset; tap Park→MOH ticks
+  into forge, Unpark swaps back to fresh WS channels (synthetic PCM).
+- **core:** controller park→retrieve round-trip over a stub WS server
+  (park yields `stop{park}` + WS close; the call stays alive; retrieve
+  opens a fresh WS that receives `start{retrieved:true}`; ends normally).
+  Timeout→hangup and timeout→keep. Caller-BYE-while-parked tears down
+  cleanly. `ParkRegistry` + `ParkAdmin` unit tests (cap, not-parked, etc.).
+- **bridge:** round-trip the new `park` / `stop{park}` / `start.retrieved`.
+- **telemetry:** the three admin routes + status mapping.
+- **config:** `[park]` load/validate (bad action, missing moh_file, cap 0).
+- **SIPp (chunk 5):** park→retrieve→hangup and park→timeout→hangup.
+
+---
+
+## 12. Decisions to confirm
+
+1. **`ArcSwap` on `CallHandle.bridge_events_tx`** (§6.4) — the one
+   shared-state change, needed so a retrieved call's fresh bridge receives
+   acceptor-pushed Hold/Resume events. arc-swap is already a dep.
+   *Alternative:* accept that Hold/Resume is dropped on a retrieved call
+   until a future cleanup (simpler, slightly degraded). **Recommend ArcSwap.**
+2. **CDR `park.count` semantics** — episodes (a call can park/retrieve
+   repeatedly). OK?
+3. **Retrieve onto a different `ws_url`** is allowed (defaults to the call's
+   original). Confirm operators may redirect the retrieved session
+   elsewhere.
+4. **Park applies to inbound *and* outbound calls** (any call in
+   `CallControlRegistry`), consistent with chunk 3. OK?
+5. Everything else follows the locked plan (§9.3).
+
+---
+
+## 13. Deviations from this design (as built)
+
+Small departures from the draft above, recorded per the header. None
+change the locked decisions (§12), all of which held — including the
+`ArcSwap`-style bridge-sender swap (§6.4), realised as
+`CallHandle::swap_bridge_sender` invoked on retrieve.
+
+1. **`max_parked` is not a `503` at the admin API.** §10 sketched a
+   `503` from `POST /…/park` at the cap. As built, the admin `park`
+   route only confirms the call exists (`202`/`404`); the cap is
+   enforced in the call's own controller (`ParkRegistry::try_park`) and
+   a refusal surfaces as `error { code: "park_failed" }` on the call's
+   WS plus `parks_total{result="rejected"}` — consistent with the
+   "dispatch-and-return, outcome on the WS" model the rest of §10 uses.
+2. **Retrieve of a live (non-parked) call returns `409`,** not the
+   `404` §10 folded into "unknown-or-not-parked". Unknown call → `404`;
+   known-but-not-parked → `409 Conflict` (`ParkAdminError::NotParked`),
+   which distinguishes operator error from a bad id.
+3. **`retrieves_total` has labels `ok | not_parked` only** (§9 listed a
+   third `failed`). A retrieve either dispatches (`ok`) or no-ops on a
+   non-parked call (`not_parked`); there is no synchronous failure mode
+   left to count, so `failed` was dropped rather than left unemitted.
+4. **CDR `park` is a nested object `{ count, total_ms }`** (cdr
+   `ParkInfo`), matching §9's shape; `count` is park *episodes* per
+   §12.2.

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -126,6 +126,7 @@ MAY use it to detect dropped frames in their own logs.
 | `from` | string | E.164 number or SIP user; may be empty if PBX strips it. |
 | `to` | string | The dialed digits / extension / SIP user. |
 | `direction` | string | `"inbound"` (SiphonAI answered the call) or `"outbound"` (SiphonAI placed it — outbound origination, 0.6.0). An outbound bot typically speaks first. Additive; the protocol version stays `"1"`. |
+| `retrieved` | bool \| absent | `true` on the `start` of a session that is picking up a **previously parked** call (park/retrieve, 0.7.0; §4.9). **Absent** (not `false`) on a normal inbound/outbound `start`. A retrieve always opens a *fresh* session — `seq` restarts at 0 and there is no replay of pre-park traffic — so a server that ignores this field simply treats it as a brand-new call. |
 | `audio.encoding` | string | `"pcm16le"` only in v1. |
 | `audio.sample_rate` | int | `8000` or `16000`. Set by the negotiated SIP codec. |
 | `audio.channels` | int | `1` only in v1. |
@@ -304,6 +305,7 @@ on every snapshot.
 | `caller_hangup` | The far-end SIP party sent BYE. |
 | `server_hangup` | The WS server sent `hangup` (§4.3). |
 | `transfer` | A blind transfer (REFER) was accepted; SiphonAI is releasing the leg. |
+| `park` | The call was **parked** (0.7.0; §4.9). The WS session is being detached, **not** the call torn down — the SIP dialog and RTP stay up and the caller hears hold music. The server learns "you were parked, not hung up"; the call may later be retrieved onto a fresh session (with `start.retrieved: true`). |
 | `ws_disconnect` | The WS connection closed unexpectedly mid-call. SiphonAI plays the configured fallback prompt and tears down the SIP leg. |
 | `error` | A fatal error occurred; an `error` message preceded this. |
 
@@ -327,10 +329,13 @@ then closes the WebSocket cleanly (close code 1000).
 | `server_too_slow` | Server didn't begin sending audio within 5 s of `start`. |
 | `transfer_failed` | A REFER was attempted but the far end rejected it. |
 | `conference_failed` | A `conference_join` (§4.8) was refused: conferencing disabled, room or per-room cap reached, sample-rate mismatch, or already joined. The call continues on its direct pair. |
+| `park_failed` | A `park` (§4.9) was refused: park disabled (`[park].enabled = false`) or `[park].max_parked` reached. The call continues unparked on its current WS session — no `stop` follows this `error`. |
 | `internal` | SiphonAI internal error. The `message` field has details. |
 
-`error` is always followed by `stop` (with `reason: "error"`) and a
-clean close.
+A **fatal** `error` is always followed by `stop` (with `reason:
+"error"`) and a clean close. The two **non-fatal** refusals —
+`conference_failed` and `park_failed` — are the exception: they report a
+rejected control request, the call continues, and no `stop` follows.
 
 ### 3.11 `recording_started` / `recording_stopped` / `recording_failed` — recording lifecycle (0.5.0)
 
@@ -562,6 +567,37 @@ the room mixes 2N streams — each call's SIP caller and its bot — and
 hands each side the mix minus its own input. So a caller never hears
 themselves, a bot never hears its own playout, but a caller hears
 their own bot and a bot hears its own caller (STT keeps working).
+
+### 4.9 `park` — park this call (0.7.0)
+
+```json
+{ "type": "park", "call_id": "...", "slot": "lot-3" }
+```
+
+Park this call: detach the WS session and shelve the call playing hold
+music, **without** ending it. Requires `[park].enabled = true` on the
+daemon.
+
+- `slot` is an **optional** human label for the hold lot (e.g. a parking
+  orbit or agent name); it surfaces in `GET /admin/v1/parked` and the
+  `call_parked` webhook. Omit it for an unlabeled park.
+- On success SiphonAI sends `stop { reason: "park" }` (§3.9) and closes
+  **this** WebSocket cleanly. The SIP dialog and RTP stay up and the
+  caller hears hold music (`[park].moh_file`, or comfort noise). The
+  call is **not** torn down.
+- On failure — park disabled, or `[park].max_parked` reached — SiphonAI
+  replies `error { code: "park_failed" }` (§3.10) and the call continues
+  unparked on this session. No `stop` follows.
+
+**Self-scoped (§5.3):** `park` acts only on the session's *own* call.
+
+**Retrieve is operator-only.** There is no WS-server message to retrieve
+a parked call — retrieval is driven by the admin API
+(`POST /admin/v1/calls/:id/retrieve`, see [`docs/DEPLOY.md`](DEPLOY.md)),
+which opens a **fresh** WS session with `start.retrieved: true` (§3.1).
+A parked call with no WS session cannot retrieve itself; that's the
+operator control plane's job, the mirror of why participants are
+removed from conferences by the admin API rather than by a peer.
 
 ---
 

--- a/examples/echo-ws-server-python/server.py
+++ b/examples/echo-ws-server-python/server.py
@@ -72,6 +72,14 @@ class Options:
     # mixed in one room without a human driving the control channel.
     # None = disabled.
     auto_conference_join: str | None
+    # Test-harness knob: after `start`, wait auto_transfer_delay_ms and
+    # then `park` this call (optionally labelling the lot). SiphonAI
+    # replies `stop { reason: "park" }` and closes the WS; an operator
+    # retrieves the call later via the admin API. None = disabled.
+    auto_park_slot: str | None
+    # Sentinel distinguishing "--auto-park with no slot" (park, unlabeled)
+    # from "--auto-park absent" (don't park). Set alongside auto_park_slot.
+    auto_park: bool
 
 
 # ─── HTTP-side concerns: auth + subprotocol ─────────────────────────────────
@@ -167,6 +175,10 @@ async def handle(connection: ServerConnection, opts: Options) -> None:
                     LOG.error("unsupported protocol version %r; closing", version)
                     await connection.close(code=1003, reason="unsupported version")
                     return
+                if msg.get("retrieved"):
+                    # This session is picking up a previously parked call
+                    # (PROTOCOL.md §3.1 / §4.9), not a fresh inbound one.
+                    LOG.info("start call_id=%s is a retrieved (parked) call", call_id)
                 if opts.echo_marks:
                     # Optional behavior used by SiphonAI's protocol smoke
                     # tests: round-trip a `mark` to verify the control
@@ -228,6 +240,19 @@ async def handle(connection: ServerConnection, opts: Options) -> None:
                                 "room_id": opts.auto_conference_join,
                             },
                         )
+                    )
+
+                if opts.auto_park and call_id:
+                    # Test-harness behaviour: park the call from the WS
+                    # side. SiphonAI detaches this session (`stop{park}`
+                    # + close); the call lives on hold music until an
+                    # operator retrieves it. The hook for the 0.7.0
+                    # park→retrieve SIPp scenario.
+                    park_msg: dict[str, Any] = {"type": "park", "call_id": call_id}
+                    if opts.auto_park_slot:
+                        park_msg["slot"] = opts.auto_park_slot
+                    asyncio.create_task(
+                        _send_after(connection, opts.auto_transfer_delay_ms, park_msg)
                     )
 
                 if opts.auto_hangup_after_ms is not None and call_id:
@@ -378,6 +403,20 @@ def parse_args(argv: list[str] | None = None) -> Options:
         ),
     )
     p.add_argument(
+        "--auto-park",
+        nargs="?",
+        const="",
+        default=None,
+        metavar="SLOT",
+        help=(
+            "test-harness only: after `start`, emit a `park` (uses "
+            "--auto-transfer-delay-ms for the pause). Optional value is "
+            "the hold-lot label. SiphonAI replies `stop{park}` and "
+            "closes the WS — the hook for the 0.7.0 park→retrieve SIPp "
+            "scenario."
+        ),
+    )
+    p.add_argument(
         "--log-level",
         default="INFO",
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
@@ -399,6 +438,8 @@ def parse_args(argv: list[str] | None = None) -> Options:
         auto_hangup_after_ms=args.auto_hangup_after_ms,
         auto_transfer_replaces=args.auto_transfer_replaces,
         auto_conference_join=args.auto_conference_join,
+        auto_park=args.auto_park is not None,
+        auto_park_slot=args.auto_park or None,
     )
 
 

--- a/examples/echo-ws-server-python/test_smoke.py
+++ b/examples/echo-ws-server-python/test_smoke.py
@@ -78,6 +78,16 @@ def _opts(**overrides) -> srv.Options:
         auth_token=None,
         echo_marks=False,
         log_level="WARNING",
+        # Test-harness auto-* knobs all default off; mirrors parse_args
+        # defaults so the dataclass (which has no field defaults) is
+        # constructible here as fields are added across releases.
+        auto_transfer_target=None,
+        auto_transfer_delay_ms=200,
+        auto_hangup_after_ms=None,
+        auto_transfer_replaces=None,
+        auto_conference_join=None,
+        auto_park=False,
+        auto_park_slot=None,
     )
     base.update(overrides)
     return srv.Options(**base)


### PR DESCRIPTION
Chunk 4 of 5 for the **conferencing + park** theme (DEV_PLAN_0.7.0.md §2.4, §9.3). Design: `docs/DESIGN_0.7.0_PARK.md`. Follows the conference chunks (#165–#167).

**Park** shelves a call **without** a WS session: the caller hears hold music, the SIP dialog + RTP stay up, and the call is later **retrieved** onto a *fresh* WS session (or times out / hangs up). Fail-closed — `[park].enabled = false` (the default) refuses every park, so a 0.6.x deployment upgrades with zero behaviour change.

## The crux — controller lifecycle
The **tap becomes the durable owner** and the **bridge becomes swappable**. A `parked` flag guards the bridge-end arm so the park's own `stop{park}` close is non-terminal; the call lives on MOH until retrieve / timeout / caller-BYE. Retrieve respawns the bridge with a fresh `start{retrieved:true}` and swaps only *senders* (controller local + tap via `Unpark` + `handle.swap_bridge_sender`) — `control_out_rx` stays bridge-owned, so the teardown invariant is untouched (no relay, no Stop-ordering hazard).

## What's in it
- **Core:** `park.rs` (`ParkRegistry` + `ParkContext`/`ParkSettings`, `max_parked` cap), `park_admin.rs` (`ParkAdmin`), controller park/retrieve/timeout arms, `CallHandle::request_park`/`request_retrieve`, `ParkSummary`.
- **media-glue:** `moh.rs` (`MohSource` — looping `FileSource` at the call's rate, else comfort-noise fallback on mismatch/unset/error), `TapCommand::Park`/`Unpark` (20 ms monotonic MOH tick into forge playout).
- **Config:** `[park]` `enabled`/`moh_file`/`timeout_secs=300`/`timeout_action=hangup|keep`/`max_parked=32`, validated at load (`moh_file` must exist + decode when enabled).
- **Protocol** (version stays `"1"`, additive): `BridgeIn::Park{call_id, slot?}` (self-scoped), `StopReason::Park`, `StartMsg.retrieved`, `ErrorCode::ParkFailed`.
- **Admin API:** `GET /admin/v1/parked`, `POST /admin/v1/calls/:id/park {slot?}` (202), `POST /admin/v1/calls/:id/retrieve {ws_url?}` (202); 501 when off; 404 unknown call / 409 not-parked.
- **Observability** (same PR): metrics `parks_total{ok|rejected}`, `retrieves_total{ok|not_parked}`, `parked_calls_active`; webhooks `call_parked`/`call_retrieved`/`park_timeout`; CDR `park{count, total_ms}` (additive, schema stays v1).

## Deviations from the design (recorded in §13)
- Admin `max_parked` is **not** a `503` — the cap is enforced in the call's controller and surfaces as `error{park_failed}` on the WS.
- Retrieve of a live (non-parked) call returns **409**, not 404.
- `retrieves_total` carries `ok|not_parked` only (dropped the unused `failed` label).

## Docs & examples
PROTOCOL.md (§3.1/§3.9/§3.10/§4.9), CONFIG.md (`[park]` + webhook allowlist), DEPLOY.md (admin routes, webhooks + payloads, metrics, CDR field). Echo server gains `--auto-park[=SLOT]` + a retrieved-start log; `test_smoke.py` `_opts` fixed (latently broken — `auto_*` fields never had dataclass defaults).

## Tests
3 controller park integration tests (round-trip, timeout→hangup, caller-BYE-while-parked), 8 telemetry park admin route tests, `ParkRegistry`/`ParkAdmin`/`MohSource` unit tests, `[park]` config load/validate. Full workspace `test` + `clippy -D warnings` + `fmt` green locally.

> SIPp park→retrieve / park→timeout scenarios land in chunk 5 (docs + SIPp + 0.7.0 release), per the design test plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)