### PR TITLE
chore(release): 0.7.0 — conferencing + park (docs, SIPp, version bump)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-06-15
+
+Theme: **conferencing + media-only call park** — two operator-controllable
+multi-leg features, both **off by default** (fail-closed like `[outbound]`,
+so a 0.6.x config upgrades with zero behaviour change). Conferencing mixes
+N calls into one room where *every* leg keeps its own WS session (no single
+"host" bot); call park shelves a call on hold music with **no** WS session,
+to be retrieved later onto a fresh session by an operator. Delivered across
+five chunks (room core → WS surface → conference admin → park → docs/SIPp/
+release). The WS protocol version stays `"1"` — every addition is a new
+message, event, or error code.
+
 ### Added
 
 - **Conference admin CRUD (0.7.0 chunk 3 of 5).** Operators can compose and
@@ -88,6 +100,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * Reference echo server (`examples/echo-ws-server-python`) gains
     `--auto-conference-join ROOM` and logs the new events — the harness hook
     for the chunk-5 two-caller SIPp scenario.
+
+- **Media-only call park + retrieve (0.7.0 chunk 4 of 5).** Park shelves a
+  call **without** a WS session: the caller hears hold music, the SIP dialog
+  + RTP stay up, and the call is later **retrieved** onto a *fresh* WS session
+  (or times out / hangs up). The one chunk that reworks the per-call
+  controller lifecycle — the media tap becomes the durable owner and the WS
+  bridge becomes swappable. `docs/PARK.md`, `docs/DESIGN_0.7.0_PARK.md`.
+  * `[park]` config block (`enabled` — **off by default**; `moh_file`
+    optional, validated + decoded at load, comfort noise when unset or on a
+    sample-rate mismatch; `timeout_secs` 300 / `0` = indefinite;
+    `timeout_action` `hangup`|`keep`; `max_parked` 32). Global only.
+    `docs/CONFIG.md`.
+  * WS protocol (version stays `"1"`): `park { call_id, slot? }` (server parks
+    its own call, self-scoped), `stop { reason: "park" }`, `start.retrieved`
+    on a retrieved session, and `error` code `park_failed`. `docs/PROTOCOL.md`
+    §3.1 / §3.9 / §3.10 / §4.9.
+  * MOH on a 20 ms monotonic tick into forge playout (looping `FileSource` at
+    the call's rate, else `forge-injection` comfort noise); a parked call's
+    `MediaTap` task stays alive (it owns the forge media handle), while its WS
+    bridge detaches and is re-spawned fresh on retrieve.
+  * Admin API: `GET /admin/v1/parked`, `POST /admin/v1/calls/:id/park`
+    `{slot?}`, `POST /admin/v1/calls/:id/retrieve` `{ws_url?}` (both `202`
+    dispatched; retrieve is operator-only — there is no WS retrieve message).
+    `501` when park is off, `404` unknown call, `409` retrieve of a non-parked
+    call. `docs/DEPLOY.md`.
+  * Observability: webhooks `call_parked` / `call_retrieved` / `park_timeout`;
+    metrics `siphon_ai_parks_total{result}`,
+    `siphon_ai_retrieves_total{result}`, `siphon_ai_parked_calls_active`; CDR
+    `park { count, total_ms }` (additive, schema stays v1). Recording in
+    progress at park keeps writing (records the MOH the caller hears).
+  * Applies to inbound **and** outbound calls (any call in the
+    `CallControlRegistry`). Reference echo server gains `--auto-park[=SLOT]`.
+
+- **0.7.0 docs, SIPp coverage, and release (chunk 5 of 5).** Feature guides
+  `docs/CONFERENCE.md` and `docs/PARK.md` (joining flow, admin control,
+  limits, testing); doc-drift fixes in `CLAUDE.md` §8 and `docs/DEV_PLAN.md`
+  (recording / outbound / conferencing / park are delivered, not "out of
+  scope"; `forge-mixer` + `forge-injection` are now used). SIPp signaling
+  regression gains three live phases — conference two-caller mix, park →
+  retrieve → hangup, and park → timeout → hangup — each cross-checking the
+  feature's metric.
 
 ## [0.6.2] - 2026-06-12
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,22 +392,21 @@ Same pattern, but `BridgeOut`. Plus:
 
 ## 8. Things That Are Out of Scope
 
-If asked to do any of these, **stop and confirm with the user before proceeding.** They're explicit non-goals for v1.
+If asked to do any of these, **stop and confirm with the user before proceeding.** They're explicit non-goals.
 
 - AI provider integration of any kind
-- Multi-tenancy (note: route-based dispatch in a single config is in v1; multi-tenant separation is not)
-- Outbound originated calls (inbound + transfer is the v1 set)
-- Conferencing or mixing
+- Multi-tenancy (note: route-based dispatch in a single config is in scope; multi-tenant separation is not)
 - Video
 - WebRTC client support
-- Recording (post-v1)
-- WS reconnect mid-call (post-v1)
-- SRTP (post-v1)
+- WS reconnect mid-call (post-v1). Note: park/retrieve (0.7.0) is **not** this — retrieve opens a *fresh* WS session on an operator action, it does not resume a dropped one.
+- SRTP beyond what's shipped: DTLS-SRTP is produced (0.3.0); SDES and mid-call re-key are not.
 - Custom codec implementations (use forge-codecs)
 - Reimplementing SIP transactions, dialogs, or transports (use siphon-rs)
 - Reimplementing HEP encoding (use hep-rs)
 - YAML/JSON config formats (TOML only)
 - Per-call log files (use structured logs + correlation by call_id)
+
+**Delivered since the original v1 cut** (no longer out of scope — these shipped and have their own docs/config): call recording (0.5.0), outbound origination + attended transfer (0.6.0/0.6.1), conferencing/mixing and media-only call park (0.7.0). Don't refuse work on these as "out of scope"; treat them as supported features.
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2875,7 +2875,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "base64",
  "bytes",
@@ -2936,7 +2936,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2953,7 +2953,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "regex",
  "serde",
@@ -2970,7 +2970,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -3025,7 +3025,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3049,7 +3049,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "thiserror 1.0.69",
  "tokio",
@@ -3058,7 +3058,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "regex",
  "serde",
@@ -3069,7 +3069,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3078,7 +3078,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3101,7 +3101,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -3119,7 +3119,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3140,7 +3140,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.2"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
+**v0.7.0** — eighth release. Theme: **conferencing + media-only call park.**
+Two operator-controllable multi-leg features, both **off by default**.
+Conferencing mixes N calls into one room where *every* leg keeps its own WS
+session (no single "host" bot) and each side hears the mix minus its own
+input; a WS server joins its own call (`conference_join`/`leave`), and
+operators compose rooms over `/admin/v1/conferences` (add/remove **any**
+active call, cross-call via a new bridge-id → `CallHandle` registry that keeps
+CLAUDE §4.4 intact). Call park shelves a call on hold music with **no** WS
+session — `park` detaches the bot, the SIP dialog + RTP stay up, and an
+operator **retrieves** it later onto a *fresh* session (`start.retrieved`),
+or it times out (`hangup`|`keep`). The protocol stays `version: "1"` (new
+messages/events/error codes only); a 0.6.x deployment upgrades with zero
+behaviour change. See [`docs/CONFERENCE.md`](docs/CONFERENCE.md) and
+[`docs/PARK.md`](docs/PARK.md). Full notes: [`CHANGELOG.md`](CHANGELOG.md).
+
 **v0.6.2** — patch release. Theme: **TLS trunk hardening.** Fixes found by
 running v0.6.1 against a production TLS trunk: the `Contact` on dual-listener
 daemons advertised the UDP port for TLS dialogs (losing in-dialog ACK/BYE —

--- a/docs/CONFERENCE.md
+++ b/docs/CONFERENCE.md
@@ -1,0 +1,140 @@
+# Conference Rooms
+
+SiphonAI can mix **N calls into one room** (0.7.0). Every leg keeps its own
+WebSocket session — there is no single "host" bot — and each side hears the
+room minus its own input, so a caller never hears themselves and a bot never
+hears its own playout, but a caller still hears their own bot (STT keeps
+working). Rooms are driven by the WS server (for its own call) and by
+operators (for any call) over the admin API.
+
+```
+caller A ──RTP──► SiphonAI ─┐                     ┌─► WS server A (bot A)
+caller B ──RTP──► SiphonAI ─┤  one mixed room      ├─► WS server B (bot B)
+caller C ──RTP──► SiphonAI ─┘  (mix-minus-self)    └─► WS server C (bot C)
+```
+
+A room of N member calls mixes **2N** streams — each call's SIP caller and
+its WS session — and hands each side the mix minus its own contribution.
+
+## 1. Enabling
+
+Conferencing is **off by default** and fail-closed: a `conference_join` is
+refused (`error { code: "conference_failed" }`) unless `[conference]` is
+turned on. See `docs/CONFIG.md` (`[conference]`) for every field; the short
+version:
+
+```toml
+[conference]
+enabled                   = true   # false (default) = every join refused
+max_rooms                 = 16     # live rooms across the daemon (≥ 1)
+max_participants_per_room = 8       # member CALLS per room (≥ 2)
+join_tones                = false  # short chime into the room on join/leave
+```
+
+A 0.6.x config upgrades with zero behaviour change. Conferencing is a
+daemon-level facility — global only, no per-route overrides.
+
+## 2. Joining a room (WS server, self-scoped)
+
+A WS server puts **its own** call into or out of a room over the protocol
+(`docs/PROTOCOL.md` §4.8):
+
+```json
+{ "type": "conference_join",  "call_id": "...", "room_id": "support-7" }
+{ "type": "conference_leave", "call_id": "..." }
+```
+
+- **`conference_join`** creates the room if it doesn't exist yet (subject to
+  `max_rooms` / `max_participants_per_room`). On success SiphonAI replies
+  `conference_joined { room_id, participants }` and the call's audio is mixed
+  into the room. Joining a second room moves the call (it leaves the first).
+- **`conference_leave`** removes the call from its room and restores the
+  direct caller↔WS pair; SiphonAI replies `conference_left { reason: "left" }`.
+
+A bot tracks the rest of the room via the fan-out events
+`participant_joined` / `participant_left { room_id, participant_call_id }`
+(`docs/PROTOCOL.md` §3.12), sent to every *other* member when the room's
+composition changes.
+
+**Self-scoped (§9.2):** a WS message acts only on the session's *own* call. A
+bot can put itself in or out of a room, but it cannot add or remove *another*
+participant — that's the operator control plane's job ([§3](#3-operator-control-admin-api)).
+
+## 3. Operator control (admin API)
+
+Operators compose and inspect rooms over the admin HTTP API
+(`docs/DEPLOY.md`). Requires `[conference].enabled = true` (all routes `501`
+otherwise). Same posture as the originate API — **no built-in auth**, keep
+the listener on a private network.
+
+```sh
+# Who's in which room
+curl -s http://localhost:9091/admin/v1/conferences
+# → {"count":1,"conferences":[{"room_id":"support-7","sample_rate":8000,
+#     "participants":["siphon-a","siphon-b"]}]}
+
+# Pull any active call (inbound or outbound) into a room — creates it if absent
+curl -X POST http://localhost:9091/admin/v1/conferences/support-7/participants \
+    -d '{"call_id":"siphon-c"}'        # → 202
+
+# Drop one call back to its private bot
+curl -X DELETE http://localhost:9091/admin/v1/conferences/support-7/participants/siphon-c  # → 202
+
+# End the whole room (every member reverts to its direct pair)
+curl -X DELETE http://localhost:9091/admin/v1/conferences/support-7   # → 200
+```
+
+`add`/`remove` return **`202` (dispatched)**: the daemon signals the target
+call, which joins/leaves on its **own** WS session — the outcome surfaces
+there (`conference_joined` / `conference_left` / `error`), not in the HTTP
+response. This respects CLAUDE.md §4.4 (no reaching into another call's
+controller): the admin resolves the target through a daemon-wide bridge-id →
+`CallHandle` registry and pushes a command the call's own controller runs.
+`create` returns `201 {room_id}` (a generated id when the body omits one);
+`409` if the id is already live; `503` at the `max_rooms` cap; `400` for a
+`sample_rate` other than 8000/16000.
+
+## 4. What each side hears
+
+The room model is **mix-minus-self**. For N member calls the room mixes 2N
+streams (each call's SIP caller + its bot) and gives each side the mix minus
+its own input:
+
+- a **caller** hears every other caller and every bot, but not themselves;
+- a **bot** hears every caller (including its own — so its STT still works)
+  and every other bot, but not its own playout.
+
+Leaving a room, or the room dying (last member left / operator force-end),
+always restores the direct caller↔WS pair. Per-leg recording keeps working
+while in a room — the recorded "bot" channel is the room mix the caller
+actually heard.
+
+## 5. Observability
+
+- **Metrics** — `siphon_ai_conferences_active` (live rooms),
+  `siphon_ai_conference_participants` (mixer participants across all rooms;
+  each member call contributes 2), `siphon_ai_conference_joins_total{result}`
+  (`joined` / `disabled` / `too_many_rooms` / `room_full` / `rate_mismatch` /
+  `already_joined` / `error`), plus the room-health gauges
+  `siphon_ai_room_tick_lag_seconds` and
+  `siphon_ai_room_frames_dropped_total{stage,side}`. See `docs/DEPLOY.md`.
+- **Webhooks** — `conference_created` (first join / admin pre-create) and
+  `conference_ended { duration_ms, peak_participants }` (last leave /
+  force-end), pairing 1:1. Payloads in `docs/DEPLOY.md`.
+- **Logs** — join/leave/room-lifecycle at `info`/`debug` with `call_id` and
+  `room_id` in the span.
+
+## 6. Limitations (0.7.0)
+
+- **One sample rate per room.** A room locks to its first joiner's negotiated
+  rate (8 kHz or 16 kHz); a join at a different rate is rejected
+  (`rate_mismatch`) — there is no resampling in 0.7.0.
+- **`max_participants_per_room` is kept small (default 8).** Per-sink
+  mix-minus-self is O(N²); the cap bounds per-tick mixing cost.
+- **No DTMF-IVR / PIN / host controls.** SiphonAI uses `forge-mixer` +
+  `forge-injection` directly, not `forge-conference` — menus, PINs, and
+  moderator controls are a WS-server concern (DEV_PLAN_0.7.0.md §9.4).
+- **SIPp coverage asserts lifecycle, not mixed audio.** The two-caller SIPp
+  phase verifies that two calls land in one room (metrics) and tear down
+  cleanly; audio-correctness is covered by media-glue unit tests with
+  synthetic PCM.

--- a/docs/DEV_PLAN.md
+++ b/docs/DEV_PLAN.md
@@ -36,14 +36,16 @@ It accepts inbound voice calls — either from a SIP trunk or as a registered en
 **v1 promise:**
 > "Point your PBX at SiphonAI, point SiphonAI at your WebSocket. Get real-time bidirectional audio with barge-in, DTMF, and call control. Bring your own AI."
 
-**v1 explicitly does NOT include:**
-- AI integration (any kind)
-- Multi-tenancy / per-DID routing (single global config)
-- Outbound originated calls (inbound-only for v1)
-- Conferencing
-- Video
-- Recording (deferred — forge has it, we'll expose it post-v1)
-- WebRTC client support (forge has it, but SiphonAI is SIP-only for v1)
+**The original v1 cut explicitly did NOT include:**
+- AI integration (any kind) — still out of scope, permanently
+- Multi-tenancy / per-DID routing (single global config) — still out of scope
+- Video — still out of scope
+- WebRTC client support (forge has it, but SiphonAI is SIP-only) — still out of scope
+
+**Delivered in later releases** (were deferred at the v1 cut, now shipped — off by default):
+- Recording — 0.5.0 (`docs/CONFIG.md` `[recording]`)
+- Outbound originated calls + attended transfer — 0.6.0 / 0.6.1 (`docs/OUTBOUND.md`)
+- Conferencing / mixing and media-only call park — 0.7.0 (`docs/CONFERENCE.md`, `docs/PARK.md`)
 
 ---
 
@@ -107,9 +109,9 @@ It accepts inbound voice calls — either from a SIP trunk or as a registered en
 ### 3.3 From `forge-media` — explicitly NOT used in v1
 
 - `forge-ai-stream` — SiphonAI is BYO-AI
-- `forge-conference-processor`, `forge-mixer` — 1:1 calls only
+- `forge-conference-processor` — its DTMF-IVR / PIN / host-control layer is out of scope (§9.4 of DEV_PLAN_0.7.0.md). **Update (0.7.0):** `forge-mixer` + `forge-injection` ARE now used — conferencing (mixed rooms) and call park (hold music) consume them directly.
 - `forge-webrtc` — SIP-only
-- `forge-siprec`, `forge-recording` — deferred
+- `forge-siprec` — deferred (note: `forge-recording` is used as of 0.5.0)
 - `forge-api` — we're using forge as a library, not consuming its REST API
 - `forge-ha`, `forge-kernel` — overkill for v1
 

--- a/docs/PARK.md
+++ b/docs/PARK.md
@@ -1,0 +1,137 @@
+# Call Park & Retrieve
+
+SiphonAI can **park** a call (0.7.0): shelve it without a WebSocket session,
+play hold music to the caller, and keep the SIP dialog + RTP up until the
+call is **retrieved** onto a *fresh* WS session — or it times out / hangs up.
+Park detaches the bot from the call without ending the call.
+
+```
+                       park                          retrieve (operator)
+WS server A ──────► (detached)        ... hold music ...    ──────► WS server B
+   │                   │                                              │
+caller ──RTP──► SiphonAI ─────── SIP dialog + RTP stay up ───────► SiphonAI ──► caller
+```
+
+The call's `MediaTap` task and SIP dialog are durable across a park; only the
+WS bridge detaches. Retrieve opens a **new** session (new `seq` from 0,
+`start.retrieved: true`, no replay) — it is **not** a mid-call WS reconnect.
+
+## 1. Enabling
+
+Park is **off by default** and fail-closed: a park is refused
+(`error { code: "park_failed" }`) unless `[park]` is turned on. See
+`docs/CONFIG.md` (`[park]`) for every field; the short version:
+
+```toml
+[park]
+enabled        = true                      # false (default) = every park refused
+moh_file       = "/etc/siphon-ai/moh.wav"  # optional; comfort noise if unset
+timeout_secs   = 300                       # 0 = park indefinitely
+timeout_action = "hangup"                  # "hangup" | "keep"
+max_parked     = 32                        # daemon-wide cap (≥ 1)
+```
+
+`moh_file` is **validated and decoded at load** — a missing or garbage file
+fails startup loud. Its native sample rate is resolved per-park; a call
+negotiated at a *different* rate falls back to comfort noise (no resampling
+in 0.7.0), logged once — not a park failure. Park is a daemon-level facility:
+global only, no per-route overrides, and it applies to inbound **and**
+outbound calls.
+
+## 2. Parking a call
+
+Two ways to park, both ending with SiphonAI sending `stop { reason: "park" }`
+and closing that WS while the call lives on:
+
+**WS server parks its own call** (self-scoped, `docs/PROTOCOL.md` §4.9):
+
+```json
+{ "type": "park", "call_id": "...", "slot": "lot-3" }
+```
+
+`slot` is an optional human label for the hold lot (surfaces in
+`GET /admin/v1/parked` and the `call_parked` webhook). On success the server
+receives `stop { reason: "park" }` and the WS closes — the server learns "you
+were parked, not hung up." On failure (park disabled, or `max_parked`
+reached) it gets `error { code: "park_failed" }` and the call continues
+unparked on the current session.
+
+**Operator parks any call** (admin API, `docs/DEPLOY.md`):
+
+```sh
+curl -X POST http://localhost:9091/admin/v1/calls/siphon-a/park \
+    -d '{"slot":"lot-3"}'        # → 202 (dispatched); 404 unknown call
+```
+
+`202` means *dispatched* — the daemon signals the call and its own controller
+parks it; the outcome surfaces on that call's WS (`stop{park}`) and the
+`call_parked` webhook. A park refused by the `max_parked` cap is **not** a
+`503` here — it surfaces as `park_failed` on the call's WS while the call
+continues unparked.
+
+## 3. Retrieving a parked call (operator-only)
+
+Retrieve is driven **only** by the admin API — a parked call has no WS
+session to ask, the mirror of why conference participants are removed by the
+operator and not by a peer:
+
+```sh
+# ws_url is optional — defaults to the call's original bridge ws_url
+curl -X POST http://localhost:9091/admin/v1/calls/siphon-a/retrieve \
+    -d '{"ws_url":"wss://my-bot.example/retrieve"}'   # → 202
+```
+
+SiphonAI opens a **fresh** WS session to `ws_url` and sends a new `start` with
+`retrieved: true` (`docs/PROTOCOL.md` §3.1) — the new server knows it's
+picking up a parked call, not a fresh inbound one. Responses: `202`
+dispatched, `404` unknown call, `409` if the named call exists but isn't
+parked, `501` when park is off. Inspect what's parked with:
+
+```sh
+curl -s http://localhost:9091/admin/v1/parked
+# → {"count":1,"parked":[{"call_id":"siphon-a","slot":"lot-3","parked_secs":42}]}
+```
+
+A call may park and retrieve repeatedly over its lifetime.
+
+## 4. Timeout
+
+`timeout_secs` bounds how long a call may stay parked (`0` = indefinite).
+When it fires, SiphonAI emits the `park_timeout` webhook and then applies
+`timeout_action`:
+
+- **`hangup`** — tear the call down (normal teardown, CDR written).
+- **`keep`** — leave it parked; the operator must retrieve or hang up. The
+  timer does not re-arm.
+
+A retrieve or a caller BYE before the deadline disarms the timer.
+
+## 5. Observability
+
+- **Metrics** — `siphon_ai_parks_total{result}` (`ok` / `rejected`),
+  `siphon_ai_retrieves_total{result}` (`ok` / `not_parked`), and the
+  `siphon_ai_parked_calls_active` gauge. See `docs/DEPLOY.md`.
+- **Webhooks** — `call_parked { slot? }`, `call_retrieved { ws_url }`,
+  `park_timeout { action }`. Payloads in `docs/DEPLOY.md`.
+- **CDR** — `park { count, total_ms }` (additive, schema stays v1): park
+  episodes + cumulative parked wall-time, omitted when the call was never
+  parked.
+- **Recording** — a recording in progress at park keeps writing; the parked
+  span records the MOH the caller hears (consistent with "what the caller
+  heard").
+- **Logs** — `call parked` / `call retrieved onto fresh WS session` /
+  `park timeout fired` at `info`, with `call_id` in the span.
+
+## 6. Limitations (0.7.0)
+
+- **Media-only park.** There is no SIP re-INVITE/hold — the dialog stays
+  `sendrecv` and SiphonAI keeps sending RTP (the MOH needs it).
+- **Retrieve is operator-initiated only**, onto a fresh WS session. This is
+  deliberately **not** mid-call WS reconnect (still out of scope).
+- **No resampling for MOH.** A `moh_file` whose native rate differs from the
+  call's negotiated rate falls back to comfort noise.
+- **No per-slot hold music.** The `slot` label is metadata only; every parked
+  call hears the same `moh_file` (or comfort noise).
+- **SIPp coverage asserts signaling + metrics**, not the MOH audio content:
+  the park→retrieve→hangup and park→timeout→hangup phases verify the call
+  survives a park and tears down on retrieve/timeout.

--- a/test-harness/sipp-scenarios/README.md
+++ b/test-harness/sipp-scenarios/README.md
@@ -51,6 +51,8 @@ sipp -sf basic_call_then_bye.xml -m 1 -p 5070 -s 1000 127.0.0.1:5060
 | `stir_shaken_attestation_403.xml`   | STIR/SHAKEN gate: `Identity` present but unverifiable (unreachable `x5u`) below `min_attestation = "A"` → 403 Forbidden (stir_shaken phase) |
 | `stir_shaken_attestation_pass.xml`  | STIR/SHAKEN happy path: a fully-verifiable `Identity` (fresh PASSporT, real x5u fetch, chain to the test anchor) → **200 admitted** (stir_shaken phase). Templated — `__IDENTITY__` is substituted at run time; does not run standalone. |
 | `outbound_uas_answer.xml`           | 0.6.0 outbound answer path, roles inverted: SiphonAI dials via `POST /admin/v1/calls`, SIPp answers (180 → 200 + SDP), bridge runs, SiphonAI BYEs (outbound phase) |
+| `park_caller.xml`                   | 0.7.0 call park: caller is answered + bridged, the echo-ws parks it (`--auto-park`), and SiphonAI BYEs the caller when the park resolves. Shared by the **park_timeout** and **park_retrieve** phases |
+| `conference_caller.xml`             | 0.7.0 conferencing: a caller that stays up while the echo-ws joins it to a room (`--auto-conference-join`); two run concurrently in the **conference** phase |
 
 `run-all.sh` also has an always-on **recording** auxiliary phase: it starts
 a daemon with `[recording].mode = "always"` writing to a temp dir, runs one
@@ -65,6 +67,28 @@ instance with `--auto-hangup-after-ms 1500` (so the WS side ends the call),
 backgrounds SIPp as the callee, then POSTs `/admin/v1/calls`. Pass = SIPp
 completed INVITE → ACK → BYE **and** the daemon's
 `siphon_ai_outbound_calls_total{result="answered"}` metric reads 1.
+
+`run-all.sh` has two always-on **park** auxiliary phases (0.7.0), both using
+`park_caller.xml` and an echo-ws started with `--auto-park`:
+
+- **park_timeout** — a daemon with `[park]` `timeout_secs = 1`,
+  `timeout_action = "hangup"`. The call is parked, the timeout fires, and
+  SiphonAI BYEs the caller. Pass = SIPp saw the BYE **and**
+  `siphon_ai_parks_total{result="ok"}` reads 1.
+- **park_retrieve** — `[park]` with no timeout. The runner backgrounds the
+  caller, waits until it appears in `GET /admin/v1/parked`, then POSTs
+  `/admin/v1/calls/:id/retrieve` onto a second echo-ws (`--auto-hangup-after-ms`).
+  SiphonAI opens a fresh WS to it, that side hangs up, and SiphonAI BYEs the
+  caller. Pass = SIPp saw the BYE **and**
+  `siphon_ai_retrieves_total{result="ok"}` reads 1.
+
+And an always-on **conference** phase (0.7.0): a daemon with `[conference]`
+enabled and an echo-ws started with `--auto-conference-join`. Two
+`conference_caller.xml` callers (on different ports) bridge to the same room.
+Pass = the daemon mixes both (`siphon_ai_conference_participants` reads 4 —
+two calls × SIP leg + WS session) **and** the room ends after both hang up
+(`siphon_ai_conferences_active` returns to 0). SIPp can't assert mixed audio
+content — that's covered by media-glue unit tests with synthetic PCM.
 
 The `stir_shaken_*` scenarios run in `run-all.sh`'s always-on
 **stir_shaken** auxiliary phase. It builds + runs the

--- a/test-harness/sipp-scenarios/conference_caller.xml
+++ b/test-harness/sipp-scenarios/conference_caller.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  conference_caller — SIPp acts as a caller (UAC); SiphonAI is the UAS.
+  Two instances of this scenario run concurrently (on different listen
+  ports) in run-all.sh's conference auxiliary phase: each call is
+  answered and bridged to an echo server started with
+  --auto-conference-join, so both legs land in the SAME room. While both
+  are up, the runner asserts the daemon mixed them (conferences_active=1,
+  conference_participants=4 — two calls × (SIP leg + WS session)). The
+  pause holds the call up long enough for the room to form and the metric
+  scrape to land before this leg hangs up.
+
+  SiphonAI does not send 100/180 in v1; those recv lines are optional.
+-->
+<scenario name="conference_caller">
+  <send>
+<![CDATA[
+INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+Max-Forwards: 70
+From: <sip:sipp@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:sipp@[local_ip]:[local_port]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=user1 53655765 2353687637 IN IP4 [local_ip]
+s=-
+c=IN IP4 [local_ip]
+t=0 0
+m=audio 9000 RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+]]>
+  </send>
+
+  <recv response="100" optional="true"/>
+  <recv response="180" optional="true"/>
+  <recv response="183" optional="true"/>
+
+  <recv response="200" rtd="true"/>
+
+  <send>
+<![CDATA[
+ACK sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]-ack
+Max-Forwards: 70
+From: <sip:sipp@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- Stay up while both legs join the room and the runner scrapes the
+       conference metrics. -->
+  <pause milliseconds="3000"/>
+
+  <send>
+<![CDATA[
+BYE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]-bye
+Max-Forwards: 70
+From: <sip:sipp@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 BYE
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="200" rtd="true"/>
+</scenario>

--- a/test-harness/sipp-scenarios/park_caller.xml
+++ b/test-harness/sipp-scenarios/park_caller.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  park_caller — SIPp acts as the caller (UAC); SiphonAI is the UAS. The
+  call is answered and bridged, the harness echo server parks it (started
+  with --auto-park), and SiphonAI BYEs us when the park resolves:
+    * park → timeout → hangup   ([park].timeout_action = "hangup"), or
+    * park → retrieve → hangup  (the runner retrieves onto a second echo
+      server that auto-hangs-up).
+  Either way the caller's job is the same: answer, then wait for the
+  daemon-initiated BYE. Shared by run-all.sh's two park auxiliary phases;
+  the scenario alone does nothing special — the park behaviour is driven
+  by the echo server + (for retrieve) the runner's admin call.
+
+  SiphonAI does not send 100/180 in v1; those recv lines are optional so
+  the transaction layer's retransmit timing doesn't fail the run.
+-->
+<scenario name="park_caller">
+  <send>
+<![CDATA[
+INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+Max-Forwards: 70
+From: <sip:sipp@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:sipp@[local_ip]:[local_port]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=user1 53655765 2353687637 IN IP4 [local_ip]
+s=-
+c=IN IP4 [local_ip]
+t=0 0
+m=audio 9000 RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+]]>
+  </send>
+
+  <recv response="100" optional="true"/>
+  <recv response="180" optional="true"/>
+  <recv response="183" optional="true"/>
+
+  <recv response="200" rtd="true"/>
+
+  <send>
+<![CDATA[
+ACK sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]-ack
+Max-Forwards: 70
+From: <sip:sipp@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- Call is up and bridged; the echo server parks it. SiphonAI keeps
+       the dialog + RTP alive (media-only park) and BYEs us when the park
+       resolves (timeout-hangup or retrieve then echo-B hangup). -->
+  <recv request="BYE" rtd="true"/>
+
+  <send>
+<![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+</scenario>

--- a/test-harness/sipp-scenarios/run-all.sh
+++ b/test-harness/sipp-scenarios/run-all.sh
@@ -558,6 +558,271 @@ fi
 at_cleanup
 trap - EXIT
 
+# ─── Always-on auxiliary phase: park → timeout → hangup ───────────
+# SIPp calls in; the echo-ws parks the call (--auto-park) → the WS
+# detaches and the caller hears hold music; [park].timeout_secs=1 with
+# timeout_action="hangup" fires and SiphonAI BYEs the caller. Pass =
+# SIPp saw the BYE AND parks_total{result="ok"} ticked.
+echo
+echo "─── auxiliary phase: park_timeout ─────────────────────"
+PK_WS_PORT=8770
+PK_ADMIN_PORT=9091
+PK_WS_LOG=$(mktemp -t echo-ws-pk.XXXXXX.log)
+PK_DAEMON_LOG=$(mktemp -t siphon-ai-pk.XXXXXX.log)
+PK_CONFIG=$(mktemp -t siphon-ai-pk.XXXXXX.toml)
+cat >"$PK_CONFIG" <<EOF
+[node]
+id = "siphon-ai-sipp-pk"
+[sip]
+listen = "127.0.0.1:$DAEMON_PORT"
+[media]
+codecs = ["pcmu"]
+[bridge]
+ws_url = "ws://127.0.0.1:$PK_WS_PORT/"
+[observability]
+enabled = true
+http_listen = "127.0.0.1:$PK_ADMIN_PORT"
+[park]
+enabled = true
+timeout_secs = 1
+timeout_action = "hangup"
+[[route]]
+name = "default"
+[route.match]
+any = true
+EOF
+
+PK_PYTHON="$REPO_ROOT/examples/echo-ws-server-python/.venv/bin/python"
+[[ -x "$PK_PYTHON" ]] || PK_PYTHON=python3
+"$PK_PYTHON" "$REPO_ROOT/examples/echo-ws-server-python/server.py" \
+    --bind "127.0.0.1:$PK_WS_PORT" \
+    --auto-park \
+    >"$PK_WS_LOG" 2>&1 &
+PK_WS_PID=$!
+
+RUST_LOG=siphon_ai=info "$DAEMON_BIN" --config "$PK_CONFIG" \
+    >"$PK_DAEMON_LOG" 2>&1 &
+PK_DAEMON_PID=$!
+pk_cleanup() {
+    kill "$PK_WS_PID" "$PK_DAEMON_PID" 2>/dev/null || true
+    wait "$PK_WS_PID" "$PK_DAEMON_PID" 2>/dev/null || true
+}
+trap pk_cleanup EXIT
+sleep 1.2
+
+total=$((total + 1))
+echo "─── park_timeout_hangup ──────────────────────────────"
+pk_ok=0
+if sipp -i 127.0.0.1 -sf "$SCRIPT_DIR/park_caller.xml" -m 1 -timeout 15s -trace_err \
+        -p "$SIPP_PORT" -s 1000 "127.0.0.1:$DAEMON_PORT" >/dev/null 2>&1; then
+    if curl -s "http://127.0.0.1:$PK_ADMIN_PORT/metrics" \
+        | grep -q 'siphon_ai_parks_total{result="ok"} 1'; then
+        pk_ok=1
+    fi
+fi
+if (( pk_ok )); then
+    echo "  OK"
+else
+    echo "  FAIL (daemon: $PK_DAEMON_LOG; ws: $PK_WS_LOG)"
+    failures=$((failures + 1))
+fi
+
+pk_cleanup
+trap - EXIT
+
+# ─── Always-on auxiliary phase: park → retrieve → hangup ──────────
+# SIPp calls in; echo-ws A parks the call (--auto-park, no timeout). The
+# runner waits until the call shows up in GET /admin/v1/parked, then
+# POSTs a retrieve onto echo-ws B (which auto-hangs-up). SiphonAI opens a
+# fresh WS to B, B hangs up, and SiphonAI BYEs the caller. Pass = SIPp
+# saw the BYE AND retrieves_total{result="ok"} ticked.
+echo
+echo "─── auxiliary phase: park_retrieve ────────────────────"
+PR_WS_A_PORT=8770
+PR_WS_B_PORT=8771
+PR_ADMIN_PORT=9091
+PR_WS_A_LOG=$(mktemp -t echo-ws-pr-a.XXXXXX.log)
+PR_WS_B_LOG=$(mktemp -t echo-ws-pr-b.XXXXXX.log)
+PR_DAEMON_LOG=$(mktemp -t siphon-ai-pr.XXXXXX.log)
+PR_CONFIG=$(mktemp -t siphon-ai-pr.XXXXXX.toml)
+cat >"$PR_CONFIG" <<EOF
+[node]
+id = "siphon-ai-sipp-pr"
+[sip]
+listen = "127.0.0.1:$DAEMON_PORT"
+[media]
+codecs = ["pcmu"]
+[bridge]
+ws_url = "ws://127.0.0.1:$PR_WS_A_PORT/"
+[observability]
+enabled = true
+http_listen = "127.0.0.1:$PR_ADMIN_PORT"
+[park]
+enabled = true
+timeout_secs = 0
+[[route]]
+name = "default"
+[route.match]
+any = true
+EOF
+
+PR_PYTHON="$REPO_ROOT/examples/echo-ws-server-python/.venv/bin/python"
+[[ -x "$PR_PYTHON" ]] || PR_PYTHON=python3
+# A parks the inbound call; B is the retrieve target and hangs up shortly
+# after it receives its (retrieved) start.
+"$PR_PYTHON" "$REPO_ROOT/examples/echo-ws-server-python/server.py" \
+    --bind "127.0.0.1:$PR_WS_A_PORT" --auto-park >"$PR_WS_A_LOG" 2>&1 &
+PR_WS_A_PID=$!
+"$PR_PYTHON" "$REPO_ROOT/examples/echo-ws-server-python/server.py" \
+    --bind "127.0.0.1:$PR_WS_B_PORT" --auto-hangup-after-ms 1500 >"$PR_WS_B_LOG" 2>&1 &
+PR_WS_B_PID=$!
+
+RUST_LOG=siphon_ai=info "$DAEMON_BIN" --config "$PR_CONFIG" \
+    >"$PR_DAEMON_LOG" 2>&1 &
+PR_DAEMON_PID=$!
+PR_SIPP_PID=""
+pr_cleanup() {
+    kill "$PR_WS_A_PID" "$PR_WS_B_PID" "$PR_DAEMON_PID" $PR_SIPP_PID 2>/dev/null || true
+    wait "$PR_WS_A_PID" "$PR_WS_B_PID" "$PR_DAEMON_PID" $PR_SIPP_PID 2>/dev/null || true
+}
+trap pr_cleanup EXIT
+sleep 1.2
+
+total=$((total + 1))
+echo "─── park_retrieve_hangup ─────────────────────────────"
+pr_ok=0
+# Caller in the background — it answers and then waits for the BYE.
+sipp -i 127.0.0.1 -sf "$SCRIPT_DIR/park_caller.xml" -m 1 -timeout 20s -trace_err \
+    -p "$SIPP_PORT" -s 1000 "127.0.0.1:$DAEMON_PORT" >/dev/null 2>&1 &
+PR_SIPP_PID=$!
+sleep 0.3
+
+# Wait until the call is parked, then grab its bridge call_id.
+parked_id=""
+for _ in $(seq 1 25); do
+    parked_id=$(curl -s "http://127.0.0.1:$PR_ADMIN_PORT/admin/v1/parked" \
+        | sed -n 's/.*"call_id":"\([^"]*\)".*/\1/p' | head -1)
+    [[ -n "$parked_id" ]] && break
+    sleep 0.2
+done
+
+if [[ -n "$parked_id" ]]; then
+    curl -s -o /dev/null -X POST \
+        "http://127.0.0.1:$PR_ADMIN_PORT/admin/v1/calls/$parked_id/retrieve" \
+        -d "{\"ws_url\": \"ws://127.0.0.1:$PR_WS_B_PORT/\"}"
+    # echo-ws B hangs up → SiphonAI BYEs the caller → SIPp completes.
+    if wait "$PR_SIPP_PID" && curl -s "http://127.0.0.1:$PR_ADMIN_PORT/metrics" \
+        | grep -q 'siphon_ai_retrieves_total{result="ok"} 1'; then
+        pr_ok=1
+    fi
+fi
+if (( pr_ok )); then
+    echo "  OK"
+else
+    echo "  FAIL (parked_id=$parked_id; daemon: $PR_DAEMON_LOG;" \
+         "ws A: $PR_WS_A_LOG; ws B: $PR_WS_B_LOG)"
+    failures=$((failures + 1))
+fi
+
+pr_cleanup
+trap - EXIT
+
+# ─── Always-on auxiliary phase: conference (two callers) ──────────
+# Two SIPp callers (on different ports) both bridge to one echo-ws
+# started with --auto-conference-join, so both legs land in the SAME
+# room. While both are up the runner asserts the daemon mixed them
+# (conference_participants=4 — two calls × SIP leg + WS session); after
+# both hang up the room ends (conferences_active=0).
+echo
+echo "─── auxiliary phase: conference ───────────────────────"
+CF_WS_PORT=8772
+CF_ADMIN_PORT=9091
+CF_SIPP2_PORT=5082
+CF_WS_LOG=$(mktemp -t echo-ws-cf.XXXXXX.log)
+CF_DAEMON_LOG=$(mktemp -t siphon-ai-cf.XXXXXX.log)
+CF_CONFIG=$(mktemp -t siphon-ai-cf.XXXXXX.toml)
+cat >"$CF_CONFIG" <<EOF
+[node]
+id = "siphon-ai-sipp-cf"
+[sip]
+listen = "127.0.0.1:$DAEMON_PORT"
+[media]
+codecs = ["pcmu"]
+[bridge]
+ws_url = "ws://127.0.0.1:$CF_WS_PORT/"
+[observability]
+enabled = true
+http_listen = "127.0.0.1:$CF_ADMIN_PORT"
+[conference]
+enabled = true
+[[route]]
+name = "default"
+[route.match]
+any = true
+EOF
+
+CF_PYTHON="$REPO_ROOT/examples/echo-ws-server-python/.venv/bin/python"
+[[ -x "$CF_PYTHON" ]] || CF_PYTHON=python3
+"$CF_PYTHON" "$REPO_ROOT/examples/echo-ws-server-python/server.py" \
+    --bind "127.0.0.1:$CF_WS_PORT" \
+    --auto-conference-join confroom \
+    >"$CF_WS_LOG" 2>&1 &
+CF_WS_PID=$!
+
+RUST_LOG=siphon_ai=info "$DAEMON_BIN" --config "$CF_CONFIG" \
+    >"$CF_DAEMON_LOG" 2>&1 &
+CF_DAEMON_PID=$!
+CF_S1_PID=""
+CF_S2_PID=""
+cf_cleanup() {
+    kill "$CF_WS_PID" "$CF_DAEMON_PID" $CF_S1_PID $CF_S2_PID 2>/dev/null || true
+    wait "$CF_WS_PID" "$CF_DAEMON_PID" $CF_S1_PID $CF_S2_PID 2>/dev/null || true
+}
+trap cf_cleanup EXIT
+sleep 1.2
+
+total=$((total + 1))
+echo "─── conference_two_callers ───────────────────────────"
+cf_ok=0
+# Two concurrent callers → both join "confroom" via the echo-ws.
+sipp -i 127.0.0.1 -sf "$SCRIPT_DIR/conference_caller.xml" -m 1 -timeout 20s -trace_err \
+    -p "$SIPP_PORT" -s 1000 "127.0.0.1:$DAEMON_PORT" >/dev/null 2>&1 &
+CF_S1_PID=$!
+sipp -i 127.0.0.1 -sf "$SCRIPT_DIR/conference_caller.xml" -m 1 -timeout 20s -trace_err \
+    -p "$CF_SIPP2_PORT" -s 1000 "127.0.0.1:$DAEMON_PORT" >/dev/null 2>&1 &
+CF_S2_PID=$!
+
+# Wait until both legs are mixed into the room.
+cf_mixed=0
+for _ in $(seq 1 30); do
+    if curl -s "http://127.0.0.1:$CF_ADMIN_PORT/metrics" \
+        | grep -q 'siphon_ai_conference_participants 4'; then
+        cf_mixed=1; break
+    fi
+    sleep 0.2
+done
+
+if (( cf_mixed )) && wait "$CF_S1_PID" && wait "$CF_S2_PID"; then
+    # Both callers hung up; the room ends once both legs tear down — async
+    # after the BYE/200, so poll briefly rather than scraping once.
+    for _ in $(seq 1 15); do
+        if curl -s "http://127.0.0.1:$CF_ADMIN_PORT/metrics" \
+            | grep -q 'siphon_ai_conferences_active 0'; then
+            cf_ok=1; break
+        fi
+        sleep 0.2
+    done
+fi
+if (( cf_ok )); then
+    echo "  OK"
+else
+    echo "  FAIL (mixed=$cf_mixed; daemon: $CF_DAEMON_LOG; ws: $CF_WS_LOG)"
+    failures=$((failures + 1))
+fi
+
+cf_cleanup
+trap - EXIT
+
 # ─── Optional third phase: blind_transfer ─────────────────────────
 # Needs a WS server that proactively emits BridgeIn::Transfer. The
 # runner stops the daemon, brings up an echo-ws that auto-emits


### PR DESCRIPTION
Chunk **5 of 5** — the docs / test / release finalisation for the **0.7.0** theme (conferencing + media-only call park). No new runtime behaviour; this closes out conferencing (#165–#167) and call park (#168).

## Feature guides
- **`docs/CONFERENCE.md`** — N-way mixed rooms: enabling, WS self-join (`conference_join`/`leave`), operator admin CRUD, the mix-minus-self model, observability, limitations.
- **`docs/PARK.md`** — media-only park: enabling, WS/admin park, operator-only retrieve onto a *fresh* session (`start.retrieved`), timeout, observability, limitations.

## Doc-drift fixes
`CLAUDE.md` §8 and `docs/DEV_PLAN.md` still listed recording / outbound / conferencing as "out of scope for v1" — all shipped (0.5.0 / 0.6.0 / 0.7.0). Corrected so an agent won't refuse work on supported features; `forge-mixer` + `forge-injection` are now noted as used (rooms + hold music), with only `forge-conference`'s IVR layer staying out of scope. README gains a v0.7.0 status entry.

## SIPp signaling regression
Three new **always-on** phases in `run-all.sh`, each cross-checking the feature's metric:

| Phase | Flow | Assert |
|---|---|---|
| `park_timeout` | caller answered → WS parks it → `timeout_secs=1` hangup → SiphonAI BYEs | `parks_total{result="ok"} 1` |
| `park_retrieve` | caller parked → runner reads `/admin/v1/parked`, retrieves onto a 2nd echo-ws that hangs up → SiphonAI BYEs | `retrieves_total{result="ok"} 1` |
| `conference` | two concurrent callers join one room (`--auto-conference-join`) | `conference_participants 4` up, `conferences_active 0` after teardown |

New scenarios `park_caller.xml` + `conference_caller.xml`; harness README updated. SIPp can't assert mixed audio content — that stays covered by media-glue unit tests with synthetic PCM. **Full suite green locally: 16/16.**

## Release
Workspace version **0.6.2 → 0.7.0**; `CHANGELOG.md` `[Unreleased]` → `[0.7.0]` with the park (chunk 4) and chunk-5 entries plus a theme summary.

> The tag/GitHub release for v0.7.0 is a separate step after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)