### PR TITLE
feat(media-glue): outbound SRTP (SDES) offer/answer core (chunk 1)

### DIFF
--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -377,6 +377,9 @@ impl AcceptError {
             }
             AcceptError::Setup(SetupError::Session(_))
             | AcceptError::Setup(SetupError::Tap(_))
+            // SetupError::Srtp only arises on the outbound apply_answer
+            // path (never inbound accept); map it defensively to 500.
+            | AcceptError::Setup(SetupError::Srtp(_))
             | AcceptError::Controller(_) => (500, "Server Internal Error"),
             AcceptError::SrtpModeMismatch { .. } => (488, "Not Acceptable Here"),
             AcceptError::IdentityRequired => (428, "Use Identity Header"),

--- a/crates/core/src/outbound_service.rs
+++ b/crates/core/src/outbound_service.rs
@@ -178,6 +178,9 @@ impl OutboundOriginateHandle for OutboundService {
             participant_b: ParticipantId::generate(),
             from_tag: None,
             to_tag: None,
+            // SRTP wiring from [[gateway]].srtp lands in the next chunk;
+            // plaintext for now (unchanged 0.6.x behaviour).
+            srtp: siphon_ai_media_glue::OutboundSrtp::Off,
         };
         let tap = TapOptions {
             barge_in_action: barge_in_to_tap_action(&self.defaults.barge_in),

--- a/crates/media-glue/src/lib.rs
+++ b/crates/media-glue/src/lib.rs
@@ -26,6 +26,6 @@ pub use sdp::{
 };
 pub use setup::{
     InboundAccepted, InboundCall, MediaSetup, OutboundAccepted, OutboundOffer,
-    OutboundOfferRequest, SetupError, TapOptions,
+    OutboundOfferRequest, OutboundSrtp, SetupError, TapOptions,
 };
 pub use tap::{BargeInAction, MediaTap, MediaTapError, TapCommand, TapDisconnect};

--- a/crates/media-glue/src/sdp.rs
+++ b/crates/media-glue/src/sdp.rs
@@ -27,10 +27,17 @@
 //!   `MediaBridgeManager`, no `SessionManager`. Wiring those up
 //!   together with the SDP step is the next layer's job (a future
 //!   `MediaSetup` helper or the daemon's `CallAcceptor`).
-//! - **Doesn't support SRTP.** v1 is `RTP/AVP` only; SRTP is
-//!   listed as deferred in CLAUDE.md §8.
+//! - **Inbound SRTP is forge's job.** When answering, we pass the raw
+//!   offer to forge, which negotiates SRTP (DTLS-SRTP) itself. The
+//!   *outbound* offer path here can produce an SDES `a=crypto:` /
+//!   `RTP/SAVP` offer ([`generate_offer`] with a crypto attribute) and
+//!   surface the peer's answered key ([`AnswerOutcome::peer_srtp`]); the
+//!   key install onto the forge session lives in [`crate::setup`].
 
-use forge_sdp::{helpers, MediaDescription, MediaType, SessionDescription, SessionDescriptionExt};
+use forge_sdp::sdes::{CryptoAttribute, MediaSdesAttributesExt};
+use forge_sdp::{
+    helpers, MediaDescription, MediaType, Protocol, SessionDescription, SessionDescriptionExt,
+};
 use thiserror::Error;
 
 /// Codecs SiphonAI v1 supports. Anything not in this list is
@@ -142,8 +149,19 @@ pub struct LocalCapabilities {
 impl LocalCapabilities {
     /// Build the `SessionDescription` the upstream negotiator
     /// expects. The result advertises every configured codec, in
-    /// order, at our `local_port`.
+    /// order, at our `local_port`. Plaintext `RTP/AVP` — see
+    /// [`to_sdp_with_srtp`](Self::to_sdp_with_srtp) for the SRTP offer.
     pub fn to_sdp(&self) -> SessionDescription {
+        self.to_sdp_with_srtp(None)
+    }
+
+    /// Like [`to_sdp`](Self::to_sdp), but when `srtp` is `Some` the audio
+    /// media is offered as `RTP/SAVP` carrying the given SDES `a=crypto:`
+    /// line (RFC 4568) — the master key *we* generated and will use to
+    /// encrypt our outbound RTP. Used only on the **offer** side (outbound
+    /// origination); inbound answers pass `None` (forge negotiates inbound
+    /// SRTP from the received offer).
+    pub fn to_sdp_with_srtp(&self, srtp: Option<&CryptoAttribute>) -> SessionDescription {
         // sip-sdp's negotiator uses `local_media.port` for the
         // answer's `m=audio` port (negotiate.rs §base_answer_media).
         // So whatever we put here ends up on the wire.
@@ -186,9 +204,18 @@ impl LocalCapabilities {
 
         // sendrecv is the v1 default; hold/resume re-INVITE flips
         // direction in a separate exchange.
-        let audio = audio
+        let mut audio = audio
             .with_direction("sendrecv")
             .expect("sendrecv is a valid direction");
+
+        // SRTP (SDES, RFC 4568): flip the transport to RTP/SAVP and
+        // attach the `a=crypto:` line carrying our master key. forge's
+        // RTP path encrypts once the matching key is installed on the
+        // session (see `MediaSetup::apply_answer`).
+        if let Some(crypto) = srtp {
+            audio.protocol = Protocol::RtpSavp;
+            audio.add_media_crypto(crypto);
+        }
 
         SessionDescription::builder()
             .origin("siphon-ai", &fresh_session_id(), &self.local_ip)
@@ -261,6 +288,12 @@ pub struct AnswerOutcome {
     /// by the call layer to surface hold/resume to the WS server
     /// and (eventually) pause forge's outbound RTP.
     pub negotiated_direction: MediaDirection,
+    /// The peer's SDES `a=crypto:` from the **answer**, when we offered
+    /// SRTP and the peer accepted it (RFC 4568) — the master key the peer
+    /// will encrypt *its* RTP with, i.e. our receive key. `None` on the
+    /// inbound answer path and when the peer answered plaintext `RTP/AVP`
+    /// (a downgrade). The outbound key-install path consumes this.
+    pub peer_srtp: Option<CryptoAttribute>,
 }
 
 /// Media direction per RFC 4566 / RFC 3264. The values mirror
@@ -399,6 +432,7 @@ pub fn negotiate_answer(
         negotiated_clock_rate: primary.clock_rate,
         negotiated_audio_sample_rate: codec.audio_sample_rate(),
         negotiated_direction,
+        peer_srtp: None,
     })
 }
 
@@ -413,8 +447,12 @@ pub fn build_answer(offer_sdp: &str, caps: &LocalCapabilities) -> Result<AnswerO
 /// in priority order, at our `local_port`, `sendrecv`. This is the inverse
 /// of [`negotiate_answer`]: there we answer a peer's offer; here we make the
 /// first move. The result is the body for the outbound INVITE.
-pub fn generate_offer(caps: &LocalCapabilities) -> String {
-    caps.to_sdp().serialize()
+///
+/// When `srtp` is `Some`, the offer is `RTP/SAVP` with the given SDES
+/// `a=crypto:` line (the master key we'll encrypt with); `None` offers
+/// plaintext `RTP/AVP`.
+pub fn generate_offer(caps: &LocalCapabilities, srtp: Option<&CryptoAttribute>) -> String {
+    caps.to_sdp_with_srtp(srtp).serialize()
 }
 
 /// Read the negotiated audio out of the peer's **answer** to an offer we
@@ -461,6 +499,12 @@ pub fn negotiate_offer_answer(
         .and_then(MediaDirection::from_attr)
         .unwrap_or_default();
 
+    // The peer's SDES key, when it accepted our SRTP offer. First valid
+    // `a=crypto:` only (we offer a single crypto line, so a compliant
+    // answer carries exactly one). Absent when the peer answered
+    // plaintext `RTP/AVP` — the downgrade case the caller policies on.
+    let peer_srtp = audio.get_media_crypto_attributes().into_iter().next();
+
     let answer_text = answer.serialize();
     Ok(AnswerOutcome {
         answer,
@@ -470,6 +514,7 @@ pub fn negotiate_offer_answer(
         negotiated_clock_rate: primary.clock_rate,
         negotiated_audio_sample_rate: codec.audio_sample_rate(),
         negotiated_direction,
+        peer_srtp,
     })
 }
 
@@ -538,7 +583,7 @@ a=sendrecv\r\n"
 
     #[test]
     fn generate_offer_advertises_codecs_at_local_port() {
-        let sdp = generate_offer(&caps(vec![Codec::Pcmu, Codec::Pcma]));
+        let sdp = generate_offer(&caps(vec![Codec::Pcmu, Codec::Pcma]), None);
         let parsed = parse_offer(&sdp).expect("our own offer parses");
         let audio = parsed
             .find_media(MediaType::Audio)
@@ -582,5 +627,78 @@ a=sendrecv\r\n"
             negotiate_offer_answer(&answer_sdp(4000, 0, "PCMU", 8000), &caps(vec![Codec::Pcma]))
                 .unwrap_err();
         assert!(matches!(err, SdpError::NoCommonCodec));
+    }
+
+    // ─── Outbound SRTP (SDES) ────────────────────────────────────────────
+
+    use forge_sdp::sdes::CryptoSuite;
+
+    fn a_crypto() -> CryptoAttribute {
+        CryptoAttribute::generate(1, CryptoSuite::Aes128CmHmacSha1_80)
+    }
+
+    /// Build a peer answer that ACCEPTED our SRTP offer: RTP/SAVP with an
+    /// `a=crypto:` line, assembled the same way production does.
+    fn savp_answer(port: u16, pt: u8, name: &str, clock: u32, crypto: &CryptoAttribute) -> String {
+        let mut sdp = parse_offer(&answer_sdp(port, pt, name, clock)).expect("base answer parses");
+        let audio = sdp
+            .find_media_mut(MediaType::Audio)
+            .expect("answer has audio");
+        audio.protocol = Protocol::RtpSavp;
+        audio.add_media_crypto(crypto);
+        sdp.serialize()
+    }
+
+    #[test]
+    fn generate_offer_without_srtp_is_plain_avp() {
+        let sdp = generate_offer(&caps(vec![Codec::Pcmu]), None);
+        let parsed = parse_offer(&sdp).expect("offer parses");
+        let audio = parsed.find_media(MediaType::Audio).expect("audio present");
+        assert_eq!(
+            audio.protocol,
+            Protocol::RtpAvp,
+            "default offer is plaintext"
+        );
+        assert!(
+            audio.get_media_crypto_attributes().is_empty(),
+            "no a=crypto on a plaintext offer"
+        );
+    }
+
+    #[test]
+    fn generate_offer_with_srtp_emits_savp_and_crypto() {
+        let crypto = a_crypto();
+        let sdp = generate_offer(&caps(vec![Codec::Pcmu]), Some(&crypto));
+        let parsed = parse_offer(&sdp).expect("offer parses");
+        let audio = parsed.find_media(MediaType::Audio).expect("audio present");
+        assert_eq!(
+            audio.protocol,
+            Protocol::RtpSavp,
+            "SRTP offer uses RTP/SAVP"
+        );
+        let cryptos = audio.get_media_crypto_attributes();
+        assert_eq!(cryptos.len(), 1, "exactly one a=crypto offered");
+        assert_eq!(cryptos[0].suite, CryptoSuite::Aes128CmHmacSha1_80);
+    }
+
+    #[test]
+    fn negotiate_offer_answer_extracts_peer_crypto() {
+        // Peer accepted SRTP — its a=crypto (our recv key) is surfaced.
+        let peer = a_crypto();
+        let answer = savp_answer(4000, 0, "PCMU", 8000, &peer);
+        let outcome = negotiate_offer_answer(&answer, &caps(vec![Codec::Pcmu])).unwrap();
+        let got = outcome.peer_srtp.expect("peer crypto surfaced");
+        assert_eq!(got.suite, CryptoSuite::Aes128CmHmacSha1_80);
+        // Key material is convertible (what the install path needs).
+        assert!(got.to_srtp_key_material().is_ok());
+    }
+
+    #[test]
+    fn negotiate_offer_answer_plaintext_answer_has_no_peer_crypto() {
+        // Peer answered plaintext RTP/AVP (a downgrade) — no peer key.
+        let outcome =
+            negotiate_offer_answer(&answer_sdp(4000, 0, "PCMU", 8000), &caps(vec![Codec::Pcmu]))
+                .unwrap();
+        assert!(outcome.peer_srtp.is_none());
     }
 }

--- a/crates/media-glue/src/setup.rs
+++ b/crates/media-glue/src/setup.rs
@@ -42,10 +42,12 @@
 use std::sync::Arc;
 
 use forge_core::{CallId, EventBus, ForgeError, ParticipantId};
+use forge_engine::srtp_install::install_srtp_keys;
 use forge_engine::{
     MediaBridgeManager, MediaSession, ParticipantCodecConfig, ParticipantLabel,
     ParticipantMediaUpdate, SessionManager,
 };
+use forge_sdp::sdes::{CryptoAttribute, CryptoSuite};
 use thiserror::Error;
 use tracing::{debug, info, instrument, warn};
 
@@ -171,6 +173,28 @@ pub struct OutboundOfferRequest {
     pub participant_b: ParticipantId,
     pub from_tag: Option<String>,
     pub to_tag: Option<String>,
+    /// SRTP policy for this originated call. The outbound mirror of the
+    /// inbound `[media].srtp` modes; the daemon maps its
+    /// `siphon-ai-core::SrtpMode` onto this (media-glue sits below core,
+    /// so the enum lives here).
+    pub srtp: OutboundSrtp,
+}
+
+/// SRTP policy for an **originated** call (RFC 4568 SDES on the offer).
+/// Plaintext by default; the secure modes offer `RTP/SAVP` with an
+/// `a=crypto:` key we generate, and differ only in how a peer that
+/// answers plaintext `RTP/AVP` is handled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OutboundSrtp {
+    /// Plaintext `RTP/AVP` offer (the default — unchanged 0.6.x behaviour).
+    #[default]
+    Off,
+    /// Offer SRTP, but accept a plaintext downgrade if the peer answers
+    /// `RTP/AVP` (best-effort encryption).
+    Preferred,
+    /// Offer SRTP and **require** it: a peer that answers plaintext fails
+    /// the call.
+    Required,
 }
 
 /// What [`MediaSetup::originate_offer`] hands back: the allocated session and
@@ -188,6 +212,12 @@ pub struct OutboundOffer {
     /// peer's answer.
     pub offered: LocalCapabilities,
     pub call_id: CallId,
+    /// SRTP policy this offer was built under (decides downgrade handling
+    /// in [`MediaSetup::apply_answer`]).
+    pub(crate) srtp: OutboundSrtp,
+    /// The SDES master key we offered, when `srtp` is a secure mode — our
+    /// *send* key. `None` for a plaintext offer. Consumed at `apply_answer`.
+    pub(crate) offer_crypto: Option<CryptoAttribute>,
 }
 
 impl std::fmt::Debug for OutboundOffer {
@@ -234,6 +264,11 @@ pub enum SetupError {
     /// sample rate isn't supported by the bridge crate.
     #[error(transparent)]
     Tap(#[from] MediaTapError),
+
+    /// Outbound SRTP (SDES) negotiation failed — bad key material, or the
+    /// peer refused SRTP under `[[gateway]].srtp = "required"`.
+    #[error("outbound SRTP negotiation failed: {0}")]
+    Srtp(String),
 }
 
 impl From<ForgeError> for SetupError {
@@ -413,11 +448,24 @@ impl MediaSetup {
             codecs: req.codecs.clone(),
             dtmf_payload_type: req.dtmf_payload_type,
         };
-        let offer_sdp = generate_offer(&offered);
+
+        // SRTP (SDES): mint a master key and offer RTP/SAVP. The key is our
+        // *send* key; the peer's answer carries theirs (our recv key),
+        // bound onto the session at `apply_answer`. AES_CM_128_HMAC_SHA1_80
+        // is the near-universal trunk default (e.g. Twilio).
+        let offer_crypto = match req.srtp {
+            OutboundSrtp::Off => None,
+            OutboundSrtp::Preferred | OutboundSrtp::Required => Some(CryptoAttribute::generate(
+                1,
+                CryptoSuite::Aes128CmHmacSha1_80,
+            )),
+        };
+        let offer_sdp = generate_offer(&offered, offer_crypto.as_ref());
 
         debug!(
             rtp_port = ports.rtp_port,
             codecs = req.codecs.len(),
+            srtp = ?req.srtp,
             "generated outbound offer"
         );
 
@@ -426,6 +474,8 @@ impl MediaSetup {
             offer_sdp,
             offered,
             call_id: req.call_id,
+            srtp: req.srtp,
+            offer_crypto,
         })
     }
 
@@ -444,6 +494,8 @@ impl MediaSetup {
             session,
             offered,
             call_id,
+            srtp,
+            offer_crypto,
             ..
         } = offer;
 
@@ -452,6 +504,38 @@ impl MediaSetup {
 
         // (1) Read the negotiated audio out of the peer's answer.
         let answer = negotiate_offer_answer(answer_sdp, &offered)?;
+
+        // (1a) SRTP (SDES): if we offered it, bind keys onto leg A — our
+        //      offered key for send, the peer's answered key for recv.
+        //      Installing keys is what enables encryption on the leg
+        //      (forge's SrtpContext is "enabled" once keyed). A peer that
+        //      answered plaintext RTP/AVP is a downgrade: fail under
+        //      `required`, continue in the clear under `preferred`.
+        if let Some(our_key) = &offer_crypto {
+            match &answer.peer_srtp {
+                Some(peer_key) => {
+                    let send = our_key
+                        .to_srtp_key_material()
+                        .map_err(|e| SetupError::Srtp(format!("our offer key: {e}")))?;
+                    let recv = peer_key
+                        .to_srtp_key_material()
+                        .map_err(|e| SetupError::Srtp(format!("peer answer key: {e}")))?;
+                    install_srtp_keys(session.srtp_a(), send, recv).await;
+                    debug!(call_id = %call_id, "outbound SRTP (SDES) keys installed on leg A");
+                }
+                None if srtp == OutboundSrtp::Required => {
+                    return Err(SetupError::Srtp(
+                        "peer answered plaintext RTP/AVP but [[gateway]].srtp = required".into(),
+                    ));
+                }
+                None => {
+                    warn!(
+                        call_id = %call_id,
+                        "offered SRTP but peer answered plaintext; continuing unencrypted (srtp = preferred)"
+                    );
+                }
+            }
+        }
 
         // (2) Apply the negotiated codec AND the peer's RTP endpoint to leg A
         //     — same as inbound, but the remote address comes from the answer
@@ -644,6 +728,7 @@ mod tests {
             participant_b: ParticipantId::generate(),
             from_tag: Some("ftag".into()),
             to_tag: None,
+            srtp: OutboundSrtp::Off,
         }
     }
 
@@ -734,5 +819,120 @@ a=sendrecv\r\n"
             result,
             Err(SetupError::Sdp(SdpError::NoCommonCodec))
         ));
+    }
+
+    // ─── Outbound SRTP (SDES) ────────────────────────────────────────────
+
+    fn outbound_req_srtp(
+        call_id: &str,
+        codecs: Vec<Codec>,
+        srtp: OutboundSrtp,
+    ) -> OutboundOfferRequest {
+        let mut req = outbound_req(call_id, codecs);
+        req.srtp = srtp;
+        req
+    }
+
+    /// A peer answer that ACCEPTED our SRTP offer: RTP/SAVP + a=crypto.
+    fn srtp_peer_answer(port: u16, pt: u8, name: &str) -> String {
+        use forge_sdp::sdes::{CryptoAttribute, CryptoSuite, MediaSdesAttributesExt};
+        use forge_sdp::{MediaType, Protocol, SessionDescriptionExt};
+        let crypto = CryptoAttribute::generate(1, CryptoSuite::Aes128CmHmacSha1_80);
+        let mut sdp = crate::sdp::parse_offer(&peer_answer(port, pt, name)).expect("base answer");
+        let audio = sdp.find_media_mut(MediaType::Audio).expect("audio");
+        audio.protocol = Protocol::RtpSavp;
+        audio.add_media_crypto(&crypto);
+        sdp.serialize()
+    }
+
+    #[tokio::test]
+    async fn originate_offer_required_emits_savp_crypto() {
+        let session_mgr = small_session_manager(41600, 41700);
+        let setup = setup_with(&session_mgr);
+        let offer = setup
+            .originate_offer(outbound_req_srtp(
+                "c-srtp-1",
+                vec![Codec::Pcmu],
+                OutboundSrtp::Required,
+            ))
+            .await
+            .expect("offer");
+        assert!(
+            offer.offer_sdp.contains("RTP/SAVP"),
+            "offer is SAVP: {}",
+            offer.offer_sdp
+        );
+        assert!(
+            offer.offer_sdp.contains("a=crypto:"),
+            "offer carries a=crypto"
+        );
+        assert!(offer.offer_crypto.is_some(), "our send key retained");
+    }
+
+    #[tokio::test]
+    async fn apply_answer_srtp_installs_keys_on_accept() {
+        let session_mgr = small_session_manager(41800, 41900);
+        let setup = setup_with(&session_mgr);
+        let offer = setup
+            .originate_offer(outbound_req_srtp(
+                "c-srtp-2",
+                vec![Codec::Pcmu],
+                OutboundSrtp::Required,
+            ))
+            .await
+            .expect("offer");
+        // Peer accepted SRTP — keys install, session survives.
+        let accepted = setup
+            .apply_answer(offer, &srtp_peer_answer(4000, 0, "PCMU"), tap_opts())
+            .await
+            .expect("SRTP answer applied");
+        assert_eq!(accepted.answer.negotiated_codec, Codec::Pcmu);
+        let (allocated, _) = session_mgr.port_pool_stats().await;
+        assert_eq!(allocated, 1, "session retained after SRTP install");
+    }
+
+    #[tokio::test]
+    async fn apply_answer_srtp_required_fails_on_plaintext_downgrade() {
+        let session_mgr = small_session_manager(42000, 42100);
+        let setup = setup_with(&session_mgr);
+        let offer = setup
+            .originate_offer(outbound_req_srtp(
+                "c-srtp-3",
+                vec![Codec::Pcmu],
+                OutboundSrtp::Required,
+            ))
+            .await
+            .expect("offer");
+        // Peer answered plaintext RTP/AVP — required SRTP must reject. (The
+        // SessionGuard rolls the session back on the error return; its
+        // teardown is async, so we assert the rejection, not the timing —
+        // same as `apply_answer_rejects_unoffered_codec`.)
+        let result = setup
+            .apply_answer(offer, &peer_answer(4000, 0, "PCMU"), tap_opts())
+            .await;
+        assert!(
+            matches!(result, Err(SetupError::Srtp(_))),
+            "required downgrade rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_answer_srtp_preferred_allows_plaintext_downgrade() {
+        let session_mgr = small_session_manager(42200, 42300);
+        let setup = setup_with(&session_mgr);
+        let offer = setup
+            .originate_offer(outbound_req_srtp(
+                "c-srtp-4",
+                vec![Codec::Pcmu],
+                OutboundSrtp::Preferred,
+            ))
+            .await
+            .expect("offer");
+        // Preferred: a plaintext answer is accepted, call continues unencrypted.
+        let accepted = setup
+            .apply_answer(offer, &peer_answer(4000, 0, "PCMU"), tap_opts())
+            .await
+            .expect("preferred downgrade accepted");
+        assert_eq!(accepted.answer.negotiated_codec, Codec::Pcmu);
     }
 }


### PR DESCRIPTION
Chunk **1 of 3** for **outbound SRTP** — the offer side of SDES (RFC 4568). SiphonAI can *answer* an inbound SRTP offer (forge handles it) but only ever *offered* plaintext `RTP/AVP`, so outbound calls couldn't carry audio on secure trunks (e.g. Twilio secure trunking). This closes that asymmetry.

## Self-contained — no upstream forge change
Every primitive is already public at our current pin (`e95a31a`): forge-sdp's `CryptoAttribute::{generate, to_srtp_key_material}` + SDES SDP traits, and forge-engine's `session.srtp_a()` + `install_srtp_keys`. **Keying a context enables encryption** (`SrtpContext::is_enabled()` is true once keyed, and the RTP path checks it before `protect_rtp`) — no separate "enable SRTP" step.

## SDP layer (`sdp.rs`)
- `LocalCapabilities::to_sdp_with_srtp(Some(crypto))` flips the audio transport to `RTP/SAVP` and attaches the `a=crypto:` line (our master key); `generate_offer(caps, srtp)` takes the optional crypto.
- `AnswerOutcome.peer_srtp` surfaces the peer's answered `a=crypto:` (our recv key) when it accepted SRTP; `None` on a plaintext downgrade.

## Setup layer (`setup.rs`)
- New `OutboundSrtp { Off, Preferred, Required }` on `OutboundOfferRequest` (media-glue sits below core, so the mode lives here; the daemon maps core's `SrtpMode` onto it in chunk 2).
- `originate_offer` mints an `AES_CM_128_HMAC_SHA1_80` key and offers SAVP; `apply_answer` installs send(ours)/recv(theirs) keys onto leg A via `install_srtp_keys(session.srtp_a(), …)`. A peer that answers plaintext **fails the call under `Required`** (new `SetupError::Srtp`), **continues unencrypted under `Preferred`**.

## Dormant — zero behaviour change
The outbound service still passes `OutboundSrtp::Off`. Config (`[[gateway]].srtp`), `start.srtp` on the outbound WS session, the cleartext-key-without-TLS startup warning, a metric, and docs land in **chunk 2**; the SIPp scenario + release in **chunk 3**.

## Tests
SDP: offer emits SAVP+crypto / stays AVP when off; answer extracts or omits the peer key. Live `originate→apply` round-trip against a real forge session: keys install on accept, `Required` rejects a plaintext downgrade, `Preferred` accepts it. Full workspace test + `clippy -D warnings` + fmt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)