### PR TITLE
chore(release): 0.7.1 — outbound SRTP (SIPp scenario + version bump)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-06-15
+
+Theme: **outbound SRTP** — SiphonAI could *answer* an inbound SRTP offer but
+only ever *offered* plaintext `RTP/AVP`, so outbound calls couldn't carry
+audio on secure trunks (e.g. Twilio secure trunking). This closes that
+inbound↔outbound asymmetry via SDES (RFC 4568) on the offer. **Off by
+default**; the WS protocol stays `version: "1"` and the CDR schema is
+unchanged. Self-contained in SiphonAI — no upstream forge-media change (the
+crypto primitives are public at the pinned rev). Delivered across three
+chunks (media-glue core → config/protocol/observability → SIPp/release).
+
+### Added
+
+- **Outbound SRTP via SDES (`[[gateway]].srtp`).** A call placed through a
+  gateway with `srtp = "preferred" | "required"` now *offers* SRTP: SiphonAI
+  mints an `AES_CM_128_HMAC_SHA1_80` master key, sends the INVITE as
+  `RTP/SAVP` with an `a=crypto:` line, and on a 2xx that accepts it installs
+  the send/recv keys onto the trunk leg (`session.srtp_a()` —
+  `install_srtp_keys`), so the media is encrypted.
+  * `[[gateway]].srtp` — `"off"` (default) | `"preferred"` | `"required"`,
+    the outbound mirror of `[media].srtp`. `required` fails the call if the
+    trunk answers plaintext; `preferred` continues unencrypted (downgrade).
+    A per-gateway load-time warning fires when `srtp` is set but
+    `transport != "tls"` (the SDES key would travel in cleartext on the
+    signalling plane). `docs/CONFIG.md`, `docs/OUTBOUND.md`.
+  * `start.srtp` (`{ exchange: "sdes", profile }`) is now populated on
+    **outbound** calls too, the same shape inbound uses (this also corrects
+    the stale "SDES not yet produced" note in `docs/PROTOCOL.md` — inbound
+    SDES was already produced; only the outbound offer side was missing).
+  * Metric `siphon_ai_outbound_srtp_total{result=encrypted|downgraded}`
+    (`docs/DEPLOY.md`). A SIPp **outbound_srtp** regression phase exercises
+    the full negotiation: a `required` gateway, SIPp answering `RTP/SAVP` +
+    `a=crypto`, asserting the `encrypted` metric.
+  * Implemented entirely in SiphonAI using public forge-sdp / forge-engine
+    APIs at the current pin — no upstream PR, no pin bump.
+
 ## [0.7.0] - 2026-06-15
 
 Theme: **conferencing + media-only call park** — two operator-controllable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2875,7 +2875,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "base64",
  "bytes",
@@ -2936,7 +2936,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2953,7 +2953,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "regex",
  "serde",
@@ -2970,7 +2970,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -3025,7 +3025,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3049,7 +3049,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "thiserror 1.0.69",
  "tokio",
@@ -3058,7 +3058,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "regex",
  "serde",
@@ -3069,7 +3069,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3078,7 +3078,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3101,7 +3101,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "base64",
  "rcgen",
@@ -3119,7 +3119,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3140,7 +3140,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -42,6 +42,20 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
+**v0.7.1** — patch release. Theme: **outbound SRTP.** SiphonAI could
+*answer* an inbound SRTP offer but only ever *offered* plaintext `RTP/AVP`,
+so outbound calls couldn't carry audio on secure trunks (e.g. Twilio secure
+trunking). A gateway with `[[gateway]].srtp = "preferred" | "required"` now
+*offers* SDES SRTP (RFC 4568): SiphonAI mints the master key, sends the
+INVITE as `RTP/SAVP` + `a=crypto:`, and on acceptance installs the keys so
+the trunk leg is encrypted (`required` fails the call on a plaintext answer;
+`preferred` downgrades). `start.srtp` is now populated on outbound calls
+too, and `siphon_ai_outbound_srtp_total{result}` tracks encrypted vs
+downgraded. Self-contained — no upstream forge-media change. **Off by
+default**; protocol stays `version: "1"`; a 0.7.0 deployment upgrades with
+zero behaviour change. See [`docs/OUTBOUND.md`](docs/OUTBOUND.md). Full
+notes: [`CHANGELOG.md`](CHANGELOG.md).
+
 **v0.7.0** — eighth release. Theme: **conferencing + media-only call park.**
 Two operator-controllable multi-leg features, both **off by default**.
 Conferencing mixes N calls into one room where *every* leg keeps its own WS

--- a/test-harness/sipp-scenarios/README.md
+++ b/test-harness/sipp-scenarios/README.md
@@ -51,6 +51,7 @@ sipp -sf basic_call_then_bye.xml -m 1 -p 5070 -s 1000 127.0.0.1:5060
 | `stir_shaken_attestation_403.xml`   | STIR/SHAKEN gate: `Identity` present but unverifiable (unreachable `x5u`) below `min_attestation = "A"` → 403 Forbidden (stir_shaken phase) |
 | `stir_shaken_attestation_pass.xml`  | STIR/SHAKEN happy path: a fully-verifiable `Identity` (fresh PASSporT, real x5u fetch, chain to the test anchor) → **200 admitted** (stir_shaken phase). Templated — `__IDENTITY__` is substituted at run time; does not run standalone. |
 | `outbound_uas_answer.xml`           | 0.6.0 outbound answer path, roles inverted: SiphonAI dials via `POST /admin/v1/calls`, SIPp answers (180 → 200 + SDP), bridge runs, SiphonAI BYEs (outbound phase) |
+| `outbound_srtp_uas_answer.xml`      | 0.7.1 outbound SRTP: gateway `srtp = "required"` makes SiphonAI offer `RTP/SAVP` + `a=crypto`; SIPp answers SAVP with its own `a=crypto`, keys install, call bridges (outbound_srtp phase) |
 | `park_caller.xml`                   | 0.7.0 call park: caller is answered + bridged, the echo-ws parks it (`--auto-park`), and SiphonAI BYEs the caller when the park resolves. Shared by the **park_timeout** and **park_retrieve** phases |
 | `conference_caller.xml`             | 0.7.0 conferencing: a caller that stays up while the echo-ws joins it to a room (`--auto-conference-join`); two run concurrently in the **conference** phase |
 
@@ -67,6 +68,14 @@ instance with `--auto-hangup-after-ms 1500` (so the WS side ends the call),
 backgrounds SIPp as the callee, then POSTs `/admin/v1/calls`. Pass = SIPp
 completed INVITE → ACK → BYE **and** the daemon's
 `siphon_ai_outbound_calls_total{result="answered"}` metric reads 1.
+
+And an always-on **outbound_srtp** auxiliary phase (0.7.1): the same setup
+but the `[[gateway]]` sets `srtp = "required"`, so SiphonAI's INVITE offers
+`RTP/SAVP` + `a=crypto` (SDES). `outbound_srtp_uas_answer.xml` answers SAVP
+with its own `a=crypto`; SiphonAI installs keys and bridges. Pass = SIPp
+completed the call **and** `siphon_ai_outbound_srtp_total{result="encrypted"}`
+reads 1. (SIPp doesn't carry real SRTP media — it's a signalling/negotiation
+test; the live key-install round-trip is covered by media-glue unit tests.)
 
 `run-all.sh` has two always-on **park** auxiliary phases (0.7.0), both using
 `park_caller.xml` and an echo-ws started with `--auto-park`:

--- a/test-harness/sipp-scenarios/outbound_srtp_uas_answer.xml
+++ b/test-harness/sipp-scenarios/outbound_srtp_uas_answer.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  outbound_srtp_uas_answer — like outbound_uas_answer, but the trunk
+  accepts SRTP. Roles inverted: SIPp is the CALLEE (UAS); SiphonAI is the
+  UAC placing the call via POST /admin/v1/calls through a gateway with
+  [[gateway]].srtp = "required". SiphonAI's INVITE offers RTP/SAVP with an
+  a=crypto: line (SDES, RFC 4568); this scenario answers RTP/SAVP with its
+  own a=crypto, so SiphonAI installs keys and start.srtp is populated.
+
+  The inline key is 30 zero bytes (16-byte AES_CM_128 master key + 14-byte
+  salt) base64-encoded — a structurally valid SDES key the daemon's
+  `to_srtp_key_material()` accepts. Test media is never decrypted (the echo
+  WS hangs up after a beat), so a fixed key is fine for a signalling test.
+
+  Run via run-all.sh's outbound_srtp auxiliary phase — the scenario alone
+  does nothing until the runner POSTs the originate request.
+-->
+<scenario name="outbound_srtp_uas_answer">
+  <recv request="INVITE" rtd="true"/>
+
+  <send>
+<![CDATA[
+SIP/2.0 180 Ringing
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="200"/>
+
+  <send retrans="500">
+<![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=sipp 53655765 2353687637 IN IP4 [local_ip]
+s=-
+c=IN IP4 [local_ip]
+t=0 0
+m=audio [media_port] RTP/SAVP 0
+a=rtpmap:0 PCMU/8000
+a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+]]>
+  </send>
+
+  <recv request="ACK" rtd="true"/>
+
+  <!-- Call is up + SRTP-secured; the echo WS auto-hangs-up and SiphonAI
+       BYEs us. -->
+  <recv request="BYE" rtd="true"/>
+
+  <send>
+<![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+</scenario>

--- a/test-harness/sipp-scenarios/run-all.sh
+++ b/test-harness/sipp-scenarios/run-all.sh
@@ -823,6 +823,89 @@ fi
 cf_cleanup
 trap - EXIT
 
+# ─── Always-on auxiliary phase: outbound SRTP (SDES) ──────────────
+# Like the outbound phase, but the gateway sets srtp = "required", so
+# SiphonAI's INVITE offers RTP/SAVP + a=crypto. SIPp (the callee) answers
+# RTP/SAVP with its own a=crypto; SiphonAI installs keys and bridges. Pass
+# = SIPp completed INVITE → ACK → BYE AND the daemon's
+# siphon_ai_outbound_srtp_total{result="encrypted"} metric reads 1.
+echo
+echo "─── auxiliary phase: outbound_srtp ────────────────────"
+OBS_WS_PORT=8773
+OBS_ADMIN_PORT=9091
+OBS_WS_LOG=$(mktemp -t echo-ws-obs.XXXXXX.log)
+OBS_DAEMON_LOG=$(mktemp -t siphon-ai-obs.XXXXXX.log)
+OBS_CONFIG=$(mktemp -t siphon-ai-obs.XXXXXX.toml)
+cat >"$OBS_CONFIG" <<EOF
+[node]
+id = "siphon-ai-sipp-obs"
+[sip]
+listen = "127.0.0.1:$DAEMON_PORT"
+[media]
+codecs = ["pcmu"]
+[bridge]
+ws_url = "ws://127.0.0.1:$OBS_WS_PORT/"
+[observability]
+enabled = true
+http_listen = "127.0.0.1:$OBS_ADMIN_PORT"
+[outbound]
+max_concurrent = 2
+[[gateway]]
+name = "sipp"
+proxy = "127.0.0.1:$SIPP_PORT"
+from = "sip:harness@127.0.0.1"
+srtp = "required"
+[[route]]
+name = "default"
+[route.match]
+any = true
+EOF
+
+OBS_PYTHON="$REPO_ROOT/examples/echo-ws-server-python/.venv/bin/python"
+[[ -x "$OBS_PYTHON" ]] || OBS_PYTHON=python3
+"$OBS_PYTHON" "$REPO_ROOT/examples/echo-ws-server-python/server.py" \
+    --bind "127.0.0.1:$OBS_WS_PORT" \
+    --auto-hangup-after-ms 1500 \
+    >"$OBS_WS_LOG" 2>&1 &
+OBS_WS_PID=$!
+
+RUST_LOG=siphon_ai=info "$DAEMON_BIN" --config "$OBS_CONFIG" \
+    >"$OBS_DAEMON_LOG" 2>&1 &
+OBS_DAEMON_PID=$!
+OBS_SIPP_PID=""
+obs_cleanup() {
+    kill "$OBS_WS_PID" "$OBS_DAEMON_PID" $OBS_SIPP_PID 2>/dev/null || true
+    wait "$OBS_WS_PID" "$OBS_DAEMON_PID" $OBS_SIPP_PID 2>/dev/null || true
+}
+trap obs_cleanup EXIT
+sleep 1.2
+
+total=$((total + 1))
+echo "─── outbound_srtp_uas_answer ─────────────────────────"
+obs_ok=0
+sipp -i 127.0.0.1 -sf "$SCRIPT_DIR/outbound_srtp_uas_answer.xml" \
+    -m 1 -timeout 15s -trace_err -p "$SIPP_PORT" >/dev/null 2>&1 &
+OBS_SIPP_PID=$!
+sleep 0.3
+obs_resp=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST "http://127.0.0.1:$OBS_ADMIN_PORT/admin/v1/calls" \
+    -d '{"to": "7002", "gateway": "sipp"}')
+if [[ "$obs_resp" == "202" ]] && wait "$OBS_SIPP_PID"; then
+    if curl -s "http://127.0.0.1:$OBS_ADMIN_PORT/metrics" \
+        | grep -q 'siphon_ai_outbound_srtp_total{result="encrypted"} 1'; then
+        obs_ok=1
+    fi
+fi
+if (( obs_ok )); then
+    echo "  OK"
+else
+    echo "  FAIL (originate=$obs_resp; daemon: $OBS_DAEMON_LOG; ws: $OBS_WS_LOG)"
+    failures=$((failures + 1))
+fi
+
+obs_cleanup
+trap - EXIT
+
 # ─── Optional third phase: blind_transfer ─────────────────────────
 # Needs a WS server that proactively emits BridgeIn::Transfer. The
 # runner stops the daemon, brings up an echo-ws that auto-emits


### PR DESCRIPTION
Chunk **3 of 3** — the SIPp coverage and release for the **outbound SRTP** theme (#170 media-glue core, #171 config/protocol/observability). No new runtime behaviour.

## SIPp signaling regression
New always-on **outbound_srtp** phase in `run-all.sh` + `outbound_srtp_uas_answer.xml`. Mirrors the outbound phase but the gateway sets `srtp = "required"`, so SiphonAI's INVITE offers `RTP/SAVP` + `a=crypto` (SDES); SIPp answers SAVP with its own `a=crypto`, SiphonAI installs keys and bridges. **Pass = SIPp completed the call AND `siphon_ai_outbound_srtp_total{result="encrypted"}` reads 1.** Full suite **green locally (17/17)**.

> SIPp doesn't carry real SRTP media — it's a signalling/negotiation test; the live key-install round-trip is covered by the media-glue unit tests from chunk 1.

## Release
Workspace version **0.7.0 → 0.7.1**; `CHANGELOG` `[Unreleased] → [0.7.1]` with the outbound-SRTP summary; README v0.7.1 status entry; SIPp harness README updated.

This completes the outbound SRTP theme: SiphonAI can now **offer** SDES SRTP on outbound calls (`[[gateway]].srtp`), closing the inbound↔outbound asymmetry so calls work on secure trunks like Twilio secure trunking. Off by default; protocol stays `version: "1"`.

> The tag/GitHub release for v0.7.1 is a separate step after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)