### PR TITLE
feat(bridge,core): hold/resume WS protocol surface (hold chunk 1)

### DIFF
--- a/crates/bridge/src/conn.rs
+++ b/crates/bridge/src/conn.rs
@@ -665,6 +665,8 @@ fn bridge_in_call_id(msg: &BridgeIn) -> &str {
         BridgeIn::ConferenceJoin { call_id, .. } => call_id.as_str(),
         BridgeIn::ConferenceLeave { call_id } => call_id.as_str(),
         BridgeIn::Park { call_id, .. } => call_id.as_str(),
+        BridgeIn::Hold { call_id } => call_id.as_str(),
+        BridgeIn::Resume { call_id } => call_id.as_str(),
     }
 }
 

--- a/crates/bridge/src/protocol.rs
+++ b/crates/bridge/src/protocol.rs
@@ -235,6 +235,18 @@ pub enum BridgeOut {
         participant_call_id: String,
     },
 
+    /// Confirmation that a server-requested [`BridgeIn::Hold`] took
+    /// effect (0.7.2): the caller's hold re-INVITE was acknowledged and
+    /// they're now on hold music. **Distinct from the peer-initiated
+    /// [`BridgeOut::Hold`] event**, which reports that the *far end* held
+    /// *us*. A server that sent `hold` waits for this before relying on
+    /// the hold; on failure it gets `error { code: "hold_failed" }`.
+    Held { call_id: CallId, seq: Seq },
+
+    /// Confirmation that a server-requested [`BridgeIn::Resume`] restored
+    /// two-way audio (0.7.2). Mirror of [`BridgeOut::Held`].
+    Resumed { call_id: CallId, seq: Seq },
+
     /// Last message SiphonAI sends. Followed by a clean WS close (1000).
     Stop {
         call_id: CallId,
@@ -441,6 +453,11 @@ pub enum ErrorCode {
     /// `[park].max_parked` reached). The call continues unparked.
     /// Added in 0.7.0.
     ParkFailed,
+    /// A [`BridgeIn::Hold`] or [`BridgeIn::Resume`] re-INVITE was
+    /// rejected by the peer, timed out, or lost glare resolution (0.7.2).
+    /// The call stays in its prior media state — a failed hold never
+    /// drops the call.
+    HoldFailed,
     Internal,
 }
 
@@ -573,6 +590,20 @@ pub enum BridgeIn {
     /// [`BridgeOut::ConferenceLeft`]`{ reason: "left" }` and restores
     /// the direct caller↔WS audio pair.
     ConferenceLeave { call_id: CallId },
+
+    /// Put this call's caller on hold (0.7.2): SiphonAI re-INVITEs the
+    /// caller so their media goes on hold (`a=sendonly`/`recvonly`, RFC
+    /// 3264) — they hear hold music and stop sending — while the WS
+    /// session stays open. Self-scoped. SiphonAI replies
+    /// [`BridgeOut::Held`] once the re-INVITE is acknowledged, or
+    /// `error { code: "hold_failed" }` (the call stays as it was — a
+    /// failed hold never drops it). No-op if already held. Distinct from
+    /// [`BridgeIn::Mute`], which only silences the bot's own audio.
+    Hold { call_id: CallId },
+
+    /// Resume a held call (0.7.2): re-INVITE back to two-way audio.
+    /// SiphonAI replies [`BridgeOut::Resumed`]. No-op if not held.
+    Resume { call_id: CallId },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -1271,6 +1302,54 @@ mod tests {
             panic!("expected Error");
         };
         assert_eq!(code, ErrorCode::ParkFailed);
+    }
+
+    // ─── Hold / resume (0.7.2) ───────────────────────────────────────────
+
+    #[test]
+    fn bridge_in_hold_and_resume() {
+        assert!(matches!(
+            assert_round_trip::<BridgeIn>(r#"{ "type": "hold", "call_id": "siphon-a" }"#),
+            BridgeIn::Hold { .. }
+        ));
+        assert!(matches!(
+            assert_round_trip::<BridgeIn>(r#"{ "type": "resume", "call_id": "siphon-a" }"#),
+            BridgeIn::Resume { .. }
+        ));
+    }
+
+    #[test]
+    fn bridge_out_held_and_resumed() {
+        // The bot-initiated acks — distinct `type`s from the peer-initiated
+        // `hold`/`resume` events (which stay as-is).
+        assert!(matches!(
+            assert_round_trip::<BridgeOut>(r#"{ "type": "held", "call_id": "c", "seq": 11 }"#),
+            BridgeOut::Held { .. }
+        ));
+        assert!(matches!(
+            assert_round_trip::<BridgeOut>(r#"{ "type": "resumed", "call_id": "c", "seq": 12 }"#),
+            BridgeOut::Resumed { .. }
+        ));
+    }
+
+    #[test]
+    fn peer_hold_event_still_distinct_from_held_ack() {
+        // Sanity: the peer-initiated `hold` event and the `held` ack are
+        // different messages, so a server can tell "the far end held me"
+        // from "my hold request succeeded".
+        let peer = assert_round_trip::<BridgeOut>(
+            r#"{ "type": "hold", "call_id": "c", "seq": 5, "direction": "sendonly" }"#,
+        );
+        assert!(matches!(peer, BridgeOut::Hold { .. }));
+    }
+
+    #[test]
+    fn bridge_out_error_hold_failed() {
+        let raw = r#"{ "type": "error", "call_id": "c", "seq": 7, "code": "hold_failed", "message": "488 not acceptable" }"#;
+        let BridgeOut::Error { code, .. } = assert_round_trip::<BridgeOut>(raw) else {
+            panic!("expected Error");
+        };
+        assert_eq!(code, ErrorCode::HoldFailed);
     }
 
     // ─── Negative cases ─────────────────────────────────────────────────

--- a/crates/core/src/call.rs
+++ b/crates/core/src/call.rs
@@ -809,6 +809,22 @@ impl CallController {
                             debug!(ws_call_id = %cid, ?slot, "WS park requested");
                             handle.request_park(slot);
                         }
+                        Some(BridgeIn::Hold { call_id: cid })
+                        | Some(BridgeIn::Resume { call_id: cid }) => {
+                            // Protocol surface only (0.7.2 chunk 1). The
+                            // re-INVITE drive lands in chunk 2; until then
+                            // reply hold_failed so an intermediate build
+                            // doesn't silently swallow the request. The call
+                            // is untouched (a failed hold never drops it).
+                            debug!(ws_call_id = %cid, "hold/resume received but not yet wired (chunk 2)");
+                            let _ = control_out_tx
+                                .send(OutgoingEvent::Error {
+                                    code: ErrorCode::HoldFailed,
+                                    message: "hold/resume not yet supported on this build"
+                                        .to_string(),
+                                })
+                                .await;
+                        }
                         Some(BridgeIn::Mark { call_id: cid, name }) => {
                             debug!(ws_call_id = %cid, %name, "forwarding Mark to tap");
                             // Mark is a notification request — the

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -335,12 +335,14 @@ then closes the WebSocket cleanly (close code 1000).
 | `transfer_failed` | A REFER was attempted but the far end rejected it. |
 | `conference_failed` | A `conference_join` (§4.8) was refused: conferencing disabled, room or per-room cap reached, sample-rate mismatch, or already joined. The call continues on its direct pair. |
 | `park_failed` | A `park` (§4.9) was refused: park disabled (`[park].enabled = false`) or `[park].max_parked` reached. The call continues unparked on its current WS session — no `stop` follows this `error`. |
+| `hold_failed` | A `hold` / `resume` (§4.10) re-INVITE was rejected by the peer, timed out, or lost glare resolution. The call stays in its **prior** media state (a failed hold never drops it) — no `stop` follows this `error`. |
 | `internal` | SiphonAI internal error. The `message` field has details. |
 
 A **fatal** `error` is always followed by `stop` (with `reason:
-"error"`) and a clean close. The two **non-fatal** refusals —
-`conference_failed` and `park_failed` — are the exception: they report a
-rejected control request, the call continues, and no `stop` follows.
+"error"`) and a clean close. The **non-fatal** refusals —
+`conference_failed`, `park_failed`, and `hold_failed` — are the exception:
+they report a rejected control request, the call continues, and no `stop`
+follows.
 
 ### 3.11 `recording_started` / `recording_stopped` / `recording_failed` — recording lifecycle (0.5.0)
 
@@ -391,6 +393,25 @@ flowing for this call's own leg. Audio frames are unchanged on the
 wire: SiphonAI sends the room mix (minus this call's own contribution)
 as the inbound binary frames, and the server's outbound audio is mixed
 into the room.
+
+### 3.13 `held` / `resumed` — your hold/resume request took effect (0.7.2)
+
+Confirmations that a server-initiated `hold` / `resume` (§4.10) completed —
+the re-INVITE was acknowledged by the peer. Sent **after** the SIP
+round-trip, so the server knows the hold is real before relying on it.
+
+```json
+{ "type": "held",    "call_id": "...", "seq": 61 }
+{ "type": "resumed", "call_id": "...", "seq": 80 }
+```
+
+> **`held`/`resumed` (your request) vs. `hold`/`resume` (§3.3, the peer).**
+> These are **different messages**. `held`/`resumed` confirm *your* `hold`/
+> `resume` succeeded. The §3.3 `hold`/`resume` events fire when the **far
+> end** put *you* on hold (an incoming re-INVITE) — unrelated to anything
+> you sent. A failed hold/resume request comes back as
+> `error { code: "hold_failed" }` (§3.10) instead, and the call is
+> unchanged.
 
 ---
 
@@ -603,6 +624,37 @@ which opens a **fresh** WS session with `start.retrieved: true` (§3.1).
 A parked call with no WS session cannot retrieve itself; that's the
 operator control plane's job, the mirror of why participants are
 removed from conferences by the admin API rather than by a peer.
+
+### 4.10 `hold` / `resume` — put the caller on hold (0.7.2)
+
+```json
+{ "type": "hold",   "call_id": "..." }
+{ "type": "resume", "call_id": "..." }
+```
+
+Put **this** call's caller on hold, or bring them back. Unlike park, the
+WS session **stays open** and the server resumes the call itself — this is
+the primitive for "user asks to hold → bot holds → bot resumes."
+
+- **`hold`** re-INVITEs the caller so their media goes on hold
+  (`a=sendonly`/`recvonly`, RFC 3264): they hear hold music
+  (`[media].moh_file`, or comfort noise) and stop sending, and SiphonAI
+  stops forwarding their audio to the server (so no barge-in fires during
+  hold). On success SiphonAI replies `held` (§3.13) once the re-INVITE is
+  acknowledged. No-op if already held.
+- **`resume`** re-INVITEs back to two-way audio and restores the direct
+  caller↔server pair; SiphonAI replies `resumed`. No-op if not held.
+- On failure (the peer rejects the re-INVITE, it times out, or glare can't
+  be resolved) SiphonAI replies `error { code: "hold_failed" }` (§3.10) and
+  the call stays in its **prior** state — a failed hold never drops it.
+
+**Self-scoped (§5.3):** `hold` acts only on the session's *own* call.
+
+**Distinct from `mute` (§4.6) and the `hold` *event* (§3.3).** `mute` only
+silences the server's *own* audio (the caller's mic still reaches the
+server, the dialog stays `sendrecv`); `hold` signals the far end and plays
+hold music. The §3.3 `hold` *event* is the opposite direction — the peer
+holding *you*.
 
 ---
 


### PR DESCRIPTION
Chunk **1 of 3** for bot-initiated call hold (plan: #175 / `docs/DESIGN_HOLD.md`). **Protocol surface only** — the SIP re-INVITE drive lands in chunk 2.

- **`BridgeIn::Hold` / `Resume { call_id }`** (server→SiphonAI): the bot puts its own caller on hold / brings them back. Self-scoped.
- **`BridgeOut::Held` / `Resumed { call_id, seq }`**: confirmations sent after the re-INVITE 2xx. Deliberately **past-tense and distinct** from the existing peer-initiated `hold`/`resume` events (§3.3) — "my request succeeded" vs "the far end held me".
- **`ErrorCode::HoldFailed`**: re-INVITE rejected / timed out / glare. The call stays in its prior media state (a failed hold never drops it).
- `conn.rs` `bridge_in_call_id` covers the new variants; serde round-trip tests including the peer-vs-bot distinction.
- `call.rs`: a clearly-marked **chunk-1 placeholder** arm replies `hold_failed` ("not yet supported on this build") so an intermediate build doesn't silently swallow the request — chunk 2 replaces it with the real drive.
- **PROTOCOL.md**: §3.10 (`hold_failed`), §3.13 (`held`/`resumed` + the peer-vs-bot contrast box), §4.10 (`hold`/`resume`, vs `mute` and the §3.3 event).

Protocol version stays `"1"` (additive). Full workspace test + `clippy -D warnings` + fmt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)