### PR TITLE
feat: WS reconnect on outbound legs (0.7.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.4] - 2026-06-17
+
+Follow-up to 0.7.3: **WS reconnect on outbound legs.** The reconnect drive
+shipped in 0.7.3 was inbound-only — the controller logic is bridge-generic,
+but the `[bridge].ws_reconnect_*` settings weren't threaded into the
+outbound originate path. This closes that gap, so a call placed via
+`POST /admin/v1/calls` reconnects the same way an inbound call does when
+its WS drops. Still gated by `[bridge].ws_reconnect_enabled` (off by
+default); no protocol or CDR change.
+
+### Changed
+
+- **Outbound originated calls now honour `[bridge].ws_reconnect_enabled`.**
+  The originate path threads the daemon's reconnect settings (enabled,
+  `ws_reconnect_max_secs`, and the shared `[media].moh_file` for the gap)
+  through to the call controller and puts the leg's tap in survive-WS-drop
+  mode — identical behaviour and code path to inbound. A new
+  `OutboundService::with_moh_file` carries the hold-music file.
+- SIPp **outbound_reconnect** regression phase: SiphonAI dials out, SIPp
+  answers, the echo-ws (`--drop-after-ms`) drops, SiphonAI re-dials and
+  resumes (`reconnected: true`), and the call ends cleanly — asserting
+  `ws_reconnects_total{result="recovered"}`.
+
 ## [0.7.3] - 2026-06-17
 
 Theme: **WS reconnect mid-call** — opt-in resilience. Until now, any

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2875,7 +2875,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "base64",
  "bytes",
@@ -2936,7 +2936,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2953,7 +2953,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "regex",
  "serde",
@@ -2970,7 +2970,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -3025,7 +3025,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3049,7 +3049,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "thiserror 1.0.69",
  "tokio",
@@ -3058,7 +3058,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "regex",
  "serde",
@@ -3069,7 +3069,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -3078,7 +3078,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3101,7 +3101,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "base64",
  "rcgen",
@@ -3119,7 +3119,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3140,7 +3140,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -614,6 +614,9 @@ impl Runtime {
             // Outbound bots can join conferences too (§9.1 — a room is
             // composed of any active calls). Share the same registries.
             service = service.with_control_registry(control_registry.clone());
+            // Hold music for the WS-reconnect gap on outbound legs (0.7.3) —
+            // the same [media].moh_file the inbound acceptor uses.
+            service = service.with_moh_file(media.moh_file.clone());
             if let Some(reg) = &conference_registry {
                 service = service.with_conference(reg.clone());
             }

--- a/crates/core/src/outbound_service.rs
+++ b/crates/core/src/outbound_service.rs
@@ -92,6 +92,10 @@ pub struct OutboundService {
     /// Park context (0.7.0). `Some` when `[park].enabled`; outbound
     /// bots can park/retrieve just like inbound calls.
     park: Option<ParkContext>,
+    /// `[media].moh_file` — hold music for the WS-reconnect gap (0.7.3).
+    /// Shared with the inbound side (the acceptor's `hold_moh_file`).
+    /// `None` → comfort silence.
+    moh_file: Option<std::path::PathBuf>,
 }
 
 impl OutboundService {
@@ -116,6 +120,7 @@ impl OutboundService {
             conference: None,
             control_registry: CallControlRegistry::new(),
             park: None,
+            moh_file: None,
         }
     }
 
@@ -137,6 +142,15 @@ impl OutboundService {
     /// Share the park context so outbound bots can park/retrieve.
     pub fn with_park(mut self, park: ParkContext) -> Self {
         self.park = Some(park);
+        self
+    }
+
+    /// Set the hold-music file (`[media].moh_file`) used during the
+    /// WS-reconnect gap on outbound legs (0.7.3). `None` → comfort
+    /// silence. Reconnect itself is gated by `[bridge].ws_reconnect_enabled`
+    /// (from the daemon defaults).
+    pub fn with_moh_file(mut self, moh_file: Option<std::path::PathBuf>) -> Self {
+        self.moh_file = moh_file;
         self
     }
 }
@@ -209,6 +223,11 @@ impl OutboundOriginateHandle for OutboundService {
         let conference = self.conference.clone();
         let control_registry = self.control_registry.clone();
         let park = self.park.clone();
+        // WS reconnect (0.7.3) — outbound legs reconnect on the same daemon
+        // defaults as inbound; extracted before the spawn (no `self` inside).
+        let ws_reconnect_enabled = self.defaults.ws_reconnect_enabled;
+        let ws_reconnect_max = self.defaults.ws_reconnect_max;
+        let ws_reconnect_moh_file = self.moh_file.clone();
 
         info!(call_id = %bridge_id_str, gateway = %gateway, "originating outbound call");
         let log_id = bridge_id_str.clone();
@@ -243,6 +262,9 @@ impl OutboundOriginateHandle for OutboundService {
                         control_registry,
                         park,
                         srtp_requested,
+                        ws_reconnect_enabled,
+                        ws_reconnect_max,
+                        ws_reconnect_moh_file,
                     };
                     run_call(originator, call, bridge, ctx).await;
                 }
@@ -313,6 +335,11 @@ struct OutboundCallContext {
     /// Whether this gateway offered SRTP (`[[gateway]].srtp != off`), so the
     /// answered-call path can record `encrypted` vs `downgraded`.
     srtp_requested: bool,
+    /// WS reconnect (0.7.3), from the daemon `[bridge]` defaults — outbound
+    /// legs reconnect the same way inbound does (the drive is bridge-generic).
+    ws_reconnect_enabled: bool,
+    ws_reconnect_max: std::time::Duration,
+    ws_reconnect_moh_file: Option<std::path::PathBuf>,
 }
 
 /// Run an answered outbound call's audio bridge to completion, tear it
@@ -400,7 +427,10 @@ async fn run_call(
         call_id: ctx.bridge_id.clone(),
         bridge,
         start,
-        media_tap: accepted.tap,
+        // Reconnect-enabled legs put the tap in survive-WS-drop mode so an
+        // unexpected drop doesn't tear it down before the controller redials
+        // (0.7.3) — same as the acceptor does for inbound.
+        media_tap: accepted.tap.with_ws_reconnect(ctx.ws_reconnect_enabled),
         transfer: Some(transfer),
         recording: None,
         conference: ctx.conference.clone(),
@@ -410,13 +440,11 @@ async fn run_call(
         // to build the hold/resume re-INVITE offer. Inbound legs (the
         // primary bot-answers-the-call path) carry it today.
         hold: None,
-        // WS reconnect on outbound legs is a 0.7.3 follow-up — the drive
-        // is bridge-generic, but the reconnect settings aren't threaded
-        // into the originate context yet and the chunk-3 harness only
-        // covers inbound. Disabled here; inbound carries it.
-        ws_reconnect_enabled: false,
-        ws_reconnect_max: std::time::Duration::from_secs(30),
-        ws_reconnect_moh_file: None,
+        // WS reconnect (0.7.3) — outbound legs reconnect on the daemon
+        // `[bridge]` defaults, same drive as inbound.
+        ws_reconnect_enabled: ctx.ws_reconnect_enabled,
+        ws_reconnect_max: ctx.ws_reconnect_max,
+        ws_reconnect_moh_file: ctx.ws_reconnect_moh_file.clone(),
     };
     let (controller, handle) = CallController::new(cfg);
     // Reachable by the admin conference API for this leg's lifetime.
@@ -535,6 +563,9 @@ mod tests {
             control_registry: CallControlRegistry::new(),
             park: None,
             srtp_requested: false,
+            ws_reconnect_enabled: false,
+            ws_reconnect_max: std::time::Duration::from_secs(30),
+            ws_reconnect_moh_file: None,
         };
         let view = CallTerminationView {
             cause: CdrTerminationCause::ServerHangup,

--- a/test-harness/sipp-scenarios/README.md
+++ b/test-harness/sipp-scenarios/README.md
@@ -121,6 +121,12 @@ server BYE). Pass = SIPp saw the BYE **and**
 path — no redial within the window — is covered by the controller unit test
 `ws_reconnect_exhausts_and_tears_down`.)
 
+And an always-on **outbound_reconnect** phase (0.7.4): the same drop +
+reconnect, but on the **outbound** originate path — SiphonAI dials out
+(`outbound_uas_answer.xml` as the callee), the echo-ws (`--drop-after-ms`)
+drops, SiphonAI re-dials and resumes, and the call ends cleanly. Pass = SIPp
+completed **and** `siphon_ai_ws_reconnects_total{result="recovered"}` reads 1.
+
 The `stir_shaken_*` scenarios run in `run-all.sh`'s always-on
 **stir_shaken** auxiliary phase. It builds + runs the
 `gen_test_passport` example (a `siphon-ai-stir-shaken` example) to mint a

--- a/test-harness/sipp-scenarios/run-all.sh
+++ b/test-harness/sipp-scenarios/run-all.sh
@@ -1051,6 +1051,92 @@ fi
 rc_cleanup
 trap - EXIT
 
+# ─── Always-on auxiliary phase: outbound WS reconnect ─────────────
+# Like the outbound phase (SIPp is the callee, SiphonAI the UAC dialing
+# via a gateway), but the echo-ws (--drop-after-ms) drops mid-call and
+# [bridge].ws_reconnect_enabled makes SiphonAI re-dial. The redial's start
+# carries reconnected:true, the echo-ws hangs that resumed call up, and
+# SiphonAI BYEs the SIPp callee. Proves reconnect works on the outbound
+# originate path too (0.7.4). Pass = SIPp completed AND
+# ws_reconnects_total{result="recovered"} == 1.
+echo
+echo "─── auxiliary phase: outbound_reconnect ───────────────"
+OR_WS_PORT=8776
+OR_ADMIN_PORT=9091
+OR_WS_LOG=$(mktemp -t echo-ws-or.XXXXXX.log)
+OR_DAEMON_LOG=$(mktemp -t siphon-ai-or.XXXXXX.log)
+OR_CONFIG=$(mktemp -t siphon-ai-or.XXXXXX.toml)
+cat >"$OR_CONFIG" <<EOF
+[node]
+id = "siphon-ai-sipp-or"
+[sip]
+listen = "127.0.0.1:$DAEMON_PORT"
+[media]
+codecs = ["pcmu"]
+[bridge]
+ws_url = "ws://127.0.0.1:$OR_WS_PORT/"
+ws_reconnect_enabled = true
+ws_reconnect_max_secs = 10
+[observability]
+enabled = true
+http_listen = "127.0.0.1:$OR_ADMIN_PORT"
+[outbound]
+max_concurrent = 2
+[[gateway]]
+name = "sipp"
+proxy = "127.0.0.1:$SIPP_PORT"
+from = "sip:harness@127.0.0.1"
+[[route]]
+name = "default"
+[route.match]
+any = true
+EOF
+
+OR_PYTHON="$REPO_ROOT/examples/echo-ws-server-python/.venv/bin/python"
+[[ -x "$OR_PYTHON" ]] || OR_PYTHON=python3
+"$OR_PYTHON" "$REPO_ROOT/examples/echo-ws-server-python/server.py" \
+    --bind "127.0.0.1:$OR_WS_PORT" \
+    --drop-after-ms 700 \
+    >"$OR_WS_LOG" 2>&1 &
+OR_WS_PID=$!
+
+RUST_LOG=siphon_ai=info "$DAEMON_BIN" --config "$OR_CONFIG" \
+    >"$OR_DAEMON_LOG" 2>&1 &
+OR_DAEMON_PID=$!
+OR_SIPP_PID=""
+or_cleanup() {
+    kill "$OR_WS_PID" "$OR_DAEMON_PID" $OR_SIPP_PID 2>/dev/null || true
+    wait "$OR_WS_PID" "$OR_DAEMON_PID" $OR_SIPP_PID 2>/dev/null || true
+}
+trap or_cleanup EXIT
+sleep 1.2
+
+total=$((total + 1))
+echo "─── outbound_reconnect_recovers ──────────────────────"
+or_ok=0
+sipp -i 127.0.0.1 -sf "$SCRIPT_DIR/outbound_uas_answer.xml" \
+    -m 1 -timeout 20s -trace_err -p "$SIPP_PORT" >/dev/null 2>&1 &
+OR_SIPP_PID=$!
+sleep 0.3
+or_resp=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST "http://127.0.0.1:$OR_ADMIN_PORT/admin/v1/calls" \
+    -d '{"to": "7001", "gateway": "sipp"}')
+if [[ "$or_resp" == "202" ]] && wait "$OR_SIPP_PID"; then
+    if curl -s "http://127.0.0.1:$OR_ADMIN_PORT/metrics" \
+        | grep -q 'siphon_ai_ws_reconnects_total{result="recovered"} 1'; then
+        or_ok=1
+    fi
+fi
+if (( or_ok )); then
+    echo "  OK"
+else
+    echo "  FAIL (originate=$or_resp; daemon: $OR_DAEMON_LOG; ws: $OR_WS_LOG)"
+    failures=$((failures + 1))
+fi
+
+or_cleanup
+trap - EXIT
+
 # ─── Optional third phase: blind_transfer ─────────────────────────
 # Needs a WS server that proactively emits BridgeIn::Transfer. The
 # runner stops the daemon, brings up an echo-ws that auto-emits


### PR DESCRIPTION
Follow-up to **0.7.3** (WS reconnect mid-call), which shipped **inbound-only**. The reconnect drive is bridge-generic, but the `[bridge].ws_reconnect_*` settings weren't threaded into the outbound originate path. This closes that gap — a call placed via `POST /admin/v1/calls` now reconnects on a WS drop exactly as an inbound call does. Still gated by `[bridge].ws_reconnect_enabled` (off by default); no protocol or CDR change.

## What's here
- `OutboundCallContext` carries the reconnect settings (`ws_reconnect_enabled` / `ws_reconnect_max` / `ws_reconnect_moh_file`), populated from `self.defaults` + a new `OutboundService::with_moh_file` (the shared `[media].moh_file` for the hold-music gap).
- `run_call` builds the leg's tap with `.with_ws_reconnect(enabled)` and sets the controller's reconnect fields — **identical drive + tap-survive behaviour to the inbound acceptor path**.
- Runtime wires `service.with_moh_file(media.moh_file)`; `outbound_bridge_defaults` already clones the compiled bridge defaults, so the global flag reaches outbound.
- SIPp **outbound_reconnect** run-all phase (dial out → echo-ws `--drop-after-ms` → reconnect → resume → BYE), asserts `ws_reconnects_total{result="recovered"}`.
- Version 0.7.3 → 0.7.4 + CHANGELOG.

## Verification
- Workspace **724 tests** green, `clippy -D warnings` + `fmt` clean.
- **Live**: `originate=202`, drop at 700 ms → reconnect (gap ~252 ms) → resume (`reconnected:true`) → SIPp callee BYEd, `sipp rc=0`, `ws_reconnects_total{result="recovered"} 1`.

With this, both inbound and outbound legs reconnect. (Outbound **bot-hold** remains the one open reconnect/hold follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)