### PR TITLE
feat: bot-initiated hold/resume on outbound legs (0.7.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.5] - 2026-06-17
+
+Follow-up to 0.7.2: **bot-initiated hold on outbound legs.** The hold/resume
+drive shipped in 0.7.2 was inbound-only — it built the hold/resume re-INVITE
+offers from the inbound side's cached answer SDP, which the outbound originate
+path didn't retain. This closes that gap, so a call placed via
+`POST /admin/v1/calls` can be held/resumed by the WS server exactly like an
+inbound call. No protocol or CDR change; hold remains always-available (no
+flag).
+
+### Changed
+
+- **Outbound originated calls now support `hold` / `resume`.** `apply_answer`
+  retains the SDP **offer** we sent (`OutboundAccepted.offer_sdp`), and the
+  outbound `run_call` builds a `HoldContext` from it (direction-flipped to
+  `sendonly` / `sendrecv`) with the same `DialogControl` it uses for outbound
+  transfer (the directly-held dialog, re-INVITE via the gateway UAC). The gap
+  music reuses the shared `[media].moh_file`.
+- SIPp **outbound_bot_hold** regression phase (`outbound_bot_hold_uas.xml`):
+  SiphonAI dials out, the echo-ws (`--auto-hold`) drives `hold`/`resume`, and
+  the callee asserts it receives the sendonly/sendrecv re-INVITEs —
+  `holds_total{result="ok"}` reads 2.
+
+With this, both bot-hold and WS reconnect now work on inbound **and** outbound
+legs.
+
 ## [0.7.4] - 2026-06-17
 
 Follow-up to 0.7.3: **WS reconnect on outbound legs.** The reconnect drive

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2875,7 +2875,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "base64",
  "bytes",
@@ -2936,7 +2936,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2953,7 +2953,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "regex",
  "serde",
@@ -2970,7 +2970,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -3025,7 +3025,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3049,7 +3049,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "thiserror 1.0.69",
  "tokio",
@@ -3058,7 +3058,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "regex",
  "serde",
@@ -3069,7 +3069,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -3078,7 +3078,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3101,7 +3101,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "base64",
  "rcgen",
@@ -3119,7 +3119,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3140,7 +3140,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/crates/core/src/outbound_service.rs
+++ b/crates/core/src/outbound_service.rs
@@ -27,7 +27,9 @@ use siphon_ai_cdr::{
     AudioInfo as CdrAudioInfo, CdrRecord, CdrSinkHandle, Direction as CdrDirection,
     TerminationInfo as CdrTerminationInfo, CDR_VERSION,
 };
-use siphon_ai_media_glue::{OutboundOfferRequest, OutboundSrtp, TapOptions};
+use siphon_ai_media_glue::{
+    rewrite_sdp_direction, MediaDirection, OutboundOfferRequest, OutboundSrtp, TapOptions,
+};
 use siphon_ai_telemetry::{
     OriginateRejection, OriginateRequest, OutboundOriginateHandle, OUTBOUND_CALLS_ACTIVE,
     OUTBOUND_CALLS_TOTAL, OUTBOUND_SRTP_TOTAL,
@@ -44,6 +46,7 @@ use crate::acceptor::{
 };
 use crate::call::{CallController, CallControllerConfig};
 use crate::conference::ConferenceRegistry;
+use crate::hold::HoldContext;
 use crate::outbound::{
     NotAnsweredCause, OutboundCall, OutboundError, OutboundGuard, OutboundOriginator,
     OutboundRejection,
@@ -423,6 +426,21 @@ async fn run_call(
         },
         consult_registry: ctx.consult_registry.clone(),
     };
+    // Bot-initiated hold on outbound legs (0.7.5). Same DialogControl as
+    // transfer (Direct dialog, no flow — the gateway UAC reaches the peer).
+    // The hold/resume offers are our original offer SDP with the direction
+    // flipped (the outbound analogue of inbound's cached answer); the gap
+    // MOH reuses the shared `[media].moh_file`.
+    let hold = Some(HoldContext {
+        control: DialogControl {
+            uac: originator.uac(),
+            source: DialogSource::Direct(Box::new(dialog.clone())),
+            flow: None,
+        },
+        hold_offer_sdp: rewrite_sdp_direction(&accepted.offer_sdp, MediaDirection::SendOnly),
+        resume_offer_sdp: rewrite_sdp_direction(&accepted.offer_sdp, MediaDirection::SendRecv),
+        moh_file: ctx.ws_reconnect_moh_file.clone(),
+    });
     let cfg = CallControllerConfig {
         call_id: ctx.bridge_id.clone(),
         bridge,
@@ -435,11 +453,7 @@ async fn run_call(
         recording: None,
         conference: ctx.conference.clone(),
         park: ctx.park.clone(),
-        // Bot-initiated hold on outbound legs is a 0.7.2 follow-up: it
-        // needs our original offer SDP plumbed through `apply_answer`
-        // to build the hold/resume re-INVITE offer. Inbound legs (the
-        // primary bot-answers-the-call path) carry it today.
-        hold: None,
+        hold,
         // WS reconnect (0.7.3) — outbound legs reconnect on the daemon
         // `[bridge]` defaults, same drive as inbound.
         ws_reconnect_enabled: ctx.ws_reconnect_enabled,

--- a/crates/media-glue/src/setup.rs
+++ b/crates/media-glue/src/setup.rs
@@ -247,6 +247,11 @@ pub struct OutboundAccepted {
     /// for a plaintext call or a `preferred` downgrade. The exchange is
     /// always SDES on the outbound origination path.
     pub srtp_profile: Option<String>,
+    /// The SDP **offer** we sent for this call (our local media, `sendrecv`).
+    /// Retained so the call layer can build a bot-initiated hold/resume
+    /// re-INVITE offer by flipping its direction (0.7.5) — the outbound
+    /// analogue of the inbound side's cached answer SDP.
+    pub offer_sdp: String,
 }
 
 impl std::fmt::Debug for OutboundAccepted {
@@ -507,6 +512,7 @@ impl MediaSetup {
             call_id,
             srtp,
             offer_crypto,
+            offer_sdp,
             ..
         } = offer;
 
@@ -604,6 +610,7 @@ impl MediaSetup {
             session,
             tap: media_tap,
             srtp_profile,
+            offer_sdp,
         })
     }
 }

--- a/test-harness/sipp-scenarios/README.md
+++ b/test-harness/sipp-scenarios/README.md
@@ -56,6 +56,7 @@ sipp -sf basic_call_then_bye.xml -m 1 -p 5070 -s 1000 127.0.0.1:5060
 | `conference_caller.xml`             | 0.7.0 conferencing: a caller that stays up while the echo-ws joins it to a room (`--auto-conference-join`); two run concurrently in the **conference** phase |
 | `reinvite_hold_resume.xml`          | Peer-initiated hold: SIPp **sends** a sendonly re-INVITE then a sendrecv one; SiphonAI mirrors recvonly/sendrecv (RFC 3264 §6.1) |
 | `bot_hold_caller.xml`               | 0.7.2 bot-initiated hold: the inverse — the echo-ws (`--auto-hold`) drives `hold`/`resume`, so SiphonAI **sends** the re-INVITEs and SIPp asserts it receives sendonly then sendrecv (**bot_hold** phase) |
+| `outbound_bot_hold_uas.xml`         | 0.7.5 bot-initiated hold on an **outbound** leg: SIPp is the callee (UAS), the echo-ws (`--auto-hold`) drives `hold`/`resume`, and SIPp asserts it receives the sendonly/sendrecv re-INVITEs on the outbound Direct dialog (**outbound_bot_hold** phase) |
 
 `run-all.sh` also has an always-on **recording** auxiliary phase: it starts
 a daemon with `[recording].mode = "always"` writing to a temp dir, runs one
@@ -126,6 +127,13 @@ reconnect, but on the **outbound** originate path — SiphonAI dials out
 (`outbound_uas_answer.xml` as the callee), the echo-ws (`--drop-after-ms`)
 drops, SiphonAI re-dials and resumes, and the call ends cleanly. Pass = SIPp
 completed **and** `siphon_ai_ws_reconnects_total{result="recovered"}` reads 1.
+
+And an always-on **outbound_bot_hold** phase (0.7.5): bot-initiated hold on
+the **outbound** path — SiphonAI dials out (`outbound_bot_hold_uas.xml` as
+the callee), the echo-ws (`--auto-hold`) drives `hold`/`resume`, and SiphonAI
+sends the sendonly/sendrecv re-INVITEs on the outbound Direct dialog (via the
+gateway UAC). Pass = SIPp completed (both direction asserts held) **and**
+`siphon_ai_holds_total{result="ok"}` reads 2.
 
 The `stir_shaken_*` scenarios run in `run-all.sh`'s always-on
 **stir_shaken** auxiliary phase. It builds + runs the

--- a/test-harness/sipp-scenarios/outbound_bot_hold_uas.xml
+++ b/test-harness/sipp-scenarios/outbound_bot_hold_uas.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  outbound_bot_hold_uas — roles inverted: SIPp is the CALLEE (UAS),
+  SiphonAI the UAC (placed via POST /admin/v1/calls). After the call is
+  up, the WS server (echo, --auto-hold) drives a bot-initiated hold cycle,
+  so SiphonAI sends a hold re-INVITE (a=sendonly) then a resume re-INVITE
+  (a=sendrecv) on the outbound (Direct) dialog. This asserts the callee
+  receives both, answering each (recvonly / sendrecv), then gets the BYE.
+
+  The outbound analogue of bot_hold_caller.xml (which is the inbound,
+  UAC-side caller). Validates that bot-hold works on outbound legs (0.7.5)
+  — the re-INVITE goes out the gateway UAC on the directly-held dialog.
+-->
+<scenario name="outbound_bot_hold_uas">
+  <recv request="INVITE" rtd="true"/>
+
+  <send>
+<![CDATA[
+SIP/2.0 180 Ringing
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="200"/>
+
+  <send retrans="500">
+<![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=sipp 53655765 2353687637 IN IP4 [local_ip]
+s=-
+c=IN IP4 [local_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+a=sendrecv
+]]>
+  </send>
+
+  <recv request="ACK" rtd="true"/>
+
+  <!-- HOLD: the bot (WS) drives SiphonAI to re-INVITE us sendonly. -->
+  <recv request="INVITE" crlf="true">
+    <action>
+      <ereg regexp="a=sendonly"
+            search_in="msg"
+            check_it="true"
+            assign_to="hold_offer_dir"/>
+      <log message="bot hold offer captured: a=[$hold_offer_dir]"/>
+    </action>
+  </recv>
+
+  <send>
+<![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=sipp 53655765 2353687638 IN IP4 [local_ip]
+s=-
+c=IN IP4 [local_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+a=recvonly
+]]>
+  </send>
+
+  <recv request="ACK" optional="true"/>
+
+  <!-- RESUME: re-INVITE back to sendrecv. -->
+  <recv request="INVITE" crlf="true">
+    <action>
+      <ereg regexp="a=sendrecv"
+            search_in="msg"
+            check_it="true"
+            assign_to="resume_offer_dir"/>
+      <log message="bot resume offer captured: a=[$resume_offer_dir]"/>
+    </action>
+  </recv>
+
+  <send>
+<![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=sipp 53655765 2353687639 IN IP4 [local_ip]
+s=-
+c=IN IP4 [local_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+a=sendrecv
+]]>
+  </send>
+
+  <recv request="ACK" optional="true"/>
+
+  <!-- The echo server hangs up once resume completes. -->
+  <recv request="BYE" rtd="true"/>
+
+  <send>
+<![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+</scenario>

--- a/test-harness/sipp-scenarios/run-all.sh
+++ b/test-harness/sipp-scenarios/run-all.sh
@@ -1137,6 +1137,90 @@ fi
 or_cleanup
 trap - EXIT
 
+# ─── Always-on auxiliary phase: outbound bot-hold ─────────────────
+# Like the outbound phase (SIPp the callee, SiphonAI the UAC), but the
+# echo-ws (--auto-hold) drives a bot-initiated hold cycle, so SiphonAI
+# sends a hold re-INVITE (a=sendonly) then a resume (a=sendrecv) on the
+# outbound (Direct) dialog via the gateway UAC. outbound_bot_hold_uas.xml
+# asserts the callee receives both and answers each. Proves bot-hold works
+# on outbound legs (0.7.5). Pass = SIPp completed (both direction asserts
+# held) AND siphon_ai_holds_total{result="ok"} == 2.
+echo
+echo "─── auxiliary phase: outbound_bot_hold ────────────────"
+OH_WS_PORT=8777
+OH_ADMIN_PORT=9091
+OH_WS_LOG=$(mktemp -t echo-ws-oh.XXXXXX.log)
+OH_DAEMON_LOG=$(mktemp -t siphon-ai-oh.XXXXXX.log)
+OH_CONFIG=$(mktemp -t siphon-ai-oh.XXXXXX.toml)
+cat >"$OH_CONFIG" <<EOF
+[node]
+id = "siphon-ai-sipp-oh"
+[sip]
+listen = "127.0.0.1:$DAEMON_PORT"
+[media]
+codecs = ["pcmu"]
+[bridge]
+ws_url = "ws://127.0.0.1:$OH_WS_PORT/"
+[observability]
+enabled = true
+http_listen = "127.0.0.1:$OH_ADMIN_PORT"
+[outbound]
+max_concurrent = 2
+[[gateway]]
+name = "sipp"
+proxy = "127.0.0.1:$SIPP_PORT"
+from = "sip:harness@127.0.0.1"
+[[route]]
+name = "default"
+[route.match]
+any = true
+EOF
+
+OH_PYTHON="$REPO_ROOT/examples/echo-ws-server-python/.venv/bin/python"
+[[ -x "$OH_PYTHON" ]] || OH_PYTHON=python3
+"$OH_PYTHON" "$REPO_ROOT/examples/echo-ws-server-python/server.py" \
+    --bind "127.0.0.1:$OH_WS_PORT" \
+    --auto-hold \
+    >"$OH_WS_LOG" 2>&1 &
+OH_WS_PID=$!
+
+RUST_LOG=siphon_ai=info "$DAEMON_BIN" --config "$OH_CONFIG" \
+    >"$OH_DAEMON_LOG" 2>&1 &
+OH_DAEMON_PID=$!
+OH_SIPP_PID=""
+oh_cleanup() {
+    kill "$OH_WS_PID" "$OH_DAEMON_PID" $OH_SIPP_PID 2>/dev/null || true
+    wait "$OH_WS_PID" "$OH_DAEMON_PID" $OH_SIPP_PID 2>/dev/null || true
+}
+trap oh_cleanup EXIT
+sleep 1.2
+
+total=$((total + 1))
+echo "─── outbound_bot_hold ────────────────────────────────"
+oh_ok=0
+sipp -i 127.0.0.1 -sf "$SCRIPT_DIR/outbound_bot_hold_uas.xml" \
+    -m 1 -timeout 20s -trace_err -p "$SIPP_PORT" >/dev/null 2>&1 &
+OH_SIPP_PID=$!
+sleep 0.3
+oh_resp=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST "http://127.0.0.1:$OH_ADMIN_PORT/admin/v1/calls" \
+    -d '{"to": "7001", "gateway": "sipp"}')
+if [[ "$oh_resp" == "202" ]] && wait "$OH_SIPP_PID"; then
+    if curl -s "http://127.0.0.1:$OH_ADMIN_PORT/metrics" \
+        | grep -q 'siphon_ai_holds_total{result="ok"} 2'; then
+        oh_ok=1
+    fi
+fi
+if (( oh_ok )); then
+    echo "  OK"
+else
+    echo "  FAIL (originate=$oh_resp; daemon: $OH_DAEMON_LOG; ws: $OH_WS_LOG)"
+    failures=$((failures + 1))
+fi
+
+oh_cleanup
+trap - EXIT
+
 # ─── Optional third phase: blind_transfer ─────────────────────────
 # Needs a WS server that proactively emits BridgeIn::Transfer. The
 # runner stops the daemon, brings up an echo-ws that auto-emits


### PR DESCRIPTION
Follow-up to **0.7.2** (bot-initiated hold/resume), which shipped **inbound-only**. The hold/resume re-INVITE offers were built from the inbound side's cached *answer* SDP, which the outbound originate path didn't retain. This closes that gap — a call placed via `POST /admin/v1/calls` can now be held/resumed by the WS server exactly like an inbound call. No protocol or CDR change; hold stays always-available (no flag).

## What's here
- **media-glue:** `apply_answer` retains the SDP **offer** we sent (`OutboundAccepted.offer_sdp`) — the outbound analogue of inbound's cached answer.
- **core:** outbound `run_call` builds a `HoldContext` from `accepted.offer_sdp` (direction-flipped to `sendonly`/`sendrecv`) with the **same `DialogControl` it uses for outbound transfer** — the directly-held dialog, re-INVITE via the gateway UAC, no flow. Gap MOH reuses the shared `[media].moh_file`. The controller's Hold/Resume drive is already generic.
- **Harness:** `outbound_bot_hold_uas.xml` (SIPp callee receives the bot's sendonly/sendrecv re-INVITEs) + `run-all` `outbound_bot_hold` phase (echo-ws `--auto-hold`), asserting `holds_total{result="ok"} == 2`.
- Version 0.7.4 → 0.7.5 + CHANGELOG.

## Verification
- Workspace **724 tests** green, `clippy -D warnings` + `fmt` clean.
- **Live**: `originate=202` → echo sent `hold`→`resume`→`hangup` → daemon logged **"call held (bot-initiated)"** + **"call resumed (bot-initiated)"** on the outbound Direct dialog → `sipp rc=0` (callee received both re-INVITEs).

With this, **both bot-hold and WS reconnect work on inbound and outbound legs** — the reconnect/hold follow-up list is clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)