### PR TITLE
feat: enable Opus negotiation (0.8.0 chunk 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "audiopus"
+version = "0.3.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab55eb0e56d7c6de3d59f544e5db122d7725ec33be6a276ee8241f3be6473955"
+dependencies = [
+ "audiopus_sys",
+]
+
+[[package]]
+name = "audiopus_sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62314a1546a2064e033665d658e88c620a62904be945f8147e6b16c3db9f8651"
+dependencies = [
+ "cmake",
+ "log",
+ "pkg-config",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,8 +704,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "forge-codecs"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=e95a31a959a6#e95a31a959a6c9d515c7fb59c6141818ef071369"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=3c82c2e5d175#3c82c2e5d17598e36d44aa338e1679074b292e6b"
 dependencies = [
+ "audiopus",
  "ezk-g722",
  "lazy_static",
  "thiserror 2.0.18",
@@ -695,7 +716,7 @@ dependencies = [
 [[package]]
 name = "forge-core"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=e95a31a959a6#e95a31a959a6c9d515c7fb59c6141818ef071369"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=3c82c2e5d175#3c82c2e5d17598e36d44aa338e1679074b292e6b"
 dependencies = [
  "chrono",
  "serde",
@@ -710,7 +731,7 @@ dependencies = [
 [[package]]
 name = "forge-dtmf"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=e95a31a959a6#e95a31a959a6c9d515c7fb59c6141818ef071369"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=3c82c2e5d175#3c82c2e5d17598e36d44aa338e1679074b292e6b"
 dependencies = [
  "chrono",
  "forge-core",
@@ -722,7 +743,7 @@ dependencies = [
 [[package]]
 name = "forge-engine"
 version = "0.4.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=e95a31a959a6#e95a31a959a6c9d515c7fb59c6141818ef071369"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=3c82c2e5d175#3c82c2e5d17598e36d44aa338e1679074b292e6b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -752,7 +773,7 @@ dependencies = [
 [[package]]
 name = "forge-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=e95a31a959a6#e95a31a959a6c9d515c7fb59c6141818ef071369"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=3c82c2e5d175#3c82c2e5d17598e36d44aa338e1679074b292e6b"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -765,7 +786,7 @@ dependencies = [
 [[package]]
 name = "forge-injection"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=e95a31a959a6#e95a31a959a6c9d515c7fb59c6141818ef071369"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=3c82c2e5d175#3c82c2e5d17598e36d44aa338e1679074b292e6b"
 dependencies = [
  "forge-core",
  "rubato",
@@ -778,7 +799,7 @@ dependencies = [
 [[package]]
 name = "forge-mixer"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=e95a31a959a6#e95a31a959a6c9d515c7fb59c6141818ef071369"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=3c82c2e5d175#3c82c2e5d17598e36d44aa338e1679074b292e6b"
 dependencies = [
  "bytes",
  "dashmap 6.2.1",
@@ -792,7 +813,7 @@ dependencies = [
 [[package]]
 name = "forge-recorder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=e95a31a959a6#e95a31a959a6c9d515c7fb59c6141818ef071369"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=3c82c2e5d175#3c82c2e5d17598e36d44aa338e1679074b292e6b"
 dependencies = [
  "bytes",
  "forge-core",
@@ -806,7 +827,7 @@ dependencies = [
 [[package]]
 name = "forge-resampler"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=e95a31a959a6#e95a31a959a6c9d515c7fb59c6141818ef071369"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=3c82c2e5d175#3c82c2e5d17598e36d44aa338e1679074b292e6b"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -815,7 +836,7 @@ dependencies = [
 [[package]]
 name = "forge-rtp"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=e95a31a959a6#e95a31a959a6c9d515c7fb59c6141818ef071369"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=3c82c2e5d175#3c82c2e5d17598e36d44aa338e1679074b292e6b"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -840,14 +861,14 @@ dependencies = [
 [[package]]
 name = "forge-sdp"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=e95a31a959a6#e95a31a959a6c9d515c7fb59c6141818ef071369"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=3c82c2e5d175#3c82c2e5d17598e36d44aa338e1679074b292e6b"
 dependencies = [
  "base64",
  "chrono",
  "forge-core",
  "forge-rtp",
  "rand 0.9.4",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=e95a31a959a6)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=3c82c2e5d175)",
  "smol_str",
  "thiserror 2.0.18",
 ]
@@ -855,7 +876,7 @@ dependencies = [
 [[package]]
 name = "forge-transcoder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=e95a31a959a6#e95a31a959a6c9d515c7fb59c6141818ef071369"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=3c82c2e5d175#3c82c2e5d17598e36d44aa338e1679074b292e6b"
 dependencies = [
  "bytes",
  "forge-codecs",
@@ -868,7 +889,7 @@ dependencies = [
 [[package]]
 name = "forge-vad"
 version = "0.1.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=e95a31a959a6#e95a31a959a6c9d515c7fb59c6141818ef071369"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=3c82c2e5d175#3c82c2e5d17598e36d44aa338e1679074b292e6b"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -2782,7 +2803,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=e95a31a959a6#e95a31a959a6c9d515c7fb59c6141818ef071369"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=3c82c2e5d175#3c82c2e5d17598e36d44aa338e1679074b292e6b"
 dependencies = [
  "nom",
  "smol_str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,20 +136,20 @@ sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "302
 # forge-ice, Cow/lifetime in forge-recorder), but the subset SiphonAI
 # pulls — forge-core, forge-rtp, forge-engine (g722 only), forge-codecs,
 # forge-sdp, forge-dtmf, forge-vad, forge-hep — all build cleanly.
-forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "e95a31a959a6" }
-forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "e95a31a959a6" }
-forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "e95a31a959a6", default-features = false, features = ["g722", "dtls"] }
-forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "e95a31a959a6" }
-forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "e95a31a959a6" }
-forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "e95a31a959a6" }
-forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "e95a31a959a6" }
-forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "e95a31a959a6" }
+forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "3c82c2e5d175" }
+forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "3c82c2e5d175" }
+forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "3c82c2e5d175", default-features = false, features = ["g722", "dtls", "opus"] }
+forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "3c82c2e5d175" }
+forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "3c82c2e5d175" }
+forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "3c82c2e5d175" }
+forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "3c82c2e5d175" }
+forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "3c82c2e5d175" }
 # Conference rooms (0.7.0): forge-mixer is the per-room AudioMixer;
 # forge-injection provides ToneGenerator (join/leave tones now, MOH
 # for park later). Deliberately NOT forge-conference — its DTMF
 # IVR/PIN/host-control layer is unused per DEV_PLAN_0.7.0.md §9.4.
-forge-mixer     = { git = "https://github.com/thevoiceguy/forge-media", rev = "e95a31a959a6" }
-forge-injection = { git = "https://github.com/thevoiceguy/forge-media", rev = "e95a31a959a6" }
+forge-mixer     = { git = "https://github.com/thevoiceguy/forge-media", rev = "3c82c2e5d175" }
+forge-injection = { git = "https://github.com/thevoiceguy/forge-media", rev = "3c82c2e5d175" }
 
 # hep-rs — HEP3 codec, transport, HepSink trait. Owned by the same
 # author as siphon-rs and forge-media; lives in its own repo.

--- a/crates/config/tests/load.rs
+++ b/crates/config/tests/load.rs
@@ -531,28 +531,32 @@ any = true
 }
 
 #[test]
-fn opus_in_codec_list_is_rejected_at_load() {
-    // The WS audio path is PCM16 at 8 kHz or 16 kHz (CLAUDE.md
-    // §4.2). Opus samples at 48 kHz and would crash forge tap
-    // attach with `UnsupportedSampleRate(48000)`. Refuse at config
-    // compile so the operator sees the limitation before any
-    // INVITE arrives.
+fn opus_in_codec_list_compiles() {
+    // Opus is accepted as of 0.8.0 (forge runs the codec at a 16 kHz
+    // bridge rate; libopus does the 48<->16 + stereo->mono). It now
+    // satisfies the WS audio path's 8/16 kHz contract, so it parses into
+    // the compiled codec set instead of being rejected.
     let env = MapEnv::new([]);
     let toml = r#"
+[node]
+id = "opus-test"
+public_address = "203.0.113.10"
 [sip]
 listen = "127.0.0.1:5060"
-
 [media]
 codecs = ["pcmu", "opus"]
-
 [bridge]
 ws_url = "wss://x/y"
+[[route]]
+name = "default"
+[route.match]
+any = true
 "#;
-    let err = load_from_str_with_env(toml, &env).unwrap_err();
-    let msg = err.to_string();
+    let cfg = load_from_str_with_env(toml, &env).expect("opus config compiles");
     assert!(
-        msg.contains("opus") && msg.contains("48"),
-        "expected opus-rejection error, got: {msg}"
+        cfg.bridge_defaults.codecs.contains(&Codec::Opus),
+        "Opus should be in the compiled codec set, got {:?}",
+        cfg.bridge_defaults.codecs
     );
 }
 

--- a/crates/media-glue/src/sdp.rs
+++ b/crates/media-glue/src/sdp.rs
@@ -40,15 +40,16 @@ use forge_sdp::{
 };
 use thiserror::Error;
 
-/// Codecs SiphonAI v1 supports. Anything not in this list is
-/// rejected at negotiation time.
+/// Codecs SiphonAI supports. Anything not in this list is rejected at
+/// negotiation time.
 ///
-/// We don't add OPUS yet because the v1 dev plan calls it
-/// "nice-to-have" (DEV_PLAN.md §3.2) and forge-codecs gates it
-/// behind a feature; the workspace already builds with `opus`
-/// optional. We *advertise* it but the actual encode/decode on the
-/// forge side will Refuse if the feature isn't on. That's fine for
-/// negotiation — peers that only speak G.711 will fall back.
+/// **Opus (0.8.0):** negotiable when listed in `[media].codecs`. It
+/// advertises a 48 kHz RTP clock on the wire but runs at a **16 kHz
+/// bridge rate** — forge-engine builds the Opus codec at 16 kHz mono and
+/// libopus does the 48↔16 resample + stereo→mono internally — so the WS
+/// audio path still sees 16 kHz PCM (the same wire-clock-vs-PCM-rate split
+/// as G.722). Requires forge-engine's `opus` feature (libopus via
+/// `audiopus`), enabled in the workspace `Cargo.toml`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Codec {
     /// G.711 µ-law. Static PT 0, 8 kHz, mono. Mandatory.
@@ -112,7 +113,12 @@ impl Codec {
         match self {
             Codec::Pcmu | Codec::Pcma => 8000,
             Codec::G722 => 16000,
-            Codec::Opus => 48000,
+            // Opus advertises a 48 kHz RTP clock (`opus/48000/2`) but the
+            // media engine runs the codec at 16 kHz (forge-engine builds it
+            // at 16 kHz mono; libopus does the 48↔16 + stereo→mono), so the
+            // WS bridge sees 16 kHz PCM — within the fixed 8/16 kHz contract.
+            // Same wire-clock-vs-PCM-rate split as G.722.
+            Codec::Opus => 16000,
         }
     }
 
@@ -624,6 +630,39 @@ a=rtpmap:{pt} {name}/{clock}\r\n\
 a=ptime:20\r\n\
 a=sendrecv\r\n"
         )
+    }
+
+    #[test]
+    fn negotiate_answer_opus_maps_to_16k_and_preserves_dynamic_pt() {
+        // A peer offers Opus at a dynamic PT (96, opus/48000/2). We accept
+        // it; the answer keeps the offerer's PT (RFC 3264), and the
+        // post-decode rate the WS sees is 16 kHz (not the 48 kHz clock) —
+        // forge runs Opus at a 16 kHz bridge rate.
+        let offer_sdp = "\
+v=0\r\n\
+o=peer 1 1 IN IP4 198.51.100.20\r\n\
+s=-\r\n\
+c=IN IP4 198.51.100.20\r\n\
+t=0 0\r\n\
+m=audio 4000 RTP/AVP 96\r\n\
+a=rtpmap:96 opus/48000/2\r\n\
+a=ptime:20\r\n\
+a=sendrecv\r\n";
+        let offer = parse_offer(offer_sdp).expect("offer parses");
+        let outcome = negotiate_answer(&offer, &caps(vec![Codec::Opus])).expect("opus negotiates");
+        assert_eq!(outcome.negotiated_codec, Codec::Opus);
+        assert_eq!(
+            outcome.negotiated_payload_type, 96,
+            "answer must echo the offerer's dynamic Opus PT"
+        );
+        assert_eq!(
+            outcome.negotiated_clock_rate, 48000,
+            "rtpmap clock stays 48k"
+        );
+        assert_eq!(
+            outcome.negotiated_audio_sample_rate, 16000,
+            "the WS bridge sees 16 kHz PCM for Opus"
+        );
     }
 
     #[test]

--- a/crates/media-glue/tests/sdp_negotiation.rs
+++ b/crates/media-glue/tests/sdp_negotiation.rs
@@ -79,8 +79,10 @@ fn multi_codec_offer_picks_offer_order_subject_to_our_caps() {
     // opus → opus wins (we have it in caps).
     let answer = build_answer(ASTERISK_OPUS_PREF_OFFER, &caps_full(20100)).unwrap();
     assert_eq!(answer.negotiated_codec, Codec::Opus);
+    // rtpmap clock stays 48 kHz on the wire, but the WS bridge sees Opus
+    // at 16 kHz (forge runs the codec at a 16 kHz bridge rate, 0.8.0).
     assert_eq!(answer.negotiated_clock_rate, 48000);
-    assert_eq!(answer.negotiated_audio_sample_rate, 48000);
+    assert_eq!(answer.negotiated_audio_sample_rate, 16000);
 
     // The answer should still echo the offer's PT (111), not our
     // canonical 111. They happen to match here, but for dynamic


### PR DESCRIPTION
Chunk 2 of 3 for **Opus** (`docs/DESIGN_OPUS.md`, plan #184). Turns Opus on now that forge runs it at a 16 kHz bridge rate (**forge-media #75**, merged; pin bumped here).

## What's here
- **Forge pin bump** `e95a31a959a6 → 3c82c2e5d175` (#75 Opus 16 k bridge rate; also pulls #72 SDES re-key API, unused here). Adds **`"opus"`** to the forge-engine feature list → links **libopus** via `audiopus_sys` (SiphonAI's first native build dep).
- **`Codec::Opus.audio_sample_rate()` 48000 → 16000.** This both fixes the WS-facing rate *and* un-rejects Opus at config load — `parse_codecs` gates on `is_ws_compatible` (`audio_sample_rate ∈ {8000,16000}`), so the change is data-driven (no separate `parse_codecs` edit).
- The upstream negotiator already handles Opus's **dynamic PT** (answer echoes the offerer's PT; codec matched by name) — verified by test, no hand-rolling.

## Tests
- `negotiate_answer_opus_maps_to_16k_and_preserves_dynamic_pt` (offer PT 96 → answer keeps 96; rate 16 k; clock 48 k).
- `opus_in_codec_list_compiles` (flipped from the old `_rejected`).
- Updated the multi-codec negotiation test's stale `48000` → `16000`.
- Workspace **725** green, clippy `-D warnings` + fmt clean.

## Deferred to chunk 3
**fmtp** (`stereo=0` / `useinbandfec` / `maxplaybackrate`) — it interacts with the answer's dynamic PT, and the design (§7.5) flagged the params for validation against a real softphone/carrier. Opus is correct without it (the `/2` rtpmap is emitted; forge decodes mono regardless). Chunk 3 = SIPp Opus scenario + fmtp tuning + CONFIG/DEPLOY (libopus prereq) + release 0.8.0.

Depends on forge-media#75 (merged). Independent of the docs-only plan PR #184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)