### PR TITLE
feat: Opus codec support — release 0.8.0 (opus chunk 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-17
+
+Theme: **Opus codec support.** SiphonAI advertised only G.711/G.722 and
+**rejected Opus at config load**; the v1 plan deferred it (DEV_PLAN §15.1)
+as blocked on resampling. Opus is now negotiable. It runs at a **16 kHz
+bridge rate** — `opus/48000/2` on the wire, but the WS path sees a 16 kHz
+session (`start.audio.sample_rate = 16000`) — so the fixed 8/16 kHz PCM16
+audio contract (CLAUDE.md §4.2) is unchanged and the WS protocol stays
+`version: "1"`. **Off by default** (add `"opus"` to `[media].codecs`).
+Minor-version bump because it adds SiphonAI's first **native build
+dependency** (libopus). Delivered across three chunks (forge-media PR →
+siphon-ai enablement → harness/docs/release).
+
+### Added
+
+- **Opus in `[media].codecs`.** A peer that offers `opus/48000/2` (or a
+  route that lists `"opus"` for outbound) now negotiates Opus. The media
+  engine (forge) runs the codec at 16 kHz mono — libopus decodes any
+  encoded stream to 16 kHz and downmixes stereo→mono internally, and the
+  encoder takes 16 kHz mono PCM (RFC 7587 — the RTP clock stays 48 kHz).
+  RTP timestamps step at the 48 kHz clock; only the WS-facing PCM is
+  16 kHz. The dynamic Opus payload type is preserved on the answer
+  (RFC 3264). `docs/CONFIG.md`.
+- **SIPp `opus` regression phase** (`opus_caller.xml`): offers Opus, asserts
+  the 200 OK answers Opus and the daemon brings the call up at 16 kHz
+  (`negotiated=opus sample_rate=16000`). Signalling only — the Opus
+  encode/decode round-trip is forge unit-tested.
+
+### Changed
+
+- **Upstream forge-media pin `e95a31a959a6` → `3c82c2e5d175`** — adds the
+  Opus 16 kHz bridge rate (forge-media#75, mirroring G.722's
+  wire-clock-vs-PCM-rate split) and enables forge-engine's `opus` feature.
+  Also picks up an unrelated SDES mid-call re-key API (forge-media#72),
+  unused here.
+- **New native build dependency: libopus** (via `audiopus`/`audiopus_sys`,
+  built from source). Building `siphon-ai` now needs a C toolchain + CMake;
+  the shipped Dockerfile already has them. `docs/DEPLOY.md` gains a build-
+  prerequisites note. The runtime image is unaffected (statically linked).
+
+### Notes
+
+- **SDP `fmtp` (`stereo=0` / `useinbandfec` / `maxplaybackrate`) is a
+  follow-up.** Opus is correct without it (the `/2` rtpmap is emitted and
+  forge decodes mono regardless); the params interact with the answer's
+  dynamic PT and want validation against a real softphone/carrier
+  (`docs/DESIGN_OPUS.md` §7.5).
+
 ## [0.7.5] - 2026-06-17
 
 Follow-up to 0.7.2: **bot-initiated hold on outbound legs.** The hold/resume

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.7.5"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2936,7 +2936,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.7.5"
+version = "0.8.0"
 dependencies = [
  "base64",
  "bytes",
@@ -2957,7 +2957,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.7.5"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2974,7 +2974,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.7.5"
+version = "0.8.0"
 dependencies = [
  "regex",
  "serde",
@@ -2991,7 +2991,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.7.5"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3031,7 +3031,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.7.5"
+version = "0.8.0"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -3046,7 +3046,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.7.5"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3070,7 +3070,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.7.5"
+version = "0.8.0"
 dependencies = [
  "thiserror 1.0.69",
  "tokio",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.7.5"
+version = "0.8.0"
 dependencies = [
  "regex",
  "serde",
@@ -3090,7 +3090,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.7.5"
+version = "0.8.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3099,7 +3099,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.7.5"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3122,7 +3122,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.7.5"
+version = "0.8.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -3140,7 +3140,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.7.5"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3161,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.7.5"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.5"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -101,7 +101,7 @@ mode = "session_progress"
 
 | Field                       | Type             | Default                | Notes |
 |-----------------------------|------------------|------------------------|-------|
-| `codecs`                    | `["pcmu","pcma","g722"]` | `["pcmu","pcma"]` | Priority-ordered. Opus is rejected at load — its 48 kHz audio rate isn't supported on the WS path yet. |
+| `codecs`                    | `["pcmu","pcma","g722","opus"]` | `["pcmu","pcma"]` | Priority-ordered. **`opus`** (0.8.0) negotiates `opus/48000/2` on the wire but runs at a 16 kHz bridge rate, so an Opus call surfaces as a 16 kHz session (`start.audio.sample_rate = 16000`) — forge decodes/encodes Opus at 16 kHz mono and libopus handles the 48↔16 resample + stereo→mono. Requires the daemon built with Opus support (libopus; see `docs/DEPLOY.md`). Not in the default list — add `"opus"` to enable. |
 | `dtmf`                      | `"rfc2833" \| "off"` | `"rfc2833"`      | `"off"` disables the `telephone-event` payload type. |
 | `rtp_port_range`            | `[min, max]`     | forge default          | Both ports must be even; min < max. |
 | `inactivity_timeout_secs`   | integer          | `60`                   | Tear the call down after this many seconds with no inbound RTP. `0` disables the watchdog. |

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -4,6 +4,18 @@ This is the operator's reference for running `siphon-ai` in something other
 than `cargo run`. For configuration semantics see `docs/CONFIG.md`; for the
 observability bar (the §11.8 ten questions) see `docs/OPERATIONS.md`.
 
+## Build prerequisites
+
+The daemon links **libopus** (Opus codec support, 0.8.0) — built from source
+by the `audiopus` crate at compile time. Building `siphon-ai` therefore needs
+a **C toolchain + CMake** (`cc`/`g++`, `make`, `cmake`, `perl`) on the build
+host, in addition to the Rust toolchain. The shipped `docker/Dockerfile`
+builder stage already installs these (musl-dev, cmake, make, g++, pkgconfig,
+perl), so `docker build` is turnkey. For a bare `cargo build`, install the
+equivalents (e.g. `apt install build-essential cmake` /
+`apk add musl-dev cmake make g++`). The runtime image needs nothing extra —
+libopus is statically linked into the binary.
+
 ## Container image
 
 The repo ships a multi-stage Dockerfile that builds a statically-linked

--- a/docs/DESIGN_OPUS.md
+++ b/docs/DESIGN_OPUS.md
@@ -1,11 +1,15 @@
 # Design note — Opus codec support
 
-> **Status: DRAFT — decisions in §7 (gating ones LOCKED 2026-06-17).** Same
-> design-first pass we did for park / hold / reconnect, because Opus
-> challenges the **locked WS audio contract** (CLAUDE.md §4.2, D8: PCM16
-> mono, 8 k/16 k only, exact 20 ms frames) and needs an **upstream
-> forge-media change** plus a **new native dependency**. The build follows
-> this once §7 is fully locked; deviations get noted back here.
+> **Status: IMPLEMENTED (0.8.0).** Chunk 1 (forge-media PR #75), chunk 2
+> (siphon-ai enablement #185), chunk 3 (this release). Two design unknowns
+> resolved cleanly during the chunk-1 spike: **libopus does the 48↔16
+> resample AND the stereo→mono downmix internally** (no `forge-resampler`
+> crate, no separate downmix — §7.4/§7.6), so the forge change was just
+> "run the Opus codec at a 16 kHz bridge rate" mirroring G.722. One
+> **deviation:** SDP **fmtp** (§4) is **deferred to a follow-up** — it
+> interacts with the answer's dynamic PT and the params (§7.5) want
+> validation against a real softphone/carrier. Opus is correct without it
+> (the `/2` rtpmap is emitted; forge decodes mono regardless).
 
 Adds **Opus** to the negotiable codec set. Opus is the modern wideband
 codec WebRTC/softphones prefer; SiphonAI advertises only G.711/G.722

--- a/test-harness/sipp-scenarios/README.md
+++ b/test-harness/sipp-scenarios/README.md
@@ -57,6 +57,7 @@ sipp -sf basic_call_then_bye.xml -m 1 -p 5070 -s 1000 127.0.0.1:5060
 | `reinvite_hold_resume.xml`          | Peer-initiated hold: SIPp **sends** a sendonly re-INVITE then a sendrecv one; SiphonAI mirrors recvonly/sendrecv (RFC 3264 §6.1) |
 | `bot_hold_caller.xml`               | 0.7.2 bot-initiated hold: the inverse — the echo-ws (`--auto-hold`) drives `hold`/`resume`, so SiphonAI **sends** the re-INVITEs and SIPp asserts it receives sendonly then sendrecv (**bot_hold** phase) |
 | `outbound_bot_hold_uas.xml`         | 0.7.5 bot-initiated hold on an **outbound** leg: SIPp is the callee (UAS), the echo-ws (`--auto-hold`) drives `hold`/`resume`, and SIPp asserts it receives the sendonly/sendrecv re-INVITEs on the outbound Direct dialog (**outbound_bot_hold** phase) |
+| `opus_caller.xml`                    | 0.8.0 Opus: SIPp offers `opus/48000/2` at a dynamic PT and asserts the 200 OK answers Opus; the daemon brings the call up as a 16 kHz bridge session (**opus** phase). Signalling only — SIPp can't encode Opus media. |
 
 `run-all.sh` also has an always-on **recording** auxiliary phase: it starts
 a daemon with `[recording].mode = "always"` writing to a temp dir, runs one
@@ -134,6 +135,14 @@ the callee), the echo-ws (`--auto-hold`) drives `hold`/`resume`, and SiphonAI
 sends the sendonly/sendrecv re-INVITEs on the outbound Direct dialog (via the
 gateway UAC). Pass = SIPp completed (both direction asserts held) **and**
 `siphon_ai_holds_total{result="ok"}` reads 2.
+
+And an always-on **opus** phase (0.8.0): a daemon with
+`[media].codecs = ["opus","pcmu"]`; `opus_caller.xml` offers Opus at a
+dynamic PT and asserts (via `check_it`) the 200 OK answers Opus. Pass = SIPp
+completed **and** the daemon logged `negotiated=opus sample_rate=16000` — Opus
+on the wire (`opus/48000/2`) surfacing as a 16 kHz bridge session. Signalling
+only; the Opus encode/decode round-trip is covered by forge-codecs /
+forge-engine unit tests.
 
 The `stir_shaken_*` scenarios run in `run-all.sh`'s always-on
 **stir_shaken** auxiliary phase. It builds + runs the

--- a/test-harness/sipp-scenarios/opus_caller.xml
+++ b/test-harness/sipp-scenarios/opus_caller.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  opus_caller — SIPp (UAC) offers Opus at a dynamic PT (96, opus/48000/2);
+  SiphonAI (UAS) must answer with Opus. Validates 0.8.0 Opus negotiation
+  end-to-end through the daemon: config accepts opus, the SDP negotiator
+  picks it, and the forge session comes up at the 16 kHz bridge rate.
+
+  Signalling test only — SIPp can't encode Opus media, so no RTP flows
+  (the encode/decode round-trip is covered by forge-codecs/forge-engine
+  unit tests). The 200 OK MUST carry an `opus` rtpmap, echoing the
+  offerer's PT (96) per RFC 3264. The daemon's [media].codecs must list
+  opus (run-all sets it). SiphonAI does not send 100/180 in v1; those
+  recv lines are optional.
+-->
+<scenario name="opus_caller">
+  <send>
+<![CDATA[
+INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+Max-Forwards: 70
+From: <sip:sipp-opus@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:sipp-opus@[local_ip]:[local_port]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=user1 53655765 2353687637 IN IP4 [local_ip]
+s=-
+c=IN IP4 [local_ip]
+t=0 0
+m=audio 9000 RTP/AVP 96
+a=rtpmap:96 opus/48000/2
+a=ptime:20
+a=sendrecv
+]]>
+  </send>
+
+  <recv response="100" optional="true"/>
+  <recv response="180" optional="true"/>
+  <recv response="183" optional="true"/>
+
+  <!-- 200 OK MUST answer Opus (echoing our PT 96). -->
+  <recv response="200" rtd="true">
+    <action>
+      <ereg regexp="a=rtpmap:96 opus/48000"
+            search_in="msg"
+            check_it="true"
+            assign_to="opus_answer"/>
+      <log message="opus answer rtpmap captured: [$opus_answer]"/>
+    </action>
+  </recv>
+
+  <send>
+<![CDATA[
+ACK sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]-ack
+Max-Forwards: 70
+From: <sip:sipp-opus@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="500"/>
+
+  <send>
+<![CDATA[
+BYE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]-bye
+Max-Forwards: 70
+From: <sip:sipp-opus@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 BYE
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="200" rtd="true"/>
+</scenario>

--- a/test-harness/sipp-scenarios/run-all.sh
+++ b/test-harness/sipp-scenarios/run-all.sh
@@ -1221,6 +1221,66 @@ fi
 oh_cleanup
 trap - EXIT
 
+# ─── Always-on auxiliary phase: Opus negotiation ──────────────────
+# A daemon with `[media].codecs = ["opus","pcmu"]`; SIPp offers Opus at a
+# dynamic PT (96, opus/48000/2) and asserts the 200 OK answers Opus
+# (the scenario's check_it on the answer rtpmap). Proves Opus negotiation
+# + the 16 kHz bridge session end-to-end (0.8.0). Signalling only — SIPp
+# can't encode Opus media; the codec round-trip is forge unit-tested.
+echo
+echo "─── auxiliary phase: opus ─────────────────────────────"
+OP_WS_PORT=8778
+OP_WS_LOG=$(mktemp -t echo-ws-op.XXXXXX.log)
+OP_DAEMON_LOG=$(mktemp -t siphon-ai-op.XXXXXX.log)
+OP_CONFIG=$(mktemp -t siphon-ai-op.XXXXXX.toml)
+cat >"$OP_CONFIG" <<EOF
+[node]
+id = "siphon-ai-sipp-op"
+[sip]
+listen = "127.0.0.1:$DAEMON_PORT"
+[media]
+codecs = ["opus", "pcmu"]
+[bridge]
+ws_url = "ws://127.0.0.1:$OP_WS_PORT/"
+[[route]]
+name = "default"
+[route.match]
+any = true
+EOF
+
+OP_PYTHON="$REPO_ROOT/examples/echo-ws-server-python/.venv/bin/python"
+[[ -x "$OP_PYTHON" ]] || OP_PYTHON=python3
+"$OP_PYTHON" "$REPO_ROOT/examples/echo-ws-server-python/server.py" \
+    --bind "127.0.0.1:$OP_WS_PORT" >"$OP_WS_LOG" 2>&1 &
+OP_WS_PID=$!
+
+RUST_LOG=siphon_ai=info "$DAEMON_BIN" --config "$OP_CONFIG" \
+    >"$OP_DAEMON_LOG" 2>&1 &
+OP_DAEMON_PID=$!
+op_cleanup() {
+    kill "$OP_WS_PID" "$OP_DAEMON_PID" 2>/dev/null || true
+    wait "$OP_WS_PID" "$OP_DAEMON_PID" 2>/dev/null || true
+}
+trap op_cleanup EXIT
+sleep 1.2
+
+total=$((total + 1))
+echo "─── opus_negotiation ─────────────────────────────────"
+# The scenario's check_it asserts the 200 OK carries an opus rtpmap; a
+# clean SIPp run (rc 0) means negotiation succeeded. Cross-check the
+# daemon logged a 16 kHz Opus session.
+if sipp -i 127.0.0.1 -sf "$SCRIPT_DIR/opus_caller.xml" -m 1 -timeout 12s -trace_err \
+        -p "$SIPP_PORT" -s 1000 "127.0.0.1:$DAEMON_PORT" >/dev/null 2>&1 \
+    && grep -q "negotiated=opus sample_rate=16000" "$OP_DAEMON_LOG"; then
+    echo "  OK"
+else
+    echo "  FAIL (daemon: $OP_DAEMON_LOG; ws: $OP_WS_LOG)"
+    failures=$((failures + 1))
+fi
+
+op_cleanup
+trap - EXIT
+
 # ─── Optional third phase: blind_transfer ─────────────────────────
 # Needs a WS server that proactively emits BridgeIn::Transfer. The
 # runner stops the daemon, brings up an echo-ws that auto-emits


### PR DESCRIPTION
Final chunk of the **Opus codec** theme. Folds in and **closes #184** (the docs-only design plan PR). Cuts **0.8.0**.

Theme arc: forge-media#75 (16 kHz Opus bridge rate) → siphon-ai #185 (un-reject Opus, SDP/WS rate map, forge pin bump) → **this** (harness + docs + release).

## What this PR does
- **SIPp `opus` regression phase.** `opus_caller.xml` offers `opus/48000/2` at a dynamic PT and asserts (via `check_it`) the 200 OK answers Opus; `run-all.sh`'s new `opus` phase runs a daemon with `[media].codecs = ["opus","pcmu"]` and also greps the daemon log for `negotiated=opus sample_rate=16000`. Signalling only — SIPp can't encode Opus media, so the encode/decode round-trip stays covered by forge-codecs/forge-engine unit tests.
- **Docs.** `CONFIG.md` (Opus no longer rejected; opus/48000/2 wire + 16 kHz bridge + libopus); `DEPLOY.md` (build-prerequisites: libopus needs a C toolchain + CMake, already in the Dockerfile); `DESIGN_OPUS.md` status → IMPLEMENTED with the two resolved unknowns (libopus does 48↔16 resample + stereo→mono internally) and the fmtp deferral noted.
- **Release.** `CHANGELOG [0.8.0]`; workspace version `0.7.5` → `0.8.0`.

## Contract / scope
- **Off by default** — add `"opus"` to `[media].codecs`.
- **WS protocol stays `version: "1"`.** Opus runs at a **16 kHz bridge rate** (RTP clock stays 48 kHz per RFC 7587), so the call surfaces to the WS server as a 16 kHz PCM16 session — the fixed 8/16 kHz audio contract (CLAUDE.md §4.2) is unchanged.
- **First native build dependency: libopus** (via `audiopus_sys`, built from source). Minor-version bump for that reason.
- **fmtp deferred** to a follow-up (interacts with the answer dynamic PT; params want real-device validation). Opus is correct without it.

## Validation
- `cargo fmt --all`, `cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D warnings` — all clean.
- `cargo test --workspace` — **725 passed, 0 failed**.
- Live-verified earlier in the theme: sipp rc=0, WS `start` `rate=16000`, daemon `negotiated=opus sample_rate=16000`.

Closes #184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)