### PR TITLE
fix(sip): REGISTER advertises public_address, not the wildcard bind (0.8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-06-17
+
+### Fixed
+
+- **Outbound REGISTER advertised `0.0.0.0` in `Via` and `Contact` when
+  `[sip].listen` used a wildcard bind** (`0.0.0.0:5060` / `[::]:5060`).
+  The registration drive task used the socket *bind* address for the
+  `Via` sent-by and `Contact` host, so a wildcard bind leaked into the
+  outbound REGISTER — `0.0.0.0` is not a routable Contact, so registrars
+  (e.g. CUCM) could not send INVITEs back, breaking inbound calls and
+  registrar classification. REGISTER now advertises
+  `[node].public_address` combined with the listen port — the same
+  reachable address the inbound UAS already uses for its `Contact`. The
+  socket still binds the configured (possibly wildcard) address; only
+  the advertised SIP headers changed. A concrete, non-wildcard
+  `[sip].listen` is unaffected. (`[node].public_address` is required
+  whenever the bind is unspecified, so the advertised address is always
+  routable.)
+
 ## [0.8.0] - 2026-06-17
 
 Theme: **Opus codec support.** SiphonAI advertised only G.711/G.722 and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2936,7 +2936,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "base64",
  "bytes",
@@ -2957,7 +2957,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2974,7 +2974,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "regex",
  "serde",
@@ -2991,7 +2991,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3031,7 +3031,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -3046,7 +3046,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3070,7 +3070,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "thiserror 1.0.69",
  "tokio",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "regex",
  "serde",
@@ -3090,7 +3090,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3099,7 +3099,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3122,7 +3122,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "base64",
  "rcgen",
@@ -3140,7 +3140,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3161,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/bins/siphon-ai/src/registration.rs
+++ b/bins/siphon-ai/src/registration.rs
@@ -38,7 +38,7 @@ use sip_core::Response;
 use sip_dns::SipResolver;
 use sip_transaction::{TransactionManager, TransportDispatcher};
 use sip_uac::integrated::{IntegratedUAC, RequestTarget};
-use siphon_ai_config::{RegisterConfig, SipConfig, SipTransport};
+use siphon_ai_config::{RegisterConfig, SipTransport};
 use siphon_ai_sip_glue::{
     refresh_delay, spawn_disabled_task, RegistrationManager, RegistrationStatus, ShutdownSignal,
 };
@@ -80,7 +80,7 @@ pub fn spawn_registration_tasks(
     transaction_mgr: Arc<TransactionManager>,
     dispatcher: Arc<dyn TransportDispatcher>,
     resolver: Arc<SipResolver>,
-    sip: &SipConfig,
+    advertised_addr: &str,
     webhook_sink: WebhookSinkHandle,
 ) -> Vec<JoinHandle<()>> {
     // Seed every `siphon_ai_register_state` row so a /metrics scrape
@@ -112,7 +112,7 @@ pub fn spawn_registration_tasks(
             Arc::clone(&transaction_mgr),
             Arc::clone(&dispatcher),
             Arc::clone(&resolver),
-            sip.listen_addr.to_string(),
+            advertised_addr.to_string(),
             Arc::clone(&webhook_sink),
         ));
     }
@@ -340,6 +340,19 @@ fn response_expires(resp: &Response) -> Option<Duration> {
     None
 }
 
+/// Build the `Contact` URI a registrar will route INVITEs back through.
+/// `addr` is the daemon's *advertised* SIP address (`host:port`), never
+/// the socket bind — see the caller. Kept as a pure helper so the
+/// no-wildcard-leak invariant is unit-testable without a live UAC.
+fn build_contact_uri(username: &str, addr: &str, transport: SipTransport) -> String {
+    let transport_param = match transport {
+        SipTransport::Udp => "udp",
+        SipTransport::Tcp => "tcp",
+        SipTransport::Tls => "tls",
+    };
+    format!("sip:{username}@{addr};transport={transport_param}")
+}
+
 fn build_uac(
     cfg: &RegisterConfig,
     transaction_mgr: Arc<TransactionManager>,
@@ -350,18 +363,13 @@ fn build_uac(
     // From URI is the AOR we register: sip:<username>@<server_host>.
     let local_uri = format!("sip:{}@{}", cfg.username, cfg.server_host);
     // Contact URI is where the registrar should send INVITEs back —
-    // our SIP listen address. Transport param matches what we
-    // configured for this registration (registrar may use it to pick
-    // a connection back to us).
-    let transport_param = match cfg.transport {
-        SipTransport::Udp => "udp",
-        SipTransport::Tcp => "tcp",
-        SipTransport::Tls => "tls",
-    };
-    let contact_uri = format!(
-        "sip:{}@{};transport={}",
-        cfg.username, local_addr_str, transport_param
-    );
+    // our advertised, reachable SIP address (`[node].public_address` +
+    // the listen port), NOT the socket bind address. A wildcard bind
+    // (`0.0.0.0`/`::`) must never leak into the Via/Contact a registrar
+    // routes to. Transport param matches what we configured for this
+    // registration (registrar may use it to pick a connection back to
+    // us). `local_addr` below feeds the Via sent-by the same way.
+    let contact_uri = build_contact_uri(&cfg.username, local_addr_str, cfg.transport);
 
     let builder = IntegratedUAC::builder()
         .local_uri(&local_uri)
@@ -486,5 +494,26 @@ mod tests {
     fn response_expires_ignores_garbage_value() {
         let resp = response_with(&[("Expires", "not-a-number")]);
         assert_eq!(response_expires(&resp), None);
+    }
+
+    #[test]
+    fn contact_uri_carries_advertised_addr_and_transport() {
+        let uri = build_contact_uri("+12123013382", "10.246.253.199:5060", SipTransport::Udp);
+        assert_eq!(uri, "sip:+12123013382@10.246.253.199:5060;transport=udp");
+    }
+
+    #[test]
+    fn contact_uri_never_carries_wildcard_bind() {
+        // Regression: a wildcard SIP bind (`0.0.0.0`) must not leak into
+        // the Contact a registrar routes back through. The drive task is
+        // fed `[node].public_address` (the advertised addr), never the
+        // socket bind, so the wildcard never reaches this builder.
+        let uri = build_contact_uri("alice", "10.0.0.7:5061", SipTransport::Tcp);
+        assert!(
+            !uri.contains("0.0.0.0"),
+            "contact leaked wildcard bind: {uri}"
+        );
+        assert!(uri.contains("10.0.0.7:5061"));
+        assert!(uri.ends_with(";transport=tcp"));
     }
 }

--- a/bins/siphon-ai/src/registration.rs
+++ b/bins/siphon-ai/src/registration.rs
@@ -498,8 +498,8 @@ mod tests {
 
     #[test]
     fn contact_uri_carries_advertised_addr_and_transport() {
-        let uri = build_contact_uri("+12123013382", "10.246.253.199:5060", SipTransport::Udp);
-        assert_eq!(uri, "sip:+12123013382@10.246.253.199:5060;transport=udp");
+        let uri = build_contact_uri("+15551234567", "203.0.113.199:5060", SipTransport::Udp);
+        assert_eq!(uri, "sip:+15551234567@203.0.113.199:5060;transport=udp");
     }
 
     #[test]

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -524,13 +524,23 @@ impl Runtime {
         // → refresh / retry loop. Tasks share the manager's shutdown
         // signal so the runtime's teardown path wakes them all at
         // once. See `crate::registration` for the loop semantics.
+        // REGISTER Via/Contact must advertise a reachable address, not
+        // the socket bind — a wildcard bind (`0.0.0.0`/`::`) is not a
+        // routable Contact and registrars can't send INVITEs back to it.
+        // `sip_public_addr` combines `[node].public_address` (always
+        // populated post-compile; wildcard bind without it is a load
+        // error) with the listen port; fall back to the bind addr only
+        // for a concrete, non-wildcard listen.
+        let registration_advertised_addr = sip_public_addr(&node, &sip)
+            .unwrap_or(sip.listen_addr)
+            .to_string();
         let registration_listeners = crate::registration::spawn_registration_tasks(
             &registration_mgr,
             &registrations,
             Arc::clone(&transaction_mgr),
             Arc::clone(&dispatcher),
             Arc::clone(&sip_resolver),
-            &sip,
+            &registration_advertised_addr,
             Arc::clone(&webhook_sink_for_registrations),
         );
 

--- a/bins/siphon-ai/tests/startup.rs
+++ b/bins/siphon-ai/tests/startup.rs
@@ -264,6 +264,122 @@ async fn registrations_seed_into_manager_on_startup() {
         .expect("task does not panic");
 }
 
+/// Wildcard SIP bind + `[node].public_address`. The bind stays
+/// `0.0.0.0:<port>`; the advertised address (and so the REGISTER's
+/// Via and Contact) must be the public address. Regression for the
+/// `0.0.0.0` leak that breaks CUCM/registrar reachability.
+const REGISTER_WILDCARD_FIXTURE: &str = r#"
+[node]
+public_address = "127.0.0.1"
+
+[sip]
+listen = "${TEST_SIP_LISTEN}"
+transports = ["udp"]
+
+[media]
+codecs = ["pcmu"]
+rtp_port_range = [${TEST_RTP_MIN}, ${TEST_RTP_MAX}]
+
+[bridge]
+ws_url = "wss://example.test/sip-bridge"
+
+[[register]]
+name = "cucm"
+server = "${TEST_REGISTRAR}"
+username = "+12123013382"
+password = "secret"
+
+[[route]]
+name = "default"
+[route.match]
+any = true
+"#;
+
+#[tokio::test]
+async fn register_advertises_public_address_not_wildcard_bind() {
+    install_crypto_provider();
+
+    // Fake registrar: a bare UDP socket that captures the first
+    // datagram the daemon sends it. We never answer — one REGISTER
+    // is all we need to inspect.
+    let registrar = tokio::net::UdpSocket::bind("127.0.0.1:0")
+        .await
+        .expect("registrar bind");
+    let registrar_addr = registrar.local_addr().expect("registrar addr");
+
+    // Grab a free port number, release it, then ask the daemon to
+    // bind the WILDCARD address on that port. This is the scenario in
+    // the bug report (`listen = "0.0.0.0:5060"`): the bind is
+    // unspecified, but Via/Contact must not be.
+    let listen_port = {
+        let s = std::net::UdpSocket::bind("0.0.0.0:0").expect("scratch bind");
+        s.local_addr().expect("scratch addr").port()
+    };
+
+    let listen: &'static str = Box::leak(format!("0.0.0.0:{listen_port}").into_boxed_str());
+    let registrar_str: &'static str = Box::leak(registrar_addr.to_string().into_boxed_str());
+    let env = MapEnv::new([
+        ("TEST_SIP_LISTEN", listen),
+        ("TEST_RTP_MIN", "40800"),
+        ("TEST_RTP_MAX", "40900"),
+        ("TEST_REGISTRAR", registrar_str),
+    ]);
+    let cfg = load_from_str_with_env(REGISTER_WILDCARD_FIXTURE, &env).expect("config compiles");
+
+    let runtime = Runtime::build(cfg, siphon_ai_telemetry::LogFilterHandle::noop())
+        .await
+        .expect("runtime builds");
+
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let run_handle = tokio::spawn(async move {
+        let _ = runtime
+            .run(async move {
+                let _ = shutdown_rx.await;
+            })
+            .await;
+    });
+
+    // The drive task fires REGISTER on startup; grab the first datagram.
+    let mut buf = vec![0u8; 4096];
+    let (n, _from) = tokio::time::timeout(Duration::from_secs(5), registrar.recv_from(&mut buf))
+        .await
+        .expect("REGISTER arrives within 5s")
+        .expect("registrar recv");
+    let register = String::from_utf8_lossy(&buf[..n]);
+
+    assert!(
+        register.starts_with("REGISTER "),
+        "expected a REGISTER request, got: {register}"
+    );
+    assert!(
+        !register.contains("0.0.0.0"),
+        "wildcard bind leaked into outbound REGISTER:\n{register}"
+    );
+    // Via sent-by and Contact host must both be the public address.
+    let via = register
+        .lines()
+        .find(|l| l.to_ascii_lowercase().starts_with("via:"))
+        .expect("Via header present");
+    assert!(
+        via.contains(&format!("127.0.0.1:{listen_port}")),
+        "Via must advertise public_address:port, got: {via}"
+    );
+    let contact = register
+        .lines()
+        .find(|l| l.to_ascii_lowercase().starts_with("contact:"))
+        .expect("Contact header present");
+    assert!(
+        contact.contains(&format!("127.0.0.1:{listen_port}")),
+        "Contact must advertise public_address:port, got: {contact}"
+    );
+
+    shutdown_tx.send(()).expect("shutdown signal");
+    tokio::time::timeout(Duration::from_secs(2), run_handle)
+        .await
+        .expect("runtime exits within 2s")
+        .expect("task does not panic");
+}
+
 #[tokio::test]
 async fn build_fails_when_listen_port_is_busy() {
     install_crypto_provider();

--- a/bins/siphon-ai/tests/startup.rs
+++ b/bins/siphon-ai/tests/startup.rs
@@ -286,7 +286,7 @@ ws_url = "wss://example.test/sip-bridge"
 [[register]]
 name = "cucm"
 server = "${TEST_REGISTRAR}"
-username = "+12123013382"
+username = "+15551234567"
 password = "secret"
 
 [[route]]

--- a/docs/REGISTRATION.md
+++ b/docs/REGISTRATION.md
@@ -57,7 +57,7 @@ all interfaces:
 
 ```toml
 [node]
-public_address = "10.246.253.199"   # reachable IP the registrar routes back to
+public_address = "203.0.113.199"   # reachable IP the registrar routes back to
 
 [sip]
 listen = "0.0.0.0:5060"             # bind all interfaces
@@ -66,7 +66,7 @@ listen = "0.0.0.0:5060"             # bind all interfaces
 This is the same `public_address` used in the SDP `c=` line and the inbound
 UAS `Contact`. A wildcard bind without `[node].public_address` is rejected at
 config load. A concrete, non-wildcard `[sip].listen` (e.g.
-`10.246.253.199:5060`) needs no extra setting — that address is advertised
+`203.0.113.199:5060`) needs no extra setting — that address is advertised
 directly.
 
 ## What v1 supports

--- a/docs/REGISTRATION.md
+++ b/docs/REGISTRATION.md
@@ -45,6 +45,30 @@ arrive on a registered transport get the implicit source `"trunk"`.
 You can declare any number of `[[register]]` blocks; each runs an independent
 drive task. Names must be unique.
 
+### Advertised address vs. bind address
+
+A `REGISTER`'s `Via` sent-by and `Contact` host tell the registrar where to
+send INVITEs back, so they must be a **reachable** address — never the
+wildcard bind. When `[sip].listen` binds an unspecified address
+(`0.0.0.0:5060` or `[::]:5060`), you **must** set `[node].public_address` to
+the host the registrar can route to; SiphonAI advertises that address
+(combined with the listen port) in the REGISTER, while the socket still binds
+all interfaces:
+
+```toml
+[node]
+public_address = "10.246.253.199"   # reachable IP the registrar routes back to
+
+[sip]
+listen = "0.0.0.0:5060"             # bind all interfaces
+```
+
+This is the same `public_address` used in the SDP `c=` line and the inbound
+UAS `Contact`. A wildcard bind without `[node].public_address` is rejected at
+config load. A concrete, non-wildcard `[sip].listen` (e.g.
+`10.246.253.199:5060`) needs no extra setting — that address is advertised
+directly.
+
 ## What v1 supports
 
 - Initial REGISTER + Digest auth retry (handled by the upstream


### PR DESCRIPTION
## Bug

With a wildcard SIP bind:

```toml
[sip]
listen = "0.0.0.0:5060"
```

the outbound `REGISTER` advertised `0.0.0.0` in **both** `Via` and `Contact`:

```
Via: SIP/2.0/UDP 0.0.0.0:5060;branch=...;rport
Contact: <sip:+15551234567@0.0.0.0:5060>;expires=3600
```

`0.0.0.0` is not a routable contact, so registrars (reported against **CUCM 15**) can't send INVITEs back — inbound calls fail, registrar classification breaks, NAT/response routing misbehaves. Pre-existing since registration shipped; reported against 0.7.5.

## Root cause

The per-`[[register]]` drive task used `sip.listen_addr` (the socket **bind** address) for both the `Contact` URI and the UAC's `local_addr` (which siphon-rs uses as the `Via` sent-by). The bind address and the *advertised* address are different concepts; a wildcard bind must never leak into headers a registrar routes through.

The inbound UAS already solved this — it advertises `sip_public_addr()` (`[node].public_address` + listen port) in its `Contact`. Registration just didn't use it.

## Fix

- **runtime:** derive the advertised address via the existing `sip_public_addr()` (public_address + listen port) and pass it to the registration tasks instead of the bind address. Socket still binds the configured (possibly wildcard) address — only the advertised SIP headers change.
- **registration:** extract a pure `build_contact_uri()` helper (+ unit tests proving the wildcard can't reach the Contact); the drive task now takes an `advertised_addr` string rather than the `SipConfig`.
- `[node].public_address` is **already mandatory** whenever the bind is unspecified (config-load error otherwise), so the advertised address is always routable. A concrete, non-wildcard `[sip].listen` is unaffected (falls back to it).

Resulting REGISTER with `public_address = "203.0.113.199"`, `listen = "0.0.0.0:5060"`:

```
Via: SIP/2.0/UDP 203.0.113.199:5060;branch=...;rport
Contact: <sip:+15551234567@203.0.113.199:5060>;expires=3600
```

## Tests

- **Unit** (`registration.rs`): contact URI carries the advertised addr + transport; never carries `0.0.0.0`.
- **Integration** (`tests/startup.rs`): boots a real `Runtime` with a **wildcard bind + public_address** against a fake UDP registrar, captures the REGISTER on the wire, and asserts `Via`/`Contact` carry `public_address:port` and never `0.0.0.0`. **Verified it fails without the runtime fix.**
- `cargo fmt` / `clippy -D warnings` clean; `cargo test --workspace` — **728 passed, 0 failed**.

## Docs

- `docs/REGISTRATION.md`: advertised-vs-bind callout (the minimal config previously showed `0.0.0.0:5060` without the `[node].public_address` it requires).
- `CHANGELOG [0.8.1]`; version `0.8.0` → `0.8.1`.

(Examples use documentation-safe placeholders — `+15551234567`, RFC 5737 `203.0.113.199` — not the reporter's real number/IP.)

No protocol/CDR/HEP change. Patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
