### PR TITLE
feat: outbound SIP delayed offer (offerless INVITE) — chunk 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,21 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Inbound SIP delayed offer (offerless INVITE), RFC 3264** — chunk 1 of
-  the delayed-offer theme. An inbound INVITE with no SDP is now accepted:
-  SiphonAI allocates media, puts **its own offer** in the 200 OK, and
-  reads the peer's **answer from the ACK** before bridging. This removes
-  the forced **MTP** on CUCM (and similar) trunks/phones, so media flows
-  directly. Early-offer INVITEs are unchanged. On by default; gate with
-  `[sip].allow_delayed_offer = false` to force strict early offer (an
-  offerless INVITE is then rejected `488`). New metric
-  `siphon_ai_delayed_offer_total{result}` (`answered`, `ack_timeout`,
-  `missing_sdp_answer`, `invalid_sdp_answer`, `no_compatible_codec`,
-  `invalid_remote_media`). The ACK-answer wait is bounded by SIP Timer H
-  (~32 s). The call is marked active only after the ACK answer is parsed.
-  SIPp `delayed_offer` regression phase added. *In-dialog transfer/hold
-  and SRTP-on-the-offer for delayed-offer legs, plus the outbound
-  direction, are follow-up chunks.*
+- **SIP delayed offer (offerless INVITE), RFC 3264 — inbound and
+  outbound.** Removes the forced **MTP** on CUCM (and similar)
+  trunks/phones so media flows directly. Early-offer calls are unchanged.
+  - **Inbound** (chunk 1): an inbound INVITE with no SDP is accepted —
+    SiphonAI allocates media, puts **its own offer** in the 200 OK, and
+    reads the peer's **answer from the ACK** before bridging. On by
+    default; gate with `[sip].allow_delayed_offer = false` to force strict
+    early offer (offerless INVITE then rejected `488`). The ACK-answer
+    wait is bounded by SIP Timer H (~32 s); the call is active only after
+    the answer is parsed. Metric `siphon_ai_delayed_offer_total{result}`.
+  - **Outbound** (chunk 2): `POST /admin/v1/calls` with `"delayed_offer":
+    true` dials an **offerless INVITE**, takes the peer's offer from the
+    2xx, and answers in the **ACK** (via the gateway UAC's RFC-3264 answer
+    generator). Delayed-outbound legs get transfer/hold like early-offer
+    ones. (SRTP on the delayed-offer answer is a follow-up — the offerless
+    INVITE can't carry an SDES offer.)
+  - SIPp `delayed_offer` (inbound) and `outbound_delayed` phases added.
 
 ## [0.8.2] - 2026-06-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3009,6 +3009,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=3023963ba83a)",
  "sip-transaction",
  "sip-uac",
  "sip-uas",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,11 @@ sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "302
 sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3023963ba83a" }
 sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3023963ba83a" }
 sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3023963ba83a" }
+# sip-sdp — the SAME sip-sdp sip-uac's SdpAnswerGenerator trait speaks
+# (distinct from forge-media's pinned sip-sdp). Used by the outbound
+# delayed-offer answer generator to hand the UAC a SessionDescription it
+# accepts. Must stay on the same siphon-rs rev as the rest below.
+sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3023963ba83a" }
 sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3023963ba83a" }
 # sip-identity — STIR/SHAKEN Identity-header parsing + PASSporT verification
 # (ES256 + X.509 chain validation). Consumed by the stir-shaken verifier crate.

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -571,6 +571,17 @@ impl Runtime {
         let outbound_handle: Option<AdminOutbound> = if outbound.enabled() {
             let mut gateways = HashMap::with_capacity(outbound.gateways.len());
             for gw in &outbound.gateways {
+                // Outbound delayed offer (chunk 2): the gateway's UAC and
+                // its originator share one registry — `place_delayed` parks
+                // per-call media params, the UAC's answer generator picks
+                // them up when the peer's offer arrives in the 2xx.
+                let delayed_registry: siphon_ai_core::DelayedOfferRegistry =
+                    Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
+                let answerer: Arc<dyn sip_uac::integrated::SdpAnswerGenerator> =
+                    Arc::new(siphon_ai_core::DelayedOfferAnswerer::new(
+                        (*outbound_media).clone(),
+                        Arc::clone(&delayed_registry),
+                    ));
                 let uac = build_outbound_uac(
                     TransferUacBuild {
                         local_uri: &local_uri,
@@ -582,10 +593,12 @@ impl Runtime {
                         sip_resolver: Arc::clone(&sip_resolver),
                     },
                     gw.credentials.as_ref(),
+                    Some(answerer),
                 )?;
-                let originator = Arc::new(OutboundOriginator::new(
+                let originator = Arc::new(OutboundOriginator::with_delayed_registry(
                     (*outbound_media).clone(),
                     Arc::new(uac),
+                    delayed_registry,
                 ));
                 gateways.insert(
                     gw.name.clone(),
@@ -1297,6 +1310,7 @@ fn build_transfer_uac(args: TransferUacBuild<'_>) -> Result<IntegratedUAC> {
 fn build_outbound_uac(
     args: TransferUacBuild<'_>,
     credentials: Option<&siphon_ai_config::GatewayCredentials>,
+    sdp_answer_generator: Option<Arc<dyn sip_uac::integrated::SdpAnswerGenerator>>,
 ) -> Result<IntegratedUAC> {
     let mut builder = IntegratedUAC::builder()
         .local_uri(args.local_uri)
@@ -1316,6 +1330,11 @@ fn build_outbound_uac(
             creds.username.clone(),
             creds.password.clone(),
         )));
+    }
+    // Outbound delayed offer (RFC 3264): when set, the UAC invokes this to
+    // build the SDP answer for the ACK on a 2xx carrying the peer's offer.
+    if let Some(generator) = sdp_answer_generator {
+        builder = builder.sdp_answer_generator(generator);
     }
     builder
         .build()

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -37,6 +37,7 @@ siphon-ai-webhooks.workspace   = true
 sip-core.workspace        = true
 sip-dialog.workspace      = true
 sip-uac.workspace         = true
+sip-sdp.workspace         = true
 sip-uas.workspace         = true
 sip-transaction.workspace = true
 # `DialogFlow` carries the inbound connection's writer channel,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -32,8 +32,8 @@ pub use conference::{ConferenceError, ConferenceLimits, ConferenceRegistry, Conf
 pub use conference_admin::ConferenceAdmin;
 pub use hold::HoldContext;
 pub use outbound::{
-    NotAnsweredCause, OutboundCall, OutboundError, OutboundGuard, OutboundOriginator,
-    OutboundPermit, OutboundRejection, StaticCredentials,
+    DelayedOfferAnswerer, DelayedOfferRegistry, NotAnsweredCause, OutboundCall, OutboundError,
+    OutboundGuard, OutboundOriginator, OutboundPermit, OutboundRejection, StaticCredentials,
 };
 pub use outbound_service::{OutboundGateway, OutboundService};
 pub use park::{

--- a/crates/core/src/outbound.rs
+++ b/crates/core/src/outbound.rs
@@ -18,27 +18,157 @@
 //! §4.4); this struct is process-wide plumbing (one shared UAC + media
 //! setup), not per-call state.
 
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
-use forge_core::CallId;
+use forge_core::{CallId, ParticipantId};
 use sip_core::SipUri;
+// The SAME sip-sdp sip-uac's SdpAnswerGenerator speaks — distinct from
+// forge-media's pinned sip-sdp (whose `SessionDescription` is a different
+// type to cargo). We parse our media-glue answer text into this so the UAC
+// accepts it for the ACK.
 use sip_dialog::Dialog;
-use sip_uac::integrated::{CallHandle, IntegratedUAC, RequestTarget};
+use sip_sdp::SessionDescription;
+use sip_uac::integrated::{CallHandle, IntegratedUAC, RequestTarget, SdpAnswerGenerator};
 use sip_uac::CredentialProvider;
 use siphon_ai_media_glue::{
-    MediaSetup, OutboundAccepted, OutboundOfferRequest, SetupError, TapOptions,
+    Codec, InboundAccepted, InboundCall, MediaSetup, OutboundAccepted, OutboundOfferRequest,
+    SetupError, TapOptions,
 };
 use thiserror::Error;
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio::sync::{oneshot, OwnedSemaphorePermit, Semaphore};
 use tracing::{debug, info, instrument, warn};
+
+/// Per-call state for an outbound **delayed-offer** call (we sent an
+/// offerless INVITE; the peer's offer arrives in the 2xx). Parked in the
+/// [`DelayedOfferRegistry`] by [`OutboundOriginator::place_delayed`] keyed
+/// by SIP Call-ID, consumed by [`DelayedOfferAnswerer::generate_answer`]
+/// when the 2xx lands. The fields are exactly what `accept_inbound` needs
+/// to build our answer from the peer's offer.
+///
+/// Public only because it appears in the `pub` [`DelayedOfferRegistry`]
+/// alias; its fields are private and it is constructed solely by
+/// [`OutboundOriginator::place_delayed`].
+pub struct DelayedOfferPending {
+    forge_call_id: CallId,
+    codecs: Vec<Codec>,
+    dtmf_payload_type: Option<u8>,
+    participant_a: ParticipantId,
+    participant_b: ParticipantId,
+    tap: TapOptions,
+    /// Delivers the media-setup result back to `place_delayed` once the
+    /// generator has built the answer (or failed).
+    result_tx: oneshot::Sender<Result<InboundAccepted, SetupError>>,
+}
+
+/// SIP-Call-ID → parked delayed-offer call. Shared between the
+/// [`OutboundOriginator`] (which inserts) and the per-UAC
+/// [`DelayedOfferAnswerer`] (which removes + finalizes).
+pub type DelayedOfferRegistry = Arc<Mutex<HashMap<String, DelayedOfferPending>>>;
+
+/// The UAC's [`SdpAnswerGenerator`] for outbound delayed offer. When a 2xx
+/// to an offerless INVITE carries the peer's offer, the UAC calls this to
+/// build the SDP answer that goes in the ACK. We answer via `media-glue`
+/// (`accept_inbound` — parse offer, allocate, build answer) and hand the
+/// resulting session/tap back to `place_delayed` through the registry's
+/// oneshot. One answerer per gateway UAC; per-call state is keyed by the
+/// dialog's Call-ID, so concurrent calls don't collide.
+pub struct DelayedOfferAnswerer {
+    media: MediaSetup,
+    registry: DelayedOfferRegistry,
+}
+
+impl DelayedOfferAnswerer {
+    pub fn new(media: MediaSetup, registry: DelayedOfferRegistry) -> Self {
+        Self { media, registry }
+    }
+}
+
+#[async_trait]
+impl SdpAnswerGenerator for DelayedOfferAnswerer {
+    async fn generate_answer(
+        &self,
+        offer: &SessionDescription,
+        dialog: &Dialog,
+    ) -> anyhow::Result<SessionDescription> {
+        let sip_call_id = dialog.id().call_id().to_string();
+        // Lock only to pull the parked entry out; never hold across the
+        // await below.
+        let pending = self
+            .registry
+            .lock()
+            .expect("delayed-offer registry mutex poisoned")
+            .remove(&sip_call_id);
+        let Some(pending) = pending else {
+            return Err(anyhow::anyhow!(
+                "no parked delayed-offer call for Call-ID {sip_call_id}"
+            ));
+        };
+        let DelayedOfferPending {
+            forge_call_id,
+            codecs,
+            dtmf_payload_type,
+            participant_a,
+            participant_b,
+            tap,
+            result_tx,
+        } = pending;
+
+        let offer_sdp = offer.serialize();
+        let result = self
+            .media
+            .accept_inbound(InboundCall {
+                call_id: forge_call_id,
+                offer_sdp: &offer_sdp,
+                codecs,
+                dtmf_payload_type,
+                participant_a,
+                participant_b,
+                from_tag: None,
+                to_tag: None,
+                barge_in_action: tap.barge_in_action,
+                barge_in_debounce: tap.barge_in_debounce,
+                inactivity_timeout: tap.inactivity_timeout,
+                silence_threshold: tap.silence_threshold,
+                dead_air_threshold: tap.dead_air_threshold,
+                rtp_stats_interval: tap.rtp_stats_interval,
+            })
+            .await;
+
+        match result {
+            Ok(accepted) => {
+                // Re-parse our answer text into the UAC's sip-sdp type for
+                // the ACK (media-glue's SessionDescription is forge's
+                // distinct sip-sdp), then hand the session/tap back.
+                let answer_sd = SessionDescription::parse(&accepted.answer.answer_text)
+                    .map_err(|e| anyhow::anyhow!("re-parse delayed-offer answer: {e}"))?;
+                let _ = result_tx.send(Ok(accepted));
+                Ok(answer_sd)
+            }
+            Err(e) => {
+                let msg = e.to_string();
+                let _ = result_tx.send(Err(e));
+                Err(anyhow::anyhow!("delayed-offer answer build failed: {msg}"))
+            }
+        }
+    }
+}
+
+/// How long `place_delayed` waits for the generator's media result after a
+/// 2xx before giving up (the generator runs synchronously during 2xx
+/// processing, so this only guards a 2xx that carried no usable offer).
+const DELAYED_RESULT_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Places outbound calls through a shared UAC, allocating + binding media
 /// via [`MediaSetup`]. Daemon-wide; cheap to construct.
 pub struct OutboundOriginator {
     media: MediaSetup,
     uac: Arc<IntegratedUAC>,
+    /// Shared with this gateway's [`DelayedOfferAnswerer`]. `place_delayed`
+    /// parks per-call state here for the generator to pick up.
+    delayed_registry: DelayedOfferRegistry,
 }
 
 /// An established outbound call: the bound media plus the confirmed SIP
@@ -95,7 +225,23 @@ pub enum NotAnsweredCause {
 
 impl OutboundOriginator {
     pub fn new(media: MediaSetup, uac: Arc<IntegratedUAC>) -> Self {
-        Self { media, uac }
+        Self::with_delayed_registry(media, uac, Arc::new(Mutex::new(HashMap::new())))
+    }
+
+    /// Construct sharing an explicit [`DelayedOfferRegistry`] with the
+    /// gateway's [`DelayedOfferAnswerer`] (so `place_delayed` and the UAC's
+    /// answer generator see the same parked calls). The daemon wires both
+    /// halves; tests that don't exercise delayed offer use [`Self::new`].
+    pub fn with_delayed_registry(
+        media: MediaSetup,
+        uac: Arc<IntegratedUAC>,
+        delayed_registry: DelayedOfferRegistry,
+    ) -> Self {
+        Self {
+            media,
+            uac,
+            delayed_registry,
+        }
     }
 
     /// This gateway's UAC. The outbound leg's transfer context sends
@@ -165,6 +311,133 @@ impl OutboundOriginator {
         let dialog = handle.dialog.read().await.clone();
 
         info!(code, "outbound call answered and media bridged");
+        Ok(OutboundCall {
+            accepted,
+            dialog,
+            call_handle: handle,
+            call_id,
+        })
+    }
+
+    /// Place an outbound **delayed-offer** call: send an INVITE with **no
+    /// SDP**, let the peer offer in its 2xx, and answer in the ACK. The
+    /// inverse of [`Self::place`]'s early offer. Media setup happens inside
+    /// the UAC's [`DelayedOfferAnswerer`] (it has the peer's offer); the
+    /// session/tap come back here via the registry's oneshot. Reuses
+    /// `req`'s media parameters (the `srtp` field is ignored — SRTP on the
+    /// delayed-offer answer is a follow-up).
+    #[instrument(skip(self, target, req, tap), fields(call_id = %req.call_id))]
+    pub async fn place_delayed(
+        &self,
+        target: SipUri,
+        req: OutboundOfferRequest,
+        tap: TapOptions,
+    ) -> Result<OutboundCall, OutboundError> {
+        let call_id = req.call_id.clone();
+        debug!(target = %target.as_str(), "placing outbound delayed-offer call");
+
+        // (1) Send the offerless INVITE.
+        let handle = match self.uac.invite(RequestTarget::Uri(target), None).await {
+            Ok(h) => h,
+            Err(e) => {
+                self.stop_session(&call_id).await;
+                return Err(OutboundError::Transport(e.to_string()));
+            }
+        };
+
+        // (2) Park per-call media params keyed by the INVITE's Call-ID
+        //     BEFORE awaiting the final response. The peer cannot 2xx until
+        //     it receives the INVITE we just sent, so the generator (which
+        //     fires on that 2xx) can't run before this registration.
+        let sip_call_id = handle
+            .invite_request()
+            .headers()
+            .get_smol("Call-ID")
+            .map(|s| s.to_string())
+            .unwrap_or_default();
+        let (result_tx, result_rx) = oneshot::channel();
+        self.delayed_registry
+            .lock()
+            .expect("delayed-offer registry mutex poisoned")
+            .insert(
+                sip_call_id.clone(),
+                DelayedOfferPending {
+                    forge_call_id: call_id.clone(),
+                    codecs: req.codecs,
+                    dtmf_payload_type: req.dtmf_payload_type,
+                    participant_a: req.participant_a,
+                    participant_b: req.participant_b,
+                    tap,
+                    result_tx,
+                },
+            );
+
+        // (3) Await the final response. The UAC invokes the answer
+        //     generator + sends the ACK on a 2xx itself.
+        let unpark = || {
+            self.delayed_registry
+                .lock()
+                .expect("delayed-offer registry mutex poisoned")
+                .remove(&sip_call_id);
+        };
+        let response = match handle.await_final().await {
+            Ok(r) => r,
+            Err(e) => {
+                unpark();
+                self.stop_session(&call_id).await;
+                return Err(OutboundError::Transport(e.to_string()));
+            }
+        };
+        let code = response.code();
+        if !(200..300).contains(&code) {
+            // No 2xx → the generator never ran; reclaim the parked entry.
+            unpark();
+            let cause = classify_failure(code, response.reason());
+            debug!(code, ?cause, "outbound delayed-offer INVITE not answered");
+            self.stop_session(&call_id).await;
+            return Err(OutboundError::NotAnswered(cause));
+        }
+
+        // (4) 2xx — the generator built our answer (and ran media setup)
+        //     during 2xx processing; collect the session/tap it produced.
+        let inbound = match tokio::time::timeout(DELAYED_RESULT_TIMEOUT, result_rx).await {
+            Ok(Ok(Ok(accepted))) => accepted,
+            Ok(Ok(Err(setup_err))) => {
+                // The generator ran but media build failed (it rolled its
+                // own session back). The dialog is up; mirror `place`'s
+                // post-2xx error handling and surface the setup error.
+                return Err(OutboundError::Setup(setup_err));
+            }
+            Ok(Err(_)) | Err(_) => {
+                // The generator never delivered — a 2xx that carried no
+                // usable SDP offer (a non-compliant answer to an offerless
+                // INVITE), or it timed out.
+                unpark();
+                warn!("2xx to offerless INVITE carried no usable SDP offer");
+                self.stop_session(&call_id).await;
+                return Err(OutboundError::Transport(
+                    "2xx to offerless INVITE carried no usable SDP offer".into(),
+                ));
+            }
+        };
+        let dialog = handle.dialog.read().await.clone();
+
+        // Reshape into `OutboundAccepted` so the shared outbound run_call
+        // works unchanged. `offer_sdp` = our answer text, so hold/resume
+        // flip the negotiated media the same way the inbound path does.
+        // No SRTP on the delayed answer in this cut.
+        let accepted = OutboundAccepted {
+            offer_sdp: inbound.answer.answer_text.clone(),
+            answer: inbound.answer,
+            session: inbound.session,
+            tap: inbound.tap,
+            srtp_profile: None,
+        };
+
+        info!(
+            code,
+            "outbound delayed-offer call answered and media bridged"
+        );
         Ok(OutboundCall {
             accepted,
             dialog,

--- a/crates/core/src/outbound_service.rs
+++ b/crates/core/src/outbound_service.rs
@@ -218,7 +218,10 @@ impl OutboundOriginateHandle for OutboundService {
         let from = req.from.clone().unwrap_or_else(|| gw.from.clone());
         let to = req.to.clone();
         let gateway = req.gateway.clone();
-        let srtp_requested = gw.srtp != OutboundSrtp::Off;
+        let delayed_offer = req.delayed_offer;
+        // A delayed-offer outbound INVITE carries no SDP, so we can't offer
+        // SRTP in it — the peer offers, we answer (plaintext in this cut).
+        let srtp_requested = !delayed_offer && gw.srtp != OutboundSrtp::Off;
         let originator = Arc::clone(&gw.originator);
         let cdr_sink = Arc::clone(&self.cdr_sink);
         let webhook_sink = Arc::clone(&self.webhook_sink);
@@ -247,7 +250,11 @@ impl OutboundOriginateHandle for OutboundService {
                     gateway: gateway.clone(),
                 }))
                 .await;
-            let result = originator.place(target, offer_req, tap).await;
+            let result = if delayed_offer {
+                originator.place_delayed(target, offer_req, tap).await
+            } else {
+                originator.place(target, offer_req, tap).await
+            };
             let result_label = outbound_result_label(&result);
             metrics::counter!(OUTBOUND_CALLS_TOTAL, "result" => result_label).increment(1);
             match result {

--- a/crates/telemetry/src/admin.rs
+++ b/crates/telemetry/src/admin.rs
@@ -107,6 +107,11 @@ pub struct OriginateRequest {
     /// Caller-ID override (a `sip:` URI). Falls back to the gateway's `from`.
     #[serde(default)]
     pub from: Option<String>,
+    /// Place the call as a **delayed offer** (RFC 3264): send an INVITE
+    /// with no SDP and answer the peer's offer in the ACK. Default `false`
+    /// (early offer — SiphonAI offers in the INVITE).
+    #[serde(default)]
+    pub delayed_offer: bool,
 }
 
 /// Why an originate request was refused synchronously (before the call is

--- a/docs/DESIGN_DELAYED_OFFER.md
+++ b/docs/DESIGN_DELAYED_OFFER.md
@@ -1,5 +1,20 @@
 # Design note — SIP delayed offer (offerless INVITE)
 
+> **Status: IN PROGRESS — chunks 1 (inbound) + 2 (outbound) landed.**
+> Outbound delayed offer (chunk 2): `POST /admin/v1/calls` with
+> `delayed_offer: true` dials an offerless INVITE; the gateway UAC's
+> `SdpAnswerGenerator` (a per-gateway answerer sharing a Call-ID-keyed
+> registry with the originator) builds our answer from the peer's 2xx
+> offer via `accept_inbound` and the ACK carries it. The session/tap come
+> back to `place_delayed` through the registry's oneshot, then the shared
+> outbound `run_call` bridges — so delayed-outbound legs get transfer/hold
+> for free (offer_sdp = our answer text). One wrinkle resolved: the UAC's
+> trait wants siphon-rs's `sip_sdp::SessionDescription`, distinct from
+> forge-media's pinned sip-sdp, so core gained a direct `sip-sdp` dep and
+> re-parses the answer text. SRTP on the delayed answer stays a follow-up
+> (the offerless INVITE can't carry an SDES offer). Next: chunk 3 =
+> config/docs/release (~v0.9.0).
+>
 > **Status: IN PROGRESS — chunk 1 (inbound) landed.** Inbound delayed
 > offer is implemented (offerless INVITE → offer in 200 OK → answer from
 > ACK → bridge), reusing the outbound `originate_offer` / `apply_answer`

--- a/test-harness/sipp-scenarios/README.md
+++ b/test-harness/sipp-scenarios/README.md
@@ -58,7 +58,8 @@ sipp -sf basic_call_then_bye.xml -m 1 -p 5070 -s 1000 127.0.0.1:5060
 | `bot_hold_caller.xml`               | 0.7.2 bot-initiated hold: the inverse — the echo-ws (`--auto-hold`) drives `hold`/`resume`, so SiphonAI **sends** the re-INVITEs and SIPp asserts it receives sendonly then sendrecv (**bot_hold** phase) |
 | `outbound_bot_hold_uas.xml`         | 0.7.5 bot-initiated hold on an **outbound** leg: SIPp is the callee (UAS), the echo-ws (`--auto-hold`) drives `hold`/`resume`, and SIPp asserts it receives the sendonly/sendrecv re-INVITEs on the outbound Direct dialog (**outbound_bot_hold** phase) |
 | `opus_caller.xml`                    | 0.8.0 Opus: SIPp offers `opus/48000/2` at a dynamic PT and asserts the 200 OK answers Opus **and** (0.8.2) carries our Opus fmtp re-keyed onto that PT (`a=fmtp:96 …stereo=0`); the daemon brings the call up as a 16 kHz bridge session (**opus** phase). Signalling only — SIPp can't encode Opus media. |
-| `delayed_offer_caller.xml`           | 0.9.0 delayed offer (offerless INVITE, the CUCM-without-MTP case): SIPp sends an INVITE with **no SDP** and asserts the 200 OK carries SiphonAI's own offer (`m=audio` + PCMU rtpmap, via `check_it`); SIPp then sends its SDP answer in the ACK and the call bridges + BYEs (**delayed_offer** phase). |
+| `delayed_offer_caller.xml`           | 0.9.0 inbound delayed offer (offerless INVITE, the CUCM-without-MTP case): SIPp sends an INVITE with **no SDP** and asserts the 200 OK carries SiphonAI's own offer (`m=audio` + PCMU rtpmap, via `check_it`); SIPp then sends its SDP answer in the ACK and the call bridges + BYEs (**delayed_offer** phase). |
+| `outbound_delayed_uas.xml`           | 0.9.0 **outbound** delayed offer, roles inverted: SiphonAI dials via `POST /admin/v1/calls` with `delayed_offer: true` (offerless INVITE); SIPp answers 200 with its own SDP **offer** and asserts (via `check_it`) the **ACK** carries SiphonAI's SDP **answer** (proving the gateway UAC's answer generator fired) (**outbound_delayed** phase). |
 
 `run-all.sh` also has an always-on **recording** auxiliary phase: it starts
 a daemon with `[recording].mode = "always"` writing to a temp dir, runs one
@@ -154,6 +155,15 @@ sends the answer in the ACK, the call bridges through the echo-ws and is
 BYE'd. Pass = SIPp completed **and** the daemon logged the delayed-offer
 accept. The error paths (ACK timeout, missing/invalid answer, no codec)
 are unit-tested; SIPp covers the happy-path signalling contract.
+
+And an always-on **outbound_delayed** phase (0.9.0 chunk 2): the
+roles-inverted **outbound** direction. The runner POSTs
+`/admin/v1/calls` with `delayed_offer: true`, so SiphonAI dials an
+offerless INVITE through the `[[gateway]]`; SIPp
+(`outbound_delayed_uas.xml`) answers 200 with its own SDP offer and
+asserts (via `check_it`) that SiphonAI's **ACK** carries the SDP answer
+its gateway UAC's answer generator built. Pass = SIPp completed **and**
+`siphon_ai_outbound_calls_total{result="answered"}` reads 1.
 
 The `stir_shaken_*` scenarios run in `run-all.sh`'s always-on
 **stir_shaken** auxiliary phase. It builds + runs the

--- a/test-harness/sipp-scenarios/outbound_delayed_uas.xml
+++ b/test-harness/sipp-scenarios/outbound_delayed_uas.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  outbound_delayed_uas — roles inverted, OUTBOUND delayed offer (0.9.0
+  chunk 2). SIPp is the CALLEE (UAS); SiphonAI is the UAC placing the
+  call via `POST /admin/v1/calls` with `delayed_offer: true` through a
+  `[[gateway]]` pointing at SIPp's port.
+
+  SiphonAI sends an INVITE with NO SDP; SIPp answers 200 OK carrying its
+  own SDP OFFER; SiphonAI must send the SDP ANSWER in the ACK (built by
+  the gateway UAC's delayed-offer answer generator). The scenario
+  asserts (check_it) the ACK actually carries an `m=audio` answer —
+  proving the generator fired. Then the WS bridge runs (echo-ws auto-
+  hangs-up) and SiphonAI BYEs us.
+
+  Run via run-all.sh's outbound_delayed phase — the scenario alone does
+  nothing until the runner POSTs the originate request.
+-->
+<scenario name="outbound_delayed_uas">
+  <!-- The INVITE has no SDP (delayed offer); we don't assert on the
+       absent body here — the daemon log + the ACK answer below are the
+       proof. -->
+  <recv request="INVITE" rtd="true"/>
+
+  <send>
+<![CDATA[
+SIP/2.0 180 Ringing
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="200"/>
+
+  <!-- 200 OK carrying OUR (SIPp's) SDP OFFER — the delayed-offer flow. -->
+  <send retrans="500">
+<![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=sipp 53655765 2353687637 IN IP4 [local_ip]
+s=-
+c=IN IP4 [local_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+]]>
+  </send>
+
+  <!-- ACK MUST carry SiphonAI's SDP answer (generated for the late
+       offer). check_it fails the call if the answer is absent. -->
+  <recv request="ACK" rtd="true">
+    <action>
+      <ereg regexp="m=audio [0-9]+ RTP/AVP"
+            search_in="msg"
+            check_it="true"
+            assign_to="ack_answer"/>
+      <log message="delayed-offer ACK carried answer m-line: [$ack_answer]"/>
+    </action>
+  </recv>
+
+  <!-- The call is up; the echo WS server emits hangup after ~1.5 s, so
+       SiphonAI BYEs us. -->
+  <recv request="BYE" rtd="true"/>
+
+  <send>
+<![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+</scenario>

--- a/test-harness/sipp-scenarios/run-all.sh
+++ b/test-harness/sipp-scenarios/run-all.sh
@@ -428,6 +428,88 @@ fi
 ob_cleanup
 trap - EXIT
 
+# ─── Always-on auxiliary phase: outbound delayed offer ────────────
+# (0.9.0 chunk 2) Same roles-inverted setup as `outbound`, but the
+# runner POSTs with `delayed_offer: true`: SiphonAI sends an offerless
+# INVITE, SIPp answers 200 with its own SDP OFFER, and SiphonAI's
+# gateway UAC must put the SDP ANSWER in the ACK. The scenario's
+# check_it asserts that ACK answer; pass also requires the daemon to
+# report the call ANSWERED.
+echo
+echo "─── auxiliary phase: outbound_delayed ─────────────────"
+ODO_WS_PORT=8783
+ODO_ADMIN_PORT=9097
+ODO_WS_LOG=$(mktemp -t echo-ws-odo.XXXXXX.log)
+ODO_DAEMON_LOG=$(mktemp -t siphon-ai-odo.XXXXXX.log)
+ODO_CONFIG=$(mktemp -t siphon-ai-odo.XXXXXX.toml)
+cat >"$ODO_CONFIG" <<EOF
+[node]
+id = "siphon-ai-sipp-odo"
+[sip]
+listen = "127.0.0.1:$DAEMON_PORT"
+[media]
+codecs = ["pcmu"]
+[bridge]
+ws_url = "ws://127.0.0.1:$ODO_WS_PORT/"
+[observability]
+enabled = true
+http_listen = "127.0.0.1:$ODO_ADMIN_PORT"
+[outbound]
+max_concurrent = 2
+[[gateway]]
+name = "sipp"
+proxy = "127.0.0.1:$SIPP_PORT"
+from = "sip:harness@127.0.0.1"
+[[route]]
+name = "default"
+[route.match]
+any = true
+EOF
+
+ODO_PYTHON="$REPO_ROOT/examples/echo-ws-server-python/.venv/bin/python"
+[[ -x "$ODO_PYTHON" ]] || ODO_PYTHON=python3
+"$ODO_PYTHON" "$REPO_ROOT/examples/echo-ws-server-python/server.py" \
+    --bind "127.0.0.1:$ODO_WS_PORT" \
+    --auto-hangup-after-ms 1500 \
+    >"$ODO_WS_LOG" 2>&1 &
+ODO_WS_PID=$!
+
+RUST_LOG=siphon_ai=info "$DAEMON_BIN" --config "$ODO_CONFIG" \
+    >"$ODO_DAEMON_LOG" 2>&1 &
+ODO_DAEMON_PID=$!
+odo_cleanup() {
+    kill "$ODO_WS_PID" "$ODO_DAEMON_PID" 2>/dev/null || true
+    wait "$ODO_WS_PID" "$ODO_DAEMON_PID" 2>/dev/null || true
+}
+trap odo_cleanup EXIT
+sleep 1.2
+
+total=$((total + 1))
+echo "─── outbound_delayed_uas ─────────────────────────────"
+odo_ok=0
+sipp -i 127.0.0.1 -sf "$SCRIPT_DIR/outbound_delayed_uas.xml" \
+    -m 1 -timeout 15s -trace_err -p "$SIPP_PORT" >/dev/null 2>&1 &
+ODO_SIPP_PID=$!
+sleep 0.3
+odo_resp=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST "http://127.0.0.1:$ODO_ADMIN_PORT/admin/v1/calls" \
+    -d '{"to": "7001", "gateway": "sipp", "delayed_offer": true}')
+if [[ "$odo_resp" == "202" ]] && wait "$ODO_SIPP_PID"; then
+    if curl -s "http://127.0.0.1:$ODO_ADMIN_PORT/metrics" \
+        | grep -q 'siphon_ai_outbound_calls_total{result="answered"} 1'; then
+        odo_ok=1
+    fi
+fi
+if (( odo_ok )); then
+    echo "  OK"
+else
+    echo "  FAIL (originate=$odo_resp; daemon: $ODO_DAEMON_LOG; ws: $ODO_WS_LOG)"
+    failures=$((failures + 1))
+fi
+
+odo_cleanup
+trap - EXIT
+
 # ─── Always-on auxiliary phase: attended transfer ─────────────────
 # The full 0.6.1 three-party flow with SIPp on both far ends:
 #   * leg A  — SIPp UAC calls in (the transferee); its echo-ws is


### PR DESCRIPTION
**Chunk 2 of the delayed-offer theme** (design: `docs/DESIGN_DELAYED_OFFER.md`, plan #189): the **outbound** direction. Builds on chunk 1 (#190, inbound).

## What
`POST /admin/v1/calls` with `"delayed_offer": true` dials an INVITE with **no SDP**; the peer offers in its 2xx, and SiphonAI answers in the **ACK**.

```
SiphonAI                       peer
 | INVITE (no SDP)              |
 |---------------------------->|
 | 200 OK (peer's SDP offer)   |
 |<----------------------------|
 | ACK (our SDP answer)        |   ← gateway UAC's answer generator
 |---------------------------->|
 |<========== RTP ============>|
```

## How
- **`DelayedOfferAnswerer`** (impl `sip_uac::SdpAnswerGenerator`) is set on each gateway UAC. On a 2xx-with-offer it builds our answer via `media-glue` `accept_inbound` and hands the session/tap back through a per-call **oneshot**, keyed in a shared `DelayedOfferRegistry` by SIP Call-ID (one answerer per gateway; per-call state keyed by dialog, so concurrent calls don't collide).
- **`OutboundOriginator::place_delayed`** sends `invite(None)`, **parks** per-call media params keyed by the INVITE's Call-ID *before* awaiting the final (the 2xx can't arrive before the INVITE is sent → no race), collects the generator's result on 2xx, and reshapes `InboundAccepted` → `OutboundAccepted` (`offer_sdp` = our answer text). The shared outbound `run_call` then bridges unchanged — so **delayed-outbound legs get transfer/hold for free**.
- **No siphon-rs change** — the UAC's late-offer generator hook already exists.

### One wrinkle (documented)
The UAC's trait wants siphon-rs's `sip_sdp::SessionDescription`, which cargo treats as a *distinct type* from forge-media's pinned sip-sdp (different source rev). So `core` gained a direct `sip-sdp` dep (same siphon-rs rev as the rest) and re-parses the media-glue answer text for the ACK.

## Scope
- **On by default? No** — early offer stays the default; opt in per-call with `"delayed_offer": true`.
- **SRTP on the delayed answer is a follow-up** — an offerless INVITE can't carry an SDES offer, so SRTP is suppressed for delayed-outbound calls in this cut.

## Tests
- **Live end-to-end:** POST → `202`, `sipp rc=0` with a `check_it` asserting the **ACK carries our `m=audio` answer** (proving the generator fired), and `siphon_ai_outbound_calls_total{result="answered"}` = 1.
- New `outbound_delayed_uas.xml` + `run-all.sh` `outbound_delayed` phase.
- `cargo fmt` / `clippy -D warnings` clean; `cargo test --workspace` — **733 passed, 0 failed**.

Chunk 3 (config/docs polish + release ~v0.9.0) is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
