### PR TITLE
feat: SRTP on the outbound delayed-offer answer (SDES) — 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-06-18
+
+### Added
+
+- **SRTP on the outbound delayed-offer answer (SDES, RFC 4568)** — the
+  deferred 0.9.0 follow-up. An offerless outbound INVITE can't *offer*
+  SRTP, but when the peer's 2xx carries an SDES offer (`RTP/SAVP` +
+  `a=crypto`) SiphonAI now **answers** it: the gateway UAC's delayed-offer
+  answer generator runs the same SDES negotiation the inbound early-offer
+  path uses (rewrite the peer offer for codec matching, patch the answer
+  back to `RTP/SAVP` with our `a=crypto`, install the keys on the leg).
+  Governed by `[[gateway]].srtp` — `preferred` answers SRTP when offered
+  (else plaintext), `required` fails the call on a plaintext peer offer.
+  Surfaces on `start.srtp` and `siphon_ai_outbound_srtp_total{result}`
+  like early-offer outbound SRTP. SIPp `outbound_delayed_srtp` phase
+  added. *DTLS-SRTP on a delayed answer is not handled (no per-call cert
+  in the generator), and SRTP on the **inbound** delayed-offer (where we
+  offer) remains a separate follow-up.*
+
 ## [0.9.0] - 2026-06-18
 
 Theme: **SIP delayed offer (offerless INVITE).** SiphonAI previously

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2936,7 +2936,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "base64",
  "bytes",
@@ -2957,7 +2957,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2974,7 +2974,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "regex",
  "serde",
@@ -2991,7 +2991,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3032,7 +3032,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -3047,7 +3047,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3071,7 +3071,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "thiserror 1.0.69",
  "tokio",
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "regex",
  "serde",
@@ -3091,7 +3091,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3100,7 +3100,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3123,7 +3123,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "base64",
  "rcgen",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3162,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/crates/core/src/outbound.rs
+++ b/crates/core/src/outbound.rs
@@ -24,6 +24,7 @@ use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use forge_core::{CallId, ParticipantId};
+use forge_sdp::SessionDescriptionExt as _;
 use sip_core::SipUri;
 // The SAME sip-sdp sip-uac's SdpAnswerGenerator speaks — distinct from
 // forge-media's pinned sip-sdp (whose `SessionDescription` is a different
@@ -35,11 +36,15 @@ use sip_uac::integrated::{CallHandle, IntegratedUAC, RequestTarget, SdpAnswerGen
 use sip_uac::CredentialProvider;
 use siphon_ai_media_glue::{
     Codec, InboundAccepted, InboundCall, MediaSetup, OutboundAccepted, OutboundOfferRequest,
-    SetupError, TapOptions,
+    OutboundSrtp, SetupError, TapOptions,
 };
 use thiserror::Error;
 use tokio::sync::{oneshot, OwnedSemaphorePermit, Semaphore};
 use tracing::{debug, info, instrument, warn};
+
+use crate::acceptor::{
+    enforce_srtp_mode, maybe_tweak_sdes_offer, post_process_sdes_answer, SrtpMode,
+};
 
 /// Per-call state for an outbound **delayed-offer** call (we sent an
 /// offerless INVITE; the peer's offer arrives in the 2xx). Parked in the
@@ -58,9 +63,22 @@ pub struct DelayedOfferPending {
     participant_a: ParticipantId,
     participant_b: ParticipantId,
     tap: TapOptions,
+    /// SRTP answer policy (from the gateway's `srtp` mode). We can't
+    /// *offer* SRTP in an offerless INVITE, but if the peer offers SDES in
+    /// its 2xx we answer it (Preferred) or require it (Required → a
+    /// plaintext offer fails the call). `Off` answers plaintext only.
+    srtp_mode: SrtpMode,
     /// Delivers the media-setup result back to `place_delayed` once the
     /// generator has built the answer (or failed).
-    result_tx: oneshot::Sender<Result<InboundAccepted, SetupError>>,
+    result_tx: oneshot::Sender<Result<DelayedMediaResult, SetupError>>,
+}
+
+/// What the [`DelayedOfferAnswerer`] hands back to [`OutboundOriginator::place_delayed`]
+/// once it has built the answer: the bound media plus the negotiated SDES
+/// suite (for `start.srtp`), `None` for a plaintext answer.
+struct DelayedMediaResult {
+    accepted: InboundAccepted,
+    srtp_profile: Option<String>,
 }
 
 /// SIP-Call-ID → parked delayed-offer call. Shared between the
@@ -113,15 +131,45 @@ impl SdpAnswerGenerator for DelayedOfferAnswerer {
             participant_a,
             participant_b,
             tap,
+            srtp_mode,
             result_tx,
         } = pending;
 
         let offer_sdp = offer.serialize();
+
+        // SRTP answer side (SDES): an offerless INVITE can't carry an SDES
+        // offer, so we answer the peer's offer per the gateway's policy.
+        // Gate first (Required + plaintext peer offer → fail), then if the
+        // peer offered SDES, rewrite its `RTP/SAVP` to `RTP/AVP` so the
+        // codec negotiator (which doesn't know SAVP) can match — we patch
+        // the answer back + install keys below. Mirrors the inbound
+        // early-offer path in `prepare_call_inner`. DTLS-SRTP offers aren't
+        // handled here (no per-call cert in the generator) — a follow-up.
+        if let Ok(parsed) = <forge_sdp::SessionDescription>::from_str(&offer_sdp) {
+            if let Err(e) = enforce_srtp_mode(srtp_mode, &parsed) {
+                let msg = e.to_string();
+                let _ = result_tx.send(Err(SetupError::Srtp(msg.clone())));
+                return Err(anyhow::anyhow!("delayed-offer SRTP policy: {msg}"));
+            }
+        }
+        let sdes_tweak = match maybe_tweak_sdes_offer(&offer_sdp) {
+            Ok(t) => t,
+            Err(e) => {
+                let msg = e.to_string();
+                let _ = result_tx.send(Err(SetupError::Srtp(msg.clone())));
+                return Err(anyhow::anyhow!("delayed-offer SDES offer: {msg}"));
+            }
+        };
+        let offer_for_negotiator = sdes_tweak
+            .as_ref()
+            .map(|t| t.tweaked_sdp.clone())
+            .unwrap_or_else(|| offer_sdp.clone());
+
         let result = self
             .media
             .accept_inbound(InboundCall {
                 call_id: forge_call_id,
-                offer_sdp: &offer_sdp,
+                offer_sdp: &offer_for_negotiator,
                 codecs,
                 dtmf_payload_type,
                 participant_a,
@@ -137,22 +185,48 @@ impl SdpAnswerGenerator for DelayedOfferAnswerer {
             })
             .await;
 
-        match result {
-            Ok(accepted) => {
-                // Re-parse our answer text into the UAC's sip-sdp type for
-                // the ACK (media-glue's SessionDescription is forge's
-                // distinct sip-sdp), then hand the session/tap back.
-                let answer_sd = SessionDescription::parse(&accepted.answer.answer_text)
-                    .map_err(|e| anyhow::anyhow!("re-parse delayed-offer answer: {e}"))?;
-                let _ = result_tx.send(Ok(accepted));
-                Ok(answer_sd)
-            }
+        let mut accepted = match result {
+            Ok(a) => a,
             Err(e) => {
                 let msg = e.to_string();
                 let _ = result_tx.send(Err(e));
-                Err(anyhow::anyhow!("delayed-offer answer build failed: {msg}"))
+                return Err(anyhow::anyhow!("delayed-offer answer build failed: {msg}"));
             }
-        }
+        };
+
+        // SDES post-negotiation: patch the answer back to `RTP/SAVP` with
+        // our `a=crypto:` and install the key material on the session leg.
+        let srtp_profile = if let Some(tweak) = &sdes_tweak {
+            match post_process_sdes_answer(&mut accepted.answer.answer, tweak) {
+                Ok(new_text) => {
+                    accepted.answer.answer_text = new_text;
+                    forge_engine::srtp_install::install_srtp_keys(
+                        accepted.session.srtp_a(),
+                        tweak.sdes_answer.send_key.clone(),
+                        tweak.sdes_answer.recv_key.clone(),
+                    )
+                    .await;
+                    Some(tweak.sdes_answer.local_attribute.suite.as_str().to_string())
+                }
+                Err(e) => {
+                    let msg = e.to_string();
+                    let _ = result_tx.send(Err(SetupError::Srtp(msg.clone())));
+                    return Err(anyhow::anyhow!("delayed-offer SDES answer: {msg}"));
+                }
+            }
+        } else {
+            None
+        };
+
+        // Re-parse our (possibly SAVP-patched) answer text into the UAC's
+        // sip-sdp type for the ACK, then hand the media back.
+        let answer_sd = SessionDescription::parse(&accepted.answer.answer_text)
+            .map_err(|e| anyhow::anyhow!("re-parse delayed-offer answer: {e}"))?;
+        let _ = result_tx.send(Ok(DelayedMediaResult {
+            accepted,
+            srtp_profile,
+        }));
+        Ok(answer_sd)
     }
 }
 
@@ -323,9 +397,11 @@ impl OutboundOriginator {
     /// SDP**, let the peer offer in its 2xx, and answer in the ACK. The
     /// inverse of [`Self::place`]'s early offer. Media setup happens inside
     /// the UAC's [`DelayedOfferAnswerer`] (it has the peer's offer); the
-    /// session/tap come back here via the registry's oneshot. Reuses
-    /// `req`'s media parameters (the `srtp` field is ignored — SRTP on the
-    /// delayed-offer answer is a follow-up).
+    /// session/tap come back here via the registry's oneshot. `req`'s
+    /// `srtp` mode governs the **answer** (we can't offer SRTP in an
+    /// offerless INVITE): `Preferred` answers the peer's SDES offer when
+    /// present, `Required` fails the call on a plaintext peer offer.
+    /// DTLS-SRTP offers aren't answered here (a follow-up).
     #[instrument(skip(self, target, req, tap), fields(call_id = %req.call_id))]
     pub async fn place_delayed(
         &self,
@@ -355,6 +431,13 @@ impl OutboundOriginator {
             .get_smol("Call-ID")
             .map(|s| s.to_string())
             .unwrap_or_default();
+        // The gateway's SRTP policy governs the *answer* (we can't offer in
+        // an offerless INVITE). OutboundSrtp ↔ SrtpMode are 1:1.
+        let srtp_mode = match req.srtp {
+            OutboundSrtp::Off => SrtpMode::Off,
+            OutboundSrtp::Preferred => SrtpMode::Preferred,
+            OutboundSrtp::Required => SrtpMode::Required,
+        };
         let (result_tx, result_rx) = oneshot::channel();
         self.delayed_registry
             .lock()
@@ -368,6 +451,7 @@ impl OutboundOriginator {
                     participant_a: req.participant_a,
                     participant_b: req.participant_b,
                     tap,
+                    srtp_mode,
                     result_tx,
                 },
             );
@@ -400,8 +484,8 @@ impl OutboundOriginator {
 
         // (4) 2xx — the generator built our answer (and ran media setup)
         //     during 2xx processing; collect the session/tap it produced.
-        let inbound = match tokio::time::timeout(DELAYED_RESULT_TIMEOUT, result_rx).await {
-            Ok(Ok(Ok(accepted))) => accepted,
+        let media = match tokio::time::timeout(DELAYED_RESULT_TIMEOUT, result_rx).await {
+            Ok(Ok(Ok(m))) => m,
             Ok(Ok(Err(setup_err))) => {
                 // The generator ran but media build failed (it rolled its
                 // own session back). The dialog is up; mirror `place`'s
@@ -425,17 +509,24 @@ impl OutboundOriginator {
         // Reshape into `OutboundAccepted` so the shared outbound run_call
         // works unchanged. `offer_sdp` = our answer text, so hold/resume
         // flip the negotiated media the same way the inbound path does.
-        // No SRTP on the delayed answer in this cut.
+        // `srtp_profile` carries the SDES suite when the peer's offer was
+        // answered with SRTP (drives `start.srtp` + the outbound SRTP
+        // metric); `None` for a plaintext answer.
+        let DelayedMediaResult {
+            accepted: inbound,
+            srtp_profile,
+        } = media;
         let accepted = OutboundAccepted {
             offer_sdp: inbound.answer.answer_text.clone(),
             answer: inbound.answer,
             session: inbound.session,
             tap: inbound.tap,
-            srtp_profile: None,
+            srtp_profile,
         };
 
         info!(
             code,
+            srtp = accepted.srtp_profile.is_some(),
             "outbound delayed-offer call answered and media bridged"
         );
         Ok(OutboundCall {

--- a/crates/core/src/outbound_service.rs
+++ b/crates/core/src/outbound_service.rs
@@ -219,9 +219,11 @@ impl OutboundOriginateHandle for OutboundService {
         let to = req.to.clone();
         let gateway = req.gateway.clone();
         let delayed_offer = req.delayed_offer;
-        // A delayed-offer outbound INVITE carries no SDP, so we can't offer
-        // SRTP in it — the peer offers, we answer (plaintext in this cut).
-        let srtp_requested = !delayed_offer && gw.srtp != OutboundSrtp::Off;
+        // SRTP is requested whenever the gateway asks for it. For early
+        // offer we offer SDES; for delayed offer we can't offer (no SDP in
+        // the INVITE) but we answer the peer's SDES offer per the same
+        // policy — either way the negotiated suite rides `accepted.srtp_profile`.
+        let srtp_requested = gw.srtp != OutboundSrtp::Off;
         let originator = Arc::clone(&gw.originator);
         let cdr_sink = Arc::clone(&self.cdr_sink);
         let webhook_sink = Arc::clone(&self.webhook_sink);

--- a/docs/DESIGN_DELAYED_OFFER.md
+++ b/docs/DESIGN_DELAYED_OFFER.md
@@ -1,11 +1,16 @@
 # Design note — SIP delayed offer (offerless INVITE)
 
 > **Status: IMPLEMENTED — released v0.9.0 (chunks 1 inbound #190, 2
-> outbound #191, 3 release).** Remaining follow-ups (not blocking): SRTP
-> on the delayed-offer answer (an offerless INVITE can't carry an SDES
-> offer); a per-call CDR for negotiations that fail before going active
-> (today a metric + warn). Protocol stayed `version: "1"`, CDR version
-> unchanged.
+> outbound #191, 3 release); SRTP-on-the-outbound-answer follow-up in
+> v0.9.1.** The 0.9.1 follow-up answers a peer's SDES SRTP offer on an
+> outbound delayed call (the offerless INVITE can't *offer* SRTP) by
+> running the inbound early-offer SDES path inside the gateway UAC's
+> answer generator, governed by `[[gateway]].srtp`. Remaining follow-ups
+> (not blocking): **SRTP on the inbound delayed-offer** (where *we* offer
+> — needs us to emit an SDES offer in the 200 OK); **DTLS-SRTP** on a
+> delayed answer (no per-call cert in the generator); a per-call CDR for
+> negotiations that fail before going active (today a metric + warn).
+> Protocol stayed `version: "1"`, CDR version unchanged.
 >
 > Outbound delayed offer (chunk 2): `POST /admin/v1/calls` with
 > `delayed_offer: true` dials an offerless INVITE; the gateway UAC's

--- a/test-harness/sipp-scenarios/README.md
+++ b/test-harness/sipp-scenarios/README.md
@@ -60,6 +60,7 @@ sipp -sf basic_call_then_bye.xml -m 1 -p 5070 -s 1000 127.0.0.1:5060
 | `opus_caller.xml`                    | 0.8.0 Opus: SIPp offers `opus/48000/2` at a dynamic PT and asserts the 200 OK answers Opus **and** (0.8.2) carries our Opus fmtp re-keyed onto that PT (`a=fmtp:96 …stereo=0`); the daemon brings the call up as a 16 kHz bridge session (**opus** phase). Signalling only — SIPp can't encode Opus media. |
 | `delayed_offer_caller.xml`           | 0.9.0 inbound delayed offer (offerless INVITE, the CUCM-without-MTP case): SIPp sends an INVITE with **no SDP** and asserts the 200 OK carries SiphonAI's own offer (`m=audio` + PCMU rtpmap, via `check_it`); SIPp then sends its SDP answer in the ACK and the call bridges + BYEs (**delayed_offer** phase). |
 | `outbound_delayed_uas.xml`           | 0.9.0 **outbound** delayed offer, roles inverted: SiphonAI dials via `POST /admin/v1/calls` with `delayed_offer: true` (offerless INVITE); SIPp answers 200 with its own SDP **offer** and asserts (via `check_it`) the **ACK** carries SiphonAI's SDP **answer** (proving the gateway UAC's answer generator fired) (**outbound_delayed** phase). |
+| `outbound_delayed_srtp_uas.xml`      | 0.9.1 outbound delayed offer **with SRTP on the answer**: gateway `srtp = "required"`; the offerless INVITE can't offer SRTP, so SIPp's 200 carries an `RTP/SAVP` + `a=crypto` SDES **offer** and SIPp asserts (via `check_it`) the **ACK** answers SRTP (`a=crypto`) — SiphonAI installed keys (**outbound_delayed_srtp** phase). |
 
 `run-all.sh` also has an always-on **recording** auxiliary phase: it starts
 a daemon with `[recording].mode = "always"` writing to a temp dir, runs one
@@ -164,6 +165,15 @@ offerless INVITE through the `[[gateway]]`; SIPp
 asserts (via `check_it`) that SiphonAI's **ACK** carries the SDP answer
 its gateway UAC's answer generator built. Pass = SIPp completed **and**
 `siphon_ai_outbound_calls_total{result="answered"}` reads 1.
+
+And an always-on **outbound_delayed_srtp** phase (0.9.1): outbound
+delayed offer where SRTP rides the **answer**. `[[gateway]].srtp =
+"required"` makes encryption mandatory; since the offerless INVITE can't
+carry an SDES offer, `outbound_delayed_srtp_uas.xml`'s 200 carries the
+`RTP/SAVP` + `a=crypto` offer and asserts SiphonAI's **ACK** answers SRTP.
+Pass = SIPp completed **and**
+`siphon_ai_outbound_srtp_total{result="encrypted"}` reads 1. (DTLS-SRTP
+on a delayed answer is not handled — SDES only.)
 
 The `stir_shaken_*` scenarios run in `run-all.sh`'s always-on
 **stir_shaken** auxiliary phase. It builds + runs the

--- a/test-harness/sipp-scenarios/outbound_delayed_srtp_uas.xml
+++ b/test-harness/sipp-scenarios/outbound_delayed_srtp_uas.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  outbound_delayed_srtp_uas — outbound delayed offer WITH SRTP on the
+  answer (0.9.0 follow-up). Roles inverted: SIPp is the CALLEE (UAS),
+  SiphonAI the UAC dialing via `POST /admin/v1/calls` with
+  `delayed_offer: true` through a `[[gateway]]` whose `srtp` is set.
+
+  SiphonAI sends an offerless INVITE (so it CAN'T offer SRTP). SIPp
+  answers 200 OK carrying an `RTP/SAVP` + `a=crypto` (SDES) OFFER;
+  SiphonAI must answer SRTP in the ACK — `RTP/SAVP` with its own
+  `a=crypto`. The scenario asserts (check_it) the ACK carries `a=crypto`,
+  proving SiphonAI answered the peer's SDES offer with SRTP keys
+  installed. Then the WS bridge runs (echo-ws auto-hangs-up) and
+  SiphonAI BYEs us.
+
+  Run via run-all.sh's outbound_delayed_srtp phase.
+-->
+<scenario name="outbound_delayed_srtp_uas">
+  <recv request="INVITE" rtd="true"/>
+
+  <send>
+<![CDATA[
+SIP/2.0 180 Ringing
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="200"/>
+
+  <!-- 200 OK carrying SIPp's SDES SRTP OFFER (RTP/SAVP + a=crypto). -->
+  <send retrans="500">
+<![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=sipp 53655765 2353687637 IN IP4 [local_ip]
+s=-
+c=IN IP4 [local_ip]
+t=0 0
+m=audio [media_port] RTP/SAVP 0
+a=rtpmap:0 PCMU/8000
+a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+]]>
+  </send>
+
+  <!-- ACK MUST carry SiphonAI's SDES answer: RTP/SAVP is implied by the
+       crypto line; assert the crypto is present (keys answered). -->
+  <recv request="ACK" rtd="true">
+    <action>
+      <ereg regexp="a=crypto:[0-9]+ AES_CM_128_HMAC_SHA1_80"
+            search_in="msg"
+            check_it="true"
+            assign_to="ack_crypto"/>
+      <log message="delayed-offer SRTP ACK carried crypto: [$ack_crypto]"/>
+    </action>
+  </recv>
+
+  <recv request="BYE" rtd="true"/>
+
+  <send>
+<![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+</scenario>

--- a/test-harness/sipp-scenarios/run-all.sh
+++ b/test-harness/sipp-scenarios/run-all.sh
@@ -510,6 +510,88 @@ fi
 odo_cleanup
 trap - EXIT
 
+# ─── Always-on auxiliary phase: outbound delayed offer + SRTP ─────
+# (0.9.1) Outbound delayed offer where the peer offers SDES SRTP in its
+# 2xx and SiphonAI answers it in the ACK. The `[[gateway]].srtp =
+# "required"` makes the answer mandatory. The scenario's check_it
+# asserts the ACK carries `a=crypto`; pass also requires the daemon to
+# report the call ANSWERED **and** the SRTP result `encrypted`.
+echo
+echo "─── auxiliary phase: outbound_delayed_srtp ────────────"
+ODS_WS_PORT=8785
+ODS_ADMIN_PORT=9098
+ODS_WS_LOG=$(mktemp -t echo-ws-ods.XXXXXX.log)
+ODS_DAEMON_LOG=$(mktemp -t siphon-ai-ods.XXXXXX.log)
+ODS_CONFIG=$(mktemp -t siphon-ai-ods.XXXXXX.toml)
+cat >"$ODS_CONFIG" <<EOF
+[node]
+id = "siphon-ai-sipp-ods"
+[sip]
+listen = "127.0.0.1:$DAEMON_PORT"
+[media]
+codecs = ["pcmu"]
+[bridge]
+ws_url = "ws://127.0.0.1:$ODS_WS_PORT/"
+[observability]
+enabled = true
+http_listen = "127.0.0.1:$ODS_ADMIN_PORT"
+[outbound]
+max_concurrent = 2
+[[gateway]]
+name = "sipp"
+proxy = "127.0.0.1:$SIPP_PORT"
+from = "sip:harness@127.0.0.1"
+srtp = "required"
+[[route]]
+name = "default"
+[route.match]
+any = true
+EOF
+
+ODS_PYTHON="$REPO_ROOT/examples/echo-ws-server-python/.venv/bin/python"
+[[ -x "$ODS_PYTHON" ]] || ODS_PYTHON=python3
+"$ODS_PYTHON" "$REPO_ROOT/examples/echo-ws-server-python/server.py" \
+    --bind "127.0.0.1:$ODS_WS_PORT" \
+    --auto-hangup-after-ms 1500 \
+    >"$ODS_WS_LOG" 2>&1 &
+ODS_WS_PID=$!
+
+RUST_LOG=siphon_ai=info "$DAEMON_BIN" --config "$ODS_CONFIG" \
+    >"$ODS_DAEMON_LOG" 2>&1 &
+ODS_DAEMON_PID=$!
+ods_cleanup() {
+    kill "$ODS_WS_PID" "$ODS_DAEMON_PID" 2>/dev/null || true
+    wait "$ODS_WS_PID" "$ODS_DAEMON_PID" 2>/dev/null || true
+}
+trap ods_cleanup EXIT
+sleep 1.2
+
+total=$((total + 1))
+echo "─── outbound_delayed_srtp_uas ────────────────────────"
+ods_ok=0
+sipp -i 127.0.0.1 -sf "$SCRIPT_DIR/outbound_delayed_srtp_uas.xml" \
+    -m 1 -timeout 15s -trace_err -p "$SIPP_PORT" >/dev/null 2>&1 &
+ODS_SIPP_PID=$!
+sleep 0.3
+ods_resp=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST "http://127.0.0.1:$ODS_ADMIN_PORT/admin/v1/calls" \
+    -d '{"to": "7001", "gateway": "sipp", "delayed_offer": true}')
+if [[ "$ods_resp" == "202" ]] && wait "$ODS_SIPP_PID"; then
+    if curl -s "http://127.0.0.1:$ODS_ADMIN_PORT/metrics" \
+        | grep -q 'siphon_ai_outbound_srtp_total{result="encrypted"} 1'; then
+        ods_ok=1
+    fi
+fi
+if (( ods_ok )); then
+    echo "  OK"
+else
+    echo "  FAIL (originate=$ods_resp; daemon: $ODS_DAEMON_LOG; ws: $ODS_WS_LOG)"
+    failures=$((failures + 1))
+fi
+
+ods_cleanup
+trap - EXIT
+
 # ─── Always-on auxiliary phase: attended transfer ─────────────────
 # The full 0.6.1 three-party flow with SIPp on both far ends:
 #   * leg A  — SIPp UAC calls in (the transferee); its echo-ws is


### PR DESCRIPTION
The deferred **SRTP-on-the-delayed-answer** follow-up from v0.9.0. Cuts **0.9.1**.

## What
An offerless outbound INVITE can't *offer* SRTP (no SDP in the INVITE). But when the peer's 2xx carries an SDES offer (`RTP/SAVP` + `a=crypto`), SiphonAI now **answers** it — so an outbound delayed-offer call to a secure trunk encrypts.

```
SiphonAI                       peer
 | INVITE (no SDP)              |
 |---------------------------->|
 | 200 OK (RTP/SAVP + a=crypto) |   ← peer's SDES offer
 |<----------------------------|
 | ACK (RTP/SAVP + a=crypto)    |   ← OUR SDES answer, keys installed
 |---------------------------->|
 |<====== SRTP media ==========>|
```

## How
In `DelayedOfferAnswerer::generate_answer`, reuse the **inbound early-offer SDES path** — `acceptor::{enforce_srtp_mode, maybe_tweak_sdes_offer, post_process_sdes_answer}` + `forge_engine::srtp_install::install_srtp_keys`:
1. Gate on the gateway's `srtp` mode.
2. Rewrite the peer's `RTP/SAVP` → `RTP/AVP` so the codec negotiator (which doesn't know SAVP) can match.
3. Patch the answer back to `RTP/SAVP` with our `a=crypto`; install keys on the leg.

The negotiated suite rides back to `place_delayed` (new `DelayedMediaResult` on the oneshot) → `OutboundAccepted.srtp_profile` → `start.srtp` + `siphon_ai_outbound_srtp_total{result}`, exactly like early-offer outbound SRTP.

## Policy / scope
- Governed by **`[[gateway]].srtp`** (carried as the *answer* policy): `preferred` = answer SRTP when offered, else plaintext; `required` = a plaintext peer offer fails the call. `outbound_service` no longer suppresses `srtp_requested` for delayed calls.
- **DTLS-SRTP on a delayed answer is NOT handled** (no per-call cert in the generator) — SDES only.
- **SRTP on the *inbound* delayed-offer** (where *we* offer) remains a separate follow-up.

## Tests
- **Live-verified**: gateway `srtp = "required"`, peer 2xx offers SDES → `sipp rc=0` with a `check_it` asserting the **ACK carries `a=crypto`**, `siphon_ai_outbound_srtp_total{result="encrypted"}` = 1, daemon `srtp=true`.
- New `outbound_delayed_srtp_uas.xml` + `run-all.sh` `outbound_delayed_srtp` phase.
- `cargo fmt` / `clippy -D warnings` clean; `cargo test --workspace` — **733 passed, 0 failed**.

After merge: tag **v0.9.1** + GitHub release (Latest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
