### PR TITLE
feat: DTLS-SRTP on the outbound delayed-offer answer — 0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.3] - 2026-06-18
+
+### Added
+
+- **DTLS-SRTP on the outbound delayed-offer answer (RFC 5763)** — the
+  first of the two DTLS-on-delayed follow-ups. When SiphonAI dials an
+  **offerless** outbound INVITE and the peer's 2xx offers DTLS-SRTP
+  (`UDP/TLS/RTP/SAVPF` + `a=fingerprint` + `a=setup:actpass`), SiphonAI
+  now **answers** it: the gateway UAC's delayed-offer answer generator
+  runs the inbound early-offer DTLS path (rewrite the offer for codec
+  matching, patch the answer back to the SAVPF profile with our
+  `a=fingerprint` + opposite `a=setup`, and `enable_dtls` as the
+  handshake server). The generator gained a per-process DTLS certificate;
+  the negotiated exchange (`dtls` vs `sdes`) is now carried on
+  `OutboundAccepted` so `start.srtp.exchange` reports it correctly.
+  Governed by `[[gateway]].srtp` like the SDES answer (0.9.1). SIPp
+  `outbound_delayed_dtls` phase added. *DTLS on the **inbound**
+  delayed-offer (where we'd offer DTLS) is the next follow-up.*
+
 ## [0.9.2] - 2026-06-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2936,7 +2936,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "base64",
  "bytes",
@@ -2957,7 +2957,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2974,7 +2974,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "regex",
  "serde",
@@ -2991,7 +2991,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3032,7 +3032,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -3047,7 +3047,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3071,7 +3071,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "thiserror 1.0.69",
  "tokio",
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "regex",
  "serde",
@@ -3091,7 +3091,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -3100,7 +3100,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3123,7 +3123,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "base64",
  "rcgen",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3162,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -570,6 +570,13 @@ impl Runtime {
         // (DEV_PLAN_0.6.0 §9.5/§9.6).
         let outbound_handle: Option<AdminOutbound> = if outbound.enabled() {
             let mut gateways = HashMap::with_capacity(outbound.gateways.len());
+            // Per-process DTLS cert for answering a peer's DTLS-SRTP offer
+            // on an outbound delayed call (0.9.3). Shared across gateways,
+            // same posture as the inbound acceptor's cert.
+            let outbound_dtls_cert = Arc::new(
+                forge_rtp::dtls::DtlsCertificate::generate()
+                    .map_err(|e| anyhow!("outbound DTLS cert generation failed: {e}"))?,
+            );
             for gw in &outbound.gateways {
                 // Outbound delayed offer (chunk 2): the gateway's UAC and
                 // its originator share one registry — `place_delayed` parks
@@ -581,6 +588,7 @@ impl Runtime {
                     Arc::new(siphon_ai_core::DelayedOfferAnswerer::new(
                         (*outbound_media).clone(),
                         Arc::clone(&delayed_registry),
+                        Arc::clone(&outbound_dtls_cert),
                     ));
                 let uac = build_outbound_uac(
                     TransferUacBuild {

--- a/crates/core/src/outbound.rs
+++ b/crates/core/src/outbound.rs
@@ -43,7 +43,8 @@ use tokio::sync::{oneshot, OwnedSemaphorePermit, Semaphore};
 use tracing::{debug, info, instrument, warn};
 
 use crate::acceptor::{
-    enforce_srtp_mode, maybe_tweak_sdes_offer, post_process_sdes_answer, SrtpMode,
+    enforce_srtp_mode, maybe_tweak_dtls_srtp_offer, maybe_tweak_sdes_offer,
+    post_process_dtls_srtp_answer, post_process_sdes_answer, SrtpMode,
 };
 
 /// Per-call state for an outbound **delayed-offer** call (we sent an
@@ -79,6 +80,7 @@ pub struct DelayedOfferPending {
 struct DelayedMediaResult {
     accepted: InboundAccepted,
     srtp_profile: Option<String>,
+    srtp_exchange: siphon_ai_bridge::protocol::SrtpExchange,
 }
 
 /// SIP-Call-ID → parked delayed-offer call. Shared between the
@@ -96,11 +98,24 @@ pub type DelayedOfferRegistry = Arc<Mutex<HashMap<String, DelayedOfferPending>>>
 pub struct DelayedOfferAnswerer {
     media: MediaSetup,
     registry: DelayedOfferRegistry,
+    /// Per-process DTLS certificate, for answering a peer's DTLS-SRTP
+    /// offer (its SHA-256 fingerprint goes in our answer; it's handed to
+    /// `enable_dtls` for the handshake). Shared across this gateway's
+    /// delayed calls — same posture as the inbound acceptor's cert.
+    dtls_cert: Arc<forge_rtp::dtls::DtlsCertificate>,
 }
 
 impl DelayedOfferAnswerer {
-    pub fn new(media: MediaSetup, registry: DelayedOfferRegistry) -> Self {
-        Self { media, registry }
+    pub fn new(
+        media: MediaSetup,
+        registry: DelayedOfferRegistry,
+        dtls_cert: Arc<forge_rtp::dtls::DtlsCertificate>,
+    ) -> Self {
+        Self {
+            media,
+            registry,
+            dtls_cert,
+        }
     }
 }
 
@@ -137,14 +152,14 @@ impl SdpAnswerGenerator for DelayedOfferAnswerer {
 
         let offer_sdp = offer.serialize();
 
-        // SRTP answer side (SDES): an offerless INVITE can't carry an SDES
-        // offer, so we answer the peer's offer per the gateway's policy.
-        // Gate first (Required + plaintext peer offer → fail), then if the
-        // peer offered SDES, rewrite its `RTP/SAVP` to `RTP/AVP` so the
-        // codec negotiator (which doesn't know SAVP) can match — we patch
-        // the answer back + install keys below. Mirrors the inbound
-        // early-offer path in `prepare_call_inner`. DTLS-SRTP offers aren't
-        // handled here (no per-call cert in the generator) — a follow-up.
+        // SRTP answer side: an offerless INVITE can't OFFER SRTP, so we
+        // answer the peer's offer per the gateway's policy. Gate first
+        // (Required + plaintext peer offer → fail). Then, if the peer
+        // offered DTLS-SRTP or SDES, rewrite its secure m-line profile to
+        // `RTP/AVP` so the codec negotiator (which doesn't know SAVP/SAVPF)
+        // can match — we patch the answer back + install keys / enable DTLS
+        // below. Try DTLS first, then SDES (they're mutually exclusive on
+        // one m-line). Mirrors the inbound early-offer path.
         if let Ok(parsed) = <forge_sdp::SessionDescription>::from_str(&offer_sdp) {
             if let Err(e) = enforce_srtp_mode(srtp_mode, &parsed) {
                 let msg = e.to_string();
@@ -152,17 +167,30 @@ impl SdpAnswerGenerator for DelayedOfferAnswerer {
                 return Err(anyhow::anyhow!("delayed-offer SRTP policy: {msg}"));
             }
         }
-        let sdes_tweak = match maybe_tweak_sdes_offer(&offer_sdp) {
+        let dtls_tweak = match maybe_tweak_dtls_srtp_offer(&offer_sdp) {
             Ok(t) => t,
             Err(e) => {
                 let msg = e.to_string();
                 let _ = result_tx.send(Err(SetupError::Srtp(msg.clone())));
-                return Err(anyhow::anyhow!("delayed-offer SDES offer: {msg}"));
+                return Err(anyhow::anyhow!("delayed-offer DTLS offer: {msg}"));
             }
         };
-        let offer_for_negotiator = sdes_tweak
+        let sdes_tweak = if dtls_tweak.is_none() {
+            match maybe_tweak_sdes_offer(&offer_sdp) {
+                Ok(t) => t,
+                Err(e) => {
+                    let msg = e.to_string();
+                    let _ = result_tx.send(Err(SetupError::Srtp(msg.clone())));
+                    return Err(anyhow::anyhow!("delayed-offer SDES offer: {msg}"));
+                }
+            }
+        } else {
+            None
+        };
+        let offer_for_negotiator = dtls_tweak
             .as_ref()
             .map(|t| t.tweaked_sdp.clone())
+            .or_else(|| sdes_tweak.as_ref().map(|t| t.tweaked_sdp.clone()))
             .unwrap_or_else(|| offer_sdp.clone());
 
         let result = self
@@ -194,9 +222,45 @@ impl SdpAnswerGenerator for DelayedOfferAnswerer {
             }
         };
 
-        // SDES post-negotiation: patch the answer back to `RTP/SAVP` with
-        // our `a=crypto:` and install the key material on the session leg.
-        let srtp_profile = if let Some(tweak) = &sdes_tweak {
+        // Post-negotiation: patch the answer back to the secure profile and
+        // bring up keys. DTLS-SRTP installs our fingerprint + starts the
+        // handshake (we answer, so DtlsRole::Server); SDES installs the
+        // pre-derived keys directly. `(profile, exchange)` rides back so
+        // `start.srtp` reports the right exchange.
+        let (srtp_profile, srtp_exchange) = if let Some(tweak) = &dtls_tweak {
+            let local_fp = self.dtls_cert.fingerprint_sha256().to_string();
+            let new_text = match post_process_dtls_srtp_answer(
+                &mut accepted.answer.answer,
+                tweak,
+                &local_fp,
+            ) {
+                Ok(t) => t,
+                Err(e) => {
+                    let msg = e.to_string();
+                    let _ = result_tx.send(Err(SetupError::Srtp(msg.clone())));
+                    return Err(anyhow::anyhow!("delayed-offer DTLS answer: {msg}"));
+                }
+            };
+            accepted.answer.answer_text = new_text;
+            if let Err(e) = accepted
+                .session
+                .enable_dtls(
+                    forge_engine::ParticipantLabel::A,
+                    Arc::clone(&self.dtls_cert),
+                    forge_rtp::dtls::DtlsRole::Server,
+                    tweak.remote_fingerprint.1.clone(),
+                )
+                .await
+            {
+                let msg = e.to_string();
+                let _ = result_tx.send(Err(SetupError::Srtp(format!("enable_dtls: {msg}"))));
+                return Err(anyhow::anyhow!("delayed-offer enable_dtls: {msg}"));
+            }
+            (
+                Some("AES_CM_128_HMAC_SHA1_80".to_string()),
+                siphon_ai_bridge::protocol::SrtpExchange::Dtls,
+            )
+        } else if let Some(tweak) = &sdes_tweak {
             match post_process_sdes_answer(&mut accepted.answer.answer, tweak) {
                 Ok(new_text) => {
                     accepted.answer.answer_text = new_text;
@@ -206,7 +270,10 @@ impl SdpAnswerGenerator for DelayedOfferAnswerer {
                         tweak.sdes_answer.recv_key.clone(),
                     )
                     .await;
-                    Some(tweak.sdes_answer.local_attribute.suite.as_str().to_string())
+                    (
+                        Some(tweak.sdes_answer.local_attribute.suite.as_str().to_string()),
+                        siphon_ai_bridge::protocol::SrtpExchange::Sdes,
+                    )
                 }
                 Err(e) => {
                     let msg = e.to_string();
@@ -215,16 +282,17 @@ impl SdpAnswerGenerator for DelayedOfferAnswerer {
                 }
             }
         } else {
-            None
+            (None, siphon_ai_bridge::protocol::SrtpExchange::Sdes)
         };
 
-        // Re-parse our (possibly SAVP-patched) answer text into the UAC's
-        // sip-sdp type for the ACK, then hand the media back.
+        // Re-parse our (possibly SAVP/SAVPF-patched) answer text into the
+        // UAC's sip-sdp type for the ACK, then hand the media back.
         let answer_sd = SessionDescription::parse(&accepted.answer.answer_text)
             .map_err(|e| anyhow::anyhow!("re-parse delayed-offer answer: {e}"))?;
         let _ = result_tx.send(Ok(DelayedMediaResult {
             accepted,
             srtp_profile,
+            srtp_exchange,
         }));
         Ok(answer_sd)
     }
@@ -509,12 +577,13 @@ impl OutboundOriginator {
         // Reshape into `OutboundAccepted` so the shared outbound run_call
         // works unchanged. `offer_sdp` = our answer text, so hold/resume
         // flip the negotiated media the same way the inbound path does.
-        // `srtp_profile` carries the SDES suite when the peer's offer was
-        // answered with SRTP (drives `start.srtp` + the outbound SRTP
-        // metric); `None` for a plaintext answer.
+        // `srtp_profile`/`srtp_exchange` carry the negotiated SRTP (SDES or
+        // DTLS) when the peer's offer was answered encrypted — drives
+        // `start.srtp` + the outbound SRTP metric; `None` for plaintext.
         let DelayedMediaResult {
             accepted: inbound,
             srtp_profile,
+            srtp_exchange,
         } = media;
         let accepted = OutboundAccepted {
             offer_sdp: inbound.answer.answer_text.clone(),
@@ -522,6 +591,7 @@ impl OutboundOriginator {
             session: inbound.session,
             tap: inbound.tap,
             srtp_profile,
+            srtp_exchange,
         };
 
         info!(

--- a/crates/core/src/outbound_service.rs
+++ b/crates/core/src/outbound_service.rs
@@ -397,7 +397,9 @@ async fn run_call(
             .srtp_profile
             .as_ref()
             .map(|profile| siphon_ai_bridge::protocol::SrtpInfo {
-                exchange: siphon_ai_bridge::protocol::SrtpExchange::Sdes,
+                // SDES on early offer; the delayed-offer answer path may
+                // have negotiated DTLS-SRTP (0.9.3) — use what it recorded.
+                exchange: accepted.srtp_exchange,
                 profile: profile.clone(),
             });
     if ctx.srtp_requested {

--- a/crates/media-glue/src/setup.rs
+++ b/crates/media-glue/src/setup.rs
@@ -242,11 +242,15 @@ pub struct OutboundAccepted {
     pub answer: AnswerOutcome,
     pub session: Arc<MediaSession>,
     pub tap: MediaTap,
-    /// The negotiated SDES crypto-suite when outbound SRTP was established
+    /// The negotiated SRTP crypto-suite when outbound SRTP was established
     /// (e.g. `"AES_CM_128_HMAC_SHA1_80"`), for `start.srtp.profile`. `None`
-    /// for a plaintext call or a `preferred` downgrade. The exchange is
-    /// always SDES on the outbound origination path.
+    /// for a plaintext call or a `preferred` downgrade.
     pub srtp_profile: Option<String>,
+    /// How that SRTP was keyed. SDES on the early-offer origination path;
+    /// the delayed-offer answer path can also negotiate DTLS-SRTP (0.9.3),
+    /// so the exchange is carried here rather than assumed. Ignored when
+    /// `srtp_profile` is `None`.
+    pub srtp_exchange: siphon_ai_bridge::protocol::SrtpExchange,
     /// The SDP **offer** we sent for this call (our local media, `sendrecv`).
     /// Retained so the call layer can build a bot-initiated hold/resume
     /// re-INVITE offer by flipping its direction (0.7.5) — the outbound
@@ -610,6 +614,8 @@ impl MediaSetup {
             session,
             tap: media_tap,
             srtp_profile,
+            // Early-offer origination offers SDES only.
+            srtp_exchange: siphon_ai_bridge::protocol::SrtpExchange::Sdes,
             offer_sdp,
         })
     }

--- a/docs/DESIGN_DELAYED_OFFER.md
+++ b/docs/DESIGN_DELAYED_OFFER.md
@@ -8,11 +8,15 @@
 > answer generator, governed by `[[gateway]].srtp`. v0.9.2 is the mirror:
 > on an inbound delayed offer SiphonAI is the *offerer*, so `[media].srtp`
 > `preferred`/`required` makes the 200 OK offer SDES and `apply_answer`
-> installs the peer's ACK key. Remaining follow-ups (not blocking):
-> **DTLS-SRTP** on a delayed offer/answer (the SDES paths only; no
-> per-call cert in the generator); a per-call CDR for negotiations that
-> fail before going active (today a metric + warn). Protocol stayed
-> `version: "1"`, CDR version unchanged.
+> installs the peer's ACK key. v0.9.3 adds **DTLS-SRTP on the
+> outbound delayed answer**: the gateway answer generator now runs the
+> inbound early-offer DTLS path (it gained a per-process cert), and the
+> SRTP exchange (dtls/sdes) is carried on `OutboundAccepted` so
+> `start.srtp` is right. Remaining follow-ups (not blocking): **DTLS on
+> the inbound delayed-offer** (where *we* offer DTLS — a new offer-build
+> capability); a per-call CDR for negotiations that fail before going
+> active (today a metric + warn). Protocol stayed `version: "1"`, CDR
+> version unchanged.
 >
 > Outbound delayed offer (chunk 2): `POST /admin/v1/calls` with
 > `delayed_offer: true` dials an offerless INVITE; the gateway UAC's

--- a/test-harness/sipp-scenarios/README.md
+++ b/test-harness/sipp-scenarios/README.md
@@ -62,6 +62,7 @@ sipp -sf basic_call_then_bye.xml -m 1 -p 5070 -s 1000 127.0.0.1:5060
 | `outbound_delayed_uas.xml`           | 0.9.0 **outbound** delayed offer, roles inverted: SiphonAI dials via `POST /admin/v1/calls` with `delayed_offer: true` (offerless INVITE); SIPp answers 200 with its own SDP **offer** and asserts (via `check_it`) the **ACK** carries SiphonAI's SDP **answer** (proving the gateway UAC's answer generator fired) (**outbound_delayed** phase). |
 | `outbound_delayed_srtp_uas.xml`      | 0.9.1 outbound delayed offer **with SRTP on the answer**: gateway `srtp = "required"`; the offerless INVITE can't offer SRTP, so SIPp's 200 carries an `RTP/SAVP` + `a=crypto` SDES **offer** and SIPp asserts (via `check_it`) the **ACK** answers SRTP (`a=crypto`) — SiphonAI installed keys (**outbound_delayed_srtp** phase). |
 | `delayed_offer_srtp_caller.xml`      | 0.9.2 inbound delayed offer **with SRTP on the offer**: `[media].srtp = "required"`; SIPp sends an offerless INVITE and asserts (via `check_it`) SiphonAI's 200 OK carries an SDES **offer** (`a=crypto`) — we're the offerer; SIPp answers SRTP in the ACK and the keyed call bridges (**delayed_offer_srtp** phase). |
+| `outbound_delayed_dtls_uas.xml`      | 0.9.3 outbound delayed offer **with DTLS-SRTP on the answer**: gateway `srtp = "required"`; SIPp's 200 carries a `UDP/TLS/RTP/SAVPF` + `a=fingerprint` + `a=setup:actpass` DTLS **offer** and SIPp asserts (via `check_it`) the **ACK** answers DTLS (`a=fingerprint:sha-256`) — SiphonAI enabled the handshake (**outbound_delayed_dtls** phase). Signalling only; SIPp doesn't complete a real DTLS handshake. |
 
 `run-all.sh` also has an always-on **recording** auxiliary phase: it starts
 a daemon with `[recording].mode = "always"` writing to a temp dir, runs one
@@ -182,8 +183,17 @@ inbound delayed offer *we* are the offerer. A daemon with `[media].srtp
 = "required"`; `delayed_offer_srtp_caller.xml` sends an offerless INVITE
 and asserts (via `check_it`) the 200 OK carries `a=crypto`, then answers
 SRTP in the ACK so SiphonAI installs the key and the call bridges. Pass =
-SIPp completed **and** the daemon logged the delayed accept. (DTLS-SRTP
-on a delayed offer is not produced — SDES only.)
+SIPp completed **and** the daemon logged the delayed accept.
+
+And an always-on **outbound_delayed_dtls** phase (0.9.3): outbound
+delayed offer where the peer offers **DTLS-SRTP** and SiphonAI answers
+it. `[[gateway]].srtp = "required"`; SIPp's 200 carries a
+`UDP/TLS/RTP/SAVPF` + `a=fingerprint` + `a=setup:actpass` offer and
+`outbound_delayed_dtls_uas.xml` asserts SiphonAI's **ACK** answers DTLS
+(`a=fingerprint:sha-256`). Pass = SIPp completed **and**
+`siphon_ai_outbound_srtp_total{result="encrypted"}` reads 1. Signalling
+only — SIPp doesn't complete a real DTLS handshake; the
+handshake/media path is forge-tested.
 
 The `stir_shaken_*` scenarios run in `run-all.sh`'s always-on
 **stir_shaken** auxiliary phase. It builds + runs the

--- a/test-harness/sipp-scenarios/outbound_delayed_dtls_uas.xml
+++ b/test-harness/sipp-scenarios/outbound_delayed_dtls_uas.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  outbound_delayed_dtls_uas — outbound delayed offer where the peer
+  offers DTLS-SRTP and SiphonAI ANSWERS it (0.9.3). Roles inverted: SIPp
+  is the CALLEE (UAS), SiphonAI the UAC dialing via `POST /admin/v1/calls`
+  with `delayed_offer: true` through a `[[gateway]]` whose `srtp` is set.
+
+  SiphonAI sends an offerless INVITE. SIPp answers 200 OK carrying a
+  DTLS-SRTP OFFER (`UDP/TLS/RTP/SAVPF` + `a=fingerprint` + `a=setup:actpass`);
+  SiphonAI must answer DTLS in the ACK — same profile, OUR `a=fingerprint`
+  and the opposite `a=setup`. The scenario asserts (check_it) the ACK
+  carries `a=fingerprint:sha-256`, proving SiphonAI answered the peer's
+  DTLS offer and enabled the handshake. (SIPp doesn't complete a real
+  DTLS handshake — this is a signalling test; the handshake/media path is
+  forge-tested.)
+
+  Run via run-all.sh's outbound_delayed_dtls phase.
+-->
+<scenario name="outbound_delayed_dtls_uas">
+  <recv request="INVITE" rtd="true"/>
+
+  <send>
+<![CDATA[
+SIP/2.0 180 Ringing
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="200"/>
+
+  <!-- 200 OK carrying SIPp's DTLS-SRTP OFFER. -->
+  <send retrans="500">
+<![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=sipp 53655765 2353687637 IN IP4 [local_ip]
+s=-
+c=IN IP4 [local_ip]
+t=0 0
+m=audio [media_port] UDP/TLS/RTP/SAVPF 0
+a=rtpmap:0 PCMU/8000
+a=fingerprint:sha-256 AB:AB:AB:AB:AB:AB:AB:AB:AB:AB:AB:AB:AB:AB:AB:AB:AB:AB:AB:AB:AB:AB:AB:AB:AB:AB:AB:AB:AB:AB:AB:AB
+a=setup:actpass
+]]>
+  </send>
+
+  <!-- ACK MUST carry SiphonAI's DTLS answer fingerprint. -->
+  <recv request="ACK" rtd="true">
+    <action>
+      <ereg regexp="a=fingerprint:sha-256 "
+            search_in="msg"
+            check_it="true"
+            assign_to="ack_fp"/>
+      <log message="delayed-offer DTLS ACK carried fingerprint: [$ack_fp]"/>
+    </action>
+  </recv>
+
+  <recv request="BYE" rtd="true"/>
+
+  <send>
+<![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+</scenario>

--- a/test-harness/sipp-scenarios/run-all.sh
+++ b/test-harness/sipp-scenarios/run-all.sh
@@ -592,6 +592,89 @@ fi
 ods_cleanup
 trap - EXIT
 
+# ─── Always-on auxiliary phase: outbound delayed offer + DTLS ─────
+# (0.9.3) Outbound delayed offer where the peer offers DTLS-SRTP
+# (UDP/TLS/RTP/SAVPF + a=fingerprint + a=setup:actpass) in its 2xx and
+# SiphonAI answers it in the ACK. The scenario's check_it asserts the
+# ACK carries `a=fingerprint:sha-256`; pass also requires the daemon to
+# report ANSWERED + the SRTP result `encrypted`. (SIPp doesn't run a
+# real DTLS handshake — signalling-only; forge unit-tests the media.)
+echo
+echo "─── auxiliary phase: outbound_delayed_dtls ────────────"
+ODD_WS_PORT=8789
+ODD_ADMIN_PORT=9099
+ODD_WS_LOG=$(mktemp -t echo-ws-odd.XXXXXX.log)
+ODD_DAEMON_LOG=$(mktemp -t siphon-ai-odd.XXXXXX.log)
+ODD_CONFIG=$(mktemp -t siphon-ai-odd.XXXXXX.toml)
+cat >"$ODD_CONFIG" <<EOF
+[node]
+id = "siphon-ai-sipp-odd"
+[sip]
+listen = "127.0.0.1:$DAEMON_PORT"
+[media]
+codecs = ["pcmu"]
+[bridge]
+ws_url = "ws://127.0.0.1:$ODD_WS_PORT/"
+[observability]
+enabled = true
+http_listen = "127.0.0.1:$ODD_ADMIN_PORT"
+[outbound]
+max_concurrent = 2
+[[gateway]]
+name = "sipp"
+proxy = "127.0.0.1:$SIPP_PORT"
+from = "sip:harness@127.0.0.1"
+srtp = "required"
+[[route]]
+name = "default"
+[route.match]
+any = true
+EOF
+
+ODD_PYTHON="$REPO_ROOT/examples/echo-ws-server-python/.venv/bin/python"
+[[ -x "$ODD_PYTHON" ]] || ODD_PYTHON=python3
+"$ODD_PYTHON" "$REPO_ROOT/examples/echo-ws-server-python/server.py" \
+    --bind "127.0.0.1:$ODD_WS_PORT" \
+    --auto-hangup-after-ms 1500 \
+    >"$ODD_WS_LOG" 2>&1 &
+ODD_WS_PID=$!
+
+RUST_LOG=siphon_ai=info "$DAEMON_BIN" --config "$ODD_CONFIG" \
+    >"$ODD_DAEMON_LOG" 2>&1 &
+ODD_DAEMON_PID=$!
+odd_cleanup() {
+    kill "$ODD_WS_PID" "$ODD_DAEMON_PID" 2>/dev/null || true
+    wait "$ODD_WS_PID" "$ODD_DAEMON_PID" 2>/dev/null || true
+}
+trap odd_cleanup EXIT
+sleep 1.2
+
+total=$((total + 1))
+echo "─── outbound_delayed_dtls_uas ────────────────────────"
+odd_ok=0
+sipp -i 127.0.0.1 -sf "$SCRIPT_DIR/outbound_delayed_dtls_uas.xml" \
+    -m 1 -timeout 15s -trace_err -p "$SIPP_PORT" >/dev/null 2>&1 &
+ODD_SIPP_PID=$!
+sleep 0.3
+odd_resp=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST "http://127.0.0.1:$ODD_ADMIN_PORT/admin/v1/calls" \
+    -d '{"to": "7001", "gateway": "sipp", "delayed_offer": true}')
+if [[ "$odd_resp" == "202" ]] && wait "$ODD_SIPP_PID"; then
+    if curl -s "http://127.0.0.1:$ODD_ADMIN_PORT/metrics" \
+        | grep -q 'siphon_ai_outbound_srtp_total{result="encrypted"} 1'; then
+        odd_ok=1
+    fi
+fi
+if (( odd_ok )); then
+    echo "  OK"
+else
+    echo "  FAIL (originate=$odd_resp; daemon: $ODD_DAEMON_LOG; ws: $ODD_WS_LOG)"
+    failures=$((failures + 1))
+fi
+
+odd_cleanup
+trap - EXIT
+
 # ─── Always-on auxiliary phase: attended transfer ─────────────────
 # The full 0.6.1 three-party flow with SIPp on both far ends:
 #   * leg A  — SIPp UAC calls in (the transferee); its echo-ws is


### PR DESCRIPTION
**Piece A of DTLS-on-delayed** (you opted into both directions). Cuts **0.9.3**. The DTLS mirror of the 0.9.1 SDES outbound-answer work; the inbound DTLS-*offer* side follows as a second PR.

## What
When SiphonAI dials an **offerless** outbound INVITE and the peer's 2xx offers DTLS-SRTP (`UDP/TLS/RTP/SAVPF` + `a=fingerprint` + `a=setup:actpass`), SiphonAI now **answers** it.

## How
In `DelayedOfferAnswerer::generate_answer`, try **DTLS before SDES**, reusing the inbound early-offer DTLS path: `acceptor::{maybe_tweak_dtls_srtp_offer, post_process_dtls_srtp_answer}` + `MediaSession::enable_dtls` as `DtlsRole::Server` (we answer). The generator gained a **per-process DTLS cert** (runtime generates one, shared across gateways).

The negotiated exchange (`dtls` vs `sdes`) is now carried on `OutboundAccepted.srtp_exchange` (media-glue already deps the bridge protocol), so `start.srtp.exchange` reports it correctly — `outbound_service::run_call` uses it instead of hardcoding SDES. Early-offer origination sets it to `Sdes`.

## Policy / scope
- Governed by `[[gateway]].srtp` like the SDES answer (0.9.1): `preferred` answers SRTP when offered, `required` fails on a plaintext peer offer.
- **DTLS on the *inbound* delayed-offer** (where SiphonAI would *offer* DTLS — a new offer-build capability) is the next follow-up.

## Tests
- **Live-verified**: gateway `srtp = "required"`, peer 2xx offers DTLS-SRTP → `sipp rc=0` with a `check_it` asserting the **ACK carries `a=fingerprint:sha-256`**, `siphon_ai_outbound_srtp_total{result="encrypted"}` = 1, daemon `srtp=true`. New `outbound_delayed_dtls_uas.xml` + `run-all.sh` `outbound_delayed_dtls` phase. (SIPp doesn't complete a real DTLS handshake — signalling test; the media path is forge-tested.)
- `cargo fmt` / `clippy -D warnings` clean; `cargo test --workspace` — **733 passed, 0 failed**.

After merge: tag **v0.9.3** + GitHub release (Latest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
