### PR TITLE
feat: authenticated admin listener + move /admin off observability (chunk 2)

### DIFF
--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -93,8 +93,8 @@ use siphon_ai_telemetry::{
         AdminCallRegistry, AdminConference, AdminOutbound, AdminPark, AdminState,
         CallRegistryHandle, RegistrationRow,
     },
-    install_recorder, HepTelemetry, HepTelemetryBuild, HepWorkerHandle, LogFilterHandle,
-    ObservabilityServer, ReadinessFlag,
+    install_recorder, AdminServer, HepTelemetry, HepTelemetryBuild, HepWorkerHandle,
+    LogFilterHandle, ObservabilityServer, ReadinessFlag,
 };
 use siphon_ai_webhooks::{
     FilteredSink as WebhookFilteredSink, HttpSink as WebhookHttpSink,
@@ -121,6 +121,9 @@ pub struct Runtime {
     /// `Some` when `[observability].enabled = true`. Dropped on
     /// shutdown to stop the HTTP listener.
     observability: Option<ObservabilityServer>,
+    /// `Some` when `[admin]` is configured — the authenticated admin
+    /// HTTP listener. Dropped on shutdown.
+    admin: Option<AdminServer>,
     /// `Some` when `[hep].enabled = true`. Share-by-Arc so the admin
     /// state, CDR sink, and per-call code can borrow it; the UDP
     /// worker lives separately on `hep_worker` for shutdown. The
@@ -161,10 +164,7 @@ impl Runtime {
             webhooks,
             hep,
             park,
-            // [admin] auth is parsed + validated at load (chunk 1); the
-            // separate authenticated admin listener that consumes it
-            // lands in chunk 2.
-            admin: _,
+            admin,
         } = config;
 
         // ─── Telemetry: install Prometheus recorder ─────────────────
@@ -569,9 +569,10 @@ impl Runtime {
         // One authenticated UAC + originator per `[[gateway]]`, then the
         // daemon-wide service the `POST /admin/v1/calls` endpoint drives.
         // Only when `[outbound]` is enabled (a positive concurrency cap);
-        // otherwise the endpoint returns 501. The originate endpoint has no
-        // built-in auth — the cap + rate limit are the native guardrails
-        // (DEV_PLAN_0.6.0 §9.5/§9.6).
+        // otherwise the endpoint returns 501. As of 0.10.0 the originate
+        // endpoint requires an `admin`-role bearer token (it's on the
+        // authenticated `[admin]` listener); the cap + rate limit remain
+        // the abuse guardrails on top of that (DEV_PLAN_0.6.0 §9.5/§9.6).
         let outbound_handle: Option<AdminOutbound> = if outbound.enabled() {
             let mut gateways = HashMap::with_capacity(outbound.gateways.len());
             // Per-process DTLS cert for answering a peer's DTLS-SRTP offer
@@ -706,13 +707,13 @@ impl Runtime {
                 )) as AdminPark
             }),
         };
-        let observability_server = build_observability(
-            observability,
-            readiness.clone(),
-            prometheus_handle,
-            admin_state,
-        )
-        .await?;
+        let observability_server =
+            build_observability(observability, readiness.clone(), prometheus_handle).await?;
+
+        // Authenticated admin listener (0.10.0), separate from the open
+        // observability listener. `None` when no `[admin]` block is
+        // configured — `/admin/*` is then not served at all.
+        let admin_server = build_admin(admin, admin_state).await?;
 
         // We're now serving SIP — let the readiness probe flip.
         readiness.mark_ready();
@@ -724,6 +725,7 @@ impl Runtime {
             uas,
             listeners,
             observability: observability_server,
+            admin: admin_server,
             hep_telemetry,
             hep_worker,
             registration_mgr,
@@ -786,6 +788,10 @@ impl Runtime {
         if let Some(server) = self.observability {
             server.shutdown().await;
         }
+        // Stop the authenticated admin listener.
+        if let Some(server) = self.admin {
+            server.shutdown().await;
+        }
 
         // Drain the HEP UDP worker — aborts the task, bounded wait.
         // The telemetry handle itself is dropped here too (Arc
@@ -809,16 +815,16 @@ impl Runtime {
 
 // ─── Helpers ─────────────────────────────────────────────────────────
 
-/// Spawn the observability `/health` / `/ready` / `/metrics` HTTP
-/// server with admin routes installed. The Prometheus recorder is
-/// installed earlier in `Runtime::build` (so metric calls in call
-/// layers don't crash even when `[observability]` is disabled); the
-/// `prometheus` handle here is just the renderer for `/metrics`.
+/// Spawn the **open** observability `/health` / `/ready` / `/metrics`
+/// HTTP server. The Prometheus recorder is installed earlier in
+/// `Runtime::build` (so metric calls in call layers don't crash even
+/// when `[observability]` is disabled); the `prometheus` handle here is
+/// just the renderer for `/metrics`. `/admin/*` is NOT served here
+/// (0.10.0) — see [`build_admin`].
 async fn build_observability(
     cfg: ObservabilityConfig,
     readiness: ReadinessFlag,
     prometheus: siphon_ai_telemetry::PrometheusHandle,
-    admin: AdminState,
 ) -> Result<Option<ObservabilityServer>> {
     if !cfg.enabled {
         debug!("[observability].enabled = false; skipping HTTP listener");
@@ -827,9 +833,38 @@ async fn build_observability(
     let listen = cfg
         .http_listen
         .ok_or_else(|| anyhow!("[observability].http_listen unexpectedly empty"))?;
-    let server = ObservabilityServer::start(listen, prometheus, readiness, admin)
+    let server = ObservabilityServer::start(listen, prometheus, readiness)
         .await
         .with_context(|| format!("bind observability HTTP {listen}"))?;
+    Ok(Some(server))
+}
+
+/// Spawn the **authenticated** admin HTTP server (`[admin]`). `None`
+/// when no `[admin]` block is configured — `/admin/*` is then not served
+/// at all (the secure default). Warns when the bind is not loopback: the
+/// admin listener is plain HTTP, so the bearer token would travel in the
+/// clear on a routable address (pair with a TLS-terminating proxy until
+/// native `[admin].tls` lands).
+async fn build_admin(
+    cfg: Option<siphon_ai_config::AdminConfig>,
+    admin_state: AdminState,
+) -> Result<Option<AdminServer>> {
+    let Some(cfg) = cfg else {
+        debug!("no [admin] block; /admin/* is not served");
+        return Ok(None);
+    };
+    if !cfg.listen_addr.ip().is_loopback() {
+        warn!(
+            target: "siphon_ai_config",
+            listen = %cfg.listen_addr,
+            "[admin].listen is not a loopback address and the admin listener is plain HTTP — \
+             the bearer token travels in the clear on the wire. Bind loopback or front the \
+             admin listener with a TLS-terminating proxy."
+        );
+    }
+    let server = AdminServer::start(cfg.listen_addr, cfg.auth, admin_state)
+        .await
+        .with_context(|| format!("bind admin HTTP {}", cfg.listen_addr))?;
     Ok(Some(server))
 }
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -34,10 +34,11 @@ use std::path::Path;
 use thiserror::Error;
 
 pub use compile::{
-    compile, CdrConfig, CdrFileConfig, CdrWebhookConfig, CompileError, ConferenceConfig, Config,
-    Gateway, GatewayCredentials, HepConfig, MediaConfig, NodeConfig, ObservabilityConfig,
-    OutboundConfig, ParkConfig, ParkTimeoutAction, RegisterConfig, SecurityConfig, SipConfig,
-    SipTlsConfig, SipTransport, TrunkCidr, TrunkCidrParseError, TrunkConfig, WebhooksConfig,
+    compile, AdminConfig, CdrConfig, CdrFileConfig, CdrWebhookConfig, CompileError,
+    ConferenceConfig, Config, Gateway, GatewayCredentials, HepConfig, MediaConfig, NodeConfig,
+    ObservabilityConfig, OutboundConfig, ParkConfig, ParkTimeoutAction, RegisterConfig,
+    SecurityConfig, SipConfig, SipTlsConfig, SipTransport, TrunkCidr, TrunkCidrParseError,
+    TrunkConfig, WebhooksConfig,
 };
 pub use env::{expand, expand_cow, EnvError, EnvSource, ProcessEnv};
 pub use raw::{

--- a/crates/telemetry/src/admin.rs
+++ b/crates/telemetry/src/admin.rs
@@ -26,11 +26,15 @@
 //!
 //! ## Threat model
 //!
-//! These endpoints expose enough power to take calls down. They
-//! MUST bind on a trusted address (loopback, k8s pod-internal, etc.)
-//! per CLAUDE.md §12 / docs/DEV_PLAN.md §12.1. The daemon does NOT
-//! authenticate them — front with an authenticating reverse proxy
-//! if you expose them publicly.
+//! These endpoints expose enough power to take calls down and
+//! originate **billable** outbound calls. As of 0.10.0 they are served
+//! **only on the authenticated `[admin]` listener** ([`crate::http::AdminServer`]),
+//! gated by a bearer token + RBAC ([`crate::auth`]); the open
+//! observability listener no longer serves `/admin/*`. `dispatch` itself
+//! is unauthenticated by design — it runs only after `AdminServer` has
+//! authenticated the bearer token and checked the endpoint's minimum
+//! role. The admin listener is plain HTTP, so bind it on loopback or
+//! front it with TLS termination until native `[admin].tls` lands.
 //!
 //! ## Dependency injection
 //!

--- a/crates/telemetry/src/auth.rs
+++ b/crates/telemetry/src/auth.rs
@@ -223,6 +223,55 @@ fn operator_pattern(method: &hyper::Method, path: &str) -> bool {
             && path.starts_with("/admin/v1/conferences/"))
 }
 
+/// A **bounded-cardinality** label for the admin-request metric: the
+/// route template (ids collapsed to `:id`), `"unknown"` for an
+/// unrecognised path. Never the raw path (which carries call/room ids).
+pub fn route_label(method: &hyper::Method, path: &str) -> &'static str {
+    use hyper::Method;
+    match (method, path) {
+        (&Method::GET, "/admin/calls") => "GET /admin/calls",
+        (&Method::GET, "/admin/registrations") => "GET /admin/registrations",
+        (&Method::GET, "/admin/log") => "GET /admin/log",
+        (&Method::PUT, "/admin/log") => "PUT /admin/log",
+        (&Method::POST, "/admin/hep/test") => "POST /admin/hep/test",
+        (&Method::POST, "/admin/v1/calls") => "POST /admin/v1/calls",
+        (&Method::GET, "/admin/v1/conferences") => "GET /admin/v1/conferences",
+        (&Method::POST, "/admin/v1/conferences") => "POST /admin/v1/conferences",
+        (&Method::GET, "/admin/v1/parked") => "GET /admin/v1/parked",
+        (m, p)
+            if *m == Method::POST && p.starts_with("/admin/calls/") && p.ends_with("/hangup") =>
+        {
+            "POST /admin/calls/:id/hangup"
+        }
+        (m, p)
+            if *m == Method::POST && p.starts_with("/admin/v1/calls/") && p.ends_with("/park") =>
+        {
+            "POST /admin/v1/calls/:id/park"
+        }
+        (m, p)
+            if *m == Method::POST
+                && p.starts_with("/admin/v1/calls/")
+                && p.ends_with("/retrieve") =>
+        {
+            "POST /admin/v1/calls/:id/retrieve"
+        }
+        (&Method::DELETE, p)
+            if p.starts_with("/admin/v1/conferences/") && p.contains("/participants/") =>
+        {
+            "DELETE /admin/v1/conferences/:id/participants/:cid"
+        }
+        (&Method::POST, p)
+            if p.starts_with("/admin/v1/conferences/") && p.ends_with("/participants") =>
+        {
+            "POST /admin/v1/conferences/:id/participants"
+        }
+        (&Method::DELETE, p) if p.starts_with("/admin/v1/conferences/") => {
+            "DELETE /admin/v1/conferences/:id"
+        }
+        _ => "unknown",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/telemetry/src/http.rs
+++ b/crates/telemetry/src/http.rs
@@ -1,26 +1,25 @@
-//! Hyper-based HTTP server for `/health`, `/ready`, `/metrics`,
-//! and the `/admin/*` operator surface.
+//! Hyper-based HTTP servers for the daemon's HTTP surfaces:
 //!
-//! Single bind, all routes. Spawns a per-connection task; the
-//! probe routes are zero-allocation in the steady state
-//! (`/health` and `/ready` produce literal byte slices,
-//! `/metrics` calls `PrometheusHandle::render` which owns the
-//! string allocation).
+//! - [`ObservabilityServer`] — `/health`, `/ready`, `/metrics` on
+//!   `[observability].http_listen`. **Unauthenticated** by design: it's
+//!   the scrape/probe surface (Prometheus, k8s) and carries no power.
+//!   The probe routes are zero-allocation in the steady state.
+//! - [`AdminServer`] — the `/admin/*` operator surface (see
+//!   [`crate::admin`]) on its own `[admin].listen`, **gated by a bearer
+//!   token + RBAC** ([`crate::auth`]). `/admin/*` is **no longer served**
+//!   by the observability listener (0.10.0).
 //!
-//! ## Admin endpoints
+//! Each server spawns a per-connection task. Routes that need
+//! dependencies the runtime hasn't wired up return 503 (e.g.
+//! `/admin/hep/test` with HEP disabled).
 //!
-//! See [`crate::admin`]. They go through the same listener so
-//! operators have one HTTP surface to point a probe / dashboard
-//! at, not two. Routes that need dependencies the runtime hasn't
-//! wired up return 503 (e.g., `/admin/hep/test` with HEP disabled).
+//! ## Admin transport security
 //!
-//! ## What's NOT here
-//!
-//! - **No auth** — these endpoints are intended to bind on a
-//!   loopback or trusted-network address (k8s pods, localhost). If
-//!   exposed publicly, sit them behind an authenticating reverse
-//!   proxy. Per CLAUDE.md §12 ("Security v1 minimum") that's the
-//!   v1 threat model.
+//! The admin listener is plain HTTP in this cut, so the bearer token
+//! travels in the clear on the wire — bind it on **loopback** (the
+//! default posture) or front it with a TLS-terminating proxy. A native
+//! `[admin].tls` is a follow-up; the runtime warns when the admin bind
+//! is not loopback.
 
 use std::convert::Infallible;
 use std::net::SocketAddr;
@@ -29,16 +28,18 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use http_body_util::{BodyExt, Full};
 use hyper::body::{Bytes, Incoming};
-use hyper::header::CONTENT_TYPE;
+use hyper::header::{AUTHORIZATION, CONTENT_TYPE, WWW_AUTHENTICATE};
 use hyper::service::service_fn;
 use hyper::{Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
 use metrics_exporter_prometheus::PrometheusHandle;
 use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use crate::admin::{self, AdminState};
+use crate::auth::{route_label, AdminAuth, AuthReject};
+use crate::metrics::ADMIN_REQUESTS_TOTAL;
 use crate::readiness::ReadinessFlag;
 
 /// Body byte cap on PUT/POST admin requests. 8 KiB is far more than
@@ -64,7 +65,6 @@ impl ObservabilityServer {
         addr: SocketAddr,
         prometheus: PrometheusHandle,
         readiness: ReadinessFlag,
-        admin: AdminState,
     ) -> Result<Self> {
         let listener = TcpListener::bind(addr)
             .await
@@ -75,7 +75,6 @@ impl ObservabilityServer {
         let state = Arc::new(SharedState {
             prometheus,
             readiness,
-            admin,
         });
 
         let listener = tokio::spawn(async move {
@@ -104,7 +103,6 @@ impl ObservabilityServer {
 struct SharedState {
     prometheus: PrometheusHandle,
     readiness: ReadinessFlag,
-    admin: AdminState,
 }
 
 async fn run_accept_loop(listener: TcpListener, state: Arc<SharedState>) {
@@ -168,17 +166,8 @@ async fn handle_request(req: Request<Incoming>, state: Arc<SharedState>) -> Resp
         _ => {}
     }
 
-    // Admin routes — read the body (bounded) once, then dispatch.
-    if path.starts_with("/admin") {
-        let body = match read_admin_body(req).await {
-            Ok(b) => b,
-            Err(resp) => return resp,
-        };
-        if let Some(resp) = admin::dispatch(&method, &path, body, &state.admin).await {
-            return resp;
-        }
-    }
-
+    // /admin/* is NOT served here (0.10.0) — it lives on the
+    // authenticated `AdminServer`. Anything else is a 404.
     respond(StatusCode::NOT_FOUND, "text/plain", b"not found\n")
 }
 
@@ -214,6 +203,136 @@ async fn read_admin_body(req: Request<Incoming>) -> Result<Bytes, Response<Full<
     }
 }
 
+// ─── Admin server (authenticated /admin/* on its own listener) ──────
+
+/// Handle to the running **authenticated** admin HTTP server. Bound on
+/// `[admin].listen`; every request is gated by a bearer token + RBAC
+/// ([`crate::auth`]) before reaching [`crate::admin::dispatch`].
+pub struct AdminServer {
+    bound_addr: SocketAddr,
+    listener: JoinHandle<()>,
+}
+
+struct AdminSharedState {
+    admin: AdminState,
+    auth: AdminAuth,
+}
+
+impl AdminServer {
+    /// Bind on `addr` and start serving the gated `/admin/*` surface.
+    pub async fn start(addr: SocketAddr, auth: AdminAuth, admin: AdminState) -> Result<Self> {
+        let listener = TcpListener::bind(addr)
+            .await
+            .with_context(|| format!("bind admin HTTP {}", addr))?;
+        let bound_addr = listener.local_addr().unwrap_or(addr);
+        info!(addr = %bound_addr, "admin HTTP listener bound (bearer-token auth)");
+
+        let state = Arc::new(AdminSharedState { admin, auth });
+        let listener = tokio::spawn(async move {
+            loop {
+                let (stream, peer) = match listener.accept().await {
+                    Ok(pair) => pair,
+                    Err(e) => {
+                        error!(error = %e, "admin HTTP accept failed; exiting listener");
+                        return;
+                    }
+                };
+                let state = Arc::clone(&state);
+                tokio::spawn(async move {
+                    let io = TokioIo::new(stream);
+                    let svc = service_fn(move |req| {
+                        let state = Arc::clone(&state);
+                        async move { Ok::<_, Infallible>(handle_admin_request(req, state, peer).await) }
+                    });
+                    if let Err(e) = hyper::server::conn::http1::Builder::new()
+                        .serve_connection(io, svc)
+                        .await
+                    {
+                        debug!(peer = %peer, error = %e, "admin HTTP connection closed with error");
+                    }
+                });
+            }
+        });
+
+        Ok(Self {
+            bound_addr,
+            listener,
+        })
+    }
+
+    pub fn bound_addr(&self) -> SocketAddr {
+        self.bound_addr
+    }
+
+    pub async fn shutdown(self) {
+        self.listener.abort();
+        let _ = self.listener.await;
+    }
+}
+
+async fn handle_admin_request(
+    req: Request<Incoming>,
+    state: Arc<AdminSharedState>,
+    peer: SocketAddr,
+) -> Response<Full<Bytes>> {
+    let method = req.method().clone();
+    let path = req.uri().path().to_string();
+    let endpoint = route_label(&method, &path);
+    let auth_header = req
+        .headers()
+        .get(AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
+
+    // Authenticate + authorize BEFORE reading the body — an
+    // unauthenticated caller never makes us buffer its payload.
+    match state.auth.authorize(&method, &path, auth_header.as_deref()) {
+        Err(AuthReject::Unauthenticated) => {
+            warn!(peer = %peer, endpoint, "admin request rejected: 401 unauthenticated");
+            metrics::counter!(ADMIN_REQUESTS_TOTAL, "endpoint" => endpoint, "role" => "none", "result" => "unauthenticated").increment(1);
+            let mut resp = respond(
+                StatusCode::UNAUTHORIZED,
+                "application/json",
+                br#"{"error":"unauthenticated"}"#,
+            );
+            resp.headers_mut()
+                .insert(WWW_AUTHENTICATE, "Bearer".parse().expect("static header"));
+            resp
+        }
+        Err(AuthReject::Forbidden { required, have }) => {
+            warn!(peer = %peer, endpoint, required = required.as_str(), have = have.as_str(), "admin request rejected: 403 forbidden");
+            metrics::counter!(ADMIN_REQUESTS_TOTAL, "endpoint" => endpoint, "role" => have.as_str(), "result" => "forbidden").increment(1);
+            respond(
+                StatusCode::FORBIDDEN,
+                "application/json",
+                br#"{"error":"forbidden: insufficient role"}"#,
+            )
+        }
+        Ok(token) => {
+            // Capture owned audit fields before the body read / dispatch.
+            let actor = token.name.clone();
+            let role = token.role.as_str();
+            let body = match read_admin_body(req).await {
+                Ok(b) => b,
+                Err(resp) => return resp,
+            };
+            match admin::dispatch(&method, &path, body, &state.admin).await {
+                Some(resp) => {
+                    info!(peer = %peer, actor = %actor, role, endpoint, status = resp.status().as_u16(), "admin request");
+                    metrics::counter!(ADMIN_REQUESTS_TOTAL, "endpoint" => endpoint, "role" => role, "result" => "ok").increment(1);
+                    resp
+                }
+                None => {
+                    // Authenticated, but an unknown /admin route.
+                    info!(peer = %peer, actor = %actor, role, endpoint, status = 404, "admin request (unknown route)");
+                    metrics::counter!(ADMIN_REQUESTS_TOTAL, "endpoint" => endpoint, "role" => role, "result" => "not_found").increment(1);
+                    respond(StatusCode::NOT_FOUND, "text/plain", b"not found\n")
+                }
+            }
+        }
+    }
+}
+
 fn respond(status: StatusCode, content_type: &'static str, body: &[u8]) -> Response<Full<Bytes>> {
     Response::builder()
         .status(status)
@@ -241,16 +360,107 @@ mod tests {
         // Tag a metric so /metrics has something interesting; we
         // can't install globally inside the test (other tests do
         // the same), so just reuse the handle without installing.
-        let server = ObservabilityServer::start(
-            "127.0.0.1:0".parse().unwrap(),
-            handle,
-            readiness,
-            AdminState::default(),
-        )
-        .await
-        .expect("start");
+        let server = ObservabilityServer::start("127.0.0.1:0".parse().unwrap(), handle, readiness)
+            .await
+            .expect("start");
         let url = format!("http://{}", server.bound_addr());
         (server, url)
+    }
+
+    /// An `AdminServer` with three tokens (one per role) over an empty
+    /// `AdminState` (every endpoint's deps are `None` → 503, which is
+    /// fine: these tests exercise the auth gate, not dispatch).
+    async fn spawn_admin_server() -> (AdminServer, String) {
+        use crate::auth::{AdminAuth, AdminToken, Role};
+        let auth = AdminAuth::new(vec![
+            AdminToken::new("ro", "ro-tok", Role::ReadOnly),
+            AdminToken::new("op", "op-tok", Role::Operator),
+            AdminToken::new("ad", "ad-tok", Role::Admin),
+        ]);
+        let server =
+            AdminServer::start("127.0.0.1:0".parse().unwrap(), auth, AdminState::default())
+                .await
+                .expect("admin start");
+        let url = format!("http://{}", server.bound_addr());
+        (server, url)
+    }
+
+    /// GET with an optional `Authorization` header.
+    async fn get_auth(url: String, bearer: Option<&str>) -> StatusCode {
+        let client: Client<_, Empty<Bytes>> = Client::builder(TokioExecutor::new()).build_http();
+        let mut b = Request::builder().method(Method::GET).uri(url);
+        if let Some(t) = bearer {
+            b = b.header(AUTHORIZATION, format!("Bearer {t}"));
+        }
+        let resp = tokio::time::timeout(
+            Duration::from_secs(2),
+            client.request(b.body(Empty::new()).unwrap()),
+        )
+        .await
+        .expect("request returns")
+        .expect("ok");
+        resp.status()
+    }
+
+    #[tokio::test]
+    async fn admin_listener_does_not_serve_admin() {
+        // /admin/* must NOT be on the observability listener anymore.
+        let (server, url) = spawn_test_server(ReadinessFlag::new()).await;
+        let (status, _) = get(format!("{url}/admin/calls")).await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn admin_requires_auth_and_enforces_roles() {
+        let (server, url) = spawn_admin_server().await;
+        // No token → 401.
+        assert_eq!(
+            get_auth(format!("{url}/admin/calls"), None).await,
+            StatusCode::UNAUTHORIZED
+        );
+        // Bad token → 401.
+        assert_eq!(
+            get_auth(format!("{url}/admin/calls"), Some("wrong")).await,
+            StatusCode::UNAUTHORIZED
+        );
+        // readonly token on a GET → authorized; dispatch's dep is None
+        // so it 503s, but crucially it is NOT 401/403.
+        let s = get_auth(format!("{url}/admin/calls"), Some("ro-tok")).await;
+        assert!(
+            s != StatusCode::UNAUTHORIZED && s != StatusCode::FORBIDDEN,
+            "readonly GET should pass the gate, got {s}"
+        );
+        // readonly token on an unknown route still passes the gate (404).
+        assert_eq!(
+            get_auth(format!("{url}/admin/nope"), Some("ro-tok")).await,
+            StatusCode::NOT_FOUND
+        );
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn admin_forbids_below_minimum_role() {
+        let (server, url) = spawn_admin_server().await;
+        // GET /admin/v1/conferences requires readonly — a readonly token
+        // passes the gate. (We can't easily POST originate here, but the
+        // role table is unit-tested; this confirms the 403 wiring.)
+        // Use a path that needs operator with a readonly token via the
+        // HTTP layer: POST hangup. The body read happens after auth, so
+        // GET is fine for the gate check — but hangup is POST. Send POST.
+        let client: Client<_, Empty<Bytes>> = Client::builder(TokioExecutor::new()).build_http();
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri(format!("{url}/admin/calls/abc/hangup"))
+            .header(AUTHORIZATION, "Bearer ro-tok")
+            .body(Empty::new())
+            .unwrap();
+        let resp = tokio::time::timeout(Duration::from_secs(2), client.request(req))
+            .await
+            .expect("returns")
+            .expect("ok");
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        server.shutdown().await;
     }
 
     async fn get(url: String) -> (StatusCode, String) {
@@ -325,7 +535,9 @@ mod tests {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
         use tokio::net::TcpStream;
 
-        let (server, url) = spawn_test_server(ReadinessFlag::new()).await;
+        // The body cap is enforced AFTER auth now, so the request needs a
+        // valid admin token (PUT /admin/log requires admin) to reach it.
+        let (server, url) = spawn_admin_server().await;
         let addr_str = url.strip_prefix("http://").unwrap();
         let mut sock = TcpStream::connect(addr_str).await.expect("connect");
 
@@ -336,6 +548,7 @@ mod tests {
         let chunk_header = format!("{:x}\r\n", chunk_payload.len());
         let head = "PUT /admin/log HTTP/1.1\r\n\
                     Host: localhost\r\n\
+                    Authorization: Bearer ad-tok\r\n\
                     Transfer-Encoding: chunked\r\n\
                     Content-Type: text/plain\r\n\
                     Connection: close\r\n\r\n";
@@ -379,7 +592,6 @@ mod tests {
             "127.0.0.1:0".parse().unwrap(),
             handle,
             ReadinessFlag::new(),
-            AdminState::default(),
         )
         .await
         .expect("start");

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -35,15 +35,15 @@ pub use admin::{
 };
 pub use auth::{AdminAuth, AdminToken, AuthReject, Role};
 pub use hep::{HepBuildError, HepTelemetry, HepTelemetryBuild, HepWorkerHandle};
-pub use http::ObservabilityServer;
+pub use http::{AdminServer, ObservabilityServer};
 pub use log_filter::{LogFilterError, LogFilterHandle};
 
 // Re-exports for the daemon binary so it doesn't need a second
 // direct dep on `metrics-exporter-prometheus`.
 pub use metrics::{
-    install_recorder, prometheus_builder, register_descriptions, InitError, CALLS_ACTIVE,
-    CALLS_TOTAL, CALL_DURATION_BUCKETS, CALL_DURATION_SECONDS, DELAYED_OFFER_TOTAL, HOLDS_TOTAL,
-    INVITES_TOTAL, OUTBOUND_CALLS_ACTIVE, OUTBOUND_CALLS_TOTAL, OUTBOUND_SRTP_TOTAL,
+    install_recorder, prometheus_builder, register_descriptions, InitError, ADMIN_REQUESTS_TOTAL,
+    CALLS_ACTIVE, CALLS_TOTAL, CALL_DURATION_BUCKETS, CALL_DURATION_SECONDS, DELAYED_OFFER_TOTAL,
+    HOLDS_TOTAL, INVITES_TOTAL, OUTBOUND_CALLS_ACTIVE, OUTBOUND_CALLS_TOTAL, OUTBOUND_SRTP_TOTAL,
     PARKED_CALLS_ACTIVE, PARKS_TOTAL, RECORDINGS_TOTAL, REGISTER_ATTEMPTS_TOTAL, REGISTER_STATE,
     RETRIEVES_TOTAL, ROUTE_MATCH_TOTAL, SDP_NEGOTIATE_BUCKETS, SDP_NEGOTIATE_SECONDS,
     TRANSFERS_TOTAL, VERSTAT_TOTAL, WS_CONNECT_BUCKETS, WS_CONNECT_SECONDS, WS_RECONNECTS_TOTAL,

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -97,6 +97,15 @@ pub const OUTBOUND_CALLS_TOTAL: &str = "siphon_ai_outbound_calls_total";
 /// `siphon-ai-core::outbound_service`.
 pub const OUTBOUND_SRTP_TOTAL: &str = "siphon_ai_outbound_srtp_total";
 
+/// Authenticated admin API requests (0.10.0). Labeled by `endpoint`
+/// (the route template, ids collapsed — bounded), `role` (the
+/// authenticated token's role, or `none` when auth failed), and
+/// `result` (`ok`, `unauthenticated`, `forbidden`, `not_found`). One
+/// counter per admin call on the `[admin]` listener; pairs with the
+/// structured audit log. Literal must match the call site in
+/// `siphon-ai-telemetry::http`.
+pub const ADMIN_REQUESTS_TOTAL: &str = "siphon_ai_admin_requests_total";
+
 /// Inbound delayed-offer (offerless INVITE) outcomes (0.9.0). Labeled by
 /// `result`: `answered` (peer's ACK answer negotiated and the call
 /// bridged), `ack_timeout` (no ACK before Timer H), `missing_sdp_answer`
@@ -315,6 +324,10 @@ pub fn register_descriptions() {
     describe_counter!(
         OUTBOUND_SRTP_TOTAL,
         "Outbound SRTP (SDES) outcomes for answered calls, by result (encrypted, downgraded)."
+    );
+    describe_counter!(
+        ADMIN_REQUESTS_TOTAL,
+        "Authenticated admin API requests, by endpoint (route template), role, and result (ok, unauthenticated, forbidden, not_found)."
     );
     describe_counter!(
         DELAYED_OFFER_TOTAL,

--- a/test-harness/sipp-scenarios/run-all.sh
+++ b/test-harness/sipp-scenarios/run-all.sh
@@ -33,6 +33,12 @@ cd "$SCRIPT_DIR"
 
 SIPP_PORT=5080       # SIPp's listen port (any free port works)
 DAEMON_PORT=5070     # SiphonAI's listen port (matches local-dev.toml)
+# Admin API (0.10.0): /admin/* moved to its own authenticated listener,
+# separate from the open [observability] /metrics port. Phases that drive
+# the admin API ([admin] block + these on a bearer token); phases run
+# sequentially so one fixed port/token is reused.
+ADMIN_API_PORT=9191
+ADMIN_TOKEN="sipp-harness-admin"
 DAEMON_BIN="${DAEMON_BIN:-$REPO_ROOT/target/debug/siphon-ai}"
 DAEMON_CONFIG="${SIPHON_AI_CONFIG:-$REPO_ROOT/configs/local-dev.toml}"
 
@@ -362,6 +368,12 @@ ws_url = "ws://127.0.0.1:$OB_WS_PORT/"
 [observability]
 enabled = true
 http_listen = "127.0.0.1:$OB_ADMIN_PORT"
+[admin]
+listen = "127.0.0.1:$ADMIN_API_PORT"
+[[admin.token]]
+name = "harness"
+token = "$ADMIN_TOKEN"
+role = "admin"
 [outbound]
 max_concurrent = 2
 [[gateway]]
@@ -408,7 +420,7 @@ sleep 0.3
 # Place the call. 202 + a call_id means admitted; the rest plays out
 # between the daemon, SIPp, and the echo-ws hangup.
 ob_resp=$(curl -s -o /dev/null -w "%{http_code}" \
-    -X POST "http://127.0.0.1:$OB_ADMIN_PORT/admin/v1/calls" \
+    -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "http://127.0.0.1:$ADMIN_API_PORT/admin/v1/calls" \
     -d '{"to": "7001", "gateway": "sipp"}')
 if [[ "$ob_resp" == "202" ]] && wait "$OB_SIPP_PID"; then
     # SIPp saw INVITE → ACK → BYE. Cross-check the daemon agrees the
@@ -454,6 +466,12 @@ ws_url = "ws://127.0.0.1:$ODO_WS_PORT/"
 [observability]
 enabled = true
 http_listen = "127.0.0.1:$ODO_ADMIN_PORT"
+[admin]
+listen = "127.0.0.1:$ADMIN_API_PORT"
+[[admin.token]]
+name = "harness"
+token = "$ADMIN_TOKEN"
+role = "admin"
 [outbound]
 max_concurrent = 2
 [[gateway]]
@@ -492,7 +510,7 @@ sipp -i 127.0.0.1 -sf "$SCRIPT_DIR/outbound_delayed_uas.xml" \
 ODO_SIPP_PID=$!
 sleep 0.3
 odo_resp=$(curl -s -o /dev/null -w "%{http_code}" \
-    -X POST "http://127.0.0.1:$ODO_ADMIN_PORT/admin/v1/calls" \
+    -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "http://127.0.0.1:$ADMIN_API_PORT/admin/v1/calls" \
     -d '{"to": "7001", "gateway": "sipp", "delayed_offer": true}')
 if [[ "$odo_resp" == "202" ]] && wait "$ODO_SIPP_PID"; then
     if curl -s "http://127.0.0.1:$ODO_ADMIN_PORT/metrics" \
@@ -535,6 +553,12 @@ ws_url = "ws://127.0.0.1:$ODS_WS_PORT/"
 [observability]
 enabled = true
 http_listen = "127.0.0.1:$ODS_ADMIN_PORT"
+[admin]
+listen = "127.0.0.1:$ADMIN_API_PORT"
+[[admin.token]]
+name = "harness"
+token = "$ADMIN_TOKEN"
+role = "admin"
 [outbound]
 max_concurrent = 2
 [[gateway]]
@@ -574,7 +598,7 @@ sipp -i 127.0.0.1 -sf "$SCRIPT_DIR/outbound_delayed_srtp_uas.xml" \
 ODS_SIPP_PID=$!
 sleep 0.3
 ods_resp=$(curl -s -o /dev/null -w "%{http_code}" \
-    -X POST "http://127.0.0.1:$ODS_ADMIN_PORT/admin/v1/calls" \
+    -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "http://127.0.0.1:$ADMIN_API_PORT/admin/v1/calls" \
     -d '{"to": "7001", "gateway": "sipp", "delayed_offer": true}')
 if [[ "$ods_resp" == "202" ]] && wait "$ODS_SIPP_PID"; then
     if curl -s "http://127.0.0.1:$ODS_ADMIN_PORT/metrics" \
@@ -618,6 +642,12 @@ ws_url = "ws://127.0.0.1:$ODD_WS_PORT/"
 [observability]
 enabled = true
 http_listen = "127.0.0.1:$ODD_ADMIN_PORT"
+[admin]
+listen = "127.0.0.1:$ADMIN_API_PORT"
+[[admin.token]]
+name = "harness"
+token = "$ADMIN_TOKEN"
+role = "admin"
 [outbound]
 max_concurrent = 2
 [[gateway]]
@@ -657,7 +687,7 @@ sipp -i 127.0.0.1 -sf "$SCRIPT_DIR/outbound_delayed_dtls_uas.xml" \
 ODD_SIPP_PID=$!
 sleep 0.3
 odd_resp=$(curl -s -o /dev/null -w "%{http_code}" \
-    -X POST "http://127.0.0.1:$ODD_ADMIN_PORT/admin/v1/calls" \
+    -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "http://127.0.0.1:$ADMIN_API_PORT/admin/v1/calls" \
     -d '{"to": "7001", "gateway": "sipp", "delayed_offer": true}')
 if [[ "$odd_resp" == "202" ]] && wait "$ODD_SIPP_PID"; then
     if curl -s "http://127.0.0.1:$ODD_ADMIN_PORT/metrics" \
@@ -709,6 +739,12 @@ ws_url = "ws://127.0.0.1:$AT_A_WS_PORT/"
 [observability]
 enabled = true
 http_listen = "127.0.0.1:$AT_ADMIN_PORT"
+[admin]
+listen = "127.0.0.1:$ADMIN_API_PORT"
+[[admin.token]]
+name = "harness"
+token = "$ADMIN_TOKEN"
+role = "admin"
 [outbound]
 max_concurrent = 2
 [[gateway]]
@@ -756,7 +792,7 @@ sipp -i 127.0.0.1 -sf "$SCRIPT_DIR/outbound_uas_answer.xml" \
     -m 1 -timeout 20s -trace_err -p "$AT_CONSULT_PORT" >/dev/null 2>&1 &
 AT_C_SIPP_PID=$!
 sleep 0.3
-at_consult_id=$(curl -s -X POST "http://127.0.0.1:$AT_ADMIN_PORT/admin/v1/calls" \
+at_consult_id=$(curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "http://127.0.0.1:$ADMIN_API_PORT/admin/v1/calls" \
     -d "{\"to\": \"agent\", \"gateway\": \"sipp\", \"ws_url\": \"ws://127.0.0.1:$AT_C_WS_PORT/\"}" \
     | sed -n 's/.*"call_id":"\([^"]*\)".*/\1/p')
 
@@ -829,6 +865,12 @@ ws_url = "ws://127.0.0.1:$PK_WS_PORT/"
 [observability]
 enabled = true
 http_listen = "127.0.0.1:$PK_ADMIN_PORT"
+[admin]
+listen = "127.0.0.1:$ADMIN_API_PORT"
+[[admin.token]]
+name = "harness"
+token = "$ADMIN_TOKEN"
+role = "admin"
 [park]
 enabled = true
 timeout_secs = 1
@@ -904,6 +946,12 @@ ws_url = "ws://127.0.0.1:$PR_WS_A_PORT/"
 [observability]
 enabled = true
 http_listen = "127.0.0.1:$PR_ADMIN_PORT"
+[admin]
+listen = "127.0.0.1:$ADMIN_API_PORT"
+[[admin.token]]
+name = "harness"
+token = "$ADMIN_TOKEN"
+role = "admin"
 [park]
 enabled = true
 timeout_secs = 0
@@ -947,7 +995,7 @@ sleep 0.3
 # Wait until the call is parked, then grab its bridge call_id.
 parked_id=""
 for _ in $(seq 1 25); do
-    parked_id=$(curl -s "http://127.0.0.1:$PR_ADMIN_PORT/admin/v1/parked" \
+    parked_id=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "http://127.0.0.1:$ADMIN_API_PORT/admin/v1/parked" \
         | sed -n 's/.*"call_id":"\([^"]*\)".*/\1/p' | head -1)
     [[ -n "$parked_id" ]] && break
     sleep 0.2
@@ -955,7 +1003,7 @@ done
 
 if [[ -n "$parked_id" ]]; then
     curl -s -o /dev/null -X POST \
-        "http://127.0.0.1:$PR_ADMIN_PORT/admin/v1/calls/$parked_id/retrieve" \
+        -H "Authorization: Bearer $ADMIN_TOKEN" "http://127.0.0.1:$ADMIN_API_PORT/admin/v1/calls/$parked_id/retrieve" \
         -d "{\"ws_url\": \"ws://127.0.0.1:$PR_WS_B_PORT/\"}"
     # echo-ws B hangs up → SiphonAI BYEs the caller → SIPp completes.
     if wait "$PR_SIPP_PID" && curl -s "http://127.0.0.1:$PR_ADMIN_PORT/metrics" \
@@ -1000,6 +1048,12 @@ ws_url = "ws://127.0.0.1:$CF_WS_PORT/"
 [observability]
 enabled = true
 http_listen = "127.0.0.1:$CF_ADMIN_PORT"
+[admin]
+listen = "127.0.0.1:$ADMIN_API_PORT"
+[[admin.token]]
+name = "harness"
+token = "$ADMIN_TOKEN"
+role = "admin"
 [conference]
 enabled = true
 [[route]]
@@ -1095,6 +1149,12 @@ ws_url = "ws://127.0.0.1:$OBS_WS_PORT/"
 [observability]
 enabled = true
 http_listen = "127.0.0.1:$OBS_ADMIN_PORT"
+[admin]
+listen = "127.0.0.1:$ADMIN_API_PORT"
+[[admin.token]]
+name = "harness"
+token = "$ADMIN_TOKEN"
+role = "admin"
 [outbound]
 max_concurrent = 2
 [[gateway]]
@@ -1135,7 +1195,7 @@ sipp -i 127.0.0.1 -sf "$SCRIPT_DIR/outbound_srtp_uas_answer.xml" \
 OBS_SIPP_PID=$!
 sleep 0.3
 obs_resp=$(curl -s -o /dev/null -w "%{http_code}" \
-    -X POST "http://127.0.0.1:$OBS_ADMIN_PORT/admin/v1/calls" \
+    -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "http://127.0.0.1:$ADMIN_API_PORT/admin/v1/calls" \
     -d '{"to": "7002", "gateway": "sipp"}')
 if [[ "$obs_resp" == "202" ]] && wait "$OBS_SIPP_PID"; then
     if curl -s "http://127.0.0.1:$OBS_ADMIN_PORT/metrics" \
@@ -1179,6 +1239,12 @@ ws_url = "ws://127.0.0.1:$BH_WS_PORT/"
 [observability]
 enabled = true
 http_listen = "127.0.0.1:$BH_ADMIN_PORT"
+[admin]
+listen = "127.0.0.1:$ADMIN_API_PORT"
+[[admin.token]]
+name = "harness"
+token = "$ADMIN_TOKEN"
+role = "admin"
 [[route]]
 name = "default"
 [route.match]
@@ -1254,6 +1320,12 @@ ws_reconnect_max_secs = 10
 [observability]
 enabled = true
 http_listen = "127.0.0.1:$RC_ADMIN_PORT"
+[admin]
+listen = "127.0.0.1:$ADMIN_API_PORT"
+[[admin.token]]
+name = "harness"
+token = "$ADMIN_TOKEN"
+role = "admin"
 [[route]]
 name = "default"
 [route.match]
@@ -1327,6 +1399,12 @@ ws_reconnect_max_secs = 10
 [observability]
 enabled = true
 http_listen = "127.0.0.1:$OR_ADMIN_PORT"
+[admin]
+listen = "127.0.0.1:$ADMIN_API_PORT"
+[[admin.token]]
+name = "harness"
+token = "$ADMIN_TOKEN"
+role = "admin"
 [outbound]
 max_concurrent = 2
 [[gateway]]
@@ -1366,7 +1444,7 @@ sipp -i 127.0.0.1 -sf "$SCRIPT_DIR/outbound_uas_answer.xml" \
 OR_SIPP_PID=$!
 sleep 0.3
 or_resp=$(curl -s -o /dev/null -w "%{http_code}" \
-    -X POST "http://127.0.0.1:$OR_ADMIN_PORT/admin/v1/calls" \
+    -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "http://127.0.0.1:$ADMIN_API_PORT/admin/v1/calls" \
     -d '{"to": "7001", "gateway": "sipp"}')
 if [[ "$or_resp" == "202" ]] && wait "$OR_SIPP_PID"; then
     if curl -s "http://127.0.0.1:$OR_ADMIN_PORT/metrics" \
@@ -1411,6 +1489,12 @@ ws_url = "ws://127.0.0.1:$OH_WS_PORT/"
 [observability]
 enabled = true
 http_listen = "127.0.0.1:$OH_ADMIN_PORT"
+[admin]
+listen = "127.0.0.1:$ADMIN_API_PORT"
+[[admin.token]]
+name = "harness"
+token = "$ADMIN_TOKEN"
+role = "admin"
 [outbound]
 max_concurrent = 2
 [[gateway]]
@@ -1450,7 +1534,7 @@ sipp -i 127.0.0.1 -sf "$SCRIPT_DIR/outbound_bot_hold_uas.xml" \
 OH_SIPP_PID=$!
 sleep 0.3
 oh_resp=$(curl -s -o /dev/null -w "%{http_code}" \
-    -X POST "http://127.0.0.1:$OH_ADMIN_PORT/admin/v1/calls" \
+    -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "http://127.0.0.1:$ADMIN_API_PORT/admin/v1/calls" \
     -d '{"to": "7001", "gateway": "sipp"}')
 if [[ "$oh_resp" == "202" ]] && wait "$OH_SIPP_PID"; then
     if curl -s "http://127.0.0.1:$OH_ADMIN_PORT/metrics" \


### PR DESCRIPTION
**Chunk 2 of native admin auth** (design #198, builds on chunk 1 #199): stands up the **authenticated admin listener** and moves `/admin/*` onto it. This is where the gap actually closes.

## What
- **`telemetry::http::AdminServer`** — a second HTTP server bound on `[admin].listen`. Every request is **authenticated + authorized before the body is read**: no/bad token → `401` (+ `WWW-Authenticate: Bearer`), role below the endpoint's minimum → `403`, otherwise dispatch.
- **`/admin/*` is removed from the observability listener** — it now `404`s there. `/metrics`, `/health`, `/ready` stay open for scrapers/probes.
- **Audit + metric**: each request logs `actor` (token *name*, never the secret) / `role` / `endpoint` / `status` / `peer`, and increments `siphon_ai_admin_requests_total{endpoint,role,result}` (bounded `endpoint` route-template label; `result` ∈ ok/unauthenticated/forbidden/not_found).
- **runtime** `build_admin`: spawns the listener from `[admin]` (absent → not served, the secure default), **warns** when the bind is non-loopback (plain-HTTP token-in-clear), and shuts it down with the rest. Updated the `admin.rs` threat model + the originate "no built-in auth" note (now admin-role-gated).

## ⚠️ Breaking
`/admin/*` no longer answers on `[observability].http_listen`. Any deployment POSTing admin there must point at `[admin].listen` with a bearer token. Pre-1.0, and the surface was never meant to be exposed (it had no auth) — the CHANGELOG migration note lands in chunk 3.

## Verified live
`/metrics` open (200); `/admin/calls` on observability → 404; admin listener → 401 (no/bad token), 200 (readonly GET), 403 (readonly POST `/admin/v1/calls`); audit logs + the metric series all emit as expected.

`cargo fmt` / `clippy -D warnings` clean; `cargo test --workspace` — **749 passed, 0 failed** (3 new HTTP auth-gate tests; the chunked-body-cap test moved onto the authed listener). No version bump.

Next: **chunk 3** — docs (DEPLOY §security, CONFIG `[admin]`), integration tests, CHANGELOG (breaking note), release **~v0.10.0**; `[admin].tls` follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
