### PR TITLE
docs: admin auth + RBAC docs, role-tier tests, 0.10.0 release (chunk 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-06-19
+
+### Added
+
+- **Native admin authentication + RBAC.** `/admin/*` is now gated by
+  bearer tokens with three nested roles — `readonly` ⊂ `operator` ⊂
+  `admin`. Tokens are declared under a new `[admin]` config block
+  (`[[admin.token]] { name, token, role }`), hashed (SHA-256) at load and
+  compared in constant time; the secret is never logged. The
+  endpoint→minimum-role map: `readonly` = all GET/list routes; `operator`
+  = hangup, park/retrieve, conference create/end/add/remove; `admin` =
+  **billable** origination (`POST /admin/v1/calls`), `PUT /admin/log`, and
+  `POST /admin/hep/test`. Missing/invalid token → `401` (+
+  `WWW-Authenticate: Bearer`); role below the minimum → `403`. Config is
+  validated at load (CLAUDE.md §4.6): an `[admin]` block with no tokens, an
+  empty/duplicate name, an empty secret, an unknown role, or an
+  unparseable `listen` fails the daemon at startup.
+- **Admin request audit + metric.** Every admin request emits a structured
+  log line (actor = token **name**, role, endpoint template, result, peer
+  — never the secret) and ticks
+  `siphon_ai_admin_requests_total{endpoint, role, result}` (`result` ∈
+  `ok` | `unauthenticated` | `forbidden` | `not_found`; `endpoint` is a
+  bounded route template with ids collapsed to `:id`).
+
+### Changed
+
+- **BREAKING: `/admin/*` moved off the metrics listener.** Admin endpoints
+  are now served **only** on the dedicated `[admin].listen`; the
+  `[observability].http_listen` port serves just `/metrics`, `/health`,
+  `/ready` and returns `404` for `/admin/*`. **Migration:** add an
+  `[admin]` block with at least one token, repoint admin tooling at the new
+  port with an `Authorization: Bearer …` header, and remove any `/admin/*`
+  allow rules (or front-proxy auth) from the metrics port. If `[admin]` is
+  omitted, `/admin/*` is **not served at all** (secure default) — the
+  daemon still starts and serves metrics/health. The admin listener is
+  plain HTTP for now (`[admin].tls` is a planned follow-up); bind it on
+  loopback or front it with TLS termination. A non-loopback bind logs a
+  warning at startup.
+
 ## [0.9.5] - 2026-06-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.9.5"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2936,7 +2936,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.9.5"
+version = "0.10.0"
 dependencies = [
  "base64",
  "bytes",
@@ -2957,7 +2957,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.9.5"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2974,7 +2974,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.9.5"
+version = "0.10.0"
 dependencies = [
  "regex",
  "serde",
@@ -2992,7 +2992,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.9.5"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3033,7 +3033,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.9.5"
+version = "0.10.0"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.9.5"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3072,7 +3072,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.9.5"
+version = "0.10.0"
 dependencies = [
  "thiserror 1.0.69",
  "tokio",
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.9.5"
+version = "0.10.0"
 dependencies = [
  "regex",
  "serde",
@@ -3092,7 +3092,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.9.5"
+version = "0.10.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3101,7 +3101,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.9.5"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3124,7 +3124,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.9.5"
+version = "0.10.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -3142,7 +3142,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.9.5"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.9.5"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.5"
+version = "0.10.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/crates/telemetry/src/http.rs
+++ b/crates/telemetry/src/http.rs
@@ -463,6 +463,65 @@ mod tests {
         server.shutdown().await;
     }
 
+    /// Send `method url` with an optional bearer token; return the status.
+    async fn send_auth(method: Method, url: String, bearer: Option<&str>) -> StatusCode {
+        let client: Client<_, Empty<Bytes>> = Client::builder(TokioExecutor::new()).build_http();
+        let mut b = Request::builder().method(method).uri(url);
+        if let Some(t) = bearer {
+            b = b.header(AUTHORIZATION, format!("Bearer {t}"));
+        }
+        let resp = tokio::time::timeout(
+            Duration::from_secs(2),
+            client.request(b.body(Empty::new()).unwrap()),
+        )
+        .await
+        .expect("request returns")
+        .expect("ok");
+        resp.status()
+    }
+
+    #[tokio::test]
+    async fn admin_role_tiers_gate_by_minimum_role() {
+        // Walk the nested role ladder against representative endpoints:
+        //   GET  /admin/calls           → readonly
+        //   POST /admin/calls/:id/hangup→ operator
+        //   POST /admin/v1/calls        → admin (billable originate)
+        // A token at or above the endpoint's minimum passes the gate
+        // (never 401/403 — downstream may 404/503/501 with deps absent);
+        // a token below it is 403.
+        let (server, url) = spawn_admin_server().await;
+        let passed = |s: StatusCode| s != StatusCode::UNAUTHORIZED && s != StatusCode::FORBIDDEN;
+
+        // operator endpoint: readonly forbidden, operator + admin pass.
+        let hangup = format!("{url}/admin/calls/abc/hangup");
+        assert_eq!(
+            send_auth(Method::POST, hangup.clone(), Some("ro-tok")).await,
+            StatusCode::FORBIDDEN
+        );
+        assert!(passed(
+            send_auth(Method::POST, hangup.clone(), Some("op-tok")).await
+        ));
+        assert!(passed(
+            send_auth(Method::POST, hangup, Some("ad-tok")).await
+        ));
+
+        // admin endpoint: readonly + operator forbidden, admin passes.
+        let originate = format!("{url}/admin/v1/calls");
+        assert_eq!(
+            send_auth(Method::POST, originate.clone(), Some("ro-tok")).await,
+            StatusCode::FORBIDDEN
+        );
+        assert_eq!(
+            send_auth(Method::POST, originate.clone(), Some("op-tok")).await,
+            StatusCode::FORBIDDEN
+        );
+        assert!(passed(
+            send_auth(Method::POST, originate, Some("ad-tok")).await
+        ));
+
+        server.shutdown().await;
+    }
+
     async fn get(url: String) -> (StatusCode, String) {
         let client: Client<_, Empty<Bytes>> = Client::builder(TokioExecutor::new()).build_http();
         let req = Request::builder()

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -24,7 +24,8 @@ before TOML parsing. Unset variables without a default fail the load.
 [conference]      # conference rooms (0.7.0); off by default
 [park]            # media-only call park (0.7.0); off by default
 [cdr]             # call detail records: file + webhook sinks
-[observability]   # /metrics, /health, /ready, /admin
+[observability]   # /metrics, /health, /ready
+[admin]           # authenticated /admin/* listener (0.10.0); off → /admin not served
 [webhooks]        # lifecycle events (call_start, call_end, …)
 [hep]             # HEP3 shipping to Homer
 ```
@@ -542,7 +543,43 @@ regardless of sub-block state. Adding fields to the CDR schema bumps the
 | Field         | Type        | Default        | Notes |
 |---------------|-------------|----------------|-------|
 | `enabled`     | bool        | `false`        | Master switch for the HTTP server. |
-| `http_listen` | `host:port` | required if on | Exposes `/metrics`, `/health`, `/ready`, `/admin/*`. |
+| `http_listen` | `host:port` | required if on | Exposes `/metrics`, `/health`, `/ready`. **Since 0.10.0 it no longer serves `/admin/*`** (returns `404`) — admin moved to the authenticated `[admin]` listener below. |
+
+This listener is unauthenticated by design (metrics/health are safe to
+scrape). The privileged `/admin/*` surface lives on its own
+[`[admin]`](#admin) listener.
+
+## `[admin]`
+
+Authenticated admin API listener (0.10.0). Serves `/admin/*` (hangup,
+**billable** origination, conference / park control, log-filter changes)
+gated by a bearer token + role. **Omit `[admin]` entirely and `/admin/*`
+is not served at all** — a secure default; the daemon still starts and
+serves `[observability]`. Operator guide + the endpoint→role table:
+`docs/DEPLOY.md` → *Admin API* / *Admin auth & RBAC*.
+
+```toml
+[admin]
+listen = "127.0.0.1:9092"      # dedicated listener; plain HTTP (bind loopback
+                               # or front with TLS until [admin].tls lands)
+
+[[admin.token]]                # one block per token; at least one required
+name  = "ops-oncall"           # actor label in audit logs — NOT a secret
+token = "${SIPHON_ADMIN_OP}"   # the bearer secret; ${VAR} expansion works
+role  = "operator"             # readonly | operator | admin (roles nest)
+```
+
+| Field            | Type        | Default        | Notes |
+|------------------|-------------|----------------|-------|
+| `listen`         | `host:port` | required if on | Where `/admin/*` is served. A non-loopback bind logs a warning (plain HTTP). |
+| `token`          | table array | ≥ 1 required   | At least one `[[admin.token]]`; an `[admin]` block with no tokens is a fatal config error. |
+| `token[].name`   | string      | required       | Unique, non-empty label recorded as the audit-log actor. Duplicate names are a fatal error. |
+| `token[].token`  | string      | required       | The bearer secret (non-empty). Hashed (SHA-256) at load, compared in constant time, never logged. Use `${VAR}` to keep it out of the file. |
+| `token[].role`   | enum        | required       | `readonly` (GET/list) ⊂ `operator` (hangup, park/retrieve, conference CRUD) ⊂ `admin` (origination, `PUT /admin/log`, `hep/test`). Unknown value → fatal error. |
+
+Validation is at load time (CLAUDE.md §4.6): no tokens, an empty name or
+secret, a duplicate name, an unknown role, or an unparseable `listen` all
+fail the daemon at startup rather than at first request.
 
 ## `[webhooks]`
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -310,36 +310,111 @@ Both live on the `[observability]` listener.
 
 ## Admin API
 
-`/admin/*` lives on the same port as `/metrics`. **No auth in v1** — keep
-the listener on a private network.
+`/admin/*` is served **only on the dedicated `[admin]` listener**, gated by
+a bearer token + RBAC (0.10.0). It is **no longer** on the
+`[observability].http_listen` port — that port now serves only `/metrics`,
+`/health`, `/ready`, and returns `404` for `/admin/*`. Set up the listener
+and tokens first ([Admin auth & RBAC](#admin-auth--rbac) below); every
+example in this section assumes the admin port and an
+`Authorization: Bearer …` header.
 
-| Method | Path                          | Body            | Purpose |
-|--------|-------------------------------|-----------------|---------|
-| GET    | `/admin/calls`                | —               | List active per-call SIP Call-IDs. |
-| POST   | `/admin/calls/:id/hangup`     | —               | Force-shutdown a specific call by Call-ID. |
-| GET    | `/admin/registrations`        | —               | Snapshot of every `[[register]]` row and its current state. |
-| GET    | `/admin/log`                  | —               | Current `tracing` filter directive. |
-| PUT    | `/admin/log`                  | text directive  | Replace the filter (e.g., `siphon_ai=info,siphon_ai_bridge=debug`). Returns the previous filter. |
-| POST   | `/admin/v1/calls`             | JSON (below)    | **Originate an outbound call** (0.6.0). Returns `202 {"call_id": "..."}`; the call proceeds asynchronously. `501` when `[outbound]` is disabled. |
-| GET    | `/admin/v1/conferences`       | —               | **List conference rooms** + members (0.7.0). `501` when `[conference]` is disabled. |
-| POST   | `/admin/v1/conferences`       | JSON (opt.)     | **Pre-create a room** (0.7.0). Body `{room_id?, sample_rate?}`; returns `201 {"room_id": "..."}`. |
-| DELETE | `/admin/v1/conferences/:id`   | —               | **Force-end a room** (0.7.0). Every member reverts to its direct pair (`conference_left { room_closed }`). `404` if unknown. |
-| POST   | `/admin/v1/conferences/:id/participants`          | JSON | **Add a call to a room** (0.7.0). Body `{call_id}`; `202` (dispatched). |
-| DELETE | `/admin/v1/conferences/:id/participants/:call_id` | —    | **Remove a call from a room** (0.7.0). `202` (dispatched). |
-| GET    | `/admin/v1/parked`            | —               | **List parked calls** (0.7.0). `501` when `[park]` is disabled. |
-| POST   | `/admin/v1/calls/:id/park`    | JSON (opt.)     | **Park an active call** (0.7.0). Body `{slot?}`; `202` (dispatched). `404` if no active call has that id. `501` when `[park]` is disabled. |
-| POST   | `/admin/v1/calls/:id/retrieve`| JSON (opt.)     | **Retrieve a parked call** (0.7.0). Body `{ws_url?}`; `202` (dispatched). `404` unknown call, `409` if the call isn't parked. `501` when `[park]` is disabled. |
+The **Min role** column is the lowest role a token needs to reach the
+endpoint (roles nest: `readonly` ⊂ `operator` ⊂ `admin`). Below it → `403`;
+no/invalid token → `401`.
+
+| Method | Path                          | Body            | Min role | Purpose |
+|--------|-------------------------------|-----------------|----------|---------|
+| GET    | `/admin/calls`                | —               | readonly | List active per-call SIP Call-IDs. |
+| POST   | `/admin/calls/:id/hangup`     | —               | operator | Force-shutdown a specific call by Call-ID. |
+| GET    | `/admin/registrations`        | —               | readonly | Snapshot of every `[[register]]` row and its current state. |
+| GET    | `/admin/log`                  | —               | readonly | Current `tracing` filter directive. |
+| PUT    | `/admin/log`                  | text directive  | admin    | Replace the filter (e.g., `siphon_ai=info,siphon_ai_bridge=debug`). Returns the previous filter. |
+| POST   | `/admin/hep/test`             | —               | admin    | Emit a probe HEP log packet. |
+| POST   | `/admin/v1/calls`             | JSON (below)    | admin    | **Originate an outbound call** (0.6.0). Returns `202 {"call_id": "..."}`; the call proceeds asynchronously. `501` when `[outbound]` is disabled. |
+| GET    | `/admin/v1/conferences`       | —               | readonly | **List conference rooms** + members (0.7.0). `501` when `[conference]` is disabled. |
+| POST   | `/admin/v1/conferences`       | JSON (opt.)     | operator | **Pre-create a room** (0.7.0). Body `{room_id?, sample_rate?}`; returns `201 {"room_id": "..."}`. |
+| DELETE | `/admin/v1/conferences/:id`   | —               | operator | **Force-end a room** (0.7.0). Every member reverts to its direct pair (`conference_left { room_closed }`). `404` if unknown. |
+| POST   | `/admin/v1/conferences/:id/participants`          | JSON | operator | **Add a call to a room** (0.7.0). Body `{call_id}`; `202` (dispatched). |
+| DELETE | `/admin/v1/conferences/:id/participants/:call_id` | —    | operator | **Remove a call from a room** (0.7.0). `202` (dispatched). |
+| GET    | `/admin/v1/parked`            | —               | readonly | **List parked calls** (0.7.0). `501` when `[park]` is disabled. |
+| POST   | `/admin/v1/calls/:id/park`    | JSON (opt.)     | operator | **Park an active call** (0.7.0). Body `{slot?}`; `202` (dispatched). `404` if no active call has that id. `501` when `[park]` is disabled. |
+| POST   | `/admin/v1/calls/:id/retrieve`| JSON (opt.)     | operator | **Retrieve a parked call** (0.7.0). Body `{ws_url?}`; `202` (dispatched). `404` unknown call, `409` if the call isn't parked. `501` when `[park]` is disabled. |
+
+### Admin auth & RBAC
+
+Define the listener and at least one token under `[admin]` (full field
+reference in `docs/CONFIG.md` `[admin]`):
+
+```toml
+[admin]
+# Dedicated listener for /admin/*. Bind to loopback (or a private
+# interface) — it is plain HTTP until native [admin].tls lands, so
+# front it with TLS termination if it must leave the host.
+listen = "127.0.0.1:9092"
+
+# One block per token. The secret is hashed (SHA-256) at load and
+# compared in constant time; it is never logged. role ∈ readonly |
+# operator | admin (roles nest: readonly ⊂ operator ⊂ admin).
+[[admin.token]]
+name  = "dashboard"          # actor label in audit logs (not a secret)
+token = "${SIPHON_ADMIN_RO}" # ${VAR} expansion works — keep secrets out of the file
+role  = "readonly"
+
+[[admin.token]]
+name  = "ops-oncall"
+token = "${SIPHON_ADMIN_OP}"
+role  = "operator"
+
+[[admin.token]]
+name  = "automation"
+token = "${SIPHON_ADMIN_ADMIN}"
+role  = "admin"
+```
+
+Roles, lowest to highest (each inherits everything below it):
+
+| Role       | Can do |
+|------------|--------|
+| `readonly` | All `GET` / list endpoints (calls, registrations, log, conferences, parked). |
+| `operator` | Everything `readonly` can, plus hangup, park / retrieve, and conference create / end / add / remove. |
+| `admin`    | Everything `operator` can, plus **billable** origination (`POST /admin/v1/calls`), `PUT /admin/log`, and `POST /admin/hep/test`. |
+
+Every request is audited: a structured log line (actor = token **name**,
+role, endpoint template, result, peer address — never the secret) and the
+`siphon_ai_admin_requests_total{endpoint, role, result}` counter
+(`result` ∈ `ok` | `unauthenticated` | `forbidden` | `not_found`).
+
+A bearer token goes on every call:
+
+```sh
+ADMIN=http://127.0.0.1:9092
+curl -s -H "Authorization: Bearer $SIPHON_ADMIN_RO" $ADMIN/admin/calls
+# missing/invalid token → 401 + WWW-Authenticate: Bearer
+# token below the endpoint's min role → 403
+```
+
+> **Upgrade note (0.10.0, breaking).** Before 0.10.0 `/admin/*` was
+> unauthenticated on the `[observability].http_listen` port. It has moved
+> to the dedicated `[admin]` listener and now requires a token. **Action
+> required:** add an `[admin]` block with at least one token, point admin
+> tooling at the new port with an `Authorization: Bearer …` header, and
+> drop any `/admin/*` allow rules from the metrics port. If you omit
+> `[admin]` entirely, `/admin/*` is **not served at all** (secure default)
+> — the daemon still starts and serves metrics/health. A reverse proxy
+> that previously added auth in front of the metrics port should move that
+> auth (or hand off to the native tokens) to the admin port.
 
 ### `POST /admin/v1/calls` — outbound origination
 
 Requires `[outbound].max_concurrent > 0` and at least one `[[gateway]]` (see
-`docs/CONFIG.md`; full guide: `docs/OUTBOUND.md`). **This endpoint places billable calls and has no built-in
-auth** — restrict access to it (bind to a private network / front with an
-authenticating reverse proxy). The `max_concurrent` cap + `rate_limit_per_sec`
-are the native guardrails.
+`docs/CONFIG.md`; full guide: `docs/OUTBOUND.md`). **This endpoint places
+billable calls** and requires an **`admin`-role** token (see
+[Admin auth & RBAC](#admin-auth--rbac)). The `max_concurrent` cap +
+`rate_limit_per_sec` are the native guardrails on top of the role gate.
 
 ```sh
-curl -X POST http://localhost:9091/admin/v1/calls -d '{
+curl -X POST -H "Authorization: Bearer $SIPHON_ADMIN_ADMIN" \
+  http://127.0.0.1:9092/admin/v1/calls -d '{
   "to": "+15558675309",
   "gateway": "twilio",
   "ws_url": "wss://my-bot.example/outbound"
@@ -363,26 +438,31 @@ finishes) or `outbound_failed` (see [Lifecycle webhooks](#lifecycle-webhooks)).
 
 ### `/admin/v1/conferences` — conference admin (0.7.0)
 
-Requires `[conference].enabled = true` (all routes `501` otherwise). Same
-no-auth posture as the originate API — keep the listener private. A room is
-N calls sharing one mixed audio room; see `docs/CONFIG.md` `[conference]`
-and the WS protocol's `conference_*` messages (`docs/PROTOCOL.md` §3.12 / §4.8).
+Requires `[conference].enabled = true` (all routes `501` otherwise). The
+list route needs `readonly`; create / end / add / remove need `operator`
+(see [Admin auth & RBAC](#admin-auth--rbac)). A room is N calls sharing one
+mixed audio room; see `docs/CONFIG.md` `[conference]` and the WS protocol's
+`conference_*` messages (`docs/PROTOCOL.md` §3.12 / §4.8).
 
 ```sh
-# Who's in which room
-curl -s http://localhost:9091/admin/v1/conferences
+ADMIN=http://127.0.0.1:9092
+# Who's in which room (readonly)
+curl -s -H "Authorization: Bearer $SIPHON_ADMIN_RO" $ADMIN/admin/v1/conferences
 # → {"count":1,"conferences":[{"room_id":"support-7","sample_rate":8000,
 #     "participants":["siphon-a","siphon-b"]}]}
 
-# Pull an active call into a room (creates it if absent)
-curl -X POST http://localhost:9091/admin/v1/conferences/support-7/participants \
+# Pull an active call into a room (creates it if absent) — operator
+curl -X POST -H "Authorization: Bearer $SIPHON_ADMIN_OP" \
+    $ADMIN/admin/v1/conferences/support-7/participants \
     -d '{"call_id":"siphon-c"}'        # → 202
 
-# Drop one call back to its private bot
-curl -X DELETE http://localhost:9091/admin/v1/conferences/support-7/participants/siphon-c  # → 202
+# Drop one call back to its private bot — operator
+curl -X DELETE -H "Authorization: Bearer $SIPHON_ADMIN_OP" \
+    $ADMIN/admin/v1/conferences/support-7/participants/siphon-c  # → 202
 
-# End the whole room (every member reverts to its direct pair)
-curl -X DELETE http://localhost:9091/admin/v1/conferences/support-7   # → 200
+# End the whole room (every member reverts to its direct pair) — operator
+curl -X DELETE -H "Authorization: Bearer $SIPHON_ADMIN_OP" \
+    $ADMIN/admin/v1/conferences/support-7   # → 200
 ```
 
 `add`/`remove` participant return **`202` (dispatched)**: the daemon signals
@@ -396,32 +476,39 @@ body omits `room_id`); `409` if the id is already live; `503` at the
 Example: bump bridge logging to debug for an incident, then revert.
 
 ```sh
-prev=$(curl -s http://localhost:9091/admin/log)
-curl -X PUT --data 'siphon_ai=info,siphon_ai_bridge=debug' \
-    http://localhost:9091/admin/log
+ADMIN=http://127.0.0.1:9092
+# GET is readonly; PUT (mutates the running filter) is admin.
+prev=$(curl -s -H "Authorization: Bearer $SIPHON_ADMIN_RO" $ADMIN/admin/log)
+curl -X PUT -H "Authorization: Bearer $SIPHON_ADMIN_ADMIN" \
+    --data 'siphon_ai=info,siphon_ai_bridge=debug' $ADMIN/admin/log
 # … reproduce the issue …
-curl -X PUT --data "$prev" http://localhost:9091/admin/log
+curl -X PUT -H "Authorization: Bearer $SIPHON_ADMIN_ADMIN" \
+    --data "$prev" $ADMIN/admin/log
 ```
 
 ### `/admin/v1/parked` — park admin (0.7.0)
 
-Requires `[park].enabled = true` (all routes `501` otherwise). Same no-auth
-posture as the other v1 admin routes — keep the listener private. Park
-shelves a call playing hold music with **no** WS session; see
-`docs/CONFIG.md` `[park]` and the WS protocol (`docs/PROTOCOL.md` §4.9).
+Requires `[park].enabled = true` (all routes `501` otherwise). The list
+route needs `readonly`; park / retrieve need `operator` (see
+[Admin auth & RBAC](#admin-auth--rbac)). Park shelves a call playing hold
+music with **no** WS session; see `docs/CONFIG.md` `[park]` and the WS
+protocol (`docs/PROTOCOL.md` §4.9).
 
 ```sh
-# What's parked, and for how long
-curl -s http://localhost:9091/admin/v1/parked
+ADMIN=http://127.0.0.1:9092
+# What's parked, and for how long (readonly)
+curl -s -H "Authorization: Bearer $SIPHON_ADMIN_RO" $ADMIN/admin/v1/parked
 # → {"count":1,"parked":[{"call_id":"siphon-a","slot":"lot-3","parked_secs":42}]}
 
-# Park an active call (slot label optional)
-curl -X POST http://localhost:9091/admin/v1/calls/siphon-a/park \
+# Park an active call (slot label optional) — operator
+curl -X POST -H "Authorization: Bearer $SIPHON_ADMIN_OP" \
+    $ADMIN/admin/v1/calls/siphon-a/park \
     -d '{"slot":"lot-3"}'        # → 202
 
 # Retrieve it onto a fresh WS session (ws_url optional — defaults to the
-# call's original bridge ws_url)
-curl -X POST http://localhost:9091/admin/v1/calls/siphon-a/retrieve \
+# call's original bridge ws_url) — operator
+curl -X POST -H "Authorization: Bearer $SIPHON_ADMIN_OP" \
+    $ADMIN/admin/v1/calls/siphon-a/retrieve \
     -d '{"ws_url":"wss://my-bot.example/retrieve"}'   # → 202
 ```
 
@@ -648,6 +735,7 @@ on the metrics crate's defaults (CLAUDE.md §7.4).
 | `siphon_ai_parked_calls_active`         | gauge     | —                                     | Currently-parked calls (0.7.0). Incremented on park, decremented on retrieve or teardown. |
 | `siphon_ai_holds_total`                 | counter   | `result=ok\|failed`                   | Bot-initiated hold/resume re-INVITEs (0.7.2 — the WS server sends `hold`/`resume`). Covers both directions. `failed` = the re-INVITE was rejected / timed out / glared, or hold was rejected (already held by the far end, tap unavailable, not configured); the call stays in its prior media state. Does **not** count far-end (peer-initiated) holds. |
 | `siphon_ai_ws_reconnects_total`         | counter   | `result=recovered\|exhausted`         | WS reconnect episodes mid-call (0.7.3 — `[bridge].ws_reconnect_enabled`). One increment per unexpected drop that entered the reconnect path. `recovered` = re-dialed the same `ws_url` within `ws_reconnect_max_secs`; `exhausted` = the window elapsed (or the call ended mid-gap) and the call tore down (`ws_disconnect`). |
+| `siphon_ai_admin_requests_total`        | counter   | `endpoint`, `role`, `result=ok\|unauthenticated\|forbidden\|not_found` | Admin API requests on the `[admin]` listener (0.10.0). `endpoint` is the bounded route template (e.g. `POST /admin/v1/calls`, ids collapsed to `:id`), `role` is the authenticated token's role (`none` for `unauthenticated`). `unauthenticated` = 401 (missing/bad token); `forbidden` = 403 (role below the endpoint minimum). Pair with the structured audit log (actor = token name) for per-request detail. |
 | `forge_rtcp_*`                          | various   | per-call (forge-side)                 | RTP/RTCP quality. See forge-media's own metric inventory. |
 | `heplify_*`                             | various   | from the HEP collector                | Only visible if you scrape heplify too. |
 


### PR DESCRIPTION
Final chunk of the native admin auth + RBAC theme. Chunks 1 (#199, auth core + `[admin]` config) and 2 (#200, authenticated listener + breaking `/admin/*` move) are merged; this chunk is docs + tests + release.

## What's here

**Docs**
- `docs/DEPLOY.md` — Admin API section rewritten: `/admin/*` now lives only on the `[admin]` listener; new **Min role** column; an **Admin auth & RBAC** subsection (`[admin]` config, role table, audit log + metric); every curl example carries the admin port + `Authorization: Bearer`; breaking **upgrade note** with migration steps. New `siphon_ai_admin_requests_total` row in the metrics table.
- `docs/CONFIG.md` — new `[admin]` section (listen + `[[admin.token]]` fields, load-time validation rules); `[observability].http_listen` note updated (no longer serves `/admin/*` → 404); top-level layout list updated.

**Tests**
- `admin_role_tiers_gate_by_minimum_role` — exercises the full nested-role matrix over real endpoints: readonly→403 / operator→pass / admin→pass on an operator route, and readonly+operator→403 / admin→pass on the billable originate route. Rounds out the chunk-2 401/403 gate tests.

**Release**
- `CHANGELOG.md` 0.10.0 entry (Added: auth + RBAC, audit + metric; Changed: **BREAKING** `/admin/*` moved off the metrics listener + migration).
- Workspace version `0.9.5` → `0.10.0`.

## Verification
- `cargo fmt --all`, `cargo clippy --workspace --all-targets -D warnings` clean.
- `cargo test --workspace` green (telemetry 58 incl. the new test).

`[admin].tls` remains a tracked follow-up; the listener is plain HTTP (loopback default + non-loopback warning) for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)