### PR TITLE
docs: webhook/CDR delivery trust+durability docs + CHANGELOG + 0.11.0 (durability chunk 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-06-19
+
+### Added
+
+- **Webhook & CDR delivery trust + durability.** The shared outbound HTTP
+  transport (lifecycle webhooks **and** the CDR webhook) gains, all
+  additively — bodies are unchanged, so the webhook and CDR schema
+  `version`s are **not** bumped:
+  - **Idempotency.** Every delivery carries `X-SiphonAI-Event-Id` (+ an
+    `Idempotency-Key` alias) — a UUIDv4 stable across retries and any spool
+    replay. Delivery is at-least-once; receivers dedupe on this id.
+  - **Authenticity (opt-in `secret`).** When `[webhooks].secret` /
+    `[cdr.webhook].secret` is set, deliveries carry
+    `X-SiphonAI-Signature: t=<unix>,v1=<hex>` — HMAC-SHA256 over
+    `"<unix>.<raw-body>"`. The timestamp is inside the signed string, giving
+    the receiver replay protection from a freshness window. The secret is
+    `${VAR}`-expanded and never logged.
+  - **Durability (opt-in `spool_dir`).** When `[webhooks].spool_dir` /
+    `[cdr.webhook].spool_dir` is set, a delivery that exhausts the in-memory
+    retry budget is persisted to disk and re-attempted by a background
+    worker that **resumes after a daemon restart** (spool-on-failure: the
+    happy path stays zero-disk-I/O). Oldest-first with capped backoff; a
+    `4xx` or poison entry is eventually discarded; a per-sink file cap bounds
+    disk (dropping the newest, never evicting an already-persisted entry).
+    The directory is created + write-probed at startup, so a bad path fails
+    the daemon loudly (CLAUDE.md §4.6). Unset ⇒ today's best-effort behavior,
+    unchanged.
+  - **Delivery metrics.** `siphon_ai_webhook_deliveries_total{sink,result}`,
+    `siphon_ai_webhook_delivery_attempts_total{sink,outcome}`,
+    `siphon_ai_webhook_spool_depth{sink}` (gauge), and
+    `siphon_ai_webhook_delivery_seconds{sink}` (histogram). `sink` ∈
+    `lifecycle` | `cdr`.
+
+  See `docs/DEPLOY.md` → *Webhook delivery: signing, idempotency, durability*
+  (incl. a receiver verification snippet) and the `[webhooks]` /
+  `[cdr.webhook]` config reference.
+
 ## [0.10.0] - 2026-06-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2936,7 +2936,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "base64",
  "bytes",
@@ -2957,7 +2957,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2974,7 +2974,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "regex",
  "serde",
@@ -2992,7 +2992,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3033,7 +3033,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "hmac",
  "http-body-util",
@@ -3053,7 +3053,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3077,7 +3077,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "thiserror 1.0.69",
  "tokio",
@@ -3086,7 +3086,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "regex",
  "serde",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3106,7 +3106,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3129,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -3147,7 +3147,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3170,7 +3170,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -530,6 +530,8 @@ path    = "/var/log/siphon-ai/cdr.jsonl"
 enabled    = true
 url        = "https://billing.example.com/cdr"
 auth_header = "Bearer ${CDR_TOKEN}"
+secret     = "${CDR_WEBHOOK_SECRET}"          # optional HMAC signing (0.11.0)
+spool_dir  = "/var/lib/siphon-ai/spool/cdr"   # optional durable retry (0.11.0)
 retry_max  = 3
 timeout_ms = 5000
 ```
@@ -537,6 +539,14 @@ timeout_ms = 5000
 Both sinks can run simultaneously. Master `enabled = false` silences both
 regardless of sub-block state. Adding fields to the CDR schema bumps the
 `version` field; consumers should treat new keys as additive.
+
+The CDR webhook shares the delivery transport with `[webhooks]`, so
+`secret` (HMAC `X-SiphonAI-Signature`), `spool_dir` (durable retry), the
+`X-SiphonAI-Event-Id` idempotency header, and the `siphon_ai_webhook_*`
+delivery metrics all behave identically here (0.11.0). The CDR JSON body is
+unchanged — these are transport-layer headers/behavior, so the CDR schema
+`version` is **not** bumped. See `docs/DEPLOY.md` → *Webhook delivery:
+signing, idempotency, durability*.
 
 ## `[observability]`
 
@@ -588,9 +598,15 @@ fail the daemon at startup rather than at first request.
 | `enabled`     | bool     | `false`                | |
 | `url`         | URL      | required if on         | POST target. |
 | `auth_header` | string   | unset                  | Sent verbatim. `${VAR}` expansion works. |
+| `secret`      | string   | unset                  | HMAC-SHA256 signing secret (0.11.0). When set, every POST carries `X-SiphonAI-Signature` for authenticity + replay protection. `${VAR}` expansion works; never logged. See `docs/DEPLOY.md` → *Webhook delivery: signing, idempotency, durability*. |
+| `spool_dir`   | path     | unset                  | Durable retry spool directory (0.11.0). When set, a delivery that exhausts `retry_max` is persisted here and re-delivered by a background worker that survives restarts. Unset ⇒ best-effort (dropped after `retry_max`). Created + write-probed at startup (fail-loud). `${VAR}` expansion works. |
 | `events`      | string[] | all                    | Allowlist. Valid today: `"call_start"`, `"call_end"`, `"registration_state_changed"`, `"outbound_initiated"`, `"outbound_answered"`, `"outbound_failed"`, `"conference_created"`, `"conference_ended"`, `"call_parked"`, `"call_retrieved"`, `"park_timeout"`. |
-| `retry_max`   | integer  | `3`                    | |
+| `retry_max`   | integer  | `3`                    | In-memory retries before spooling (or dropping). |
 | `timeout_ms`  | integer  | `5000`                 | |
+
+Every delivery — webhook **and** CDR — also carries `X-SiphonAI-Event-Id`
+(+ an `Idempotency-Key` alias): a stable id, reused across retries and any
+spool replay, so a receiver can dedupe an at-least-once redelivery (0.11.0).
 
 ## `[hep]`
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -630,12 +630,17 @@ where CDRs cover bridged calls only.
 
 The webhook sink delivers the same JSON to `[cdr.webhook].url` with
 `Content-Type: application/json`. Retries on non-2xx up to
-`[cdr.webhook].retry_max` times with exponential backoff.
+`[cdr.webhook].retry_max` times with exponential backoff, then drops —
+unless `[cdr.webhook].spool_dir` is set, which makes delivery durable
+across restarts. Set `[cdr.webhook].secret` to sign each POST. See
+[Webhook delivery: signing, idempotency, durability](#webhook-delivery-signing-idempotency-durability).
 
 ## Lifecycle webhooks
 
-Off-band events (NOT the per-call WS bridge). Same retry semantics as the
-CDR webhook. Event types:
+Off-band events (NOT the per-call WS bridge). Same delivery transport as the
+CDR webhook — see [Webhook delivery: signing, idempotency,
+durability](#webhook-delivery-signing-idempotency-durability) for signing,
+the idempotency id, and the durable spool. Event types:
 
 | `type`                          | When                                             |
 |---------------------------------|--------------------------------------------------|
@@ -681,6 +686,86 @@ or (on timeout) `park_timeout`. A call may park/retrieve repeatedly.
 { "type": "park_timeout", "version": 1, "call_id": "siphon-…",
   "timestamp": "2026-06-14T10:05:00Z", "action": "hangup" }
 ```
+
+## Webhook delivery: signing, idempotency, durability
+
+Lifecycle webhooks (`[webhooks]`) and the CDR webhook (`[cdr.webhook]`)
+share one delivery transport, so the following applies identically to both
+(0.11.0). All of it is **additive** — the JSON bodies are unchanged
+(webhook + CDR schema versions are **not** bumped); these are
+transport-layer headers and behavior.
+
+### Headers on every delivery
+
+| Header | When | Purpose |
+|--------|------|---------|
+| `X-SiphonAI-Event-Id` | always | A UUIDv4 unique to one logical delivery, **stable across retries and any spool replay**. |
+| `Idempotency-Key` | always | Alias of `X-SiphonAI-Event-Id` for receivers/middleware that key on the conventional name. |
+| `X-SiphonAI-Signature` | when `secret` set | `t=<unix>,v1=<hex>` — HMAC-SHA256 over `"<unix>.<raw-body>"`. |
+
+**Idempotency.** Delivery is *at-least-once* (a retry or a post-restart
+spool replay can redeliver a body the receiver already processed but failed
+to ACK). Dedupe on `X-SiphonAI-Event-Id` — persist seen ids and skip
+duplicates.
+
+**Signature verification.** Set `secret` to enable
+`X-SiphonAI-Signature`. The timestamp is inside the signed string, so a
+captured POST can't be replayed outside your freshness window. To verify:
+split `t=`/`v1=`, recompute the HMAC over `"<t>.<raw-request-body>"` with
+your secret, compare in constant time, and reject if `t` is too old.
+
+```python
+# Flask receiver — verify a SiphonAI webhook/CDR POST.
+import hmac, hashlib, time
+from flask import request, abort
+
+SECRET = b"whsec_..."          # same value as [webhooks].secret
+MAX_SKEW = 300                 # seconds
+
+def verify(req):
+    sig = req.headers.get("X-SiphonAI-Signature", "")
+    parts = dict(p.split("=", 1) for p in sig.split(",") if "=" in p)
+    t, v1 = parts.get("t"), parts.get("v1")
+    if not t or not v1 or abs(time.time() - int(t)) > MAX_SKEW:
+        abort(401)                                   # missing / stale
+    signed = f"{t}.".encode() + req.get_data()       # raw body bytes
+    expected = hmac.new(SECRET, signed, hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(expected, v1):
+        abort(401)                                   # bad signature
+    return req.headers["X-SiphonAI-Event-Id"]        # dedupe on this
+```
+
+> Verify against the **raw request body bytes**, before any JSON
+> re-serialization — SiphonAI signs the exact bytes it sends.
+
+### Durability (spool)
+
+Without `spool_dir`, delivery is best-effort: after `retry_max` in-memory
+retries (exponential backoff) a failed delivery is logged and dropped.
+
+Set `spool_dir` to make delivery durable. A delivery that exhausts the
+in-memory budget is written to that directory and re-attempted by a
+background worker; the worker resumes pending entries after a daemon
+**restart**. The happy path is unchanged (no disk I/O — entries are only
+written on failure). Entries are retried oldest-first with capped backoff;
+a `4xx` rejection or a poison entry that never succeeds is eventually
+discarded (with a metric). The directory is created and write-probed at
+startup, so a bad path fails the daemon loudly rather than at the first
+failed delivery. Bound disk with the per-sink file cap (a full spool drops
+the newest delivery rather than evicting an already-persisted one).
+
+Point the file sink (`[cdr.file]`) at the same record stream if you want a
+second, append-only durable copy of CDRs independent of HTTP delivery.
+
+### Delivery health
+
+Watch `siphon_ai_webhook_deliveries_total{sink,result}` (terminal
+outcomes), `siphon_ai_webhook_delivery_attempts_total{sink,outcome}` (per
+HTTP attempt), `siphon_ai_webhook_spool_depth{sink}` (a rising value means
+deliveries are failing and backing up on disk), and
+`siphon_ai_webhook_delivery_seconds{sink}` (latency incl. spool dwell). See
+the [Metrics](#metrics) table. Per-delivery detail lives in the logs,
+keyed by `event_id` (the audit-friendly id, not the secret).
 
 ## HEP / Homer
 
@@ -736,6 +821,10 @@ on the metrics crate's defaults (CLAUDE.md §7.4).
 | `siphon_ai_holds_total`                 | counter   | `result=ok\|failed`                   | Bot-initiated hold/resume re-INVITEs (0.7.2 — the WS server sends `hold`/`resume`). Covers both directions. `failed` = the re-INVITE was rejected / timed out / glared, or hold was rejected (already held by the far end, tap unavailable, not configured); the call stays in its prior media state. Does **not** count far-end (peer-initiated) holds. |
 | `siphon_ai_ws_reconnects_total`         | counter   | `result=recovered\|exhausted`         | WS reconnect episodes mid-call (0.7.3 — `[bridge].ws_reconnect_enabled`). One increment per unexpected drop that entered the reconnect path. `recovered` = re-dialed the same `ws_url` within `ws_reconnect_max_secs`; `exhausted` = the window elapsed (or the call ended mid-gap) and the call tore down (`ws_disconnect`). |
 | `siphon_ai_admin_requests_total`        | counter   | `endpoint`, `role`, `result=ok\|unauthenticated\|forbidden\|not_found` | Admin API requests on the `[admin]` listener (0.10.0). `endpoint` is the bounded route template (e.g. `POST /admin/v1/calls`, ids collapsed to `:id`), `role` is the authenticated token's role (`none` for `unauthenticated`). `unauthenticated` = 401 (missing/bad token); `forbidden` = 403 (role below the endpoint minimum). Pair with the structured audit log (actor = token name) for per-request detail. |
+| `siphon_ai_webhook_deliveries_total`    | counter   | `sink=lifecycle\|cdr`, `result=delivered\|spooled\|rejected\|dropped` | Terminal webhook/CDR delivery outcomes (0.11.0). One increment per logical delivery. `delivered` = 2xx; `spooled` = persisted to the durable spool after the in-memory budget; `rejected` = non-retryable 4xx; `dropped` = budget (or spool) exhausted, or payload not serializable. |
+| `siphon_ai_webhook_delivery_attempts_total` | counter | `sink`, `outcome=ok\|transient\|error\|rejected` | Individual HTTP delivery attempts (0.11.0) — a retried delivery ticks several times. `transient` = retryable 5xx/408/429; `error` = connect/timeout; `rejected` = non-retryable 4xx. Divide by `siphon_ai_webhook_deliveries_total` for attempts-per-delivery. |
+| `siphon_ai_webhook_spool_depth`         | gauge     | `sink`                                | Deliveries waiting in the durable spool (0.11.0, set when `spool_dir` is configured). Sampled by the drain worker each pass (self-correcting across restarts). Healthy = 0; a rising value means deliveries are failing and backing up on disk. |
+| `siphon_ai_webhook_delivery_seconds`    | histogram | `sink`                                | Delivery latency in seconds, accepted → 2xx (0.11.0). Includes spool dwell, so a slow/recovered receiver shows as a fat tail. Buckets 5 ms – 30 s. |
 | `forge_rtcp_*`                          | various   | per-call (forge-side)                 | RTP/RTCP quality. See forge-media's own metric inventory. |
 | `heplify_*`                             | various   | from the HEP collector                | Only visible if you scrape heplify too. |
 


### PR DESCRIPTION
Final chunk of the **webhook/CDR delivery trust + durability** theme. Chunks 1 (#202, signing + idempotency + metrics) and 2 (#203, durable spool) are merged; this chunk is **docs + release** (no code change).

## What's here

**Docs**
- `docs/CONFIG.md` — `[webhooks]` table gains `secret` + `spool_dir` rows + the idempotency-header note; `[cdr.webhook]` example + note (shares the transport; **no CDR schema version bump**).
- `docs/DEPLOY.md` — new **"Webhook delivery: signing, idempotency, durability"** section:
  - per-delivery headers table (`X-SiphonAI-Event-Id` / `Idempotency-Key` / `X-SiphonAI-Signature`)
  - at-least-once dedupe guidance
  - a **Flask receiver signature-verify snippet** (verify over raw body bytes, constant-time, freshness window)
  - the spool/durability model + restart behavior
  - delivery-health metrics pointers
  - CDR consumers + Lifecycle webhooks notes now cross-link it
  - four new metrics in the metrics table: `deliveries_total`, `delivery_attempts_total`, `spool_depth`, `delivery_seconds`.

**Release**
- `CHANGELOG.md` 0.11.0 entry (idempotency id, opt-in HMAC `secret`, opt-in durable `spool_dir`, delivery metrics — all additive, no schema bump).
- Workspace version `0.10.0` → `0.11.0`.

## Verification
- `cargo build --workspace` clean; fmt clean. (No Rust changed in this chunk; the transport + tests landed in #202/#203.)

After merge: tag `v0.11.0` + GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)