### PR TITLE
feat: siphon-ai check subcommand + optional-subcommand CLI (config-cli chunk 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2927,6 +2927,7 @@ dependencies = [
  "siphon-ai-stir-shaken",
  "siphon-ai-telemetry",
  "siphon-ai-webhooks",
+ "tempfile",
  "tokio",
  "tokio-rustls",
  "tracing",

--- a/bins/siphon-ai/Cargo.toml
+++ b/bins/siphon-ai/Cargo.toml
@@ -82,3 +82,4 @@ forge-rtp.workspace    = true
 
 [dev-dependencies]
 tokio        = { workspace = true, features = ["macros", "rt", "time", "net", "sync"] }
+tempfile     = "3"

--- a/bins/siphon-ai/src/main.rs
+++ b/bins/siphon-ai/src/main.rs
@@ -9,11 +9,12 @@
 //! The actual wiring lives in [`runtime::Runtime`]; this module is
 //! the thin shell that bridges process startup into a `Runtime`.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result};
-use clap::Parser;
+use anyhow::{anyhow, Context, Result};
+use clap::{Parser, Subcommand};
 use siphon_ai::Runtime;
+use siphon_ai_config::Config;
 use siphon_ai_telemetry::LogFilterHandle;
 use tracing::info;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
@@ -21,15 +22,38 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilte
 #[derive(Parser, Debug)]
 #[command(name = "siphon-ai", version, about = "SIP-to-WebSocket media bridge")]
 struct Cli {
-    /// Path to the TOML configuration file.
-    #[arg(long, short, env = "SIPHON_AI_CONFIG")]
-    config: PathBuf,
+    /// Path to the TOML configuration file. Required to run the
+    /// daemon and by every subcommand. `global` so it can appear
+    /// before or after the subcommand — `siphon-ai --config X check`
+    /// and `siphon-ai check --config X` both work.
+    #[arg(long, short, env = "SIPHON_AI_CONFIG", global = true)]
+    config: Option<PathBuf>,
 
     /// Override the tracing filter (`siphon_ai=debug,siphon=info`).
     /// Defaults to `RUST_LOG` if set, or the built-in default
-    /// otherwise.
-    #[arg(long, env = "SIPHON_AI_LOG")]
+    /// otherwise. Only affects running the daemon.
+    #[arg(long, env = "SIPHON_AI_LOG", global = true)]
     log: Option<String>,
+
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// Validate and compile the config file, then exit — without
+    /// starting the daemon or binding any sockets. Exit code 0 if the
+    /// config is valid, 1 otherwise. Safe as a pre-deploy / CI
+    /// preflight (e.g. before `systemctl reload`).
+    Check,
+}
+
+/// The config path, from `--config` or `$SIPHON_AI_CONFIG`. A clap
+/// `global` arg can't be `required`, so enforce presence here.
+fn config_path(cli: &Cli) -> Result<PathBuf> {
+    cli.config
+        .clone()
+        .ok_or_else(|| anyhow!("--config <PATH> is required (or set SIPHON_AI_CONFIG)"))
 }
 
 #[tokio::main]
@@ -48,11 +72,22 @@ async fn main() -> Result<()> {
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
     let cli = Cli::parse();
+
+    // Read-only subcommands dispatch here and exit — no tracing
+    // subscriber, no socket binding, no runtime.
+    if let Some(command) = &cli.command {
+        match command {
+            Command::Check => run_check(&config_path(&cli)?),
+        }
+    }
+
+    // No subcommand → run the daemon.
+    let config = config_path(&cli)?;
     let log_filter = init_tracing(cli.log.as_deref());
 
-    info!(config = %cli.config.display(), "loading configuration");
-    let config = siphon_ai_config::load_from_path(&cli.config)
-        .with_context(|| format!("load config {}", cli.config.display()))?;
+    info!(config = %config.display(), "loading configuration");
+    let config = siphon_ai_config::load_from_path(&config)
+        .with_context(|| format!("load config {}", config.display()))?;
 
     info!(
         node_id = %config.node.id,
@@ -67,6 +102,122 @@ async fn main() -> Result<()> {
         .context("runtime build failed")?;
 
     runtime.run(shutdown_signal()).await
+}
+
+/// `siphon-ai check` — load + compile the config and exit. Prints a
+/// one-screen summary on success (exit 0); prints the validation error
+/// to stderr and exits 1 on failure. Never starts the daemon.
+fn run_check(path: &Path) -> ! {
+    match siphon_ai_config::load_from_path(path) {
+        Ok(config) => {
+            print_check_summary(path, &config);
+            std::process::exit(0);
+        }
+        Err(e) => {
+            eprintln!("config INVALID: {}", path.display());
+            eprintln!("  {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// One-screen summary of a valid compiled config — what the daemon
+/// would run with. A missing default route warns (matching the
+/// daemon's startup warning) but does not fail the check.
+fn print_check_summary(path: &Path, config: &Config) {
+    use std::fmt::Write as _;
+
+    let transports = config
+        .sip
+        .transports
+        .iter()
+        .map(|t| match t {
+            siphon_ai_config::SipTransport::Udp => "udp",
+            siphon_ai_config::SipTransport::Tcp => "tcp",
+            siphon_ai_config::SipTransport::Tls => "tls",
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    // Optional subsystems that are switched on.
+    let mut enabled: Vec<String> = Vec::new();
+    if config.outbound.max_concurrent > 0 && !config.outbound.gateways.is_empty() {
+        enabled.push(format!(
+            "outbound({} gateway(s))",
+            config.outbound.gateways.len()
+        ));
+    }
+    if !matches!(config.recording.mode, siphon_ai_config::RecordingMode::Off) {
+        enabled.push("recording".into());
+    }
+    if config.cdr.enabled {
+        let mut sinks = Vec::new();
+        if config.cdr.file.is_some() {
+            sinks.push("file");
+        }
+        if config.cdr.webhook.is_some() {
+            sinks.push("webhook");
+        }
+        enabled.push(format!("cdr({})", sinks.join("+")));
+    }
+    if config.webhooks.enabled {
+        enabled.push("webhooks".into());
+    }
+    if config.conference.enabled {
+        enabled.push("conference".into());
+    }
+    if config.park.enabled {
+        enabled.push("park".into());
+    }
+    if config.hep.enabled {
+        enabled.push("hep".into());
+    }
+    if config.admin.is_some() {
+        enabled.push("admin".into());
+    }
+    if config.security.stir_shaken.enabled {
+        enabled.push("stir_shaken".into());
+    }
+
+    let mut out = String::new();
+    let _ = writeln!(out, "config OK: {}", path.display());
+    let _ = writeln!(out, "  node id:       {}", config.node.id);
+    let _ = writeln!(
+        out,
+        "  sip listen:    {} [{}]",
+        config.sip.listen_addr, transports
+    );
+    let _ = writeln!(out, "  public addr:   {}", config.node.public_address);
+    let default = if config.routes.has_default() {
+        "yes"
+    } else {
+        "NO — add a final `any = true` route"
+    };
+    let _ = writeln!(
+        out,
+        "  routes:        {} (default route: {default})",
+        config.routes.len()
+    );
+    let _ = writeln!(
+        out,
+        "  registrations: {}    trunks: {}",
+        config.registrations.len(),
+        config.trunks.len()
+    );
+    let _ = writeln!(
+        out,
+        "  enabled:       {}",
+        if enabled.is_empty() {
+            "(none)".to_string()
+        } else {
+            enabled.join(", ")
+        }
+    );
+    print!("{out}");
+
+    if !config.routes.has_default() {
+        eprintln!("warning: no default route (`any = true`) — calls matching no route get SIP 404");
+    }
 }
 
 /// Initialise the global tracing subscriber and return a reload

--- a/bins/siphon-ai/tests/cli.rs
+++ b/bins/siphon-ai/tests/cli.rs
@@ -1,0 +1,140 @@
+//! CLI integration tests for the `siphon-ai check` subcommand (config
+//! CLI chunk 1). Drives the built binary as a subprocess over fixture
+//! TOMLs and asserts on exit code + stdout/stderr.
+//!
+//! `CARGO_BIN_EXE_siphon-ai` is set by Cargo for integration tests and
+//! points at the freshly-built daemon binary.
+
+use std::io::Write;
+use std::process::Command;
+
+use tempfile::NamedTempFile;
+
+const BIN: &str = env!("CARGO_BIN_EXE_siphon-ai");
+
+const VALID: &str = r#"
+[node]
+id = "cli-test"
+[sip]
+listen = "127.0.0.1:5060"
+[bridge]
+ws_url = "wss://example/ws"
+[[route]]
+name = "default"
+[route.match]
+any = true
+"#;
+
+/// A config with no final `any = true` route — valid, but the daemon
+/// (and `check`) warns about it.
+const NO_DEFAULT_ROUTE: &str = r#"
+[node]
+id = "cli-test"
+[sip]
+listen = "127.0.0.1:5060"
+[bridge]
+ws_url = "wss://example/ws"
+[[route]]
+name = "only"
+[route.match]
+to_user = "1000"
+"#;
+
+/// An unparseable `[sip].listen` — fails at compile time.
+const INVALID: &str = r#"
+[sip]
+listen = "not-a-socket-addr"
+[[route]]
+name = "default"
+[route.match]
+any = true
+"#;
+
+fn write_cfg(body: &str) -> NamedTempFile {
+    let mut f = NamedTempFile::new().expect("temp file");
+    f.write_all(body.as_bytes()).expect("write config");
+    f
+}
+
+#[test]
+fn check_valid_config_exits_zero_with_summary() {
+    let cfg = write_cfg(VALID);
+    let out = Command::new(BIN)
+        .arg("check")
+        .arg("--config")
+        .arg(cfg.path())
+        .output()
+        .expect("run check");
+    assert!(
+        out.status.success(),
+        "expected exit 0; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("config OK:"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("node id:       cli-test"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("default route: yes"), "stdout: {stdout}");
+}
+
+#[test]
+fn check_invalid_config_exits_one_with_error() {
+    let cfg = write_cfg(INVALID);
+    let out = Command::new(BIN)
+        .args(["check", "--config"])
+        .arg(cfg.path())
+        .output()
+        .expect("run check");
+    assert_eq!(out.status.code(), Some(1), "expected exit 1");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("config INVALID:"), "stderr: {stderr}");
+    // The underlying compile error message is surfaced.
+    assert!(stderr.contains("listen"), "stderr: {stderr}");
+}
+
+#[test]
+fn check_config_flag_works_before_or_after_subcommand() {
+    let cfg = write_cfg(VALID);
+    let path = cfg.path().to_str().unwrap();
+    for args in [
+        vec!["check", "--config", path],
+        vec!["--config", path, "check"],
+    ] {
+        let out = Command::new(BIN).args(&args).output().expect("run check");
+        assert!(
+            out.status.success(),
+            "args {args:?} expected exit 0; stderr: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+}
+
+#[test]
+fn check_missing_config_errors() {
+    let out = Command::new(BIN).arg("check").output().expect("run check");
+    assert_eq!(out.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&out.stderr).contains("--config"));
+}
+
+#[test]
+fn check_warns_on_missing_default_route_but_exits_zero() {
+    let cfg = write_cfg(NO_DEFAULT_ROUTE);
+    let out = Command::new(BIN)
+        .arg("check")
+        .arg("--config")
+        .arg(cfg.path())
+        .output()
+        .expect("run check");
+    assert!(
+        out.status.success(),
+        "a missing default route is a warning, not an error"
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("default route: NO"), "stdout: {stdout}");
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("no default route"),
+        "expected a default-route warning on stderr"
+    );
+}

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -69,7 +69,7 @@ administrator; use the anchors that authority publishes.
    ```sh
    openssl crl2pkcs7 -nocrl -certfile /etc/siphon-ai/sti-pa-roots.pem \
      | openssl pkcs7 -print_certs -noout      # lists each subject — sanity check
-   siphon-ai --config /etc/siphon-ai/config.toml --check   # fails loud on a bad bundle
+   siphon-ai check --config /etc/siphon-ai/config.toml   # fails loud on a bad bundle
    ```
 
 ### Keeping it current

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -46,6 +46,9 @@ pub use raw::{
     RawMedia, RawNode, RawObservability, RawOutbound, RawPark, RawRegister, RawSip, RawSipTls,
     RawTrunk, RawWebhooks,
 };
+// Re-exported so the daemon binary's `check`/`print-config` can read
+// `Config.recording.mode` without a direct dep on the recording crate.
+pub use siphon_ai_recording::RecordingMode;
 
 /// Top-level error type. Loaders surface this; consumers match on
 /// the underlying variants when they need to discriminate.

--- a/docs/DESIGN_CONFIG_CLI.md
+++ b/docs/DESIGN_CONFIG_CLI.md
@@ -1,0 +1,191 @@
+# Design: config CLI — check, render, route-test (+ reload?)
+
+Status: **DRAFT — decisions pending** (this note + an AskUserQuestion lock
+the forks, then chunked PRs, same cadence as admin-auth → v0.10.0 and
+webhook-durability → v0.11.0).
+
+Theme: P1 from the post-delivery-plan list — *"Config operations are
+restart-heavy and missing a real validation CLI. Add `siphon-ai check
+--config`, rendered config output, route-test tooling, and eventually safe
+reload for routes/gateways/webhooks."*
+
+---
+
+## 1. The gap today
+
+The daemon has one job and one shape: `siphon-ai --config X` loads + compiles
+the TOML and **runs**. There is no way to:
+
+- **Validate a config without starting the daemon.** Operators (and CI, and
+  Ansible/Helm preflight) can't check a file before a deploy. Worse,
+  `contrib/README.md:72` documents `siphon-ai --config … --check` — a flag
+  that **doesn't exist**, so the documented preflight silently does nothing
+  (it's parsed as an unknown arg and clap errors, or is ignored).
+- **See the *effective* config.** Config compiles globals + per-route
+  overrides + env-expanded `${VAR}`s into a `Config`; an operator can't see
+  what their file actually resolved to (which `${VAR}` won the merge, what a
+  route inherits vs overrides).
+- **Test routing.** The dialplan is order-sensitive first-match-wins
+  (`RouteSet::find_match`); there's no way to ask "given a call from X to Y
+  on trunk Z, which route wins and what bridge config does it get?" short of
+  placing a real call.
+- **Reload.** Any change needs a full process restart. `SIGHUP` today only
+  hot-swaps the SIP/TLS cert (`spawn_sighup_handler`); routes/gateways/
+  webhooks changes require a restart, dropping every in-flight call.
+
+The good news: validation is **already a pure function** —
+`siphon_ai_config::load_from_path(path) -> Result<Config, LoadError>` does
+read → `${VAR}` expand → serde → `compile()` (all validation, CLAUDE.md
+§4.6). `check` is mostly "call that and report"; `print-config` and
+`route-test` are renderers over the resulting `Config`.
+
+## 2. Goals / non-goals
+
+**Goals**
+1. **`check`** — validate + compile a config file and exit non-zero on any
+   error, with a concise OK summary on success. The CI/preflight primitive.
+   Fixes the phantom `--check` in `contrib/README.md`.
+2. **`print-config`** — render the *effective* compiled config (post-merge,
+   post-`${VAR}`), **secrets redacted**, so an operator can see what their
+   file resolved to.
+3. **`route-test`** — given synthetic call attributes (from/to/RURI/
+   register_source/headers), report which route wins (first-match-wins) and
+   the effective merged bridge/media/security/recording config for it.
+
+**Non-goals (this theme — see §6 reload decision)**
+- A config *server* / dynamic API. These are CLI subcommands of the existing
+  binary.
+- Changing the config schema. This theme only *reads* config.
+- Hot reload of socket-binding sections (`[sip].listen`, `[observability]`,
+  `[admin].listen`) — those inherently need a restart.
+
+## 3. Design
+
+### 3.1 CLI shape (decision 1)
+
+The binary gains optional subcommands; **no subcommand = run the daemon**, so
+`siphon-ai --config X` (systemd unit, every existing invocation) is
+unchanged. `--config` stays a shared top-level arg.
+
+```
+siphon-ai --config X                       # run the daemon (today's behavior)
+siphon-ai check        --config X          # validate + compile, exit 0/1
+siphon-ai print-config --config X [--show-secrets] [--format text|json]
+siphon-ai route-test   --config X --to 1000 [--from …] [--ruri-user …]
+                                           [--register-source trunk] [-H 'X-K: v']…
+```
+
+`check` / `print-config` / `route-test` are read-only, never bind a socket,
+and exit when done. `--log` stays run-only (ignored by the tooling
+subcommands). Alternative considered — flat flags (`--check`,
+`--print-config`, `--route-test-*`) — rejected: route-test alone needs ~6
+inputs and the flag soup doesn't extend (see decision 1 in §6).
+
+### 3.2 `check`
+
+Calls `load_from_path`. On `Err(LoadError)` → print the error (the existing
+`thiserror` messages are already operator-grade — bad listen, unknown role,
+missing register_source, invalid regex, …) to stderr and **exit 1**. On
+`Ok(Config)` → print a one-screen summary (node id, sip listen + transports,
+route count + whether a default route exists, which optional subsystems are
+enabled: outbound/conference/park/recording/cdr/webhooks/hep/admin/
+stir_shaken) and **exit 0**. A missing default route prints a warning
+(matches the daemon's startup `has_default()` warning) but still exits 0.
+
+### 3.3 `print-config` (rendered effective config)
+
+A bespoke text renderer that walks the compiled `Config` and prints the
+effective values — *not* a TOML round-trip (the compiled graph holds
+`SocketAddr`, compiled `Regex`, hashed admin tokens, etc. that don't
+round-trip). **Secrets are redacted by default**: any `auth_header`,
+`secret`, `password`, `capture_password`, gateway credential, or admin token
+renders as `<redacted>` when set / `<unset>` when absent. `--show-secrets`
+opts out (for local debugging). `--format json` is a follow-up nicety; text
+is the default.
+
+### 3.4 `route-test`
+
+Builds a `CallInfo` from CLI flags (defaults: `register_source=trunk`, empty
+header set; `--to`/`--from`/`--ruri-user`/`--ruri-host`/`-H key:val` set the
+rest), runs `RouteSet::find_match`, and prints the matched route's `name` (or
+"no match → SIP 404") plus its effective merged bridge/media/security/
+recording config (globals + the route's overrides). This makes the
+order-sensitive first-match-wins dialplan testable offline and in CI.
+
+## 4. Redaction set (locked default)
+
+Redacted in `print-config` unless `--show-secrets`:
+`[webhooks].auth_header` / `.secret`, `[cdr.webhook].auth_header` /
+`.secret`, `[[register]].password`, `[hep].capture_password`,
+`[[gateway]]` credentials, `[[admin.token]].token` (already stored hashed —
+shown as `<hashed>`). File *paths* (TLS key, trust anchors, MOH file,
+recording dir) are not secrets and render verbatim.
+
+## 5. Observability / tests
+
+These are CLI tools, not daemon paths, so no metrics. Tests: a
+`bins/siphon-ai/tests/cli.rs` integration test drives the built binary over
+fixture TOMLs (valid → exit 0 + summary; invalid → exit 1 + error on stderr;
+`route-test` matches the expected route for representative inputs;
+`print-config` redacts a secret). Reuse `bins/siphon-ai/tests/fixtures`.
+
+## 6. Decisions — LOCKED (2026-06-19)
+
+1. **CLI shape = optional subcommands**, daemon as the no-subcommand default.
+   `siphon-ai --config X` still runs the daemon (systemd + every existing
+   invocation unchanged); `check` / `print-config` / `route-test` are
+   explicit subcommands. `contrib/README.md`'s phantom `--check` flag becomes
+   the `check` subcommand.
+2. **Reload is IN this theme** (its own chunk), not deferred. `SIGHUP`
+   re-reads the config and hot-applies the reload-safe sections; see §6a.
+
+(Redaction-by-default, daemon-default-run back-compat, text output, and the
+read-only/no-schema-change scope for the *tooling* subcommands are defaults.)
+
+## 6a. Reload design (chunk 3)
+
+Extends the existing `spawn_sighup_handler` (which today only hot-swaps the
+SIP/TLS cert). On `SIGHUP` (= `systemctl reload siphon-ai`) the daemon
+re-reads + recompiles the **same `--config` path**:
+
+- **Fail-safe.** A reload that fails to load/compile is *not applied* — the
+  running config stays live, the error is logged, and a metric ticks. A bad
+  edit can never take down a running daemon. (This is why `check` matters as
+  the pre-reload preflight.)
+- **Reload-safe sections, hot-applied atomically** behind a swappable handle
+  (e.g. `arc_swap::ArcSwap<...>` or `tokio::sync::watch`): the **route table**
+  (consulted per-INVITE in the acceptor), **gateways** (read at originate
+  time), and **webhook / CDR sinks**. New calls pick up the new values;
+  in-flight calls keep the config they already captured (no retroactive
+  remap). The log-filter is already runtime-mutable via the admin API and is
+  out of scope here.
+- **Restart-required sections.** `[sip]` listen/transports, `[node]`,
+  `[observability]`/`[admin]` listeners, and `[media]` bind-time choices
+  can't change without rebinding sockets / re-creating the engine. If a
+  reload's value for any of these differs from the live one, the reload
+  **applies the safe sections and logs a prominent warning** naming the
+  section(s) that need a restart — it does not silently pretend they changed.
+- **Observability.** `siphon_ai_config_reloads_total{result=applied|failed|
+  no_change}` counter + an `info` log summarizing what changed. Each reload
+  is auditable.
+
+The mechanic cost is real: the runtime must hold the reloadable bits behind
+shared swappable handles instead of owning them outright (the acceptor's
+`RouteSet`, the outbound service's gateways, the webhook/CDR sink handles).
+That refactor is the bulk of the chunk.
+
+## 7. Chunks (target ~v0.12.0)
+
+1. **`check` + CLI restructure.** Optional-subcommand CLI (daemon = default),
+   `check` (validate + summary + exit code), fix `contrib/README.md` (+ any
+   other doc) to the real `check` subcommand, CLI integration tests. The
+   cheap quick-win.
+2. **`print-config` + `route-test`.** Effective-config renderer (redaction +
+   `--show-secrets`) and the offline route matcher; tests.
+3. **Reload.** `SIGHUP` re-read + fail-safe apply of routes/gateways/webhooks
+   behind swappable handles; restart-required warning for socket sections;
+   `config_reloads_total` metric; tests (good reload applies; bad reload
+   keeps the old config; socket-section change warns).
+4. **Docs + release.** `docs/CONFIG.md` ("Validating, inspecting & reloading
+   config"), `docs/DEPLOY.md` / `OPERATIONS.md` preflight + `systemctl
+   reload` guidance, CHANGELOG, tag ~v0.12.0.


### PR DESCRIPTION
First chunk of the **config CLI + reload** theme (P1). Design note: `docs/DESIGN_CONFIG_CLI.md` (decisions locked: optional subcommands with the daemon as default; reload included later in the theme).

## What's here
- **CLI restructure** — `main.rs` gains an optional `command` (clap `Subcommand`). **No subcommand still runs the daemon**, so `siphon-ai --config X` (systemd unit + every existing invocation) is unchanged. `--config`/`--log` are now `global`, so they work before *or* after the subcommand.
- **`siphon-ai check --config X`** — load + compile the config and exit, with **no tracing subscriber, no socket binding, no runtime**:
  - **exit 0** + a one-screen effective summary (node id, SIP listen + transports, route count + default-route check, registrations/trunks, enabled subsystems) on success;
  - **exit 1** + the validation error on stderr on failure.
  - A missing default route **warns** (matching the daemon's startup warning) but still exits 0.
  - Safe as a CI / pre-`systemctl reload` preflight.
- **`contrib/README.md`** — fixes the documented-but-nonexistent `--config X --check` flag → the real `check --config X` subcommand.
- **config** re-exports `RecordingMode` so the binary can read `Config.recording.mode` without a direct recording-crate dep.

## Verification
- `cargo fmt --all`, `cargo clippy --workspace --all-targets -D warnings` clean; `cargo test --workspace` green.
- New `bins/siphon-ai/tests/cli.rs` drives the built binary: valid → 0 + summary; invalid → 1 + error; `--config` before/after the subcommand; missing `--config` errors; missing default route warns but exits 0.

## Example
```
$ siphon-ai check --config /etc/siphon-ai/config.toml
config OK: /etc/siphon-ai/config.toml
  node id:       siphon-ai
  sip listen:    0.0.0.0:5060 [udp, tcp]
  public addr:   203.0.113.10
  routes:        5 (default route: yes)
  registrations: 1    trunks: 2
  enabled:       outbound(2 gateway(s)), cdr(file+webhook), webhooks, admin, stir_shaken
```

## Not in this chunk
- `print-config` + `route-test` (chunk 2); SIGHUP reload (chunk 3); CONFIG/OPERATIONS docs + release ~v0.12.0 (chunk 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)