### PR TITLE
feat: print-config + route-test subcommands (config-cli chunk 2)

### DIFF
--- a/bins/siphon-ai/src/inspect.rs
+++ b/bins/siphon-ai/src/inspect.rs
@@ -1,0 +1,465 @@
+//! Read-only config inspection for the `print-config` and `route-test`
+//! subcommands (config CLI chunk 2).
+//!
+//! Both walk an already-compiled [`Config`] and render text — no
+//! sockets, no runtime. `print-config` shows the *effective* config
+//! (post-`${VAR}`, post-merge) with secrets redacted by default;
+//! `route-test` runs the dialplan against synthetic call attributes
+//! and reports the winning route + its effective bridge config.
+//!
+//! The renderer is a bespoke text walker rather than a serde dump: the
+//! compiled graph holds non-serde types (compiled `Regex`, hashed admin
+//! tokens, `SocketAddr`) and we want secret redaction, not a faithful
+//! round-trip.
+
+use std::fmt::Write as _;
+
+use siphon_ai_config::{Config, RecordingMode, SipTransport};
+use siphon_ai_routes::{CallInfo, Headers};
+
+/// Inputs to `route-test`, collected from CLI flags.
+pub struct RouteTestInput {
+    pub ruri_user: String,
+    pub ruri_host: String,
+    pub to_user: String,
+    pub to_host: String,
+    pub from_user: String,
+    pub from_host: String,
+    pub register_source: String,
+    /// `("X-Header", "value")` pairs.
+    pub headers: Vec<(String, String)>,
+}
+
+/// `<unset>` / `<redacted>` / the value, depending on `show`.
+fn secret(opt: &Option<String>, show: bool) -> String {
+    match opt {
+        None => "<unset>".into(),
+        Some(_) if !show => "<redacted>".into(),
+        Some(v) => v.clone(),
+    }
+}
+
+/// Present a plain optional string (no redaction).
+fn opt(o: &Option<String>) -> String {
+    o.clone().unwrap_or_else(|| "<unset>".into())
+}
+
+fn transport_str(t: &SipTransport) -> &'static str {
+    match t {
+        SipTransport::Udp => "udp",
+        SipTransport::Tcp => "tcp",
+        SipTransport::Tls => "tls",
+    }
+}
+
+/// Render the effective compiled config as human-readable text.
+/// Secrets are redacted unless `show_secrets`.
+pub fn render_config(config: &Config, show_secrets: bool) -> String {
+    let mut o = String::new();
+    let s = &mut o;
+
+    let _ = writeln!(s, "# Effective configuration (compiled, post-${{VAR}}).");
+    if !show_secrets {
+        let _ = writeln!(s, "# Secrets redacted — pass --show-secrets to reveal.");
+    }
+    let _ = writeln!(s);
+
+    // [node]
+    let _ = writeln!(s, "[node]");
+    let _ = writeln!(s, "  id             = {}", config.node.id);
+    let _ = writeln!(s, "  public_address = {}", config.node.public_address);
+
+    // [sip]
+    let transports = config
+        .sip
+        .transports
+        .iter()
+        .map(transport_str)
+        .collect::<Vec<_>>()
+        .join(", ");
+    let _ = writeln!(s, "[sip]");
+    let _ = writeln!(s, "  listen             = {}", config.sip.listen_addr);
+    let _ = writeln!(s, "  transports         = [{transports}]");
+    let _ = writeln!(
+        s,
+        "  tls                = {}",
+        if config.sip.tls.is_some() {
+            "on"
+        } else {
+            "off"
+        }
+    );
+    let _ = writeln!(
+        s,
+        "  allow_delayed_offer = {}",
+        config.sip.allow_delayed_offer
+    );
+
+    // [media]
+    let _ = writeln!(s, "[media]");
+    let _ = writeln!(s, "  srtp           = {:?}", config.media.srtp);
+    let _ = writeln!(
+        s,
+        "  rtp_port_range = {}",
+        match config.media.rtp_port_range {
+            Some((lo, hi)) => format!("{lo}-{hi}"),
+            None => "<forge default>".into(),
+        }
+    );
+    let _ = writeln!(
+        s,
+        "  moh_file       = {}",
+        config
+            .media
+            .moh_file
+            .as_ref()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| "<comfort noise>".into())
+    );
+
+    // [bridge] defaults
+    let b = &config.bridge_defaults;
+    let _ = writeln!(s, "[bridge] (defaults)");
+    let _ = writeln!(s, "  ws_url         = {}", opt(&b.ws_url));
+    let _ = writeln!(
+        s,
+        "  auth_header    = {}",
+        secret(&b.auth_header, show_secrets)
+    );
+    let _ = writeln!(s, "  codecs         = {:?}", b.codecs);
+    let _ = writeln!(s, "  barge_in       = {:?}", b.barge_in.mode);
+    let _ = writeln!(
+        s,
+        "  forward_headers = {}",
+        if b.forward_headers.is_empty() {
+            "[]".into()
+        } else {
+            format!("{:?}", b.forward_headers)
+        }
+    );
+
+    // [[route]]
+    let _ = writeln!(
+        s,
+        "routes ({}, default route: {})",
+        config.routes.len(),
+        if config.routes.has_default() {
+            "yes"
+        } else {
+            "NO"
+        }
+    );
+    for (i, r) in config.routes.iter().enumerate() {
+        let _ = writeln!(s, "  [{i}] {}", r.name);
+        // Per-route overrides that are actually set (None = inherits).
+        if let Some(u) = &r.bridge.ws_url {
+            let _ = writeln!(s, "        ws_url       -> {u}");
+        }
+        if r.bridge.ws_auth_header.is_some() {
+            let _ = writeln!(
+                s,
+                "        ws_auth_header -> {}",
+                secret(&r.bridge.ws_auth_header, show_secrets)
+            );
+        }
+        if let Some(c) = &r.media.codecs {
+            let _ = writeln!(s, "        codecs       -> {c:?}");
+        }
+        if let Some(m) = &r.media.srtp {
+            let _ = writeln!(s, "        srtp         -> {m}");
+        }
+        if let Some(m) = &r.recording.mode {
+            let _ = writeln!(s, "        recording    -> {m}");
+        }
+        if let Some(a) = &r.security.min_attestation {
+            let _ = writeln!(s, "        min_attestation -> {a}");
+        }
+    }
+
+    // [[register]]
+    if !config.registrations.is_empty() {
+        let _ = writeln!(s, "registrations ({})", config.registrations.len());
+        for reg in &config.registrations {
+            let _ = writeln!(
+                s,
+                "  {} -> {} [{}] user={} password={} expires={}s on_startup={}",
+                reg.name,
+                reg.server_host,
+                transport_str(&reg.transport),
+                reg.username,
+                if show_secrets {
+                    &reg.password
+                } else {
+                    "<redacted>"
+                },
+                reg.expires.as_secs(),
+                reg.register_on_startup,
+            );
+        }
+    }
+
+    // [[trunk]]
+    if !config.trunks.is_empty() {
+        let _ = writeln!(s, "trunks ({})", config.trunks.len());
+        for t in &config.trunks {
+            let _ = writeln!(
+                s,
+                "  {} peer_addrs={} from_hosts={:?}",
+                t.name,
+                t.peer_addrs.len(),
+                t.from_hosts
+            );
+        }
+    } else {
+        let _ = writeln!(s, "trunks: none (accepts INVITEs from any source)");
+    }
+
+    // [security]
+    let _ = writeln!(s, "[security]");
+    let _ = writeln!(
+        s,
+        "  stir_shaken    = {}",
+        if config.security.stir_shaken.enabled {
+            "on"
+        } else {
+            "off"
+        }
+    );
+    let _ = writeln!(
+        s,
+        "  min_attestation = {:?}",
+        config.security.min_attestation
+    );
+
+    // [recording]
+    let _ = writeln!(s, "[recording]");
+    let _ = writeln!(s, "  mode           = {:?}", config.recording.mode);
+    if !matches!(config.recording.mode, RecordingMode::Off) {
+        let _ = writeln!(s, "  dir            = {}", config.recording.dir.display());
+    }
+
+    // [outbound] + [[gateway]]
+    let _ = writeln!(s, "[outbound]");
+    let _ = writeln!(s, "  max_concurrent = {}", config.outbound.max_concurrent);
+    let _ = writeln!(
+        s,
+        "  rate_limit/s   = {}",
+        config
+            .outbound
+            .rate_limit_per_sec
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| "<none>".into())
+    );
+    for g in &config.outbound.gateways {
+        let creds = match &g.credentials {
+            None => "none".to_string(),
+            Some(c) => format!(
+                "user={} password={}",
+                c.username,
+                if show_secrets {
+                    &c.password
+                } else {
+                    "<redacted>"
+                }
+            ),
+        };
+        let _ = writeln!(
+            s,
+            "  gateway {} -> {}:{} [{}] from={} srtp={:?} creds=({creds})",
+            g.name,
+            g.proxy_host,
+            g.proxy_port,
+            transport_str(&g.transport),
+            g.from,
+            g.srtp,
+        );
+    }
+
+    // [conference] / [park]
+    let _ = writeln!(
+        s,
+        "[conference] enabled={} max_rooms={} max_participants_per_room={}",
+        config.conference.enabled,
+        config.conference.max_rooms,
+        config.conference.max_participants_per_room
+    );
+    let _ = writeln!(
+        s,
+        "[park] enabled={} max_parked={} timeout={} action={:?}",
+        config.park.enabled,
+        config.park.max_parked,
+        config
+            .park
+            .timeout
+            .map(|d| format!("{}s", d.as_secs()))
+            .unwrap_or_else(|| "<none>".into()),
+        config.park.timeout_action,
+    );
+
+    // [cdr]
+    let _ = writeln!(s, "[cdr] enabled={}", config.cdr.enabled);
+    if let Some(f) = &config.cdr.file {
+        let _ = writeln!(s, "  file    -> {}", f.path.display());
+    }
+    if let Some(w) = &config.cdr.webhook {
+        let _ = writeln!(
+            s,
+            "  webhook -> {} auth_header={} secret={} spool_dir={}",
+            w.url,
+            secret(&w.auth_header, show_secrets),
+            secret(&w.secret, show_secrets),
+            opt(&w.spool_dir),
+        );
+    }
+
+    // [webhooks]
+    let _ = writeln!(s, "[webhooks] enabled={}", config.webhooks.enabled);
+    if config.webhooks.enabled {
+        let _ = writeln!(
+            s,
+            "  url={} auth_header={} secret={} spool_dir={} events={:?}",
+            opt(&config.webhooks.url),
+            secret(&config.webhooks.auth_header, show_secrets),
+            secret(&config.webhooks.secret, show_secrets),
+            opt(&config.webhooks.spool_dir),
+            config.webhooks.events,
+        );
+    }
+
+    // [observability]
+    let _ = writeln!(
+        s,
+        "[observability] enabled={} http_listen={}",
+        config.observability.enabled,
+        config
+            .observability
+            .http_listen
+            .map(|a| a.to_string())
+            .unwrap_or_else(|| "<unset>".into()),
+    );
+
+    // [admin]
+    match &config.admin {
+        None => {
+            let _ = writeln!(s, "[admin] not configured (/admin/* not served)");
+        }
+        Some(a) => {
+            let _ = writeln!(
+                s,
+                "[admin] listen={} tokens={}",
+                a.listen_addr,
+                a.auth.len()
+            );
+            for t in a.auth.iter() {
+                let _ = writeln!(s, "  token {} role={}", t.name, t.role.as_str());
+            }
+        }
+    }
+
+    // [hep]
+    let _ = writeln!(s, "[hep] enabled={}", config.hep.enabled);
+    if config.hep.enabled {
+        let _ = writeln!(
+            s,
+            "  collector={} capture_id={} capture_password={}",
+            config
+                .hep
+                .collector
+                .map(|a| a.to_string())
+                .unwrap_or_else(|| "<unset>".into()),
+            config
+                .hep
+                .capture_id
+                .map(|i| i.to_string())
+                .unwrap_or_else(|| "<unset>".into()),
+            secret(&config.hep.capture_password, show_secrets),
+        );
+    }
+
+    o
+}
+
+/// Run the dialplan against synthetic call attributes and report the
+/// winning route + its effective bridge config (route override merged
+/// over the `[bridge]` default for the headline fields).
+pub fn route_test(config: &Config, input: &RouteTestInput) -> String {
+    let mut headers = Headers::new();
+    for (k, v) in &input.headers {
+        headers.insert(k, v.clone());
+    }
+    let info = CallInfo {
+        request_uri_user: &input.ruri_user,
+        request_uri_host: &input.ruri_host,
+        to_user: &input.to_user,
+        to_host: &input.to_host,
+        from_user: &input.from_user,
+        from_host: &input.from_host,
+        register_source: &input.register_source,
+        headers: &headers,
+    };
+
+    let mut o = String::new();
+    let s = &mut o;
+    let _ = writeln!(s, "route-test input:");
+    let _ = writeln!(s, "  request-uri = {}@{}", input.ruri_user, input.ruri_host);
+    let _ = writeln!(s, "  to          = {}@{}", input.to_user, input.to_host);
+    let _ = writeln!(s, "  from        = {}@{}", input.from_user, input.from_host);
+    let _ = writeln!(s, "  register_source = {}", input.register_source);
+    if !input.headers.is_empty() {
+        let _ = writeln!(s, "  headers     = {:?}", input.headers);
+    }
+    let _ = writeln!(s);
+
+    match config.routes.find_match(&info) {
+        None => {
+            let _ = writeln!(s, "NO MATCH — the call would be rejected with SIP 404.");
+            if !config.routes.has_default() {
+                let _ = writeln!(
+                    s,
+                    "(no default `any = true` route is configured — add one to catch unmatched calls)"
+                );
+            }
+        }
+        Some(r) => {
+            let _ = writeln!(s, "matched route: {}", r.name);
+            // Effective bridge config for the headline fields: the route
+            // override wins, else the global default.
+            let eff_ws_url = r
+                .bridge
+                .ws_url
+                .clone()
+                .or_else(|| config.bridge_defaults.ws_url.clone());
+            let _ = writeln!(
+                s,
+                "  effective ws_url = {}",
+                match &eff_ws_url {
+                    Some(u) => u.clone(),
+                    None => "<unset> — call would be rejected 503 (no ws_url)".into(),
+                }
+            );
+            let inherits = r.bridge.ws_url.is_none();
+            let _ = writeln!(
+                s,
+                "    (from {})",
+                if inherits {
+                    "[bridge] default"
+                } else {
+                    "route override"
+                }
+            );
+            if let Some(c) = &r.media.codecs {
+                let _ = writeln!(s, "  effective codecs = {c:?} (route override)");
+            } else {
+                let _ = writeln!(
+                    s,
+                    "  effective codecs = {:?} ([bridge] default)",
+                    config.bridge_defaults.codecs
+                );
+            }
+            if let Some(m) = &r.recording.mode {
+                let _ = writeln!(s, "  recording = {m} (route override)");
+            }
+        }
+    }
+    o
+}

--- a/bins/siphon-ai/src/main.rs
+++ b/bins/siphon-ai/src/main.rs
@@ -19,6 +19,8 @@ use siphon_ai_telemetry::LogFilterHandle;
 use tracing::info;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
+mod inspect;
+
 #[derive(Parser, Debug)]
 #[command(name = "siphon-ai", version, about = "SIP-to-WebSocket media bridge")]
 struct Cli {
@@ -46,6 +48,49 @@ enum Command {
     /// config is valid, 1 otherwise. Safe as a pre-deploy / CI
     /// preflight (e.g. before `systemctl reload`).
     Check,
+
+    /// Print the effective compiled configuration (post-`${VAR}`,
+    /// post per-route merge) and exit. Secrets are redacted unless
+    /// `--show-secrets` is passed.
+    PrintConfig {
+        /// Reveal secret values (auth headers, signing secrets,
+        /// passwords) instead of `<redacted>`.
+        #[arg(long)]
+        show_secrets: bool,
+    },
+
+    /// Report which route a synthetic call matches (first-match-wins)
+    /// and its effective bridge config, then exit. Unset attributes
+    /// default to empty / `trunk`.
+    RouteTest {
+        /// Request-URI user (the dialed number on the RURI).
+        #[arg(long = "ruri-user", default_value = "")]
+        ruri_user: String,
+        /// Request-URI host.
+        #[arg(long = "ruri-host", default_value = "")]
+        ruri_host: String,
+        /// To-header user (dialed number). Also used for `--ruri-user`
+        /// when that is left empty.
+        #[arg(long, default_value = "")]
+        to: String,
+        /// To-header host.
+        #[arg(long = "to-host", default_value = "")]
+        to_host: String,
+        /// From-header user (caller).
+        #[arg(long, default_value = "")]
+        from: String,
+        /// From-header host.
+        #[arg(long = "from-host", default_value = "")]
+        from_host: String,
+        /// `register_source`: `trunk` (unregistered inbound) or a
+        /// `[[register]]` block name.
+        #[arg(long = "register-source", default_value = "trunk")]
+        register_source: String,
+        /// Repeatable SIP header, `Name: Value`, matched against
+        /// `[route.match].header.*`.
+        #[arg(long = "header", short = 'H')]
+        headers: Vec<String>,
+    },
 }
 
 /// The config path, from `--config` or `$SIPHON_AI_CONFIG`. A clap
@@ -76,8 +121,38 @@ async fn main() -> Result<()> {
     // Read-only subcommands dispatch here and exit — no tracing
     // subscriber, no socket binding, no runtime.
     if let Some(command) = &cli.command {
+        let path = config_path(&cli)?;
         match command {
-            Command::Check => run_check(&config_path(&cli)?),
+            Command::Check => run_check(&path),
+            Command::PrintConfig { show_secrets } => run_print_config(&path, *show_secrets),
+            Command::RouteTest {
+                ruri_user,
+                ruri_host,
+                to,
+                to_host,
+                from,
+                from_host,
+                register_source,
+                headers,
+            } => run_route_test(
+                &path,
+                inspect::RouteTestInput {
+                    // RURI user defaults to the To-user when unset — a
+                    // common case where they're the same dialed number.
+                    ruri_user: if ruri_user.is_empty() {
+                        to.clone()
+                    } else {
+                        ruri_user.clone()
+                    },
+                    ruri_host: ruri_host.clone(),
+                    to_user: to.clone(),
+                    to_host: to_host.clone(),
+                    from_user: from.clone(),
+                    from_host: from_host.clone(),
+                    register_source: register_source.clone(),
+                    headers: parse_headers(headers)?,
+                },
+            ),
         }
     }
 
@@ -104,21 +179,54 @@ async fn main() -> Result<()> {
     runtime.run(shutdown_signal()).await
 }
 
-/// `siphon-ai check` — load + compile the config and exit. Prints a
-/// one-screen summary on success (exit 0); prints the validation error
-/// to stderr and exits 1 on failure. Never starts the daemon.
-fn run_check(path: &Path) -> ! {
+/// Load + compile a config for a read-only subcommand, or print the
+/// validation error to stderr and exit 1. Shared by `check`,
+/// `print-config`, and `route-test`.
+fn load_or_exit(path: &Path) -> Config {
     match siphon_ai_config::load_from_path(path) {
-        Ok(config) => {
-            print_check_summary(path, &config);
-            std::process::exit(0);
-        }
+        Ok(config) => config,
         Err(e) => {
             eprintln!("config INVALID: {}", path.display());
             eprintln!("  {e}");
             std::process::exit(1);
         }
     }
+}
+
+/// `siphon-ai check` — validate + compile, print a one-screen summary
+/// (exit 0) or the error (exit 1). Never starts the daemon.
+fn run_check(path: &Path) -> ! {
+    let config = load_or_exit(path);
+    print_check_summary(path, &config);
+    std::process::exit(0);
+}
+
+/// `siphon-ai print-config` — render the effective compiled config
+/// (secrets redacted unless `show_secrets`) and exit.
+fn run_print_config(path: &Path, show_secrets: bool) -> ! {
+    let config = load_or_exit(path);
+    print!("{}", inspect::render_config(&config, show_secrets));
+    std::process::exit(0);
+}
+
+/// `siphon-ai route-test` — report the matched route + effective bridge
+/// config for the synthetic call, and exit.
+fn run_route_test(path: &Path, input: inspect::RouteTestInput) -> ! {
+    let config = load_or_exit(path);
+    print!("{}", inspect::route_test(&config, &input));
+    std::process::exit(0);
+}
+
+/// Parse `--header 'Name: Value'` flags into `(name, value)` pairs.
+fn parse_headers(raw: &[String]) -> Result<Vec<(String, String)>> {
+    raw.iter()
+        .map(|h| {
+            let (k, v) = h
+                .split_once(':')
+                .ok_or_else(|| anyhow!("bad --header {h:?}; expected 'Name: Value'"))?;
+            Ok((k.trim().to_string(), v.trim().to_string()))
+        })
+        .collect()
 }
 
 /// One-screen summary of a valid compiled config — what the daemon

--- a/bins/siphon-ai/tests/cli.rs
+++ b/bins/siphon-ai/tests/cli.rs
@@ -138,3 +138,111 @@ fn check_warns_on_missing_default_route_but_exits_zero() {
         "expected a default-route warning on stderr"
     );
 }
+
+/// Config with a secret + two routes (a specific one + a default).
+const WITH_SECRET_AND_ROUTES: &str = r#"
+[node]
+id = "cli-test"
+[sip]
+listen = "127.0.0.1:5060"
+[bridge]
+ws_url = "wss://default/ws"
+ws_auth_header = "Bearer SUPERSECRET"
+[[route]]
+name = "sales"
+[route.match]
+to_user = "1000"
+[route.bridge]
+ws_url = "wss://sales/ws"
+[[route]]
+name = "default"
+[route.match]
+any = true
+"#;
+
+#[test]
+fn print_config_redacts_secrets_by_default() {
+    let cfg = write_cfg(WITH_SECRET_AND_ROUTES);
+    let out = Command::new(BIN)
+        .arg("print-config")
+        .arg("--config")
+        .arg(cfg.path())
+        .output()
+        .expect("run print-config");
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("auth_header    = <redacted>"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        !stdout.contains("SUPERSECRET"),
+        "secret leaked into default print-config output"
+    );
+    // The effective values + per-route override are rendered.
+    assert!(stdout.contains("ws_url         = wss://default/ws"));
+    assert!(stdout.contains("ws_url       -> wss://sales/ws"));
+}
+
+#[test]
+fn print_config_show_secrets_reveals_them() {
+    let cfg = write_cfg(WITH_SECRET_AND_ROUTES);
+    let out = Command::new(BIN)
+        .args(["print-config", "--show-secrets", "--config"])
+        .arg(cfg.path())
+        .output()
+        .expect("run print-config");
+    assert!(out.status.success());
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("Bearer SUPERSECRET"),
+        "--show-secrets should reveal the secret"
+    );
+}
+
+#[test]
+fn route_test_resolves_first_match_wins() {
+    let cfg = write_cfg(WITH_SECRET_AND_ROUTES);
+    // to=1000 matches the `sales` route and its ws_url override.
+    let out = Command::new(BIN)
+        .args(["route-test", "--to", "1000", "--config"])
+        .arg(cfg.path())
+        .output()
+        .expect("run route-test");
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("matched route: sales"), "stdout: {stdout}");
+    assert!(stdout.contains("wss://sales/ws"), "stdout: {stdout}");
+
+    // A non-matching number falls through to the default route, which
+    // inherits the global ws_url.
+    let out = Command::new(BIN)
+        .args(["route-test", "--to", "9999", "--config"])
+        .arg(cfg.path())
+        .output()
+        .expect("run route-test");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("matched route: default"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("wss://default/ws") && stdout.contains("[bridge] default"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn route_test_no_match_reports_404() {
+    // Only a specific route, no default → an unmatched call is 404.
+    let cfg = write_cfg(NO_DEFAULT_ROUTE);
+    let out = Command::new(BIN)
+        .args(["route-test", "--to", "9999", "--config"])
+        .arg(cfg.path())
+        .output()
+        .expect("run route-test");
+    assert!(out.status.success());
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("NO MATCH"),
+        "expected a no-match report"
+    );
+}

--- a/crates/telemetry/src/auth.rs
+++ b/crates/telemetry/src/auth.rs
@@ -95,6 +95,18 @@ impl AdminAuth {
         self.tokens.is_empty()
     }
 
+    /// Number of configured tokens.
+    pub fn len(&self) -> usize {
+        self.tokens.len()
+    }
+
+    /// Iterate the configured tokens (name + role; the hashed secret is
+    /// never exposed). Used by `siphon-ai print-config` to list the
+    /// admin tokens without revealing any secret material.
+    pub fn iter(&self) -> impl Iterator<Item = &AdminToken> {
+        self.tokens.iter()
+    }
+
     /// Match a presented bearer token against the table in constant time.
     /// Returns the matching entry (with its role), or `None` for no
     /// match. We hash the candidate once and `ct_eq` every stored hash


### PR DESCRIPTION
Second chunk of the **config CLI + reload** theme. Two read-only inspection subcommands over the compiled config — no sockets, no runtime. Design note: `docs/DESIGN_CONFIG_CLI.md`.

## What's here
- **`siphon-ai print-config --config X [--show-secrets]`** — render the *effective* compiled config (post-`${VAR}`, post per-route merge) as human-readable text. **Secrets redacted by default** (auth headers, signing secrets, register/gateway passwords, admin token hashes, HEP password → `<redacted>`); `--show-secrets` reveals them. Covers every section, including each route's overrides (what it changes vs inherits) and the admin token name+role list. Bespoke text walker (the compiled graph holds non-serde `Regex`/`SocketAddr`/hashed tokens), not a serde round-trip.
- **`siphon-ai route-test --config X --to N [--from … --ruri-user … --to-host … --register-source … -H 'K: V' …]`** — build a synthetic `CallInfo`, run the dialplan (first-match-wins), and report the winning route (or **NO MATCH → 404**) plus its effective `ws_url`/`codecs` (route override vs `[bridge]` default). `--ruri-user` defaults to `--to` when unset.
- New `bins/siphon-ai/src/inspect.rs` holds both renderers.
- `telemetry`: `AdminAuth` gains `len()` + `iter()` so print-config can list admin token names+roles without exposing the hashed secret.

## Example
```
$ siphon-ai route-test --config x.toml --to 1000
matched route: sales
  effective ws_url = wss://sales/ws
    (from route override)
  effective codecs = [Pcmu, Pcma] ([bridge] default)

$ siphon-ai print-config --config x.toml | grep auth_header
  auth_header    = <redacted>
```

## Verification
- 4 new CLI integration tests (print-config redacts by default; `--show-secrets` reveals; route-test first-match-wins + inheritance; no-match → 404). All 9 `cli` tests + telemetry green; `cargo clippy --workspace --all-targets -D warnings` clean.

## Not in this chunk
- SIGHUP reload (chunk 3); CONFIG/OPERATIONS docs + release ~v0.12.0 (chunk 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)