### PR TITLE
docs: config CLI + reload docs + CHANGELOG + 0.12.0 (config-cli chunk 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-06-19
+
+### Added
+
+- **Config CLI subcommands.** The daemon gains read-only subcommands;
+  running the daemon is unchanged (`siphon-ai --config X`, no subcommand).
+  - `siphon-ai check --config X` — validate + compile and exit (no sockets,
+    no runtime). Exit `0` + a one-screen summary if valid, `1` + the error
+    on stderr otherwise. The CI / pre-deploy / pre-`systemctl reload`
+    preflight. (Also fixes the documented-but-nonexistent `--check` flag in
+    `contrib/README.md`.)
+  - `siphon-ai print-config --config X [--show-secrets]` — render the
+    effective compiled config (post-`${VAR}`, post per-route merge); secrets
+    redacted by default.
+  - `siphon-ai route-test --config X --to N [...]` — run the dialplan against
+    a synthetic call (first-match-wins) and report the winning route (or
+    `NO MATCH → 404`) + its effective bridge config.
+- **`SIGHUP` config hot-reload.** `systemctl reload siphon-ai` re-reads the
+  `--config` file and hot-applies the reload-safe sections **without dropping
+  calls**: the **route table** (new INVITEs use the new dialplan; in-flight
+  calls keep their match) and the **`[webhooks]` / `[cdr]` sinks** (rebuilt +
+  swapped, unless a durable `spool_dir` is active for that sink — its drain
+  worker can't be hot-swapped). The `[sip.tls]` cert reload (0.3.0) is folded
+  into the same handler.
+  - **Fail-safe:** a config that doesn't load/compile is logged + counted and
+    the running config is kept — a bad edit can't take the daemon down.
+  - **Restart-required sections** (`[sip]` listen/transports, `[node]`,
+    `[media]`, `[observability]`, `[admin]`, `[hep]`,
+    `[security.stir_shaken]`, and `[[gateway]]` — gateway hot-reload is a
+    planned follow-up) are applied-by-restart; a reload that changes one logs
+    a warning naming it and still applies the safe sections.
+  - New metric `siphon_ai_config_reloads_total{result=applied|no_change|failed}`.
+
 ## [0.11.0] - 2026-06-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2937,7 +2937,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "base64",
  "bytes",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2975,7 +2975,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "regex",
  "serde",
@@ -2993,7 +2993,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "hmac",
  "http-body-util",
@@ -3054,7 +3054,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3078,7 +3078,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "thiserror 1.0.69",
  "tokio",
@@ -3087,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "regex",
  "serde",
@@ -3098,7 +3098,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3107,7 +3107,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3131,7 +3131,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -3149,7 +3149,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -625,9 +625,70 @@ unreachable collector flips `siphon_ai_hep_collector_up` to 0. The audio
 path never blocks on HEP (CLAUDE.md §4.7). See `docs/HEP.md` for what each
 layer ships and how Homer correlates them.
 
-## Reload
+## Validating, inspecting & reloading config
 
-The daemon does not currently support config reload — changes take effect on
-process restart. Routing changes that operators want to apply mid-shift
-should be made via the admin API (`POST /admin/calls/:id/hangup`,
-`PUT /admin/log`) rather than by reloading.
+The daemon has read-only subcommands for working with a config file without
+starting it, plus `SIGHUP` hot-reload for a subset of sections (0.12.0).
+Running the daemon is unchanged — `siphon-ai --config X` with no subcommand.
+
+### `siphon-ai check --config X`
+
+Validate and compile the config, then exit — **no sockets, no runtime**.
+Exit `0` (with a one-screen summary) if valid, `1` (with the error on
+stderr) otherwise. The CI / pre-deploy / pre-`systemctl reload` preflight.
+
+```sh
+siphon-ai check --config /etc/siphon-ai/config.toml || echo "bad config, not deploying"
+```
+
+A missing default route (`any = true`) warns but still exits `0` (matches
+the daemon's startup behavior).
+
+### `siphon-ai print-config --config X [--show-secrets]`
+
+Print the **effective** compiled config (post-`${VAR}`, post per-route
+merge) so you can see what your file actually resolved to — which `${VAR}`
+won, what each route inherits vs overrides. **Secrets are redacted** (auth
+headers, signing secrets, register/gateway passwords, admin token hashes,
+HEP password → `<redacted>`); `--show-secrets` reveals them for local
+debugging.
+
+### `siphon-ai route-test --config X --to N [...]`
+
+Run the dialplan against a synthetic call (first-match-wins) and report the
+winning route — or `NO MATCH → SIP 404` — plus its effective `ws_url` /
+codecs (route override vs `[bridge]` default). Flags: `--to` / `--from` /
+`--ruri-user` / `--ruri-host` / `--to-host` / `--from-host` /
+`--register-source` (default `trunk`) / `-H 'Name: Value'` (repeatable).
+`--ruri-user` defaults to `--to`.
+
+```sh
+siphon-ai route-test --config x.toml --to 1000 --from sip:alice@pbx --register-source trunk
+```
+
+### Hot reload (`SIGHUP` / `systemctl reload`)
+
+`SIGHUP` re-reads the **same `--config` file** and hot-applies the
+reload-safe sections without dropping calls:
+
+- **routes** — new INVITEs use the new dialplan; in-flight calls keep the
+  route they matched;
+- **webhook + CDR sinks** (`[webhooks]`, `[cdr]`) — rebuilt and swapped,
+  **unless** a durable spool (`spool_dir`) is active for that sink (its
+  background drain worker can't be hot-swapped → restart required);
+- the **`[sip.tls]` cert** is reloaded too (the 0.3.0 behavior, unchanged).
+
+**Fail-safe:** if the new config doesn't load/compile, the error is logged,
+the running config is **kept**, and `siphon_ai_config_reloads_total{result="failed"}`
+ticks — a bad edit can't take the daemon down. Run `siphon-ai check` first.
+
+**Restart-required sections.** Anything that binds a socket or builds
+process-wide state — `[sip]` listen/transports, `[node]`, `[media]`,
+`[observability]`, `[admin]`, `[hep]`, `[security.stir_shaken]`, and
+`[[gateway]]` (gateway hot-reload is a planned follow-up) — needs a process
+restart. A reload that changes one of these applies the safe sections and
+logs a warning naming the section(s) that did **not** take effect.
+
+Watch `siphon_ai_config_reloads_total{result}` (`applied` / `no_change` /
+`failed`); each reload also logs what it did. See `docs/DEPLOY.md` for the
+`systemctl reload` flow.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -187,7 +187,9 @@ the listener's `ServerConfig` without dropping in-flight TLS
 sessions (RFC 5746-compliant rotation — existing dialogs keep
 using the cert they handshook with; new dialogs pick up the
 fresh cert). The systemd unit's `ExecReload=` wires `systemctl
-reload siphon-ai` to the SIGHUP.
+reload siphon-ai` to the SIGHUP. Since 0.12.0 the same `SIGHUP`
+also reloads the **config file** — see [Config file
+reload](#config-file-reload-0120) below.
 
 ```sh
 # Let's Encrypt deploy-hook (/etc/letsencrypt/renewal-hooks/deploy/)
@@ -228,6 +230,40 @@ pipeline that always restarts services on config change), the
 0.2.0 recipe still works — replace `systemctl reload` with
 `systemctl restart`. A restart drops in-flight calls; SIGHUP
 doesn't.
+
+#### Config file reload (0.12.0)
+
+The same `SIGHUP` (`systemctl reload siphon-ai`) also re-reads the
+`--config` file and **hot-applies the reload-safe sections without
+dropping calls**:
+
+- **routes** — new INVITEs use the new dialplan; in-flight calls keep the
+  route they matched;
+- **`[webhooks]` + `[cdr]` sinks** — rebuilt and swapped, *unless* a
+  durable `spool_dir` is active for that sink (its drain worker can't be
+  hot-swapped → restart required for delivery changes there);
+- the `[sip.tls]` cert (above).
+
+**Always `check` before you reload** — a reload is exactly as safe as the
+config you feed it:
+
+```sh
+siphon-ai check --config /etc/siphon-ai/config.toml && systemctl reload siphon-ai
+```
+
+**Fail-safe.** A config that doesn't load/compile is logged, the running
+config is **kept**, and `siphon_ai_config_reloads_total{result="failed"}`
+ticks — a bad edit can't take the daemon down (same posture as the cert
+reload). On success the counter ticks `applied`, or `no_change` when the
+file is byte-identical to the last load.
+
+**Restart-required sections.** `[sip]` listen/transports, `[node]`,
+`[media]`, `[observability]`, `[admin]`, `[hep]`,
+`[security.stir_shaken]`, and `[[gateway]]` (gateway hot-reload is a
+planned follow-up) bind sockets or build process-wide state and need a
+process **restart**. A reload that changes one of these applies the safe
+sections and logs a `warn!` naming the section(s) that did not take effect
+— grep the journal for `require a restart` after a reload to catch this.
 
 ### 6. Smoke test
 
@@ -810,6 +846,7 @@ on the metrics crate's defaults (CLAUDE.md §7.4).
 | `siphon_ai_rtp_packet_loss_ratio`       | histogram | —                                     | Packet-loss ratio (0.0-1.0) recorded on every `rtp_stats` emission. |
 | `siphon_ai_rtp_rtt_ms`                  | histogram | —                                     | RTCP-derived round-trip time (ms) per received Receiver Report (RFC 3550 §A.7). Populated since 0.3.2 (forge originates SRs); explicit buckets 10ms–1s. Records a sample roughly every RTCP cycle (~5s) once bidirectional RTCP is flowing. |
 | `siphon_ai_sip_tls_reload_attempts_total` | counter | `outcome=ok\|failed`                  | One tick per SIGHUP cert-reload attempt. `failed` means a broken cert/key on disk; the listener keeps serving the previous cert. |
+| `siphon_ai_config_reloads_total`        | counter   | `result=applied\|no_change\|failed`   | SIGHUP config-file reloads (0.12.0). `applied` = a changed config loaded and the hot-reloadable sections (routes, webhook/CDR sinks) were swapped; `no_change` = the file was byte-identical to the last load; `failed` = the new config didn't load/compile and the running config was kept. Alert on `failed` after a deploy. |
 | `siphon_ai_conference_joins_total`      | counter   | `result=joined\|disabled\|too_many_rooms\|room_full\|rate_mismatch\|already_joined\|error` | Conference joins attempted (0.7.0). Every non-`joined` row leaves the call on its direct caller↔WS pair. |
 | `siphon_ai_conferences_active`          | gauge     | —                                     | Live conference rooms (0.7.0). A room spawns on first join and exits when its last member leaves. |
 | `siphon_ai_conference_participants`     | gauge     | —                                     | Mixer participants across all rooms (0.7.0). Each member call contributes 2 — its SIP leg and its WS session; two calls in one room read 4. |


### PR DESCRIPTION
Final chunk of the **config CLI + reload** theme. Chunks 1–3 (#205 check, #206 print-config/route-test, #207 SIGHUP reload) are merged; this is **docs + release**.

## What's here
- **`docs/CONFIG.md`** — replaces the stale "Reload" section (which said reload was unsupported) with **"Validating, inspecting & reloading config"**: `check` / `print-config` / `route-test` subcommands + the SIGHUP hot-reload semantics (reload-safe vs restart-required sections, fail-safe behavior, the durable-spool caveat, the metric).
- **`docs/DEPLOY.md`** — broadens the SIGHUP section: the cert-reload §5 now notes config reload, plus a new **"Config file reload (0.12.0)"** subsection (the `check`-then-`reload` flow, fail-safe, restart-required list). Adds `siphon_ai_config_reloads_total` to the metrics table.
- **CHANGELOG** 0.12.0 (subcommands + SIGHUP config reload + reloads metric).
- Workspace version `0.11.0` → `0.12.0`.

## Verification
- `cargo build --workspace` clean; fmt clean. (No Rust changed — the CLI + reload landed in #205–#207.)

After merge: tag `v0.12.0` + GitHub release. Gateway hot-reload (chunk 3b) is the planned fast-follow into 0.12.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)