### PR TITLE
feat: SIGHUP outbound gateway hot-reload + 0.12.1 (config-cli chunk 3b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-06-19
+
+### Added
+
+- **SIGHUP outbound gateway hot-reload.** `systemctl reload siphon-ai` now
+  also rebuilds and swaps the `[[gateway]]` set — add / remove / modify
+  trunks without a restart. In-flight outbound calls keep the trunk
+  (`OutboundOriginator`) they're on; new originations use the new set. The
+  gateway table moved behind an `ArcSwap` in the outbound service; each
+  reload mints fresh per-gateway UACs (stateless senders over the shared
+  transaction manager). Requires outbound enabled and the `[outbound]`
+  limits unchanged — `max_concurrent` / `rate_limit_per_sec` resize the live
+  admission semaphore and stay restart-required (a reload that changes them
+  warns and applies only the safe sections). Completes the `SIGHUP` reload
+  surface started in 0.12.0.
+
 ## [0.12.0] - 2026-06-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2996,6 +2996,7 @@ name = "siphon-ai-core"
 version = "0.12.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "async-trait",
  "bytes",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2937,7 +2937,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "base64",
  "bytes",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2975,7 +2975,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "regex",
  "serde",
@@ -2993,7 +2993,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3035,7 +3035,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "hmac",
  "http-body-util",
@@ -3055,7 +3055,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "thiserror 1.0.69",
  "tokio",
@@ -3088,7 +3088,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "regex",
  "serde",
@@ -3099,7 +3099,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3108,7 +3108,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3132,7 +3132,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "base64",
  "rcgen",
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3173,7 +3173,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/bins/siphon-ai/src/reload.rs
+++ b/bins/siphon-ai/src/reload.rs
@@ -10,7 +10,11 @@
 //! - the **webhook + CDR sinks** — swapped behind the delegating
 //!   wrappers in this module, *unless* a durable spool is active for
 //!   that sink (its background drain worker can't be hot-swapped, so
-//!   delivery changes there need a restart).
+//!   delivery changes there need a restart);
+//! - the **outbound gateway set** (`[[gateway]]`) — rebuilt (fresh
+//!   per-gateway UACs) and swapped when outbound is enabled and its
+//!   `[outbound]` limits are unchanged; in-flight outbound calls keep
+//!   the originator they captured.
 //!
 //! It is **fail-safe**: a new config that doesn't load/compile is
 //! logged + counted and the running config is kept — a bad edit can't
@@ -19,10 +23,11 @@
 //!
 //! Sections that bind sockets or build process-wide state (`[sip]`
 //! listen/transports, `[node]`, `[observability]`, `[admin]`,
-//! `[media]`, `[hep]`, `[security.stir_shaken]`, and — until a focused
-//! follow-up — `[[gateway]]`) **require a restart**. A reload whose
-//! value for any of those differs from the running one applies the
-//! safe sections and logs a prominent warning naming them.
+//! `[media]`, `[hep]`, `[security.stir_shaken]`, and `[outbound]`
+//! limits — the concurrency cap / rate limit, which also flip outbound
+//! on/off) **require a restart**. A reload whose value for any of those
+//! differs from the running one applies the safe sections and logs a
+//! prominent warning naming them.
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -30,7 +35,8 @@ use std::sync::Arc;
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use siphon_ai_cdr::{CdrRecord, CdrSink, CdrSinkHandle};
-use siphon_ai_config::{Config, SipTlsConfig};
+use siphon_ai_config::{Config, OutboundConfig, SipTlsConfig};
+use siphon_ai_core::OutboundService;
 use siphon_ai_routes::RouteSet;
 use siphon_ai_telemetry::{HepTelemetry, CONFIG_RELOADS_TOTAL};
 use siphon_ai_webhooks::{WebhookEvent, WebhookSink, WebhookSinkHandle};
@@ -103,15 +109,12 @@ impl CdrSink for SwappableCdrSink {
 /// Fingerprint the config sections that require a daemon **restart** to
 /// change (they bind sockets / build process-wide state). A reload
 /// compares these against the running values and warns on any diff.
-/// `[[gateway]]` is here until gateway hot-reload lands as a follow-up.
+///
+/// `[outbound].limits` (the concurrency cap + rate limit, which also
+/// flips outbound on/off) is restart-required — resizing the live
+/// admission semaphore isn't safe. The *gateway set* itself is
+/// hot-reloadable (see [`gateway_fingerprint`]) and is **not** here.
 pub fn restart_fingerprints(c: &Config) -> Vec<(&'static str, String)> {
-    let mut gateways: Vec<&str> = c
-        .outbound
-        .gateways
-        .iter()
-        .map(|g| g.name.as_str())
-        .collect();
-    gateways.sort_unstable();
     vec![
         ("[sip].listen", c.sip.listen_addr.to_string()),
         ("[sip].transports", format!("{:?}", c.sip.transports)),
@@ -140,13 +143,52 @@ pub fn restart_fingerprints(c: &Config) -> Vec<(&'static str, String)> {
             c.security.stir_shaken.enabled.to_string(),
         ),
         (
-            "[[gateway]]",
-            format!("{}|{:?}", c.outbound.max_concurrent, gateways),
+            "[outbound].limits",
+            format!(
+                "{}|{:?}",
+                c.outbound.max_concurrent, c.outbound.rate_limit_per_sec
+            ),
         ),
     ]
 }
 
+/// Fingerprint the **gateway set** (hot-reloadable). Captures every field
+/// that affects how a gateway dials, sorted + joined so the order in the
+/// file doesn't matter. A change here, with `[outbound].limits`
+/// unchanged, triggers a gateway rebuild on reload.
+pub fn gateway_fingerprint(outbound: &OutboundConfig) -> String {
+    let mut gws: Vec<String> = outbound
+        .gateways
+        .iter()
+        .map(|g| {
+            format!(
+                "{}|{}:{}|{}|{}|{:?}|creds={}",
+                g.name,
+                g.proxy_host,
+                g.proxy_port,
+                g.transport.uri_param(),
+                g.from,
+                g.srtp,
+                g.credentials.is_some(),
+            )
+        })
+        .collect();
+    gws.sort_unstable();
+    gws.join(",")
+}
+
 // ─── SIGHUP reload handler ──────────────────────────────────────────
+
+/// The outbound service + its gateway-build deps, kept so a reload can
+/// rebuild + swap the gateway set. `None` when `[outbound]` was disabled
+/// at startup (there's no service to reload into — gateway changes are
+/// then restart-required, caught by the `[outbound].limits` fingerprint).
+pub struct OutboundReload {
+    pub service: Arc<OutboundService>,
+    pub deps: crate::runtime::GatewayBuildDeps,
+    /// Gateway-set fingerprint at startup (rolled forward by the handler).
+    pub gateway_fingerprint: String,
+}
 
 /// Everything the SIGHUP reload loop needs. Built once in
 /// `Runtime::build` and moved into the spawned handler.
@@ -162,6 +204,8 @@ pub struct ReloadContext {
     pub webhook_spool_active: bool,
     /// `[cdr.webhook].spool_dir` set on the running config.
     pub cdr_spool_active: bool,
+    /// Outbound gateway hot-reload handle; `None` when outbound is off.
+    pub outbound: Option<OutboundReload>,
     /// `Some` when TLS is configured — the cert is reloaded too (the
     /// prior dedicated TLS-reload behavior, folded into this handler).
     pub tls: Option<(SipTlsConfig, Arc<ArcSwap<ServerConfig>>)>,
@@ -193,6 +237,11 @@ pub fn spawn_reload_handler(ctx: ReloadContext) {
         let mut fingerprints = ctx.restart_fingerprints;
         let mut webhook_spool_active = ctx.webhook_spool_active;
         let mut cdr_spool_active = ctx.cdr_spool_active;
+        let mut gateway_fp = ctx
+            .outbound
+            .as_ref()
+            .map(|o| o.gateway_fingerprint.clone())
+            .unwrap_or_default();
 
         while stream.recv().await.is_some() {
             // 1. TLS cert reload (independent of the config file).
@@ -239,22 +288,25 @@ pub fn spawn_reload_handler(ctx: ReloadContext) {
                 &ctx.webhook_swap,
                 &ctx.cdr_swap,
                 ctx.hep_telemetry.as_deref(),
+                ctx.outbound.as_ref(),
                 &fingerprints,
                 webhook_spool_active,
                 cdr_spool_active,
+                &gateway_fp,
             )
             .await;
 
             if !applied.restart_required.is_empty() {
                 warn!(sections = ?applied.restart_required, "SIGHUP: these sections changed but require a restart to take effect; NOT applied");
             }
-            info!("SIGHUP: config reload applied (routes + sinks)");
+            info!("SIGHUP: config reload applied");
             metrics::counter!(CONFIG_RELOADS_TOTAL, "result" => "applied").increment(1);
 
             last_text = text;
             fingerprints = applied.fingerprints;
             webhook_spool_active = applied.webhook_spool_active;
             cdr_spool_active = applied.cdr_spool_active;
+            gateway_fp = applied.gateway_fingerprint;
         }
         warn!("SIGHUP signal stream ended; config hot-reload offline");
     });
@@ -268,13 +320,17 @@ pub(crate) struct ReloadApplied {
     pub fingerprints: Vec<(&'static str, String)>,
     pub webhook_spool_active: bool,
     pub cdr_spool_active: bool,
+    /// Fresh gateway-set fingerprint (carried to the next reload).
+    pub gateway_fingerprint: String,
 }
 
-/// Hot-apply the reload-safe sections of a freshly-loaded config:
-/// store the new route table, and rebuild + swap the webhook / CDR
-/// sinks unless a durable spool is active for that sink. Returns which
-/// restart-required sections changed and the updated rolling state.
-/// Split out from the SIGHUP loop so it's unit-testable without signals.
+/// Hot-apply the reload-safe sections of a freshly-loaded config: store
+/// the new route table, rebuild + swap the webhook / CDR sinks (unless a
+/// durable spool is active for that sink), and rebuild + swap the
+/// outbound gateway set (when outbound is enabled and its `limits` are
+/// unchanged). Returns which restart-required sections changed and the
+/// updated rolling state. Split out from the SIGHUP loop so it's
+/// unit-testable without signals.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn apply_reload(
     new: Config,
@@ -282,9 +338,11 @@ pub(crate) async fn apply_reload(
     webhook_swap: &SwappableWebhookSink,
     cdr_swap: &SwappableCdrSink,
     hep: Option<&HepTelemetry>,
+    outbound_reload: Option<&OutboundReload>,
     prev_fingerprints: &[(&'static str, String)],
     prev_webhook_spool: bool,
     prev_cdr_spool: bool,
+    prev_gateway_fp: &str,
 ) -> ReloadApplied {
     let new_fp = restart_fingerprints(&new);
     let restart_required: Vec<&'static str> = prev_fingerprints
@@ -293,6 +351,7 @@ pub(crate) async fn apply_reload(
         .filter(|(old, new)| old.1 != new.1)
         .map(|(old, _)| old.0)
         .collect();
+    let new_gateway_fp = gateway_fingerprint(&new.outbound);
 
     // Snapshot the new spool state, then take the sections we hot-apply
     // (partial move out of `new`).
@@ -307,6 +366,7 @@ pub(crate) async fn apply_reload(
         routes,
         webhooks,
         cdr,
+        outbound,
         ..
     } = new;
 
@@ -334,11 +394,32 @@ pub(crate) async fn apply_reload(
         }
     }
 
+    // Gateways: rebuild + swap the set when outbound is running, its
+    // `limits` (cap/rate — restart-required) didn't change, and the
+    // gateway set actually differs. Enable/disable + cap changes are
+    // covered by the `[outbound].limits` restart-required warning.
+    if let Some(ob) = outbound_reload {
+        let limits_changed = restart_required.contains(&"[outbound].limits");
+        if outbound.enabled() && !limits_changed && new_gateway_fp != prev_gateway_fp {
+            match crate::runtime::build_gateways(&outbound, &ob.deps) {
+                Ok(gateways) => {
+                    let n = gateways.len();
+                    ob.service.reload_gateways(gateways);
+                    info!(gateways = n, "SIGHUP: outbound gateways reloaded");
+                }
+                Err(e) => {
+                    warn!(error = %e, "SIGHUP: rebuilding gateways failed; keeping previous set")
+                }
+            }
+        }
+    }
+
     ReloadApplied {
         restart_required,
         fingerprints: new_fp,
         webhook_spool_active: new_webhook_spool,
         cdr_spool_active: new_cdr_spool,
+        gateway_fingerprint: new_gateway_fp,
     }
 }
 
@@ -375,7 +456,19 @@ any = true
         // New config renames the route; reload should swap it in.
         let new = cfg(&BASE.replace("name = \"default\"", "name = \"renamed\""));
         let fp = restart_fingerprints(&cfg(BASE));
-        let out = apply_reload(new, &route_swap, &wh, &cd, None, &fp, false, false).await;
+        let out = apply_reload(
+            new,
+            &route_swap,
+            &wh,
+            &cd,
+            None,
+            None,
+            &fp,
+            false,
+            false,
+            "",
+        )
+        .await;
 
         assert_eq!(route_swap.load().iter().next().unwrap().name, "renamed");
         assert!(
@@ -393,7 +486,19 @@ any = true
 
         // Change the SIP listen port — a restart-required section.
         let new = cfg(&BASE.replace("127.0.0.1:5060", "127.0.0.1:5999"));
-        let out = apply_reload(new, &route_swap, &wh, &cd, None, &fp, false, false).await;
+        let out = apply_reload(
+            new,
+            &route_swap,
+            &wh,
+            &cd,
+            None,
+            None,
+            &fp,
+            false,
+            false,
+            "",
+        )
+        .await;
 
         assert!(
             out.restart_required.contains(&"[sip].listen"),
@@ -407,5 +512,57 @@ any = true
         let a = restart_fingerprints(&cfg(BASE));
         let b = restart_fingerprints(&cfg(&BASE.replace("name = \"default\"", "name = \"x\"")));
         assert_eq!(a, b, "a route rename must not change restart fingerprints");
+    }
+
+    const OUTBOUND: &str = r#"
+[node]
+id = "reload-test"
+[sip]
+listen = "127.0.0.1:5060"
+[bridge]
+ws_url = "wss://base/ws"
+[outbound]
+max_concurrent = 4
+[[gateway]]
+name = "twilio"
+proxy = "sip.twilio.example"
+from = "sip:+1@x"
+[[route]]
+name = "default"
+[route.match]
+any = true
+"#;
+
+    #[test]
+    fn gateway_fingerprint_tracks_gateway_changes_not_restart_sections() {
+        let base = cfg(OUTBOUND);
+        // A changed proxy changes the gateway fingerprint...
+        let changed = cfg(&OUTBOUND.replace("sip.twilio.example", "sip.other.example"));
+        assert_ne!(
+            gateway_fingerprint(&base.outbound),
+            gateway_fingerprint(&changed.outbound)
+        );
+        // ...but does NOT appear in the restart-required fingerprints
+        // (the gateway set is hot-reloadable).
+        assert_eq!(
+            restart_fingerprints(&base),
+            restart_fingerprints(&changed),
+            "a gateway change must not be flagged restart-required"
+        );
+    }
+
+    #[test]
+    fn outbound_limits_change_is_restart_required() {
+        let base = restart_fingerprints(&cfg(OUTBOUND));
+        let capped = restart_fingerprints(&cfg(
+            &OUTBOUND.replace("max_concurrent = 4", "max_concurrent = 8")
+        ));
+        let changed: Vec<_> = base
+            .iter()
+            .zip(&capped)
+            .filter(|(a, b)| a.1 != b.1)
+            .map(|(a, _)| a.0)
+            .collect();
+        assert_eq!(changed, vec!["[outbound].limits"]);
     }
 }

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -480,40 +480,11 @@ impl Runtime {
                 _ => None,
             };
 
-        // SIGHUP cert-reload task. Spawned only when TLS is on; reads
-        // the same `[sip.tls]` config the listener uses, so the
-        // semantics match: same cert/key paths, same key-pair
-        // validation, just performed on every SIGHUP rather than only
-        // at startup.
-        // Always install a SIGHUP handler at startup. The default
-        // Unix disposition for SIGHUP is *terminate the process* —
-        // if we don't claim the signal, `systemctl reload
-        // siphon-ai` on a non-TLS deployment would kill the daemon.
-        // When TLS is configured the handler does the cert reload;
-        // when it isn't, the handler is a no-op (just consumes the
-        // signal so it doesn't fire the default action).
-        match config_path {
-            // Daemon with a backing config file: full SIGHUP reload
-            // (config file + TLS cert).
-            Some(path) => {
-                let initial_text = std::fs::read_to_string(&path).unwrap_or_default();
-                crate::reload::spawn_reload_handler(crate::reload::ReloadContext {
-                    config_path: path,
-                    initial_text,
-                    route_swap: Arc::clone(&route_swap),
-                    webhook_swap: Arc::clone(&webhook_swap),
-                    cdr_swap: Arc::clone(&cdr_swap),
-                    hep_telemetry: hep_telemetry.clone(),
-                    webhook_spool_active,
-                    cdr_spool_active,
-                    tls: sip.tls.clone().zip(tls_server_config.clone()),
-                    restart_fingerprints,
-                });
-            }
-            // No backing file (tests): preserve the prior TLS-cert /
-            // no-op SIGHUP behavior.
-            None => spawn_sighup_handler(sip.tls.clone(), tls_server_config.clone()),
-        }
+        // The SIGHUP handler (config reload + TLS cert reload) is
+        // spawned *after* the outbound service is built (it needs the
+        // gateway-reload handle). The TLS swap handle is consumed by the
+        // listeners below, so clone it for the handler here.
+        let tls_for_reload = tls_server_config.clone();
 
         // ─── Integrated UAS ────────────────────────────────────────
         let local_uri = sip_local_uri(&node, &sip);
@@ -635,71 +606,31 @@ impl Runtime {
         // endpoint requires an `admin`-role bearer token (it's on the
         // authenticated `[admin]` listener); the cap + rate limit remain
         // the abuse guardrails on top of that (DEV_PLAN_0.6.0 §9.5/§9.6).
+        // SIGHUP gateway hot-reload (0.12.1): when outbound is enabled we
+        // keep the build deps + the concrete service so a reload can
+        // rebuild + swap the gateway set.
+        let outbound_reload: Option<crate::reload::OutboundReload>;
         let outbound_handle: Option<AdminOutbound> = if outbound.enabled() {
-            let mut gateways = HashMap::with_capacity(outbound.gateways.len());
             // Per-process DTLS cert for answering a peer's DTLS-SRTP offer
-            // on an outbound delayed call (0.9.3). Shared across gateways,
-            // same posture as the inbound acceptor's cert.
+            // on an outbound delayed call (0.9.3). Shared across gateways
+            // (and reused across reloads), same posture as the inbound
+            // acceptor's cert.
             let outbound_dtls_cert = Arc::new(
                 forge_rtp::dtls::DtlsCertificate::generate()
                     .map_err(|e| anyhow!("outbound DTLS cert generation failed: {e}"))?,
             );
-            for gw in &outbound.gateways {
-                // Outbound delayed offer (chunk 2): the gateway's UAC and
-                // its originator share one registry — `place_delayed` parks
-                // per-call media params, the UAC's answer generator picks
-                // them up when the peer's offer arrives in the 2xx.
-                let delayed_registry: siphon_ai_core::DelayedOfferRegistry =
-                    Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
-                let answerer: Arc<dyn sip_uac::integrated::SdpAnswerGenerator> =
-                    Arc::new(siphon_ai_core::DelayedOfferAnswerer::new(
-                        (*outbound_media).clone(),
-                        Arc::clone(&delayed_registry),
-                        Arc::clone(&outbound_dtls_cert),
-                    ));
-                let uac = build_outbound_uac(
-                    TransferUacBuild {
-                        local_uri: &local_uri,
-                        contact_uri: &contact_uri,
-                        listen_addr: sip.listen_addr,
-                        public_addr: sip_public_addr(&node, &sip),
-                        transaction_mgr: Arc::clone(&transaction_mgr),
-                        dispatcher: Arc::clone(&dispatcher),
-                        sip_resolver: Arc::clone(&sip_resolver),
-                    },
-                    gw.credentials.as_ref(),
-                    Some(answerer),
-                )?;
-                let originator = Arc::new(OutboundOriginator::with_delayed_registry(
-                    (*outbound_media).clone(),
-                    Arc::new(uac),
-                    delayed_registry,
-                ));
-                gateways.insert(
-                    gw.name.clone(),
-                    OutboundGateway {
-                        originator,
-                        proxy_host: gw.proxy_host.clone(),
-                        proxy_port: gw.proxy_port,
-                        transport_uri_param: gw.transport.uri_param(),
-                        from: gw.from.clone(),
-                        // Map the config SRTP policy onto the media-glue
-                        // offer mode (core's SrtpMode is the inbound enum;
-                        // OutboundSrtp is its outbound mirror).
-                        srtp: match gw.srtp {
-                            siphon_ai_core::SrtpMode::Off => {
-                                siphon_ai_media_glue::OutboundSrtp::Off
-                            }
-                            siphon_ai_core::SrtpMode::Preferred => {
-                                siphon_ai_media_glue::OutboundSrtp::Preferred
-                            }
-                            siphon_ai_core::SrtpMode::Required => {
-                                siphon_ai_media_glue::OutboundSrtp::Required
-                            }
-                        },
-                    },
-                );
-            }
+            let gateway_deps = GatewayBuildDeps {
+                outbound_media: Arc::clone(&outbound_media),
+                outbound_dtls_cert,
+                local_uri: local_uri.clone(),
+                contact_uri: contact_uri.clone(),
+                listen_addr: sip.listen_addr,
+                public_addr: sip_public_addr(&node, &sip),
+                transaction_mgr: Arc::clone(&transaction_mgr),
+                dispatcher: Arc::clone(&dispatcher),
+                sip_resolver: Arc::clone(&sip_resolver),
+            };
+            let gateways = build_gateways(&outbound, &gateway_deps)?;
             let guard = OutboundGuard::new(outbound.max_concurrent, outbound.rate_limit_per_sec);
             let mut service = OutboundService::new(
                 gateways,
@@ -728,10 +659,46 @@ impl Runtime {
                 max_concurrent = outbound.max_concurrent,
                 "outbound origination enabled"
             );
-            Some(Arc::new(service) as AdminOutbound)
+            let service = Arc::new(service);
+            outbound_reload = Some(crate::reload::OutboundReload {
+                gateway_fingerprint: crate::reload::gateway_fingerprint(&outbound),
+                service: Arc::clone(&service),
+                deps: gateway_deps,
+            });
+            Some(service as AdminOutbound)
         } else {
+            outbound_reload = None;
             None
         };
+
+        // ─── SIGHUP handler (config reload + TLS cert reload) ──────
+        // Spawned here so it has the gateway-reload handle. Always
+        // installed: the default SIGHUP disposition is *terminate*, so
+        // even a no-config-path / no-TLS daemon must claim the signal or
+        // `systemctl reload` would kill it.
+        match config_path {
+            // Daemon with a backing config file: full SIGHUP reload
+            // (config file + gateways + TLS cert).
+            Some(path) => {
+                let initial_text = std::fs::read_to_string(&path).unwrap_or_default();
+                crate::reload::spawn_reload_handler(crate::reload::ReloadContext {
+                    config_path: path,
+                    initial_text,
+                    route_swap: Arc::clone(&route_swap),
+                    webhook_swap: Arc::clone(&webhook_swap),
+                    cdr_swap: Arc::clone(&cdr_swap),
+                    hep_telemetry: hep_telemetry.clone(),
+                    webhook_spool_active,
+                    cdr_spool_active,
+                    outbound: outbound_reload,
+                    tls: sip.tls.clone().zip(tls_for_reload),
+                    restart_fingerprints,
+                });
+            }
+            // No backing file (tests): preserve the prior TLS-cert /
+            // no-op SIGHUP behavior.
+            None => spawn_sighup_handler(sip.tls.clone(), tls_for_reload),
+        }
 
         // ─── Build admin state + observability HTTP listener ──────
         // Deferred until now so admin endpoints have the call
@@ -1418,6 +1385,89 @@ fn build_transfer_uac(args: TransferUacBuild<'_>) -> Result<IntegratedUAC> {
     builder
         .build()
         .map_err(|e| anyhow!("transfer UAC build: {e}"))
+}
+
+/// Long-lived dependencies needed to build the outbound gateway table.
+/// Bundled so the initial build and a later SIGHUP gateway reload share
+/// one construction path (all `Arc`s / owned strings — cheap to hold for
+/// the daemon's lifetime). The DTLS cert is generated once and reused
+/// across reloads.
+pub struct GatewayBuildDeps {
+    pub outbound_media: Arc<MediaSetup>,
+    pub outbound_dtls_cert: Arc<forge_rtp::dtls::DtlsCertificate>,
+    pub local_uri: String,
+    pub contact_uri: String,
+    pub listen_addr: SocketAddr,
+    pub public_addr: Option<SocketAddr>,
+    pub transaction_mgr: Arc<TransactionManager>,
+    pub dispatcher: Arc<dyn TransportDispatcher>,
+    pub sip_resolver: Arc<sip_dns::SipResolver>,
+}
+
+/// Build the `name → OutboundGateway` table from `[outbound]` config.
+/// One authenticated UAC + delayed-offer registry + originator per
+/// `[[gateway]]`. Called once at startup and again on a SIGHUP gateway
+/// reload — each call mints fresh UACs (stateless senders over the shared
+/// transaction manager), so a reload can fully replace the set.
+pub(crate) fn build_gateways(
+    outbound: &siphon_ai_config::OutboundConfig,
+    deps: &GatewayBuildDeps,
+) -> Result<HashMap<String, OutboundGateway>> {
+    let mut gateways = HashMap::with_capacity(outbound.gateways.len());
+    for gw in &outbound.gateways {
+        // Outbound delayed offer: the gateway's UAC and its originator
+        // share one registry — `place_delayed` parks per-call media
+        // params, the UAC's answer generator picks them up on the 2xx.
+        let delayed_registry: siphon_ai_core::DelayedOfferRegistry =
+            Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
+        let answerer: Arc<dyn sip_uac::integrated::SdpAnswerGenerator> =
+            Arc::new(siphon_ai_core::DelayedOfferAnswerer::new(
+                (*deps.outbound_media).clone(),
+                Arc::clone(&delayed_registry),
+                Arc::clone(&deps.outbound_dtls_cert),
+            ));
+        let uac = build_outbound_uac(
+            TransferUacBuild {
+                local_uri: &deps.local_uri,
+                contact_uri: &deps.contact_uri,
+                listen_addr: deps.listen_addr,
+                public_addr: deps.public_addr,
+                transaction_mgr: Arc::clone(&deps.transaction_mgr),
+                dispatcher: Arc::clone(&deps.dispatcher),
+                sip_resolver: Arc::clone(&deps.sip_resolver),
+            },
+            gw.credentials.as_ref(),
+            Some(answerer),
+        )?;
+        let originator = Arc::new(OutboundOriginator::with_delayed_registry(
+            (*deps.outbound_media).clone(),
+            Arc::new(uac),
+            delayed_registry,
+        ));
+        gateways.insert(
+            gw.name.clone(),
+            OutboundGateway {
+                originator,
+                proxy_host: gw.proxy_host.clone(),
+                proxy_port: gw.proxy_port,
+                transport_uri_param: gw.transport.uri_param(),
+                from: gw.from.clone(),
+                // Map the config SRTP policy onto the media-glue offer
+                // mode (core's SrtpMode is the inbound enum; OutboundSrtp
+                // is its outbound mirror).
+                srtp: match gw.srtp {
+                    siphon_ai_core::SrtpMode::Off => siphon_ai_media_glue::OutboundSrtp::Off,
+                    siphon_ai_core::SrtpMode::Preferred => {
+                        siphon_ai_media_glue::OutboundSrtp::Preferred
+                    }
+                    siphon_ai_core::SrtpMode::Required => {
+                        siphon_ai_media_glue::OutboundSrtp::Required
+                    }
+                },
+            },
+        );
+    }
+    Ok(gateways)
 }
 
 /// Build a per-gateway outbound UAC. Same shape as [`build_transfer_uac`],

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -18,6 +18,8 @@ uuid.workspace        = true
 chrono.workspace      = true
 parking_lot.workspace = true
 metrics.workspace     = true
+# Hot-swappable outbound gateway table for SIGHUP reload (0.12.1).
+arc-swap = "1"
 # Serialize the verstat verdict to JSON for the HEP3 Verstat chunk.
 serde_json.workspace  = true
 

--- a/crates/core/src/outbound_service.rs
+++ b/crates/core/src/outbound_service.rs
@@ -19,6 +19,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use arc_swap::ArcSwap;
 use chrono::{DateTime, Utc};
 use forge_core::{CallId, ParticipantId};
 use sip_core::SipUri;
@@ -76,7 +77,11 @@ pub struct OutboundGateway {
 
 /// Daemon-wide outbound-origination service.
 pub struct OutboundService {
-    gateways: HashMap<String, OutboundGateway>,
+    /// Gateway table, behind an `ArcSwap` so a SIGHUP reload can swap
+    /// the set (add / remove / modify gateways) for new originations.
+    /// In-flight outbound calls already hold their gateway's
+    /// `Arc<OutboundOriginator>`, so they keep running on it.
+    gateways: ArcSwap<HashMap<String, OutboundGateway>>,
     guard: OutboundGuard,
     defaults: BridgeDefaults,
     call_id_factory: CallIdFactory,
@@ -113,7 +118,7 @@ impl OutboundService {
         consult_registry: ConsultRegistry,
     ) -> Self {
         Self {
-            gateways,
+            gateways: ArcSwap::from_pointee(gateways),
             guard,
             defaults,
             call_id_factory,
@@ -156,12 +161,25 @@ impl OutboundService {
         self.moh_file = moh_file;
         self
     }
+
+    /// Swap the gateway table (SIGHUP reload). New originations use the
+    /// new set; in-flight calls keep the originator they captured. The
+    /// concurrency guard (`max_concurrent` / `rate_limit`) is *not*
+    /// touched — resizing a live semaphore isn't safe, so those changes
+    /// remain restart-required.
+    pub fn reload_gateways(&self, gateways: HashMap<String, OutboundGateway>) {
+        self.gateways.store(Arc::new(gateways));
+    }
 }
 
 impl OutboundOriginateHandle for OutboundService {
     fn originate(&self, req: OriginateRequest) -> Result<String, OriginateRejection> {
-        let gw = self
-            .gateways
+        // Snapshot the gateway table for this origination. The guard
+        // lives to the end of this (synchronous) method, past every
+        // `gw` read; the spawned call captures only the cloned
+        // `Arc<OutboundOriginator>`, so a concurrent reload is safe.
+        let gateways = self.gateways.load();
+        let gw = gateways
             .get(&req.gateway)
             .ok_or_else(|| OriginateRejection::UnknownGateway(req.gateway.clone()))?;
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -676,6 +676,10 @@ reload-safe sections without dropping calls:
 - **webhook + CDR sinks** (`[webhooks]`, `[cdr]`) — rebuilt and swapped,
   **unless** a durable spool (`spool_dir`) is active for that sink (its
   background drain worker can't be hot-swapped → restart required);
+- **outbound gateways** (`[[gateway]]`, 0.12.1) — the set is rebuilt and
+  swapped (add / remove / modify trunks); in-flight outbound calls keep the
+  trunk they're on. Requires outbound enabled and the `[outbound]` limits
+  unchanged (see below);
 - the **`[sip.tls]` cert** is reloaded too (the 0.3.0 behavior, unchanged).
 
 **Fail-safe:** if the new config doesn't load/compile, the error is logged,
@@ -684,10 +688,11 @@ ticks — a bad edit can't take the daemon down. Run `siphon-ai check` first.
 
 **Restart-required sections.** Anything that binds a socket or builds
 process-wide state — `[sip]` listen/transports, `[node]`, `[media]`,
-`[observability]`, `[admin]`, `[hep]`, `[security.stir_shaken]`, and
-`[[gateway]]` (gateway hot-reload is a planned follow-up) — needs a process
-restart. A reload that changes one of these applies the safe sections and
-logs a warning naming the section(s) that did **not** take effect.
+`[observability]`, `[admin]`, `[hep]`, `[security.stir_shaken]`, and the
+`[outbound]` limits (`max_concurrent` / `rate_limit_per_sec`, which also flip
+outbound on/off — resizing the live admission semaphore isn't safe) — needs a
+process restart. A reload that changes one of these applies the safe sections
+and logs a warning naming the section(s) that did **not** take effect.
 
 Watch `siphon_ai_config_reloads_total{result}` (`applied` / `no_change` /
 `failed`); each reload also logs what it did. See `docs/DEPLOY.md` for the

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -242,6 +242,10 @@ dropping calls**:
 - **`[webhooks]` + `[cdr]` sinks** — rebuilt and swapped, *unless* a
   durable `spool_dir` is active for that sink (its drain worker can't be
   hot-swapped → restart required for delivery changes there);
+- **outbound gateways** (`[[gateway]]`, 0.12.1) — the set is rebuilt +
+  swapped (add / remove / modify trunks); in-flight outbound calls keep the
+  trunk they're on. Needs outbound enabled and the `[outbound]` limits
+  unchanged;
 - the `[sip.tls]` cert (above).
 
 **Always `check` before you reload** — a reload is exactly as safe as the
@@ -259,11 +263,12 @@ file is byte-identical to the last load.
 
 **Restart-required sections.** `[sip]` listen/transports, `[node]`,
 `[media]`, `[observability]`, `[admin]`, `[hep]`,
-`[security.stir_shaken]`, and `[[gateway]]` (gateway hot-reload is a
-planned follow-up) bind sockets or build process-wide state and need a
-process **restart**. A reload that changes one of these applies the safe
-sections and logs a `warn!` naming the section(s) that did not take effect
-— grep the journal for `require a restart` after a reload to catch this.
+`[security.stir_shaken]`, and the `[outbound]` limits (`max_concurrent` /
+`rate_limit_per_sec`, which also flip outbound on/off) bind sockets or build
+process-wide state and need a process **restart**. A reload that changes one
+of these applies the safe sections and logs a `warn!` naming the section(s)
+that did not take effect — grep the journal for `require a restart` after a
+reload to catch this.
 
 ### 6. Smoke test
 


### PR DESCRIPTION
Fast-follow to the config reload theme — v0.12.0 shipped routes + sinks reload; this completes the SIGHUP surface with **outbound gateway hot-reload**.

`systemctl reload siphon-ai` now also rebuilds and swaps the `[[gateway]]` set — add / remove / modify trunks **without a restart**. In-flight outbound calls keep the trunk (`OutboundOriginator`) they're on; new originations use the new set.

## What's here
- **core**: `OutboundService.gateways` is now `arc_swap::ArcSwap<HashMap<...>>`. `originate()` snapshots it per call (the guard outlives every `gw` read; the spawned call captures only the cloned `Arc<OutboundOriginator>`, so a concurrent reload is safe). New `OutboundService::reload_gateways(map)`. The concurrency guard is **not** touched — resizing a live semaphore isn't safe, so `[outbound]` limits stay restart-required. (`arc-swap` dep added.)
- **bin**: factored the gateway-build loop into `build_gateways(&OutboundConfig, &GatewayBuildDeps)` — a deps bundle reused by the initial build and reload. Each build mints fresh per-gateway UACs (stateless senders over the shared transaction manager — recreating them leaks nothing). The concrete `Arc<OutboundService>` + deps are kept as `OutboundReload`.
- **reload**: `gateway_fingerprint()` (hot-reloadable set) split from `restart_fingerprints()` (now `[outbound].limits`). `apply_reload` rebuilds + swaps gateways when outbound is enabled, limits unchanged, and the gateway set differs. The SIGHUP-handler spawn moved after the outbound build (it needs the gateway handle); the TLS swap is cloned for it since the listeners consume the original.
- **docs**: CONFIG/DEPLOY now list `[[gateway]]` as hot-reloadable and `[outbound]` limits as the restart-required outbound knob.

## Verification
- Unit: `gateway_fingerprint` tracks gateway changes but not restart sections; an `[outbound].limits` change is restart-required.
- **Live-verified**: adding a gateway → `outbound gateways reloaded gateways=2`; a `max_concurrent` change → restart-required warn.
- 21 bin-lib + 144 core + 9 cli green; `cargo clippy --workspace --all-targets -D warnings` clean.

CHANGELOG 0.12.1 + version bump included. After merge: tag `v0.12.1` + release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)