### PR TITLE
chore(release): 0.12.2 — config-CLI/reload bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.2] - 2026-06-20
+
+### Fixed
+
+- **`siphon-ai check` silently swallowed config load-time warnings**
+  (security-relevant). The read-only subcommands (`check` / `print-config`
+  / `route-test`) installed no tracing subscriber, so compile-time
+  `warn!`s — notably the **SRTP-master-key-in-cleartext** footgun (a
+  gateway with `srtp != off` but a non-TLS transport) — were dropped,
+  making the documented pre-deploy preflight strictly *less* informative
+  than a real boot. Tracing is now installed before the read-only
+  subcommands, so `check` surfaces exactly what the daemon prints at
+  startup (then still reports `config OK` + exit 0, since these are
+  warnings, not errors).
+- **SIGHUP webhook/CDR-spool reload warning over-fired.** With a
+  `spool_dir` configured, every reload logged "delivery changes require a
+  restart" even when `[webhooks]` / `[cdr]` hadn't changed. The warning now
+  fires only when the sink's own config actually changed (and the reload no
+  longer needlessly rebuilds an unchanged sink).
+- **`[media]` restart-required check missed codec / DTMF changes** (silent
+  config drift). The reload's restart-required fingerprint hashed only
+  `rtp_port_range` / `moh_file` / `srtp`, so changing `[media].codecs` (or
+  any `[bridge]` default) and reloading was silently swallowed — not
+  hot-applied and with no restart-required warning. The fingerprint now
+  covers the full `[media]` block plus the bridge/codec defaults, so any
+  such change surfaces as restart-required.
+
 ## [0.12.1] - 2026-06-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2937,7 +2937,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "base64",
  "bytes",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2975,7 +2975,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "regex",
  "serde",
@@ -2993,7 +2993,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3035,7 +3035,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "hmac",
  "http-body-util",
@@ -3055,7 +3055,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "thiserror 1.0.69",
  "tokio",
@@ -3088,7 +3088,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "regex",
  "serde",
@@ -3099,7 +3099,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -3108,7 +3108,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3132,7 +3132,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "base64",
  "rcgen",
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3173,7 +3173,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.12.1"
+version = "0.12.2"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Patch release for the three bugs fixed in #212 (found during v0.12.1 testing):

- **`check` swallowed config warnings** (security-relevant — the SRTP-key-in-cleartext footgun was hidden by the preflight).
- **SIGHUP webhook/CDR-spool reload warning over-fired** on every reload.
- **`[media]` codec/dtmf changes** weren't flagged restart-required (silent config drift).

CHANGELOG 0.12.2 + workspace version `0.12.1` → `0.12.2`. After merge: tag `v0.12.2` + release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)