### PR TITLE
chore(deps): bump forge-media pin to 049a19983a95 (forge-media #76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped the forge-media pin to `049a19983a95` (forge-media PR #76):
+  `forge-core`'s `EventBus::publish` no longer logs a spurious `WARN` when
+  it has no subscribers. Drops log noise on the per-call event path;
+  logging-only, no API or behavior change.
+
 ## [0.12.2] - 2026-06-20
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,7 +704,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "forge-codecs"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=3c82c2e5d175#3c82c2e5d17598e36d44aa338e1679074b292e6b"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=049a19983a95#049a19983a9515a2f5ccc289b23974f5057f2919"
 dependencies = [
  "audiopus",
  "ezk-g722",
@@ -716,7 +716,7 @@ dependencies = [
 [[package]]
 name = "forge-core"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=3c82c2e5d175#3c82c2e5d17598e36d44aa338e1679074b292e6b"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=049a19983a95#049a19983a9515a2f5ccc289b23974f5057f2919"
 dependencies = [
  "chrono",
  "serde",
@@ -731,7 +731,7 @@ dependencies = [
 [[package]]
 name = "forge-dtmf"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=3c82c2e5d175#3c82c2e5d17598e36d44aa338e1679074b292e6b"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=049a19983a95#049a19983a9515a2f5ccc289b23974f5057f2919"
 dependencies = [
  "chrono",
  "forge-core",
@@ -743,7 +743,7 @@ dependencies = [
 [[package]]
 name = "forge-engine"
 version = "0.4.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=3c82c2e5d175#3c82c2e5d17598e36d44aa338e1679074b292e6b"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=049a19983a95#049a19983a9515a2f5ccc289b23974f5057f2919"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -773,7 +773,7 @@ dependencies = [
 [[package]]
 name = "forge-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=3c82c2e5d175#3c82c2e5d17598e36d44aa338e1679074b292e6b"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=049a19983a95#049a19983a9515a2f5ccc289b23974f5057f2919"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -786,7 +786,7 @@ dependencies = [
 [[package]]
 name = "forge-injection"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=3c82c2e5d175#3c82c2e5d17598e36d44aa338e1679074b292e6b"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=049a19983a95#049a19983a9515a2f5ccc289b23974f5057f2919"
 dependencies = [
  "forge-core",
  "rubato",
@@ -799,7 +799,7 @@ dependencies = [
 [[package]]
 name = "forge-mixer"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=3c82c2e5d175#3c82c2e5d17598e36d44aa338e1679074b292e6b"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=049a19983a95#049a19983a9515a2f5ccc289b23974f5057f2919"
 dependencies = [
  "bytes",
  "dashmap 6.2.1",
@@ -813,7 +813,7 @@ dependencies = [
 [[package]]
 name = "forge-recorder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=3c82c2e5d175#3c82c2e5d17598e36d44aa338e1679074b292e6b"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=049a19983a95#049a19983a9515a2f5ccc289b23974f5057f2919"
 dependencies = [
  "bytes",
  "forge-core",
@@ -827,7 +827,7 @@ dependencies = [
 [[package]]
 name = "forge-resampler"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=3c82c2e5d175#3c82c2e5d17598e36d44aa338e1679074b292e6b"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=049a19983a95#049a19983a9515a2f5ccc289b23974f5057f2919"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -836,7 +836,7 @@ dependencies = [
 [[package]]
 name = "forge-rtp"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=3c82c2e5d175#3c82c2e5d17598e36d44aa338e1679074b292e6b"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=049a19983a95#049a19983a9515a2f5ccc289b23974f5057f2919"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -861,14 +861,14 @@ dependencies = [
 [[package]]
 name = "forge-sdp"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=3c82c2e5d175#3c82c2e5d17598e36d44aa338e1679074b292e6b"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=049a19983a95#049a19983a9515a2f5ccc289b23974f5057f2919"
 dependencies = [
  "base64",
  "chrono",
  "forge-core",
  "forge-rtp",
  "rand 0.9.4",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=3c82c2e5d175)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=049a19983a95)",
  "smol_str",
  "thiserror 2.0.18",
 ]
@@ -876,7 +876,7 @@ dependencies = [
 [[package]]
 name = "forge-transcoder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=3c82c2e5d175#3c82c2e5d17598e36d44aa338e1679074b292e6b"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=049a19983a95#049a19983a9515a2f5ccc289b23974f5057f2919"
 dependencies = [
  "bytes",
  "forge-codecs",
@@ -889,7 +889,7 @@ dependencies = [
 [[package]]
 name = "forge-vad"
 version = "0.1.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=3c82c2e5d175#3c82c2e5d17598e36d44aa338e1679074b292e6b"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=049a19983a95#049a19983a9515a2f5ccc289b23974f5057f2919"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -2794,7 +2794,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3023963ba83a#3023963ba83a0428b28133d1d1dada7cca78db8f"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=049a19983a95#049a19983a9515a2f5ccc289b23974f5057f2919"
 dependencies = [
  "nom",
  "smol_str",
@@ -2803,7 +2803,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=3c82c2e5d175#3c82c2e5d17598e36d44aa338e1679074b292e6b"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3023963ba83a#3023963ba83a0428b28133d1d1dada7cca78db8f"
 dependencies = [
  "nom",
  "smol_str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,26 +137,28 @@ sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "302
 # AI logic belongs in the WS server, never here. See CLAUDE.md §4.1 and the
 # upstream gate at https://github.com/thevoiceguy/forge-media/pull/39.
 #
-# forge-media is now pinned to `main`. PR #41 (forge-vad) merged, then
-# PR #42 (forge-hep) merged, both onto main. Some unrelated crates on
-# forge main are still broken from dependabot regressions (rand 0.9 in
-# forge-ice, Cow/lifetime in forge-recorder), but the subset SiphonAI
-# pulls — forge-core, forge-rtp, forge-engine (g722 only), forge-codecs,
-# forge-sdp, forge-dtmf, forge-vad, forge-hep — all build cleanly.
-forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "3c82c2e5d175" }
-forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "3c82c2e5d175" }
-forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "3c82c2e5d175", default-features = false, features = ["g722", "dtls", "opus"] }
-forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "3c82c2e5d175" }
-forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "3c82c2e5d175" }
-forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "3c82c2e5d175" }
-forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "3c82c2e5d175" }
-forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "3c82c2e5d175" }
+# forge-media is pinned to a `main` rev. Bumped 2026-06-20 to 049a19983a95
+# = forge-media PR #76 (fix(forge-core): don't WARN when publishing to a
+# bus with no subscribers) — a logging-only fix, no API change. (Prior
+# pin 3c82c2e5d175 was the direct parent.) Some unrelated crates on forge
+# main are still broken from dependabot regressions (rand 0.9 in forge-ice,
+# Cow/lifetime in forge-recorder), but the subset SiphonAI pulls —
+# forge-core, forge-rtp, forge-engine (g722 only), forge-codecs, forge-sdp,
+# forge-dtmf, forge-vad, forge-hep — all build cleanly.
+forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "049a19983a95" }
+forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "049a19983a95" }
+forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "049a19983a95", default-features = false, features = ["g722", "dtls", "opus"] }
+forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "049a19983a95" }
+forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "049a19983a95" }
+forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "049a19983a95" }
+forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "049a19983a95" }
+forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "049a19983a95" }
 # Conference rooms (0.7.0): forge-mixer is the per-room AudioMixer;
 # forge-injection provides ToneGenerator (join/leave tones now, MOH
 # for park later). Deliberately NOT forge-conference — its DTMF
 # IVR/PIN/host-control layer is unused per DEV_PLAN_0.7.0.md §9.4.
-forge-mixer     = { git = "https://github.com/thevoiceguy/forge-media", rev = "3c82c2e5d175" }
-forge-injection = { git = "https://github.com/thevoiceguy/forge-media", rev = "3c82c2e5d175" }
+forge-mixer     = { git = "https://github.com/thevoiceguy/forge-media", rev = "049a19983a95" }
+forge-injection = { git = "https://github.com/thevoiceguy/forge-media", rev = "049a19983a95" }
 
 # hep-rs — HEP3 codec, transport, HepSink trait. Owned by the same
 # author as siphon-rs and forge-media; lives in its own repo.


### PR DESCRIPTION
Picks up [forge-media PR #76](https://github.com/thevoiceguy/forge-media/pull/76) — `fix(forge-core): don't WARN when publishing to a bus with no subscribers`.

A **logging-only** fix: `EventBus::publish` (a tokio broadcast `send`) no longer logs a spurious `WARN` when the bus has no subscribers, which happens on SiphonAI's per-call event path. **No API or behavior change** — the prior pin (`3c82c2e5d175`) was the direct parent of #76, so this is a single-commit bump.

## Per CLAUDE.md §7.5
- All **10** `forge-*` crate pins bumped in lockstep; `Cargo.lock` uniformly at `049a19983a95`.
- `cargo build --workspace` + full `cargo test --workspace` green (47 test groups); media-glue + core (closest to forge) pass.
- `cargo clippy --workspace --all-targets -D warnings` clean.
- Noted under CHANGELOG `[Unreleased]`.

No version bump / release — this rides into the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)