### PR TITLE
fix(fail2ban): recidive must read /var/log/fail2ban.log, not the journal

### DIFF
--- a/contrib/fail2ban/jail.d/recidive.local
+++ b/contrib/fail2ban/jail.d/recidive.local
@@ -3,17 +3,28 @@
 # per-jail policy: a bot that gets siphon-ai-banned 3 times in
 # a week lands here for a week, then a month, etc.
 #
-# Watches fail2ban's OWN journal (`fail2ban.service`) for
-# `[<jail>] Ban <IP>` events. Filter ships with the fail2ban
-# package — no custom regex needed.
+# Watches fail2ban's OWN log for `[<jail>] Ban <IP>` events.
+# Filter ships with the fail2ban package — no custom regex needed.
+#
+# IMPORTANT — read the FILE, not the journal. Unlike the siphon-ai
+# jail (systemd backend, because the SiphonAI *daemon* logs to
+# journald), recidive watches fail2ban's own ban notices — and
+# fail2ban logs to a FILE by default (`logtarget = /var/log/fail2ban.log`
+# in fail2ban.conf). Its per-ban `NOTICE ... Ban <ip>` lines never
+# reach the journal, so a `backend = systemd` +
+# `journalmatch = fail2ban.service` jail matches ZERO ban events and
+# never fires — symptom: `fail2ban-client status recidive` shows
+# `Total failed: 0` even while the siphon-ai jail racks up bans.
+# (If you instead set fail2ban's `logtarget = SYSTEMD-JOURNAL`, switch
+# this jail back to `backend = systemd` to match.)
 #
 # Drop in /etc/fail2ban/jail.d/ alongside siphon-ai.local.
 
 [recidive]
 enabled      = true
 filter       = recidive
-backend      = systemd
-journalmatch = _SYSTEMD_UNIT=fail2ban.service
+backend      = auto
+logpath      = /var/log/fail2ban.log
 
 # How many *bans* (not failed logins — bans!) before recidive
 # escalates. 3 across the findtime window. Bots that come back

--- a/docs/SECURITY_FAIL2BAN.md
+++ b/docs/SECURITY_FAIL2BAN.md
@@ -137,6 +137,20 @@ The recidive filter is bundled with the fail2ban package
 (`/etc/fail2ban/filter.d/recidive.conf`); we only ship the jail
 snippet.
 
+> **Why recidive reads a file, not the journal.** The `siphon-ai`
+> jail uses `backend = systemd` because the SiphonAI *daemon* logs
+> to journald. fail2ban *itself* does not — by default it logs to
+> `/var/log/fail2ban.log` (`logtarget` in `fail2ban.conf`), so its
+> per-ban `NOTICE [siphon-ai] Ban <ip>` lines never reach the
+> journal. recidive therefore reads that **file**
+> (`backend = auto`, `logpath = /var/log/fail2ban.log`). A recidive
+> jail pointed at `_SYSTEMD_UNIT=fail2ban.service` matches **zero**
+> ban events and silently never fires — confirm with
+> `fail2ban-client status recidive`: if `Total failed: 0` while the
+> siphon-ai jail is banning, the source is wrong. (If you set
+> fail2ban's `logtarget = SYSTEMD-JOURNAL`, switch recidive back to
+> the systemd backend.)
+
 ### Stack the two
 
 To get progressively longer recidive bans, enable
@@ -170,7 +184,7 @@ sudo fail2ban-client status recidive
 # |- Filter
 # |  |- Currently failed: 0
 # |  |- Total failed:     12
-# |  `- Journal matches:  _SYSTEMD_UNIT=fail2ban.service
+# |  `- File list:        /var/log/fail2ban.log
 # `- Actions
 #    |- Currently banned: 2
 #    |- Total banned:     4

--- a/scripts/install-fail2ban.sh
+++ b/scripts/install-fail2ban.sh
@@ -119,10 +119,11 @@ step "Section 1: Install packages"
 # though Debian's package metadata only declares one of them hard.
 #
 #   fail2ban           — the daemon itself.
-#   python3-systemd    — required by the journal backend our jails
-#                        use. Already a Depends of fail2ban; listed
-#                        here for explicitness so a future repackage
-#                        wouldn't silently break us.
+#   python3-systemd    — required by the systemd journal backend the
+#                        siphon-ai jail uses (recidive reads a file,
+#                        not the journal). Already a Depends of
+#                        fail2ban; listed here for explicitness so a
+#                        future repackage wouldn't silently break us.
 #   nftables           — provides `nft` and the kernel module our
 #                        action (`nftables-allports`) writes rules
 #                        through. Debian only marks this as Recommends
@@ -377,6 +378,22 @@ fi
 if status=$(sudo fail2ban-client status recidive 2>&1); then
   ok "recidive jail active."
   printf '%s\n' "$status" | sed 's/^/    /'
+
+  # recidive watches fail2ban's OWN ban events, which land in a FILE
+  # (logtarget = /var/log/fail2ban.log), NOT the journal — fail2ban's
+  # per-ban `NOTICE [jail] Ban <ip>` lines never reach the journal. A
+  # recidive jail pointed at the systemd backend matches zero events
+  # and silently never fires (status shows `Journal matches:` and
+  # `Total failed: 0` forever, even while siphon-ai racks up bans).
+  # Assert it's reading the file so that misconfiguration is caught
+  # HERE, at install time, instead of in an incident months later.
+  if ! printf '%s\n' "$status" | grep -q "File list:.*fail2ban\.log"; then
+    warn "recidive is up but is NOT reading /var/log/fail2ban.log (no \
+'File list:' in status). It will never fire — fail2ban logs bans to that \
+file, not the journal. Ensure jail.d/recidive.local uses 'backend = auto' \
++ 'logpath = /var/log/fail2ban.log' (or, if you set fail2ban's \
+logtarget = SYSTEMD-JOURNAL, switch recidive back to 'backend = systemd')."
+  fi
 else
   warn "recidive jail not active (this is unusual — was the file installed?)."
 fi


### PR DESCRIPTION
## Problem

The `recidive` jail never fired. `fail2ban-client status recidive` showed `Total failed: 0` indefinitely, even while the `siphon-ai` jail was actively banning SIP scanners.

**Root cause:** `recidive.local` used `backend = systemd` + `journalmatch = _SYSTEMD_UNIT=fail2ban.service` to watch fail2ban's own ban events. But fail2ban logs to a **file** by default (`logtarget = /var/log/fail2ban.log` in `fail2ban.conf`) — its per-ban `NOTICE [jail] Ban <ip>` lines never reach the journal. So the jail matched zero events and never escalated repeat offenders.

This is subtly different from the `siphon-ai` jail, which *correctly* uses the systemd backend because the **SiphonAI daemon** logs to journald. fail2ban itself does not.

## Fix

- `contrib/fail2ban/jail.d/recidive.local`: `backend = systemd` + `journalmatch` → `backend = auto` + `logpath = /var/log/fail2ban.log`, matching the stock Debian recidive jail. Added a comment block explaining the file-vs-journal trap.
- `scripts/install-fail2ban.sh`: the verify step reported "recidive jail active" even when the jail was reading the wrong source — exactly why this went unnoticed. Added an assertion that recidive shows `File list: …/fail2ban.log` at install time (mirroring the existing `Journal matches:` check for siphon-ai), plus corrected the `python3-systemd` comment (only the siphon-ai jail uses the journal backend now).
- `docs/SECURITY_FAIL2BAN.md`: documented why recidive reads a file, and corrected the sample status output.

The `siphon-ai` jail is unchanged.

## Verification

- `fail2ban-regex` against the bundled recidive filter: correctly matches `[siphon-ai] Ban` lines, ignores `[recidive]` self-bans and `Unban` lines.
- **Live on the box:** after applying, recidive went from `0/0` to reading **594** ban events and **immediately banning 17 repeat-offender IPs**. Status flipped from `Journal matches: …fail2ban.service` to `File list: /var/log/fail2ban.log`.
- `bash -n scripts/install-fail2ban.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)