### PR TITLE
docs(deploy): correct stale "/admin/* has no auth in v1" ports row

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -45,7 +45,8 @@ operator's network, and the daemon container.
 | `[sip].listen`    | TCP    | TOML           | inbound   | Same port number when `transports` includes `"tcp"`. |
 | `[sip.tls].listen`| TCP    | TOML           | inbound   | TLS signaling. Defaults to the SIP IP + 5061. |
 | `[media].rtp_port_range` | UDP | TOML       | both      | RTP/RTCP. Forge allocates one even-numbered RTP port + the next odd RTCP port per call. Forward the whole range. |
-| `[observability].http_listen` | TCP | TOML  | inbound (cluster-local) | `/metrics`, `/health`, `/ready`, `/admin/*`. Don't expose this to the public internet — `/admin/*` has no auth in v1. |
+| `[observability].http_listen` | TCP | TOML  | inbound (cluster-local) | `/metrics`, `/health`, `/ready`. Unauthenticated — keep it cluster-local. Since 0.10.0 `/admin/*` is **not** served here (returns `404`); it moved to the dedicated `[admin]` listener below. |
+| `[admin].listen`  | TCP    | TOML           | inbound (cluster-local) | `/admin/*` control plane (0.10.0). Bearer-token auth + RBAC (`readonly` ⊂ `operator` ⊂ `admin`); omit `[admin]` and `/admin/*` isn't served at all. Still keep it off the public internet. |
 | Outbound, dynamic | TCP    | `[bridge].ws_url` (per route) | outbound | WebSocket from daemon to operator's WS server. |
 | Outbound, dynamic | TCP    | `[cdr.webhook].url`, `[webhooks].url` | outbound | HTTP POSTs for CDRs and lifecycle webhooks. |
 | Outbound 9060     | UDP    | `[hep].collector` | outbound | HEP3 to Homer. UDP only in v1. |


### PR DESCRIPTION
The "Required ports" table in `docs/DEPLOY.md` still listed `/admin/*` on the `[observability].http_listen` with **"no auth in v1"** — stale since **0.10.0**, which moved the admin control plane to a dedicated `[admin]` listener behind bearer-token auth + RBAC (and made the observability listener return `404` for `/admin/*`). The §*Admin auth & RBAC* section already documented this correctly; only the ports table lagged.

- Observability row: drop `/admin/*` + the "no auth" note; note it returns `404` there since 0.10.0.
- New `[admin].listen` row: bearer-token auth + RBAC (`readonly` ⊂ `operator` ⊂ `admin`), omit-to-disable, keep cluster-local.

Docs-only; `doc-links` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)