### PR TITLE
feat(bridge,core): emit rtp_timeout / audio_format / protocol_error (#4 step 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Error-signaling: `rtp_timeout`, `audio_format`, `protocol_error`**
+  (PROTOCOL.md §2.2 / §3.10) — the last three documented `error` codes the
+  daemon detected (or could trivially detect) but never emitted. Closes the
+  protocol doc↔impl drift (bug #4).
+  - **`rtp_timeout`** — when the media inactivity watchdog fires (no inbound
+    RTP for `[media].inactivity_timeout_secs`), the WS server is now told
+    *why* (`error{rtp_timeout}` + `stop`) before the socket closes, instead
+    of seeing a bare close.
+  - **`audio_format`** — inbound binary frames are validated against the
+    negotiated frame size (320 B @ 8 kHz, 640 B @ 16 kHz). A wrong-size frame
+    is **dropped** (non-fatal) and reported via `error{audio_format}`,
+    **rate-limited** to the first bad frame + at most one/sec. The call stays
+    up — one malformed frame can't kill it; persistent failure is still
+    caught by the dead-air / rtp watchdog.
+  - **`protocol_error`** — malformed JSON, an unknown message `type`, or a
+    `call_id` that doesn't match the connection now emits
+    `error{protocol_error}` + `stop` before closing. A **definitive**
+    teardown (new `DisconnectReason::ProtocolError`, not reconnect-eligible —
+    a buggy server would just repeat the violation). Previously these
+    conditions tore down silently and *were* reconnect-eligible.
+
 ## [0.13.0] - 2026-06-20
 
 ### Added

--- a/crates/bridge/src/conn.rs
+++ b/crates/bridge/src/conn.rs
@@ -276,6 +276,13 @@ pub enum DisconnectReason {
     /// definitive teardown — never reconnect-eligible (redialing the same
     /// slow server wouldn't help).
     ServerTooSlow,
+    /// The server sent an invalid WS message — malformed JSON, an unknown
+    /// `type`, or a `call_id` that doesn't match the connection
+    /// (PROTOCOL.md §3.10 `protocol_error`). The conn emitted
+    /// `error { code: "protocol_error" }` + `stop` and closed. A
+    /// definitive teardown — never reconnect-eligible (a buggy server
+    /// would just repeat the violation).
+    ProtocolError,
 }
 
 #[derive(Debug, Error)]
@@ -486,6 +493,15 @@ async fn run_loop(
 
     let (mut sink, mut stream) = ws.split();
 
+    // Expected inbound audio-frame size from the negotiated format, for the
+    // §2.2 `audio_format` check. PCM16 = 2 bytes/sample; e.g. 8 kHz/20 ms/mono
+    // = 320 B, 16 kHz = 640 B. `0` (an unset/odd format) disables the check.
+    // Captured before `start` is moved into the `Start` message below.
+    let expected_audio_bytes = (start.audio.sample_rate as usize / 1000)
+        * start.audio.frame_ms as usize
+        * start.audio.channels as usize
+        * 2;
+
     // Send `start` as the first message. `seq = 0` already enforced.
     let start_json = serde_json::to_string(&BridgeOut::Start(start))
         .map_err(|e| BridgeError::Internal(format!("serialize start: {e}")))?;
@@ -525,6 +541,11 @@ async fn run_loop(
     // audio frame or a `hangup`. `None` = disabled or already satisfied.
     let mut start_deadline: Option<tokio::time::Instant> = (!liveness.start_deadline.is_zero())
         .then(|| tokio::time::Instant::now() + liveness.start_deadline);
+
+    // Rate-limit `audio_format` emits (§2.2): a server stuck sending
+    // wrong-size frames shouldn't flood the WS with one error per frame
+    // (~50/s). Emit on the first bad frame, then at most one per second.
+    let mut last_audio_format_emit: Option<tokio::time::Instant> = None;
 
     loop {
         tokio::select! {
@@ -576,22 +597,74 @@ async fn run_loop(
                         // when triaging WS payout issues without
                         // drowning their dashboards at info.
                         tracing::trace!(bytes = data.len(), "ws inbound audio");
-                        // First server audio satisfies the start-deadline
-                        // (§3.1) — the strict "begin sending audio" rule.
+                        // §2.2 audio_format: a frame whose size doesn't
+                        // match the negotiated format is a server bug.
+                        // Drop it and tell the server (rate-limited,
+                        // NON-fatal — no `stop`), but keep the call up:
+                        // one bad frame mustn't kill a live call, and
+                        // persistent failure is caught by the dead-air /
+                        // rtp watchdog. A dropped frame does NOT satisfy
+                        // the start-deadline.
+                        if expected_audio_bytes > 0 && data.len() != expected_audio_bytes {
+                            let now = tokio::time::Instant::now();
+                            let emit = last_audio_format_emit
+                                .map(|t| now.duration_since(t) >= Duration::from_secs(1))
+                                .unwrap_or(true);
+                            if emit {
+                                last_audio_format_emit = Some(now);
+                                warn!(call_id = %call_id, got = data.len(),
+                                    expected = expected_audio_bytes,
+                                    "dropping wrong-size audio frame (audio_format)");
+                                let err = BridgeOut::Error {
+                                    call_id: call_id.clone(),
+                                    seq,
+                                    code: ErrorCode::AudioFormat,
+                                    message: format!(
+                                        "expected {expected_audio_bytes}-byte PCM16 frame, got {}",
+                                        data.len()
+                                    ),
+                                };
+                                seq = seq.wrapping_add(1);
+                                sink.send(Message::Text(serialize_or_drop(&err))).await?;
+                            }
+                            continue;
+                        }
+                        // First (valid) server audio satisfies the
+                        // start-deadline (§3.1) — the strict "begin
+                        // sending audio" rule.
                         start_deadline = None;
                         if audio_in_tx.send(data).await.is_err() {
                             return Ok(DisconnectReason::ControllerHungUp);
                         }
                     }
                     Some(Ok(Message::Text(text))) => {
-                        let parsed: BridgeIn = serde_json::from_str(&text)
-                            .map_err(|e| BridgeError::BadJson(e.to_string()))?;
+                        // §3.10 protocol_error: malformed JSON or an
+                        // unknown `type` (serde rejects both identically)
+                        // is a fatal protocol violation. Tell the server
+                        // (`error{protocol_error}` + `stop`) then close.
+                        // Definitive teardown — a buggy server would just
+                        // repeat it, so NOT reconnect-eligible.
+                        let parsed: BridgeIn = match serde_json::from_str(&text) {
+                            Ok(p) => p,
+                            Err(e) => {
+                                warn!(call_id = %call_id, error = %e,
+                                    "malformed or unknown WS message from server");
+                                let _ = emit_fatal(&mut sink, &call_id, &mut seq,
+                                    ErrorCode::ProtocolError,
+                                    "malformed or unknown message").await;
+                                let _ = close_clean(&mut sink).await;
+                                return Ok(DisconnectReason::ProtocolError);
+                            }
+                        };
                         let got = bridge_in_call_id(&parsed);
                         if got != call_id.as_str() {
-                            return Err(BridgeError::CallIdMismatch {
-                                expected: call_id.0.clone(),
-                                got: got.to_string(),
-                            });
+                            warn!(call_id = %call_id, got,
+                                "WS message call_id does not match the connection");
+                            let _ = emit_fatal(&mut sink, &call_id, &mut seq,
+                                ErrorCode::ProtocolError,
+                                "call_id does not match the connection").await;
+                            let _ = close_clean(&mut sink).await;
+                            return Ok(DisconnectReason::ProtocolError);
                         }
                         // Debug-level: every received control message
                         // (Clear, Mark, Hangup, Transfer, SendDtmf).

--- a/crates/bridge/tests/connection.rs
+++ b/crates/bridge/tests/connection.rs
@@ -418,7 +418,9 @@ async fn audio_frames_round_trip_to_server_and_back() {
     // Wait for `start` so the server is in steady state.
     tokio::time::sleep(Duration::from_millis(50)).await;
 
-    let frame = vec![0xAB, 0xCD, 0xEF, 0x01];
+    // 320 B = the negotiated 8 kHz/20 ms/mono frame, so the echoed copy
+    // passes the inbound §2.2 size check rather than being dropped.
+    let frame = vec![0xAB; 320];
     audio_out.send(frame.clone()).await.unwrap();
 
     let echoed = tokio::time::timeout(Duration::from_millis(500), audio_in.recv())
@@ -531,9 +533,22 @@ async fn server_sent_bridge_in_messages_are_parsed_and_dispatched() {
     let _ = conn.await.unwrap();
 }
 
+/// Drain the server's received text frames (up to a timeout) and return
+/// true once one contains `needle`.
+async fn server_saw_text(server: &mut ServerHandle, needle: &str) -> bool {
+    while let Ok(Some(text)) =
+        tokio::time::timeout(Duration::from_millis(500), server.client_text_rx.recv()).await
+    {
+        if text.contains(needle) {
+            return true;
+        }
+    }
+    false
+}
+
 #[tokio::test]
-async fn mismatched_call_id_yields_error() {
-    let server = spawn_server(ServerOpts::echoing()).await;
+async fn mismatched_call_id_yields_protocol_error() {
+    let mut server = spawn_server(ServerOpts::echoing()).await;
     let (chans, _audio_out, _control_out, _audio_in, _control_in) = fixture_channels();
     let conn = tokio::spawn(connect_and_run(
         fixture_config(server.ws_url()),
@@ -553,18 +568,20 @@ async fn mismatched_call_id_yields_error() {
         .await
         .expect("conn task should return")
         .unwrap();
-    match result {
-        Err(BridgeError::CallIdMismatch { expected, got }) => {
-            assert_eq!(expected, "expected-id");
-            assert_eq!(got, "WRONG");
-        }
-        other => panic!("expected CallIdMismatch, got {other:?}"),
-    }
+    assert_eq!(
+        result.expect("a protocol_error is a clean teardown, not an Err"),
+        DisconnectReason::ProtocolError
+    );
+    // The server is told why before the close (§3.10 fatal: error + stop).
+    assert!(
+        server_saw_text(&mut server, "\"protocol_error\"").await,
+        "expected an error{{protocol_error}} frame"
+    );
 }
 
 #[tokio::test]
 async fn malformed_json_from_server_is_a_protocol_error() {
-    let server = spawn_server(ServerOpts::echoing()).await;
+    let mut server = spawn_server(ServerOpts::echoing()).await;
     let (chans, _audio_out, _control_out, _audio_in, _control_in) = fixture_channels();
     let conn = tokio::spawn(connect_and_run(
         fixture_config(server.ws_url()),
@@ -582,10 +599,55 @@ async fn malformed_json_from_server_is_a_protocol_error() {
         .await
         .expect("conn task should return")
         .unwrap();
-    assert!(
-        matches!(result, Err(BridgeError::BadJson(_))),
-        "got {result:?}"
+    assert_eq!(
+        result.expect("protocol_error is a clean teardown"),
+        DisconnectReason::ProtocolError
     );
+    assert!(
+        server_saw_text(&mut server, "\"protocol_error\"").await,
+        "expected an error{{protocol_error}} frame"
+    );
+}
+
+/// A wrong-size audio frame is dropped (non-fatal) — the server is told
+/// via `error{audio_format}`, the call stays up, and a correctly-sized
+/// frame still flows through to the audio-in channel.
+#[tokio::test]
+async fn wrong_size_audio_frame_is_dropped_not_fatal() {
+    let mut server = spawn_server(ServerOpts::echoing()).await;
+    let (chans, _audio_out, _control_out, mut audio_in, _control_in) = fixture_channels();
+    // fixture_start negotiates 8 kHz/20 ms/mono → 320-byte frames.
+    let conn = tokio::spawn(connect_and_run(
+        fixture_config(server.ws_url()),
+        fixture_start("c"),
+        chans,
+    ));
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    // Wrong size (200 B): dropped, must NOT reach audio_in.
+    server
+        .server_send_tx
+        .send(WsMessage::Binary(vec![0u8; 200]))
+        .unwrap();
+    assert!(
+        server_saw_text(&mut server, "\"audio_format\"").await,
+        "expected an error{{audio_format}} frame for the bad size"
+    );
+
+    // Correct size (320 B): flows through.
+    server
+        .server_send_tx
+        .send(WsMessage::Binary(vec![1u8; 320]))
+        .unwrap();
+    let got = tokio::time::timeout(Duration::from_secs(1), audio_in.recv())
+        .await
+        .expect("a valid frame should arrive")
+        .expect("audio_in channel open");
+    assert_eq!(got.len(), 320, "the valid frame should pass unmodified");
+
+    // The call is still alive — neither frame tore it down.
+    assert!(!conn.is_finished(), "a bad frame must not be fatal");
+    conn.abort();
 }
 
 #[tokio::test]
@@ -688,7 +750,10 @@ async fn dropped_audio_in_rx_disconnects_with_controller_hung_up() {
     ));
 
     tokio::time::sleep(Duration::from_millis(50)).await;
-    audio_out.send(vec![1, 2, 3, 4]).await.unwrap();
+    // 320 B so the echoed frame passes the §2.2 size check and is actually
+    // forwarded to the (now-closed) audio_in — which is what trips the
+    // ControllerHungUp path under test.
+    audio_out.send(vec![1u8; 320]).await.unwrap();
 
     let result = tokio::time::timeout(Duration::from_secs(1), conn)
         .await

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -2230,6 +2230,7 @@ fn bridge_detail(res: Option<Result<DisconnectReason, siphon_ai_bridge::BridgeEr
             DisconnectReason::ServerClosed => "server_closed".into(),
             DisconnectReason::ControllerHungUp => "controller_hung_up".into(),
             DisconnectReason::ServerTooSlow => "server_too_slow".into(),
+            DisconnectReason::ProtocolError => "protocol_error".into(),
         },
         Some(Err(e)) => format!("error: {e}"),
     }

--- a/crates/core/src/call.rs
+++ b/crates/core/src/call.rs
@@ -1642,6 +1642,28 @@ impl CallController {
                             return Err(CallError::TaskJoin(join_err));
                         }
                     }
+                    // PROTOCOL.md §3.10 `rtp_timeout`: the media inactivity
+                    // watchdog fired (no inbound RTP for
+                    // `[media].inactivity_timeout_secs`). Tell the WS server
+                    // *why* before we close — queue `error{rtp_timeout}` +
+                    // `stop`; the conn drains both (biased recv) and emits
+                    // them before teardown drops `control_out_tx`.
+                    // Best-effort: the bridge may already be gone. The CDR
+                    // termination cause stays `TapEnded` (the rtp timeout is
+                    // the cause; the stop is just the mechanism).
+                    if matches!(tap_result, Some(Ok(TapDisconnect::InactivityTimeout))) {
+                        let _ = control_out_tx
+                            .send(OutgoingEvent::Error {
+                                code: ErrorCode::RtpTimeout,
+                                message: "no inbound RTP within the inactivity timeout".into(),
+                            })
+                            .await;
+                        let _ = control_out_tx
+                            .send(OutgoingEvent::Stop {
+                                reason: StopReason::Error,
+                            })
+                            .await;
+                    }
                     termination = CallTermination::TapEnded;
                     break;
                 }
@@ -1858,6 +1880,9 @@ fn reconnect_eligible(outcome: &Result<DisconnectReason, BridgeError>) -> bool {
         // `server_too_slow` is a healthy connection with a slow server —
         // redialing the same endpoint wouldn't help. Definitive teardown.
         Ok(DisconnectReason::ServerTooSlow) => false,
+        // `protocol_error` is a buggy server sending invalid frames —
+        // redialing just repeats the violation. Definitive teardown.
+        Ok(DisconnectReason::ProtocolError) => false,
         Err(_) => true,
     }
 }

--- a/crates/core/tests/controller_lifecycle.rs
+++ b/crates/core/tests/controller_lifecycle.rs
@@ -225,6 +225,47 @@ fn make_controller_full(
     CallController::new(cfg)
 }
 
+/// Controller whose tap arms the RTP inactivity watchdog with a short
+/// window — used to drive the `rtp_timeout` path (0.13.x). No real RTP
+/// peer feeds the tap, so the watchdog fires after `timeout`.
+fn make_controller_inactivity(
+    port: u16,
+    call_id: &str,
+    timeout: Duration,
+) -> (CallController, siphon_ai_core::CallHandle) {
+    let manager = Arc::new(MediaBridgeManager::new());
+    let tap = MediaTap::attach(
+        &manager,
+        &::std::sync::Arc::new(forge_core::EventBus::new()),
+        ForgeCallId::new(call_id),
+        8000,
+    )
+    .expect("attach tap")
+    .with_inactivity_timeout(Some(timeout));
+    Box::leak(Box::new(manager));
+    let cfg = CallControllerConfig {
+        call_id: CallId::new(call_id),
+        bridge: BridgeConfig {
+            ws_url: format!("ws://127.0.0.1:{port}/"),
+            auth_header: None,
+            connect_timeout: Duration::from_secs(2),
+            tls: None,
+            ..Default::default()
+        },
+        start: start_msg(call_id),
+        media_tap: tap,
+        transfer: None,
+        recording: None,
+        conference: None,
+        park: None,
+        hold: None,
+        ws_reconnect_enabled: false,
+        ws_reconnect_max: Duration::from_secs(30),
+        ws_reconnect_moh_file: None,
+    };
+    CallController::new(cfg)
+}
+
 /// A park context for tests: an enabled registry, no MOH file (comfort
 /// noise — no fixture needed), no webhook sink, and a caller-supplied
 /// timeout policy.
@@ -687,4 +728,43 @@ async fn caller_bye_while_parked_tears_down() {
     let outcome = run.await.expect("join").expect("run");
     assert_eq!(outcome.termination, CallTermination::LocalShutdown);
     assert_eq!(outcome.park.expect("park summary").count, 1);
+}
+
+#[tokio::test]
+async fn rtp_inactivity_emits_rtp_timeout_then_stop() {
+    // Server reads frames and forwards text to a channel; it never sends
+    // hangup or closes itself, so the ONLY thing that can end the call is
+    // the tap's RTP inactivity watchdog → `rtp_timeout`.
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+    let port = one_shot_server(move |mut ws| async move {
+        while let Some(Ok(msg)) = ws.next().await {
+            if let Message::Text(t) = msg {
+                let _ = tx.send(t);
+            }
+        }
+    })
+    .await;
+
+    let (controller, _handle) =
+        make_controller_inactivity(port, "rtp-1", Duration::from_millis(200));
+    let outcome = controller.run().await.expect("run");
+    assert_eq!(outcome.termination, CallTermination::TapEnded);
+
+    // Before the close, the server must have been told why: error{rtp_timeout}
+    // followed by stop (§3.10 fatal invariant).
+    let mut saw_rtp_timeout = false;
+    let mut saw_stop = false;
+    while let Ok(Some(text)) = tokio::time::timeout(Duration::from_millis(500), rx.recv()).await {
+        if text.contains("\"rtp_timeout\"") {
+            saw_rtp_timeout = true;
+        }
+        if text.contains("\"type\":\"stop\"") {
+            saw_stop = true;
+        }
+    }
+    assert!(
+        saw_rtp_timeout,
+        "server should receive error{{rtp_timeout}}"
+    );
+    assert!(saw_stop, "a fatal error must be followed by stop");
 }

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -45,7 +45,8 @@ operator's network, and the daemon container.
 | `[sip].listen`    | TCP    | TOML           | inbound   | Same port number when `transports` includes `"tcp"`. |
 | `[sip.tls].listen`| TCP    | TOML           | inbound   | TLS signaling. Defaults to the SIP IP + 5061. |
 | `[media].rtp_port_range` | UDP | TOML       | both      | RTP/RTCP. Forge allocates one even-numbered RTP port + the next odd RTCP port per call. Forward the whole range. |
-| `[observability].http_listen` | TCP | TOML  | inbound (cluster-local) | `/metrics`, `/health`, `/ready`, `/admin/*`. Don't expose this to the public internet — `/admin/*` has no auth in v1. |
+| `[observability].http_listen` | TCP | TOML  | inbound (cluster-local) | `/metrics`, `/health`, `/ready`. Unauthenticated — keep it cluster-local. Since 0.10.0 `/admin/*` is **not** served here (returns `404`); it moved to the dedicated `[admin]` listener below. |
+| `[admin].listen`  | TCP    | TOML           | inbound (cluster-local) | `/admin/*` control plane (0.10.0). Bearer-token auth + RBAC (`readonly` ⊂ `operator` ⊂ `admin`); omit `[admin]` and `/admin/*` isn't served at all. Still keep it off the public internet. |
 | Outbound, dynamic | TCP    | `[bridge].ws_url` (per route) | outbound | WebSocket from daemon to operator's WS server. |
 | Outbound, dynamic | TCP    | `[cdr.webhook].url`, `[webhooks].url` | outbound | HTTP POSTs for CDRs and lifecycle webhooks. |
 | Outbound 9060     | UDP    | `[hep].collector` | outbound | HEP3 to Homer. UDP only in v1. |

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -81,10 +81,14 @@ audio at the same cadence to avoid buffer churn; SiphonAI tolerates
 bursts up to the 200 ms outbound buffer (§5.5).
 
 A frame of the wrong **size** (not the negotiated 20 ms — 320 bytes @ 8 kHz,
-640 @ 16 kHz) is rejected with `error { code: "audio_format" }`. A raw PCM16
-frame carries no sample-rate or channel metadata, so the daemon validates
-only the byte length and otherwise assumes the negotiated rate + mono — send
-the wrong rate or stereo and it is interpreted, not detected.
+640 @ 16 kHz) is **dropped** and the server is told with
+`error { code: "audio_format" }`. This is **non-fatal**: the bad frame is
+discarded, the call continues, and the error is **rate-limited** (the first
+bad frame, then at most one per second) so a misconfigured server can't
+flood the WS. A raw PCM16 frame carries no sample-rate or channel metadata,
+so the daemon validates only the byte length and otherwise assumes the
+negotiated rate + mono — send the wrong rate or stereo and it is
+interpreted, not detected.
 
 ---
 
@@ -337,8 +341,8 @@ then closes the WebSocket cleanly (close code 1000).
 | Code | Meaning |
 |---|---|
 | `rtp_timeout` | No incoming RTP for the configured idle period (`media.rtp_idle_timeout_ms`). |
-| `audio_format` | Server sent an audio frame of an unexpected **size** — not the negotiated 20 ms frame (320 bytes @ 8 kHz, 640 @ 16 kHz). Only the byte length is checkable: a binary audio frame carries no sample-rate or channel metadata, so the daemon assumes the negotiated rate + mono. |
-| `protocol_error` | A WS message was malformed JSON, used an unknown `type`, or had a `call_id` that doesn't match the connection. |
+| `audio_format` | Server sent an audio frame of an unexpected **size** — not the negotiated 20 ms frame (320 bytes @ 8 kHz, 640 @ 16 kHz). Only the byte length is checkable: a binary audio frame carries no sample-rate or channel metadata, so the daemon assumes the negotiated rate + mono. **Non-fatal:** the frame is dropped, the call continues, and the error is rate-limited (§2.2) — no `stop` follows. |
+| `protocol_error` | A WS message was malformed JSON, used an unknown `type`, or had a `call_id` that doesn't match the connection. **Fatal** and definitive — the call is torn down and (with `ws_reconnect_enabled`) **not** reconnected, since a buggy server would just repeat it. |
 | `server_too_slow` | Server didn't send its first audio frame (or a `hangup`) within the start-deadline of `start` — `[bridge].server_start_deadline_secs`, default 5 s (§3.1). |
 | `transfer_failed` | A REFER was attempted but the far end rejected it. |
 | `conference_failed` | A `conference_join` (§4.8) was refused: conferencing disabled, room or per-room cap reached, sample-rate mismatch, or already joined. The call continues on its direct pair. |
@@ -347,10 +351,10 @@ then closes the WebSocket cleanly (close code 1000).
 | `internal` | SiphonAI internal error. The `message` field has details — e.g. `ws keepalive timeout` when a half-open connection fails the §5.6 keepalive (best-effort: an unresponsive peer may never receive it). |
 
 A **fatal** `error` is always followed by `stop` (with `reason:
-"error"`) and a clean close. The **non-fatal** refusals —
-`conference_failed`, `park_failed`, and `hold_failed` — are the exception:
-they report a rejected control request, the call continues, and no `stop`
-follows.
+"error"`) and a clean close. The **non-fatal** codes —
+`conference_failed`, `park_failed`, `hold_failed`, and `audio_format` — are
+the exception: they report a rejected control request or a discarded frame,
+the call continues, and no `stop` follows.
 
 > **Codec negotiation failure is not a WS error.** There is no
 > `codec_unsupported` code: codec selection happens entirely at the SIP

--- a/docs/design/DESIGN_ERROR_SIGNALING.md
+++ b/docs/design/DESIGN_ERROR_SIGNALING.md
@@ -1,0 +1,102 @@
+# Design: error-signaling — rtp_timeout / audio_format / protocol_error
+
+Status: **DRAFT — decisions pending** (this note + an AskUserQuestion lock
+the forks, then chunked PR(s), same cadence as prior themes).
+
+Theme: **step 3** (final) of closing the protocol doc↔impl drift (bug #4).
+Make the daemon actually *emit* the three remaining documented `error`
+codes whose underlying conditions are already detected (or trivially
+detectable) but which never reach the WS server. Step 1 corrected the
+"can't happen" codes; step 2 implemented the liveness codes
+(`server_too_slow`, keepalive `internal`). This closes the set.
+
+---
+
+## 1. The gap
+
+Three documented `error` codes (PROTOCOL.md §3.10) are still never emitted:
+
+- **`rtp_timeout`** — the media-glue inactivity watchdog
+  (`[media].inactivity_timeout_secs`, default 60 s of no inbound RTP)
+  already fires and tears the call down (`TapDisconnect::InactivityTimeout`
+  → `CallTermination::TapEnded`). But the WS server is never told *why* —
+  no `error { code: "rtp_timeout" }` is sent before the socket closes. The
+  server just sees a bare close and has to guess.
+- **`audio_format`** — PROTOCOL.md §2.2 says a binary frame of the wrong
+  **size** (not the negotiated 20 ms — 320 B @ 8 kHz, 640 B @ 16 kHz) is
+  rejected with this code. Reality: `conn.rs` forwards every inbound binary
+  frame to media-glue unchecked. A server bug (e.g. 10 ms or 30 ms frames)
+  is silently mis-injected.
+- **`protocol_error`** — malformed JSON, an unknown message `type`, or a
+  `call_id` that doesn't match the connection. Reality: `conn.rs` *detects*
+  all three (`BridgeError::BadJson` / `CallIdMismatch`) and tears down — but
+  returns a bare error and closes **without** emitting
+  `error { code: "protocol_error" }` first, so the server never learns it
+  sent something invalid.
+
+The emit machinery already exists: `OutgoingEvent::{Error,Stop}` map
+through `build_bridge_out`, and `conn.rs` has an `emit_fatal` helper (added
+in step 2) that sends `error` + `stop` per the §3.10 invariant.
+
+## 2. Design
+
+### 2.1 `rtp_timeout` (cross-task, controller-driven)
+
+The watchdog lives in media-glue; the WS sink lives in the conn task. The
+controller (`core::call`) already bridges them via `control_out_tx`. On the
+`tap_task` arm, when the result is `Ok(TapDisconnect::InactivityTimeout)`,
+queue `OutgoingEvent::Error { code: RtpTimeout, .. }` then
+`OutgoingEvent::Stop { reason: Error }` **before** `break`. Teardown then
+`drop(control_out_tx)`; the conn drains both (biased recv), emits them, and
+closes within the existing 250 ms budget. CDR termination stays
+`TapEnded` (the *cause* is the RTP timeout; the stop is just the mechanism).
+Not reconnect-related — this is a SIP/tap-side timeout, never the WS path.
+
+### 2.2 `audio_format` (conn-local detection)
+
+Capture the expected frame size once, before `start` is moved into the
+`Start` message: `bytes = sample_rate/1000 * frame_ms * channels * 2`
+(PCM16). In the inbound `Message::Binary` arm, compare `data.len()`.
+Behavior on mismatch is **decision 1** below.
+
+### 2.3 `protocol_error` (conn-local detection)
+
+In the `Message::Text` arm, the `BadJson` and `CallIdMismatch` paths emit
+`error { code: "protocol_error" }` + `stop` (best-effort) then close. This
+is a **definitive** teardown — a server sending invalid frames is buggy, so
+reconnecting to it just repeats the failure. Return a new
+`DisconnectReason::ProtocolError` (NOT reconnect-eligible, mirroring
+`ServerTooSlow`) rather than the current reconnect-eligible `Err`. Unknown
+`type` handling is **decision 2** below.
+
+## 3. Decisions — LOCKED
+
+1. **`audio_format` = drop-and-continue.** Drop the wrong-size frame, emit
+   `error{audio_format}` **non-fatal, rate-limited** (first occurrence +
+   at most one/sec), keep the call up. A bridge shouldn't kill a live call
+   over a malformed frame; persistent failure is still caught by the
+   dead-air / rtp watchdog. `audio_format` moves into the §3.10 **non-fatal**
+   set (alongside `*_failed`) — no `stop` follows it.
+2. **Unknown `type` = strict fatal.** An unknown message `type` is a
+   `protocol_error` (fatal teardown), same as malformed JSON. No two-stage
+   parse needed — serde's tagged-enum decode already rejects both
+   identically, so `BridgeError::BadJson` covers both.
+
+(Engineering calls, not asked: `protocol_error` is a definitive,
+non-reconnect-eligible teardown; `rtp_timeout` emits via the existing tap
+teardown; the fatal `protocol_error` path uses the step-2 `emit_fatal`
+helper.)
+
+## 4. Chunks
+
+1. **`protocol_error` + `audio_format`** (conn-local) — both in `conn.rs`,
+   plus `DisconnectReason::ProtocolError` + `reconnect_eligible` arm; unit
+   tests (bad JSON / mismatched call_id / wrong-size frame). Honors
+   decisions 1 & 2.
+2. **`rtp_timeout`** (controller) — emit on the `tap_task`
+   `InactivityTimeout` arm in `core::call`; test via the existing tap
+   harness (a call that goes RTP-silent → server sees `error{rtp_timeout}`
+   + `stop`).
+3. **Docs + release** — reconcile PROTOCOL.md §2.2 / §3.10 (fatal-vs-
+   non-fatal classification per decision 1), CHANGELOG, tag. (May fold into
+   the earlier chunks if small.)


### PR DESCRIPTION
**Step 3 (final)** of closing the protocol doc↔impl drift (bug #4): the daemon now actually *emits* the last three documented `error` codes whose conditions it detected (or could trivially detect) but never signaled. After this, every code in PROTOCOL.md §3.10 is real.

Design note + locked decisions: `docs/design/DESIGN_ERROR_SIGNALING.md`.

## What it does
- **`rtp_timeout`** (`core::call`) — when the media inactivity watchdog fires (`TapDisconnect::InactivityTimeout`, no inbound RTP for `[media].inactivity_timeout_secs`), queue `OutgoingEvent::Error{rtp_timeout}` + `Stop` before teardown; the conn drains both (biased recv) and emits them before `control_out_tx` is dropped. The server learns *why* instead of seeing a bare close. CDR cause stays `TapEnded`.
- **`audio_format`** (`conn`) — inbound binary frames validated against the negotiated frame size (320 B @ 8 kHz / 640 B @ 16 kHz, captured from `start.audio` before the `Start` move).
- **`protocol_error`** (`conn`) — malformed JSON / unknown `type` / `call_id` mismatch now emit `error{protocol_error}` + `stop` before close.

## Locked decisions (AskUserQuestion)
1. **`audio_format` = drop-and-continue.** Wrong-size frame dropped, server told via **non-fatal** `error{audio_format}` (**rate-limited**: first bad frame + ≤1/sec), call stays up. One bad frame mustn't kill a live call; persistent failure is still caught by the dead-air/rtp watchdog. → moved to the §3.10 non-fatal set.
2. **Unknown `type` = strict fatal.** Treated as `protocol_error`, same as malformed JSON — serde rejects both identically, so no two-stage parse.

## Notable behavior change
`protocol_error` is a **definitive** teardown — new `DisconnectReason::ProtocolError`, **not** reconnect-eligible (a buggy server would just repeat the violation). Previously malformed-JSON / call_id-mismatch returned a reconnect-eligible `Err` and signaled nothing to the server.

## Tests
- 3 new bridge tests: `protocol_error` for bad JSON + call_id mismatch (incl. the server-visible frame); wrong-size frame dropped-not-fatal + a valid 320 B frame still flows through.
- 1 new core integration test: RTP inactivity (short `with_inactivity_timeout`) → server receives `error{rtp_timeout}` + `stop`, termination `TapEnded`.
- Updated 2 pre-existing tests whose 4-byte dummy frames now need the negotiated 320 B to round-trip past the size check.

Full `fmt` / `clippy -D warnings` / `cargo test --workspace` green; `doc-links` clean.

## Docs
`PROTOCOL.md` §2.2 (audio_format drop/rate-limit/non-fatal) + §3.10 (audio_format → non-fatal set; protocol_error definitive), CHANGELOG under `[Unreleased]`.

This is a feature theme → suggest **v0.14.0** after merge. With this, bug #4 is fully closed (all of §3.10 now emitted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)