### PR TITLE
refactor(bridge): drop unconstructed BridgeError::{BadJson,CallIdMismatch}

### DIFF
--- a/crates/bridge/src/conn.rs
+++ b/crates/bridge/src/conn.rs
@@ -298,12 +298,10 @@ pub enum BridgeError {
     #[error("connect timed out after {0:?}")]
     ConnectTimeout(Duration),
 
-    #[error("server returned malformed JSON: {0}")]
-    BadJson(String),
-
-    #[error("server message has wrong call_id (expected {expected}, got {got})")]
-    CallIdMismatch { expected: String, got: String },
-
+    // Note: malformed JSON, an unknown `type`, and a mismatched `call_id`
+    // are no longer surfaced as `BridgeError`s — since 0.14.0 they emit
+    // `error { code: "protocol_error" }` + `stop` and return
+    // `DisconnectReason::ProtocolError` (a definitive teardown) instead.
     #[error("internal: {0}")]
     Internal(String),
 


### PR DESCRIPTION
Tidy follow-up to the error-signaling work. Since **0.14.0 (#223)** malformed JSON / unknown `type` / `call_id` mismatch no longer return a `BridgeError` — they emit `error { code: "protocol_error" }` + `stop` and return `DisconnectReason::ProtocolError`. That left `BridgeError::BadJson` and `BridgeError::CallIdMismatch` defined but never constructed (confirmed: no producers, matches, or test references anywhere in the tree).

Removed both; left a short note pointing at the `protocol_error` path.

Internal-only (workspace crate, no external consumers); no behavior change. `clippy` clean, bridge tests green (19/19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)