### PR TITLE
fix(media-glue): activate forge session in apply_answer (delayed-offer/outbound had no audio)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Delayed-offer and outbound calls never bridged audio** (no RTP in
+  either direction). Every offer/answer media path — inbound delayed offer
+  (offerless INVITE → offer in 200 OK → answer in ACK) and outbound
+  origination — funnels through `MediaSetup::apply_answer`, which bound the
+  codec + remote address and attached the tap but **never activated the
+  forge session**. The session stayed in `Initializing`, so forge's RTP
+  forwarding task was never spawned: nothing was decoded inbound or sent
+  outbound. The tap still attached (its timers fired `rtp_stats` /
+  `silence_detected`), which masked the dead media — and on inbound calls
+  the v0.13.0 start-deadline then tore the call down with `server_too_slow`.
+  `apply_answer` now activates the session (`Initializing → Active`, starting
+  forwarding), mirroring what the early-offer inbound path already did via
+  `start_session` before its 200 OK. Only the early-offer inbound path
+  (INVITE-with-SDP) was unaffected, which is why forcing CUCM Early Offer /
+  an MTP appeared to "fix" it. Regression test asserts the session reaches
+  `Active` after `apply_answer`.
+
 ## [0.14.0] - 2026-06-20
 
 ### Added

--- a/crates/bridge/src/conn.rs
+++ b/crates/bridge/src/conn.rs
@@ -298,12 +298,10 @@ pub enum BridgeError {
     #[error("connect timed out after {0:?}")]
     ConnectTimeout(Duration),
 
-    #[error("server returned malformed JSON: {0}")]
-    BadJson(String),
-
-    #[error("server message has wrong call_id (expected {expected}, got {got})")]
-    CallIdMismatch { expected: String, got: String },
-
+    // Note: malformed JSON, an unknown `type`, and a mismatched `call_id`
+    // are no longer surfaced as `BridgeError`s — since 0.14.0 they emit
+    // `error { code: "protocol_error" }` + `stop` and return
+    // `DisconnectReason::ProtocolError` (a definitive teardown) instead.
     #[error("internal: {0}")]
     Internal(String),
 

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -3615,8 +3615,12 @@ impl BridgingAcceptor {
         };
 
         // Build OUR offer + allocate the forge session. This mirrors
-        // outbound origination, which never calls `start_session`
-        // explicitly — `apply_answer` + the controller bring media up.
+        // outbound origination: the forge session is created here
+        // (Initializing) and `apply_answer` — once the peer's answer
+        // arrives in the ACK — binds the remote and **activates** it
+        // (Initializing → Active, starting RTP forwarding). The early-offer
+        // inbound path instead activates explicitly via `start_session`
+        // before its 200 OK, because it knows the remote up front.
         // `srtp` makes the offer SDES per the resolved policy above.
         let offer = match self
             .media

--- a/crates/media-glue/src/setup.rs
+++ b/crates/media-glue/src/setup.rs
@@ -28,9 +28,14 @@
 //!
 //! ## What this module does NOT do
 //!
-//! - **Doesn't start RTP forwarding.** Forwarding belongs after the
-//!   200 OK is on the wire (and arguably after ACK) — call
-//!   `SessionManager::start_session` from the controller's lifecycle.
+//! - **The early-offer inbound path doesn't start RTP forwarding here.**
+//!   For an inbound early offer the remote is known up front, but
+//!   forwarding belongs after the 200 OK is on the wire — the acceptor
+//!   calls `SessionManager::start_session` explicitly at that point.
+//!   (The offer/answer paths are different: [`MediaSetup::apply_answer`]
+//!   activates the session itself, since it's the one place every
+//!   offer/answer call — outbound + inbound delayed offer — converges and
+//!   the remote isn't known until the answer arrives.)
 //! - **Doesn't build the bridge `StartMsg`.** That stitches in
 //!   SIP-side facts (From/To/Call-ID) the SDP layer has no view of.
 //!   `CallController`'s caller composes the message from the answer
@@ -600,6 +605,23 @@ impl MediaSetup {
         .with_idle_thresholds(tap.silence_threshold, tap.dead_air_threshold)
         .with_rtp_stats_interval(tap.rtp_stats_interval);
 
+        // (4) Activate the forge session: Initializing → Active, which spawns
+        //     the RTP forwarding task (decode/forward inbound, send outbound).
+        //     Without this the session stays Initializing forever and **no RTP
+        //     flows** — the tap still attaches (its timers fire `rtp_stats` /
+        //     `silence_detected`), but nothing is bridged. Every offer/answer
+        //     path funnels through `apply_answer` (outbound origination,
+        //     outbound + inbound delayed offer), so this is their single media
+        //     activation point — the mirror of the early-offer inbound path's
+        //     explicit `start_session` before its 200 OK. forge requires the
+        //     Initializing → Active transition exactly once; `apply_answer` is
+        //     called once per call, before the remote is bound above. Done
+        //     before `guard.disarm()` so a failure still rolls the session back.
+        self.session_manager
+            .start_session(&call_id)
+            .await
+            .map_err(SetupError::from)?;
+
         guard.disarm();
 
         info!(
@@ -830,6 +852,16 @@ a=sendrecv\r\n"
         // The session survived — still allocated, not rolled back.
         let (allocated, _) = session_mgr.port_pool_stats().await;
         assert_eq!(allocated, 1);
+        // Regression — the delayed-offer / outbound "no audio" bug: apply_answer
+        // must ACTIVATE the session (start forge's RTP forwarding), not merely
+        // bind the codec + attach the tap. A session left in `Initializing`
+        // never spawns the forwarding task, so no RTP flows in either direction
+        // (the tap attaches and its timers fire, but nothing is bridged).
+        assert_eq!(
+            accepted.session.state().await,
+            forge_engine::SessionState::Active,
+            "apply_answer must start RTP forwarding (Initializing → Active)"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Symptom
On a CUCM **delayed-offer** call (offerless INVITE), no audio establishes — the echo server reports `frames_echoed=0` and the call dies at 5 s with `server_too_slow`. Forcing CUCM **Early Offer** (insert MTP) makes audio work.

## Root cause
forge only starts its RTP forwarding task when a session moves `Initializing → Active` (`Session::start_forwarding`, gated on `Initializing`). Core calls `start_session()` — the entry point for that transition — in **exactly one place: the early-offer inbound path** (`acceptor.rs`, before the 200 OK).

Every **offer/answer** path goes through `MediaSetup::apply_answer` instead:
- inbound **delayed offer** (`finalize_delayed_offer`)
- **outbound** origination (`outbound.rs`)
- outbound delayed-offer answerer

…and `apply_answer` bound the codec + remote address and attached the tap but **never activated the session**. So the session sat in `Initializing`, the forwarding task never spawned, and **no RTP flowed in either direction**. The tap still attached — its timers fired `rtp_stats` / `silence_detected`, which masked the dead media — and on inbound the 0.13.0 start-deadline then tore the call down. Early offer worked only because that path calls `start_session` explicitly (so "force MTP" = Early Offer = the one path that activated media).

This also means **outbound origination never bridged real audio** — latent, masked by SIPp-only signaling tests.

## Fix
`apply_answer` now calls `session_manager().start_session(&call_id)` after binding the remote + attaching the tap, before `guard.disarm()` (so a failure still rolls the session back). It's the single convergence point for all offer/answer paths, and forge's `Initializing → Active` must happen exactly once — which holds: `apply_answer` runs once per call and the early-offer inbound path doesn't go through it (no double-activation).

## Test
Regression assertion in `apply_answer_binds_codec_and_attaches_tap`: the session must be `SessionState::Active` after `apply_answer` (not left `Initializing`). Full `fmt` / `clippy -D warnings` / `cargo test --workspace` green; `doc-links` clean.

## Notes
- Misleading comments corrected (delayed-offer path in `acceptor.rs`; the `media-glue/src/setup.rs` "doesn't start forwarding" module note).
- Suggest a **v0.14.1** patch right after merge — this is a real audio-path fix for delayed-offer and outbound. Ready to deploy to the CUCM test box to confirm with a live call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)