### PR TITLE
chore(release): 0.14.1 — fix delayed-offer/outbound no-audio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.1] - 2026-06-22
+
 ### Fixed
 
 - **Delayed-offer and outbound calls never bridged audio** (no RTP in
@@ -1587,7 +1589,8 @@ the WebSocket server's job.
 - Reference WebSocket servers in `examples/`: echo (Python / Node),
   an OpenAI Realtime bridge, and a Deepgram + LLM voice bot.
 
-[Unreleased]: https://github.com/thevoiceguy/siphon-ai/compare/v0.14.0...HEAD
+[Unreleased]: https://github.com/thevoiceguy/siphon-ai/compare/v0.14.1...HEAD
+[0.14.1]: https://github.com/thevoiceguy/siphon-ai/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/thevoiceguy/siphon-ai/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/thevoiceguy/siphon-ai/compare/v0.12.2...v0.13.0
 [0.6.2]: https://github.com/thevoiceguy/siphon-ai/compare/v0.6.1...v0.6.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2937,7 +2937,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "base64",
  "bytes",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2975,7 +2975,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "regex",
  "serde",
@@ -2993,7 +2993,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3035,7 +3035,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "hmac",
  "http-body-util",
@@ -3055,7 +3055,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "thiserror 1.0.69",
  "tokio",
@@ -3088,7 +3088,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "regex",
  "serde",
@@ -3099,7 +3099,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3108,7 +3108,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3132,7 +3132,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "base64",
  "rcgen",
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3173,7 +3173,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Patch release **v0.14.1**. Version bump `0.14.0 → 0.14.1` + CHANGELOG roll.

Ships **#226** — `apply_answer` now activates the forge session (`Initializing → Active`), so RTP forwarding actually starts on the offer/answer paths. Fixes **no audio on inbound delayed-offer and outbound calls** (surfaced on CUCM delayed-offer interop without an MTP).

Tag `v0.14.1` + GitHub release after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)