### PR TITLE
examples: add OpenAI cascaded voice bot (STT → LLM → TTS)

### DIFF
--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -73,6 +73,28 @@ production bridge looks like; copy it if you want a starting point.
 Requires an `OPENAI_API_KEY`. See the README inside the directory for
 the full setup.
 
+## `examples/openai-pipeline-bot-py/`
+
+The **cascaded** counterpart to the Realtime bridge above: a closed-loop
+voice agent that uses only OpenAI, but as three independent calls —
+Whisper/gpt-4o-transcribe (STT) → chat completions (LLM) →
+gpt-4o-mini-tts/tts-1 (TTS). Reach for this when you want to pick each
+model independently, mix providers, or inspect the transcript and LLM
+turns; reach for `openai-realtime-bridge-py` when you want the lowest
+latency from a single speech-to-speech session.
+
+- Does its **own turn-taking** with `webrtcvad` over the inbound 20 ms
+  frames, so it needs no SiphonAI VAD config — works with the same default
+  route as the echo server.
+- Greets the caller on `start` (which also satisfies the `server_too_slow`
+  start-deadline), and handles barge-in by cancelling the in-flight
+  response and sending `clear`.
+- Resamples OpenAI's 24 kHz TTS down to the call rate and re-chunks into
+  exact 20 ms frames.
+- Offline smoke test (helpers + endpointer) that needs no API key.
+
+Requires an `OPENAI_API_KEY`. See the README inside the directory.
+
 ## `examples/homer-stack/`
 
 A local Homer + heplify-server + Postgres stack via `docker compose up`,

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -162,6 +162,43 @@ queryable history).
 
 ---
 
+## P2 — Registration management (admin)
+
+Today a `[[register]]` row only re-REGISTERs on its own refresh timer (or a
+daemon restart). When an upstream (e.g. CUCM) drops or stales a binding,
+operators have no way to force it back without bouncing the daemon — which
+interrupts active calls. Extends the existing read-only `GET
+/admin/registrations` (0.10.0) on the authenticated `[admin]` listener with
+two write actions (operator role), neither of which touches media:
+
+- **`POST /admin/registrations/{name}/refresh`** — fire an immediate
+  authenticated REGISTER for one binding, off-cycle, without a restart.
+  Implementation: give each registration task a `Notify` (or a small command
+  channel) and have its loop select over all three wake sources —
+
+  ```rust
+  tokio::select! {
+      _ = tokio::time::sleep(refresh_delay)   => {}  // normal cadence
+      _ = refresh_signal.notified()           => {}  // operator-triggered
+      _ = shutdown_signal.cancelled()         => return,
+  }
+  ```
+
+  so a refresh just nudges the existing loop rather than spawning anything.
+
+- **`POST /admin/registrations/{name}/restart`** — full unregister/register
+  cycle: REGISTER with `Expires: 0` to clear the binding, then a fresh
+  authenticated REGISTER. For when a refresh isn't enough (server-side stale
+  state, contact rebinding after an IP change).
+
+Both return the resulting registration state (reuse the `GET` snapshot
+shape). `404` for an unknown `{name}`; bounded-cardinality metric on
+trigger; audit-logged (actor = token name) like every other admin write.
+Per-binding only — no global "refresh all" in the first cut (operators can
+script the list).
+
+---
+
 ## P2 — Security & CDR (small, high-signal)
 
 - **Optional `/metrics` bearer auth** — token on `/metrics` only, off by
@@ -212,3 +249,29 @@ Not roadmap items — deliberate non-goals (`CLAUDE.md` §8, `DEV_PLAN.md` §1):
 AI-provider code (the WS server's job), multi-tenancy, video, WebRTC client
 support, YAML/JSON config, in-daemon acoustic echo cancellation, per-call log
 files.
+
+Good feature addition
+
+A useful future endpoint would be:
+
+POST /admin/registrations/{name}/refresh
+
+For example:
+
+curl -X POST \
+  -H "Authorization: Bearer ${SIPHON_ADMIN_TOKEN}" \
+  http://127.0.0.1:9092/admin/registrations/cucm-phone/refresh
+
+Internally, each registration task could listen for three events:
+
+tokio::select! {
+    _ = tokio::time::sleep(refresh_delay) => {}
+    _ = refresh_signal.notified() => {}
+    _ = shutdown_signal.cancelled() => return,
+}
+
+That would permit an immediate authenticated REGISTER without restarting SiphonAI or interrupting active calls. A second endpoint could support a full unregister/register cycle:
+
+POST /admin/registrations/{name}/restart
+
+That operation would send REGISTER with Expires: 0, followed by a fresh authenticated REGISTER.

--- a/examples/openai-pipeline-bot-py/.dockerignore
+++ b/examples/openai-pipeline-bot-py/.dockerignore
@@ -1,0 +1,5 @@
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+.DS_Store

--- a/examples/openai-pipeline-bot-py/Dockerfile
+++ b/examples/openai-pipeline-bot-py/Dockerfile
@@ -1,0 +1,30 @@
+# OpenAI cascaded voice-bot image. Mirrors the other Python examples —
+# python:3.13-slim, install deps, run as a non-root user.
+#
+# Build:
+#     docker build -t siphon-ai/openai-pipeline-bot:dev \
+#         examples/openai-pipeline-bot-py/
+#
+# Run (with your real key):
+#     docker run --rm \
+#         -e OPENAI_API_KEY=sk-... \
+#         -p 8080:8080 \
+#         siphon-ai/openai-pipeline-bot:dev
+
+FROM python:3.13-slim
+
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY server.py ./
+
+ARG UID=10001
+RUN groupadd --system --gid ${UID} bot \
+ && useradd --system --uid ${UID} --gid bot --no-create-home bot
+USER bot
+
+EXPOSE 8080
+
+ENTRYPOINT ["python3", "/app/server.py"]
+CMD ["--bind", "0.0.0.0:8080"]

--- a/examples/openai-pipeline-bot-py/README.md
+++ b/examples/openai-pipeline-bot-py/README.md
@@ -1,0 +1,117 @@
+# OpenAI cascaded voice bot (STT → LLM → TTS)
+
+A reference SiphonAI WebSocket server that runs a full voice assistant using
+**only OpenAI** — Whisper/gpt-4o-transcribe for speech-to-text, chat
+completions for the LLM, and gpt-4o-mini-tts/tts-1 for text-to-speech:
+
+```
+caller audio ──► STT ──► LLM ──► TTS ──► caller audio
+                (OpenAI)  (OpenAI)  (OpenAI)
+```
+
+SiphonAI is the SIP↔WebSocket bridge and contains **no AI code** — all of it
+lives here, in the WS server, which is exactly the layer it belongs in.
+
+## This vs. `openai-realtime-bridge-py`
+
+| | This bot (cascaded) | `openai-realtime-bridge-py` |
+|---|---|---|
+| OpenAI API | 3 calls: transcriptions + chat + speech | 1 speech-to-speech Realtime session |
+| Pick models independently | ✅ (swap STT / LLM / TTS freely) | ❌ (one Realtime model) |
+| See transcript + LLM turns | ✅ | partial |
+| Latency | higher (sequential pipeline) | lower |
+| Complexity | easy to follow / customise | more moving parts |
+
+Reach for this one when you want control over each stage or to mix providers
+(the STT/LLM/TTS calls are isolated and trivial to repoint).
+
+## How it works
+
+- **Transport (protocol v1).** One WebSocket per call. SiphonAI sends a
+  `start` JSON message with the audio format, then 20 ms PCM16-LE mono binary
+  frames of caller audio. The bot sends 20 ms PCM16 frames back to play into
+  the call. See [`docs/PROTOCOL.md`](../../docs/PROTOCOL.md).
+- **Turn-taking is done in the bot.** OpenAI transcription is batch (you send
+  a finished utterance), so the bot detects end-of-speech itself with
+  [`webrtcvad`](https://github.com/wiseman/py-webrtcvad) over the inbound
+  20 ms frames. **No SiphonAI VAD config is required** — it works with the
+  same default route config as the echo server.
+- **Barge-in.** When the caller starts talking while the bot is speaking, the
+  bot cancels the in-flight response and sends `clear` to flush SiphonAI's
+  outbound queue. (SiphonAI's default `auto_clear` barge-in also does this;
+  the explicit `clear` additionally covers `notify_only` deployments.)
+- **Greeting on connect.** The bot speaks a greeting immediately on `start`,
+  which also satisfies SiphonAI's `server_too_slow` start-deadline (default
+  5 s).
+
+## Prerequisites
+
+- Python 3.11+ (the Docker image uses 3.13).
+- An OpenAI API key with access to the chosen STT/LLM/TTS models.
+
+```bash
+cd examples/openai-pipeline-bot-py
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+export OPENAI_API_KEY=sk-...
+python3 server.py --bind 0.0.0.0:8080
+```
+
+Then point a SiphonAI route at it:
+
+```toml
+[[route]]
+name = "openai-bot"
+[route.match]
+any = true
+[route.bridge]
+ws_url = "ws://127.0.0.1:8080/"
+# Default [bridge.barge_in] mode = "auto_clear" gives the snappiest barge-in.
+```
+
+Place a call into SiphonAI and talk to the bot.
+
+## Configuration (environment variables)
+
+| Var | Default | Purpose |
+|---|---|---|
+| `OPENAI_API_KEY` | *(required)* | OpenAI auth. |
+| `OPENAI_BASE_URL` | OpenAI | Point STT/LLM/TTS at an OpenAI-compatible base URL. |
+| `BOT_STT_MODEL` | `whisper-1` | Transcription model (e.g. `gpt-4o-transcribe`). |
+| `BOT_LLM_MODEL` | `gpt-4o-mini` | Chat-completions model. |
+| `BOT_TTS_MODEL` | `gpt-4o-mini-tts` | Speech model (e.g. `tts-1`). |
+| `BOT_TTS_VOICE` | `alloy` | TTS voice. |
+| `BOT_SYSTEM_PROMPT` | *(built-in)* | LLM system prompt. |
+| `BOT_GREETING` | *(built-in)* | First thing the bot says. |
+| `BOT_AUTH_TOKEN` | *(off)* | Require `Authorization: Bearer <token>` on the upgrade. |
+| `BOT_VAD_AGGRESSIVENESS` | `2` | webrtcvad 0–3 (higher = filters more non-speech). |
+| `BOT_START_SPEECH_MS` | `120` | Speech needed to open an utterance. |
+| `BOT_END_SILENCE_MS` | `700` | Trailing silence that ends a turn. |
+| `BOT_PREROLL_MS` | `200` | Audio kept before the trigger so onsets aren't clipped. |
+| `BOT_MAX_UTTERANCE_MS` | `30000` | Hard cap so a noisy line can't buffer forever. |
+
+## Notes & limitations
+
+- **Latency.** For clarity the bot waits for the full TTS response before
+  playback. To shave latency, stream OpenAI's PCM chunks straight into the
+  pacer (resample incrementally with an `audioop.ratecv` state) and/or stream
+  LLM tokens into sentence-chunked TTS. Marked in `server.py`.
+- **Audio rates.** SiphonAI runs the call at 8 kHz or 16 kHz; OpenAI TTS
+  `pcm` output is 24 kHz, resampled down here. STT receives a WAV at the call
+  rate.
+- **`webrtcvad` wheels.** `requirements.txt` uses `webrtcvad-wheels` so no C
+  compiler is needed. On Python 3.13 the `audioop-lts` backport supplies the
+  `audioop` module (stdlib through 3.12).
+- This is a reference, not a hardened product: no retry/backoff on OpenAI
+  errors (it logs and stays on the call), no auth on outbound OpenAI calls
+  beyond the API key, single in-memory conversation per connection.
+
+## Tests
+
+`test_smoke.py` covers the pure helpers (WAV wrapping, resampling, 20 ms
+framing) and the endpointer state machine with a scripted VAD — offline, no
+key needed:
+
+```bash
+python3 -m pytest test_smoke.py
+```

--- a/examples/openai-pipeline-bot-py/requirements.txt
+++ b/examples/openai-pipeline-bot-py/requirements.txt
@@ -1,0 +1,10 @@
+# OpenAI SDK (STT + chat completions + TTS), the WS transport, and a VAD
+# for turn-taking. Kept short for readability; pin + audit for production.
+openai>=1.40
+websockets>=13
+# Prebuilt webrtcvad wheels — the plain `webrtcvad` sdist needs a C compiler.
+# Imported as `webrtcvad`.
+webrtcvad-wheels>=2.0.14
+# `audioop` is stdlib through Python 3.12; this backport supplies it on 3.13+
+# (used only for TTS rate conversion). Installs as the `audioop` module.
+audioop-lts>=0.2.1; python_version >= "3.13"

--- a/examples/openai-pipeline-bot-py/server.py
+++ b/examples/openai-pipeline-bot-py/server.py
@@ -1,0 +1,530 @@
+#!/usr/bin/env python3
+"""
+OpenAI cascaded voice bot for the SiphonAI bridge protocol v1.
+
+A reference WebSocket server (the developer's "BYO AI" side of SiphonAI)
+that runs a full **cascaded** voice pipeline using only OpenAI:
+
+    caller audio ──► STT (Whisper / gpt-4o-transcribe)
+                        ──► LLM (chat completions)
+                            ──► TTS (gpt-4o-mini-tts / tts-1) ──► caller
+
+This is the *cascaded pipeline* counterpart to ``openai-realtime-bridge-py``
+(which uses OpenAI's single speech-to-speech Realtime API). Use this one when
+you want to pick STT / LLM / TTS independently, swap models, or inspect the
+transcript + LLM turns. It's higher-latency than Realtime but far easier to
+reason about and customise.
+
+SiphonAI is provider-neutral and contains no AI code — all of that lives
+here, in the WS server, which is exactly the layer it belongs in.
+
+How it works
+------------
+- **Transport (SiphonAI protocol v1).** One WebSocket per call. SiphonAI
+  sends a ``start`` JSON message (audio format), then 20 ms PCM16-LE mono
+  binary frames of caller audio. We push 20 ms PCM16 frames back to play
+  into the call. See ``docs/PROTOCOL.md``.
+- **Endpointing (turn-taking) is done here, in the bot.** OpenAI's
+  transcription API is batch (you send a complete utterance), so we need to
+  know when the caller stopped talking. We run ``webrtcvad`` over the inbound
+  20 ms frames — no dependency on any SiphonAI VAD config, so this works with
+  the same default route config as the echo server.
+- **Barge-in.** When the caller starts talking while the bot is speaking, we
+  cancel the in-flight response and send a ``clear`` (flush SiphonAI's
+  outbound queue). SiphonAI's own ``auto_clear`` barge-in handles this too;
+  the explicit ``clear`` also covers ``notify_only`` deployments.
+- **Greeting on connect.** We synthesize a greeting immediately on ``start``
+  so the bot speaks first — good UX, and it satisfies SiphonAI's
+  ``server_too_slow`` start-deadline (default 5 s; raise
+  ``[bridge].server_start_deadline_secs`` if your models cold-start slowly).
+
+Audio format
+------------
+SiphonAI pins inbound + outbound to PCM16-LE, mono, 20 ms frames at the
+negotiated rate (8 kHz → 320 B, 16 kHz → 640 B). OpenAI TTS ``pcm`` output is
+24 kHz, so we resample it down to the call rate and re-chunk into exact 20 ms
+frames before sending.
+
+Run
+---
+    export OPENAI_API_KEY=sk-...
+    python3 server.py --bind 0.0.0.0:8080
+
+Configure the SiphonAI route's ``ws_url`` to point here. No special route
+config is required (the bot endpoints itself), though leaving the default
+``[bridge.barge_in] mode = "auto_clear"`` on gives the snappiest barge-in.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import io
+import json
+import logging
+import os
+import signal
+import time
+import wave
+from collections import deque
+from dataclasses import dataclass, field
+
+# `audioop` is stdlib through Python 3.12 and provided by the `audioop-lts`
+# backport on 3.13+ (see requirements.txt). Used only for rate conversion.
+import audioop
+
+import webrtcvad
+import websockets
+from openai import AsyncOpenAI
+from websockets.asyncio.server import ServerConnection, serve
+from websockets.http11 import Request, Response
+
+LOG = logging.getLogger("openai-bot")
+SUBPROTOCOL = "siphon-ai.v1"
+
+# OpenAI TTS `response_format="pcm"` is fixed at 24 kHz, 16-bit, mono, LE.
+TTS_PCM_RATE = 24000
+SAMPLE_WIDTH = 2  # PCM16
+
+
+# ─── Config ──────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class Config:
+    bind_host: str
+    bind_port: int
+    auth_token: str | None
+    log_level: str
+    # OpenAI
+    stt_model: str
+    llm_model: str
+    tts_model: str
+    tts_voice: str
+    system_prompt: str
+    greeting: str
+    base_url: str | None
+    # Endpointing (webrtcvad)
+    vad_aggressiveness: int  # 0..3, higher = more aggressive filtering
+    start_speech_ms: int  # consecutive speech needed to open an utterance
+    end_silence_ms: int  # trailing silence that closes an utterance
+    preroll_ms: int  # audio kept before trigger so onsets aren't clipped
+    max_utterance_ms: int  # hard cap so a noisy line can't buffer forever
+
+
+def config_from(args: argparse.Namespace) -> Config:
+    host, _, port = args.bind.partition(":")
+    if not port:
+        raise SystemExit("--bind must be HOST:PORT")
+    return Config(
+        bind_host=host,
+        bind_port=int(port),
+        auth_token=os.environ.get("BOT_AUTH_TOKEN") or args.auth_token,
+        log_level=args.log_level,
+        stt_model=os.environ.get("BOT_STT_MODEL", "whisper-1"),
+        llm_model=os.environ.get("BOT_LLM_MODEL", "gpt-4o-mini"),
+        tts_model=os.environ.get("BOT_TTS_MODEL", "gpt-4o-mini-tts"),
+        tts_voice=os.environ.get("BOT_TTS_VOICE", "alloy"),
+        system_prompt=os.environ.get(
+            "BOT_SYSTEM_PROMPT",
+            "You are a friendly, concise voice assistant on a phone call. "
+            "Keep replies short and conversational — one or two sentences — "
+            "since they will be spoken aloud. Do not use markdown or emoji.",
+        ),
+        greeting=os.environ.get(
+            "BOT_GREETING", "Hi! Thanks for calling. How can I help you today?"
+        ),
+        base_url=os.environ.get("OPENAI_BASE_URL"),
+        vad_aggressiveness=int(os.environ.get("BOT_VAD_AGGRESSIVENESS", "2")),
+        start_speech_ms=int(os.environ.get("BOT_START_SPEECH_MS", "120")),
+        end_silence_ms=int(os.environ.get("BOT_END_SILENCE_MS", "700")),
+        preroll_ms=int(os.environ.get("BOT_PREROLL_MS", "200")),
+        max_utterance_ms=int(os.environ.get("BOT_MAX_UTTERANCE_MS", "30000")),
+    )
+
+
+# ─── Audio helpers (pure; covered by test_smoke.py) ──────────────────────────
+
+
+def pcm_to_wav_bytes(pcm: bytes, rate: int) -> bytes:
+    """Wrap raw PCM16-LE mono samples in a WAV container for the STT API."""
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(SAMPLE_WIDTH)
+        w.setframerate(rate)
+        w.writeframes(pcm)
+    return buf.getvalue()
+
+
+def resample_pcm(pcm: bytes, in_rate: int, out_rate: int) -> bytes:
+    """Resample mono PCM16-LE between rates (anti-aliased via audioop)."""
+    if in_rate == out_rate:
+        return pcm
+    converted, _ = audioop.ratecv(pcm, SAMPLE_WIDTH, 1, in_rate, out_rate, None)
+    return converted
+
+
+def frame_chunks(pcm: bytes, frame_bytes: int):
+    """Yield exactly-``frame_bytes`` PCM frames; zero-pad the final frame.
+
+    SiphonAI requires every outbound binary frame to be exactly one 20 ms
+    chunk — never "approximately". A short tail is padded with silence.
+    """
+    for off in range(0, len(pcm), frame_bytes):
+        frame = pcm[off : off + frame_bytes]
+        if len(frame) < frame_bytes:
+            frame = frame + b"\x00" * (frame_bytes - len(frame))
+        yield frame
+
+
+# ─── Endpointer (webrtcvad turn detection) ───────────────────────────────────
+
+
+@dataclass
+class Endpointer:
+    """Per-call utterance detector over 20 ms PCM16 frames.
+
+    Emits ``"start"`` once the caller has been speaking for ``start_speech_ms``
+    and ``("end", pcm)`` once they've been silent for ``end_silence_ms``. A
+    short pre-roll is prepended so the onset isn't clipped.
+    """
+
+    rate: int
+    frame_bytes: int
+    cfg: Config
+    _vad: webrtcvad.Vad = field(init=False)
+    _triggered: bool = False
+    _utterance: bytearray = field(default_factory=bytearray)
+    _preroll: deque = field(init=False)
+    _speech_run: int = 0
+    _silence_run: int = 0
+
+    def __post_init__(self) -> None:
+        self._vad = webrtcvad.Vad(self.cfg.vad_aggressiveness)
+        self._preroll = deque(maxlen=max(1, self.cfg.preroll_ms // 20))
+        self._start_frames = max(1, self.cfg.start_speech_ms // 20)
+        self._end_frames = max(1, self.cfg.end_silence_ms // 20)
+        self._max_frames = max(1, self.cfg.max_utterance_ms // 20)
+
+    def process(self, frame: bytes):
+        """Feed one 20 ms frame. Returns None, "start", or ("end", pcm)."""
+        # webrtcvad only accepts exact 10/20/30 ms 16-bit mono frames; a
+        # wrong-sized frame (shouldn't happen on a compliant bridge) is
+        # treated as non-speech but still buffered if we're mid-utterance.
+        is_speech = (
+            len(frame) == self.frame_bytes and self._vad.is_speech(frame, self.rate)
+        )
+
+        if not self._triggered:
+            self._preroll.append(frame)
+            if is_speech:
+                self._speech_run += 1
+                if self._speech_run >= self._start_frames:
+                    self._triggered = True
+                    self._utterance = bytearray(b"".join(self._preroll))
+                    self._preroll.clear()
+                    self._silence_run = 0
+                    return "start"
+            else:
+                self._speech_run = 0
+            return None
+
+        # Triggered: accumulate until trailing silence (or the hard cap).
+        self._utterance += frame
+        if is_speech:
+            self._silence_run = 0
+        else:
+            self._silence_run += 1
+
+        ended = (
+            self._silence_run >= self._end_frames
+            or len(self._utterance) >= self._max_frames * self.frame_bytes
+        )
+        if ended:
+            utt = bytes(self._utterance)
+            self._reset()
+            return ("end", utt)
+        return None
+
+    def _reset(self) -> None:
+        self._triggered = False
+        self._utterance = bytearray()
+        self._speech_run = 0
+        self._silence_run = 0
+        self._preroll.clear()
+
+
+# ─── Call session ────────────────────────────────────────────────────────────
+
+
+class CallSession:
+    """Owns one call: VAD turn-taking, the OpenAI pipeline, and playback."""
+
+    def __init__(self, conn: ServerConnection, client: AsyncOpenAI, cfg: Config):
+        self.conn = conn
+        self.client = client
+        self.cfg = cfg
+        self.call_id: str | None = None
+        self.rate = 8000
+        self.frame_bytes = 320
+        self.endpointer: Endpointer | None = None
+        # Conversation history for the LLM (system prompt seeded on start).
+        self.history: list[dict[str, str]] = []
+        # The in-flight response (STT→LLM→TTS→playback). Cancelled on barge-in.
+        self.turn: asyncio.Task | None = None
+
+    # -- lifecycle --
+
+    async def on_start(self, msg: dict) -> None:
+        self.call_id = msg.get("call_id")
+        audio = msg.get("audio", {})
+        self.rate = int(audio.get("sample_rate", 8000))
+        self.frame_bytes = self.rate // 50 * SAMPLE_WIDTH  # 20 ms of PCM16
+        self.endpointer = Endpointer(self.rate, self.frame_bytes, self.cfg)
+        self.history = [{"role": "system", "content": self.cfg.system_prompt}]
+        LOG.info(
+            "start call_id=%s rate=%d frame_bytes=%d from=%s to=%s",
+            self.call_id, self.rate, self.frame_bytes, msg.get("from"), msg.get("to"),
+        )
+        # Speak first: greeting doubles as the start-deadline keep-alive.
+        self.turn = asyncio.create_task(self._speak(self.cfg.greeting))
+
+    async def on_audio(self, frame: bytes) -> None:
+        if self.endpointer is None:
+            return
+        event = self.endpointer.process(frame)
+        if event == "start":
+            # Caller began talking. If the bot is mid-response, that's a
+            # barge-in: cancel playback and flush SiphonAI's outbound queue.
+            await self._barge_in()
+        elif isinstance(event, tuple) and event[0] == "end":
+            utterance = event[1]
+            # Latest utterance wins — cancel any still-running response.
+            await self._cancel_turn()
+            self.turn = asyncio.create_task(self._respond(utterance))
+
+    async def close(self) -> None:
+        await self._cancel_turn()
+
+    # -- barge-in / cancellation --
+
+    async def _barge_in(self) -> None:
+        if self.turn and not self.turn.done():
+            LOG.info("barge-in (call_id=%s) — cancelling response", self.call_id)
+            await self._cancel_turn()
+            await self._send_clear()
+
+    async def _cancel_turn(self) -> None:
+        if self.turn and not self.turn.done():
+            self.turn.cancel()
+            try:
+                await self.turn
+            except asyncio.CancelledError:
+                pass
+        self.turn = None
+
+    async def _send_clear(self) -> None:
+        if self.call_id:
+            await self._send_json({"type": "clear", "call_id": self.call_id})
+
+    # -- pipeline --
+
+    async def _respond(self, utterance_pcm: bytes) -> None:
+        """STT → LLM → TTS → playback for one caller utterance."""
+        t0 = time.monotonic()
+        try:
+            transcript = await self._transcribe(utterance_pcm)
+            if not transcript.strip():
+                LOG.info("empty transcript — ignoring")
+                return
+            LOG.info("caller: %s", transcript)
+
+            self.history.append({"role": "user", "content": transcript})
+            reply = await self._chat()
+            self.history.append({"role": "assistant", "content": reply})
+            LOG.info("bot: %s  (think=%.0fms)", reply, (time.monotonic() - t0) * 1000)
+
+            await self._speak(reply)
+        except asyncio.CancelledError:
+            LOG.debug("response cancelled (barge-in or newer utterance)")
+            raise
+        except Exception:
+            LOG.exception("pipeline error; staying on the call")
+
+    async def _transcribe(self, pcm: bytes) -> str:
+        wav = pcm_to_wav_bytes(pcm, self.rate)
+        resp = await self.client.audio.transcriptions.create(
+            model=self.cfg.stt_model,
+            file=("utterance.wav", wav, "audio/wav"),
+        )
+        return resp.text or ""
+
+    async def _chat(self) -> str:
+        resp = await self.client.chat.completions.create(
+            model=self.cfg.llm_model,
+            messages=self.history,
+            temperature=0.6,
+        )
+        return (resp.choices[0].message.content or "").strip()
+
+    async def _speak(self, text: str) -> None:
+        """Synthesize ``text`` and stream it into the call as 20 ms frames.
+
+        For clarity this collects the full TTS audio before playback begins;
+        for lower latency you'd stream OpenAI's PCM chunks straight into the
+        pacer (resampling incrementally with an audioop.ratecv state).
+        """
+        if not text.strip():
+            return
+        pcm24 = bytearray()
+        async with self.client.audio.speech.with_streaming_response.create(
+            model=self.cfg.tts_model,
+            voice=self.cfg.tts_voice,
+            input=text,
+            response_format="pcm",
+        ) as response:
+            async for chunk in response.iter_bytes():
+                pcm24 += chunk
+
+        pcm = resample_pcm(bytes(pcm24), TTS_PCM_RATE, self.rate)
+        await self._play(pcm)
+
+    async def _play(self, pcm: bytes) -> None:
+        """Send PCM as paced 20 ms frames (real-time, drift-corrected)."""
+        loop = asyncio.get_running_loop()
+        next_t = loop.time()
+        for frame in frame_chunks(pcm, self.frame_bytes):
+            await self.conn.send(frame)
+            next_t += 0.02
+            delay = next_t - loop.time()
+            if delay > 0:
+                # Cancellation (barge-in) lands here as CancelledError.
+                await asyncio.sleep(delay)
+
+    async def _send_json(self, payload: dict) -> None:
+        try:
+            await self.conn.send(json.dumps(payload))
+        except websockets.exceptions.ConnectionClosed:
+            pass
+
+
+# ─── HTTP-side concerns: auth + healthz ──────────────────────────────────────
+
+
+def make_request_handler(cfg: Config):
+    def process_request(connection: ServerConnection, request: Request) -> Response | None:
+        if request.path == "/healthz":
+            return connection.respond(200, "ok\n")
+        if cfg.auth_token is None:
+            return None
+        if request.headers.get("Authorization", "") != f"Bearer {cfg.auth_token}":
+            LOG.warning("rejecting upgrade: bad/missing Authorization header")
+            return connection.respond(401, "Unauthorized\n")
+        return None
+
+    return process_request
+
+
+# ─── Connection handler ──────────────────────────────────────────────────────
+
+
+async def handle(connection: ServerConnection, client: AsyncOpenAI, cfg: Config) -> None:
+    peer = connection.remote_address
+    LOG.info("connect peer=%s subprotocol=%r", peer, connection.subprotocol)
+    session = CallSession(connection, client, cfg)
+    try:
+        async for message in connection:
+            if isinstance(message, bytes):
+                await session.on_audio(message)
+                continue
+            try:
+                msg = json.loads(message)
+            except json.JSONDecodeError as e:
+                LOG.warning("invalid JSON text frame: %s — ignoring", e)
+                continue
+            mtype = msg.get("type")
+            if mtype == "start":
+                if msg.get("version") != "1":
+                    await connection.close(code=1003, reason="unsupported version")
+                    return
+                await session.on_start(msg)
+            elif mtype == "stop":
+                LOG.info("stop call_id=%s reason=%s", session.call_id, msg.get("reason"))
+                break
+            elif mtype == "error":
+                LOG.warning("SiphonAI error: %s", {k: v for k, v in msg.items() if k != "type"})
+            elif mtype in {"speech_started", "speech_stopped", "dtmf", "mark"}:
+                # We do our own endpointing; these are informational here.
+                LOG.debug("%s: %s", mtype, {k: v for k, v in msg.items() if k != "type"})
+            else:
+                LOG.debug("unhandled message type=%r", mtype)
+    except websockets.exceptions.ConnectionClosedError as e:
+        LOG.info("connection closed unexpectedly: %s", e)
+    except websockets.exceptions.ConnectionClosedOK:
+        LOG.info("connection closed cleanly")
+    finally:
+        await session.close()
+        LOG.info("done peer=%s call_id=%s", peer, session.call_id)
+
+
+# ─── Entrypoint ──────────────────────────────────────────────────────────────
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="OpenAI cascaded voice bot for SiphonAI v1.")
+    p.add_argument("--bind", default="0.0.0.0:8080", metavar="HOST:PORT")
+    p.add_argument(
+        "--auth-token",
+        default=None,
+        help="require Authorization: Bearer <token> (or set BOT_AUTH_TOKEN)",
+    )
+    p.add_argument("--log-level", default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR"])
+    return p.parse_args(argv)
+
+
+async def main(cfg: Config) -> None:
+    if not os.environ.get("OPENAI_API_KEY"):
+        raise SystemExit("OPENAI_API_KEY is not set")
+    client = AsyncOpenAI(base_url=cfg.base_url) if cfg.base_url else AsyncOpenAI()
+
+    async def handler(connection: ServerConnection) -> None:
+        await handle(connection, client, cfg)
+
+    async with serve(
+        handler,
+        host=cfg.bind_host,
+        port=cfg.bind_port,
+        subprotocols=[SUBPROTOCOL],
+        process_request=make_request_handler(cfg),
+        max_size=256 * 1024,  # PROTOCOL.md §2.1
+        ping_interval=15,
+        ping_timeout=10,
+    ) as server:
+        LOG.info(
+            "listening on ws://%s:%d  (stt=%s llm=%s tts=%s/%s, auth=%s)",
+            cfg.bind_host, cfg.bind_port, cfg.stt_model, cfg.llm_model,
+            cfg.tts_model, cfg.tts_voice, "on" if cfg.auth_token else "off",
+        )
+        loop = asyncio.get_running_loop()
+        stop = loop.create_future()
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            loop.add_signal_handler(sig, lambda s=sig: stop.set_result(s))
+        try:
+            await stop
+        finally:
+            server.close()
+            await server.wait_closed()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    cfg = config_from(args)
+    logging.basicConfig(
+        level=getattr(logging, cfg.log_level),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    try:
+        asyncio.run(main(cfg))
+    except KeyboardInterrupt:
+        pass

--- a/examples/openai-pipeline-bot-py/test_smoke.py
+++ b/examples/openai-pipeline-bot-py/test_smoke.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Offline smoke tests for the OpenAI pipeline bot's pure helpers.
+
+No network and no OPENAI_API_KEY needed — importing ``server`` only defines
+things (``main`` is guarded by ``__main__``). Run:
+
+    pip install -r requirements.txt
+    python3 -m pytest test_smoke.py     # or: python3 test_smoke.py
+"""
+
+from __future__ import annotations
+
+import io
+import wave
+
+import server
+from server import Config, Endpointer, frame_chunks, pcm_to_wav_bytes, resample_pcm
+
+
+def _cfg(**over) -> Config:
+    base = dict(
+        bind_host="0.0.0.0", bind_port=8080, auth_token=None, log_level="INFO",
+        stt_model="whisper-1", llm_model="gpt-4o-mini", tts_model="gpt-4o-mini-tts",
+        tts_voice="alloy", system_prompt="sp", greeting="hi", base_url=None,
+        vad_aggressiveness=2, start_speech_ms=40, end_silence_ms=60,
+        preroll_ms=40, max_utterance_ms=30000,
+    )
+    base.update(over)
+    return Config(**base)
+
+
+def test_pcm_to_wav_roundtrips_header() -> None:
+    pcm = b"\x01\x02" * 160  # 160 samples = 20 ms @ 8 kHz
+    wav = pcm_to_wav_bytes(pcm, 8000)
+    with wave.open(io.BytesIO(wav), "rb") as w:
+        assert w.getnchannels() == 1
+        assert w.getsampwidth() == 2
+        assert w.getframerate() == 8000
+        assert w.readframes(w.getnframes()) == pcm
+
+
+def test_resample_changes_length_proportionally() -> None:
+    # 24 kHz → 8 kHz should be ~1/3 the samples.
+    pcm24 = b"\x00\x00" * 2400  # 2400 samples @ 24 kHz = 100 ms
+    pcm8 = resample_pcm(pcm24, 24000, 8000)
+    out_samples = len(pcm8) // 2
+    assert 760 <= out_samples <= 840, out_samples  # ~800
+    # Identity rate is a no-op (same object semantics not required, just equal).
+    assert resample_pcm(pcm24, 8000, 8000) == pcm24
+
+
+def test_frame_chunks_are_exact_and_padded() -> None:
+    frame_bytes = 320
+    # 2.5 frames of data → 3 frames out, last one zero-padded.
+    pcm = b"\xAB" * (frame_bytes * 2 + 100)
+    frames = list(frame_chunks(pcm, frame_bytes))
+    assert len(frames) == 3
+    assert all(len(f) == frame_bytes for f in frames)
+    assert frames[2].endswith(b"\x00" * (frame_bytes - 100))
+
+
+class _FakeVad:
+    """Scripted VAD: returns the next bool each call (sticks on the last)."""
+
+    def __init__(self, script: list[bool]) -> None:
+        self._s = script
+        self._i = 0
+
+    def is_speech(self, frame: bytes, rate: int) -> bool:
+        v = self._s[min(self._i, len(self._s) - 1)]
+        self._i += 1
+        return v
+
+
+def test_endpointer_emits_start_then_end() -> None:
+    fb = 320
+    ep = Endpointer(8000, fb, _cfg(preroll_ms=40, start_speech_ms=40, end_silence_ms=60))
+    # 2-frame preroll/start, 3-frame end-silence.
+    script = [False, True, True, True, False, False, False]
+    ep._vad = _FakeVad(script)  # type: ignore[assignment]
+
+    events = [ep.process(b"\x00" * fb) for _ in script]
+    kinds = [e if isinstance(e, str) else (e[0] if e else None) for e in events]
+
+    assert "start" in kinds, kinds
+    end = next(e for e in events if isinstance(e, tuple) and e[0] == "end")
+    # Utterance = 2 preroll/speech frames + frames 3..6 = 6 frames total.
+    assert len(end[1]) == 6 * fb, len(end[1])
+    # Exactly one start and one end over the run.
+    assert kinds.count("start") == 1
+    assert sum(1 for e in events if isinstance(e, tuple)) == 1
+
+
+def test_frame_bytes_match_rate() -> None:
+    # The session computes 20 ms of PCM16 from the negotiated rate.
+    assert 8000 // 50 * server.SAMPLE_WIDTH == 320
+    assert 16000 // 50 * server.SAMPLE_WIDTH == 640
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            print(f"ok  {name}")
+    print("all smoke tests passed")


### PR DESCRIPTION
Adds `examples/openai-pipeline-bot-py/` — a reference SiphonAI WS server that runs a full voice assistant using **only OpenAI**, as a **cascaded pipeline** of three independent calls:

```
caller audio ──► STT (Whisper / gpt-4o-transcribe)
                   ──► LLM (chat completions)
                       ──► TTS (gpt-4o-mini-tts / tts-1) ──► caller
```

The counterpart to the existing `openai-realtime-bridge-py` (single speech-to-speech Realtime session). Use this when you want to pick each model independently, mix providers, or inspect the transcript + LLM turns; use Realtime for lowest latency. As always, all AI lives in the WS server — SiphonAI stays provider-neutral (CLAUDE.md §4.1).

## Highlights
- **Own turn-taking** with `webrtcvad` over the inbound 20 ms frames — needs **no** SiphonAI VAD config, so it runs with the same default route as the echo server. (Notably, `PROTOCOL.md` §3.2 ties `speech_started/stopped` to a `bridge.vad = true` key that doesn't actually exist in the config crate — a separate doc-drift I'll flag — so self-endpointing is also the *robust* choice here.)
- **Greets on `start`**, which also satisfies the 0.13.0 `server_too_slow` start-deadline.
- **Barge-in**: cancels the in-flight response and sends `clear` when the caller talks over the bot.
- Resamples OpenAI's 24 kHz TTS `pcm` down to the 8/16 kHz call rate and re-chunks into exact 20 ms frames.
- **Offline smoke test** (WAV wrapping, resampling, 20 ms framing, and the endpointer state machine driven by a scripted VAD) — no API key/network. Verified passing on Python 3.13 (`audioop-lts` + `webrtcvad-wheels` install cleanly).

Files: `server.py`, `requirements.txt`, `README.md`, `Dockerfile`, `.dockerignore`, `test_smoke.py`. Catalogued in `docs/EXAMPLES.md`. `doc-links` clean.

> Note: it's a reference (clarity over latency) — TTS is collected before playback; the README documents how to stream for lower latency. Separately, I'll open a tiny follow-up for the `bridge.vad` doc-drift in PROTOCOL.md §3.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)