### PR TITLE
chore(release): 0.15.0 — per-route [route.bridge.tls] mTLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-06-24
+
 ### Added
 
 - **Per-route `[route.bridge.tls]` override** — a route can now carry its

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2937,7 +2937,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "base64",
  "bytes",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2975,7 +2975,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "regex",
  "serde",
@@ -2993,7 +2993,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3035,7 +3035,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "hmac",
  "http-body-util",
@@ -3055,7 +3055,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "thiserror 1.0.69",
  "tokio",
@@ -3088,7 +3088,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "regex",
  "serde",
@@ -3100,7 +3100,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3133,7 +3133,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3174,7 +3174,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.14.1"
+version = "0.15.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## v0.15.0 — per-route `[route.bridge.tls]` mTLS

Release-engineering commit:
- workspace version `0.14.1 → 0.15.0` (+ `Cargo.lock`)
- moved the staged `[Unreleased]` CHANGELOG block under `## [0.15.0] - 2026-06-24`

### What's in this release

- **Per-route `[route.bridge.tls]` mTLS override** (#231) — a `[[route]]` carries its own WS-leg client cert/key + optional SPKI pin; fully replaces global `[bridge.tls]` for matching calls, else inherits. Compiled at config load (fail-loud at startup) and onto `CompiledRoute` (atomic SIGHUP swap).

Also rolled in since v0.14.1: example OpenAI cascaded voice bot (#229), protocol gating doc fix (#230), roadmap updates.

Protocol stays v1, CDR unchanged. Off unless a route opts in.

After merge: annotated tag `v0.15.0` + GitHub release marked Latest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
