### PR TITLE
fix(release): allow pre-release tags without a CHANGELOG section

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,21 @@ jobs:
       - name: CHANGELOG has a section for this version
         run: |
           python3 scripts/extract-changelog.py --selftest
-          python3 scripts/extract-changelog.py "${TAG#v}" > /dev/null
+          version="${TAG#v}"
+          # A final tag must have its own dated CHANGELOG section. A
+          # pre-release for an upcoming version may not be documented yet
+          # (the publish step falls back to the base section, then a
+          # generic note) — so it's allowed, just reported.
+          if [[ "$version" == *-* ]]; then
+            base="${version%%-*}"
+            if python3 scripts/extract-changelog.py "$base" > /dev/null 2>&1; then
+              echo "Pre-release: will use the $base CHANGELOG section."
+            else
+              echo "Pre-release: no $base CHANGELOG section yet; generic notes will be used."
+            fi
+          else
+            python3 scripts/extract-changelog.py "$version" > /dev/null
+          fi
 
   build:
     name: build ${{ matrix.target }}


### PR DESCRIPTION
Follow-up fix to chunk 2 (release workflow), caught by the `v0.16.0-rc.1` validation run.

The preflight `CHANGELOG has a section` step required a dated section for the full tag version, so `v0.16.0-rc.1` (not documented until 0.16.0 ships) failed preflight — even though the publish step already falls back to the base version's section, then a generic note. This aligns the preflight with that: **final tags still require their section; pre-releases report which notes will be used and proceed.**

The prerelease-aware *version* gate itself passed in the rc run; only this CHANGELOG step was over-strict.

Verified locally: `release.yml` parses; simulated step gives `v0.16.0-rc.1 → generic notes`, `v0.15.0 → section ok`.

After merge I'll re-point `v0.16.0-rc.1` at the fixed main HEAD and re-run the pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)