### PR TITLE
fix(release): static-link libopus in the musl cross build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,17 @@ jobs:
         target:
           - x86_64-unknown-linux-musl
           - aarch64-unknown-linux-musl
+    env:
+      # audiopus_sys decides static-vs-dynamic libopus from
+      # `#[cfg(target_env = "musl")]` in its build script — but build
+      # scripts see the *host* cfg, not the target. Cross-compiling from
+      # a glibc host, that probes false and it emits a dynamic `-lopus`
+      # that can't be resolved for a static musl binary (the native
+      # alpine Docker build dodges this only because host == musl).
+      # Force static linking, and always build the vendored libopus from
+      # source so no host-arch system opus can leak into the cross build.
+      LIBOPUS_STATIC: "1"
+      LIBOPUS_NO_PKG: "1"
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Follow-up fix to the release workflow, caught by the `v0.16.0-rc.1` validation run.

**Symptom:** both arch builds compiled fully, then failed at link with `unable to find dynamic system library 'opus'` (the link line carried `-Wl,-Bdynamic -lopus` even though `audiopus_sys` had built a static `libopus.a`).

**Root cause:** `audiopus_sys/build.rs` chooses static-vs-dynamic libopus via `#[cfg(target_env = "musl")]` — but a build script's `cfg` reflects the **host**, not the target. The alpine Docker build works only because its host *is* musl; cross-compiling with cargo-zigbuild from the glibc CI host, the probe is false → dynamic `-lopus` → unresolvable in a static binary.

**Fix:** set `LIBOPUS_STATIC=1` (force static link) and `LIBOPUS_NO_PKG=1` (always build the vendored libopus from source, so no host-arch system opus leaks into the cross build) on the build job — the env hooks `audiopus_sys` documents for exactly this case.

After merge I'll re-point `v0.16.0-rc.1` and re-run the pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)