### PR TITLE
ci(release): SBOM, cosign signatures, multi-arch GHCR container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,14 +4,17 @@ name: release
 # manual release flow — bump version, tag, push). `workflow_dispatch` is
 # a re-run escape hatch (supply the existing tag).
 #
-# Chunk 2 of the Release & packaging theme: multi-arch musl-static
-# binaries + SHA256SUMS, with release notes extracted from CHANGELOG.md.
-# Signing + SBOM + GHCR container (chunk 3) and the .deb (chunk 4) add
-# jobs/steps to this file; they don't replace it.
+# Release & packaging theme. Chunk 2: multi-arch musl-static binaries +
+# SHA256SUMS, release notes extracted from CHANGELOG.md. Chunk 3: a
+# CycloneDX SBOM (syft), cosign keyless signatures over the checksums,
+# and a multi-arch GHCR container (also cosign-signed). The .deb (chunk
+# 4) adds to this file; it doesn't replace it.
 #
 # Cross-compilation is cargo-zigbuild: one x86 runner builds both the
 # x86_64 and aarch64 musl targets via the zig linker — no QEMU, no
-# Docker-in-CI (DESIGN_RELEASE_PACKAGING.md §3.2, decision 3).
+# Docker-in-CI (DESIGN_RELEASE_PACKAGING.md §3.2, decision 3). The
+# container reuses those exact binaries (COPY, never recompile), so the
+# image and the standalone binary are byte-identical per arch.
 
 on:
   push:
@@ -24,6 +27,8 @@ on:
 
 permissions:
   contents: write # create the release + upload assets
+  packages: write # push the container image to GHCR
+  id-token: write # cosign keyless signing via GitHub OIDC
 
 concurrency:
   group: release-${{ github.event.inputs.tag || github.ref_name }}
@@ -159,10 +164,34 @@ jobs:
           merge-multiple: true
           path: dist
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@v0
+
+      - name: SBOM (CycloneDX, from Cargo.lock)
+        run: |
+          version="${TAG#v}"
+          syft scan dir:. \
+            -o cyclonedx-json="dist/siphon-ai-${version}-sbom.cdx.json"
+
+      # SHA256SUMS covers the tarballs *and* the SBOM, so the single
+      # cosign signature below vouches for everything that ships.
       - name: Checksums
         run: |
           cd dist
-          sha256sum *.tar.gz | tee SHA256SUMS
+          sha256sum *.tar.gz *.cdx.json | tee SHA256SUMS
+
+      # Keyless: the signature is bound to this workflow's OIDC identity
+      # (verify with `cosign verify-blob --bundle SHA256SUMS.cosign.bundle
+      #  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+      #  --certificate-identity-regexp '.../release.yml@.*' SHA256SUMS`).
+      - name: Sign checksums (cosign keyless)
+        run: |
+          cosign sign-blob --yes \
+            --bundle dist/SHA256SUMS.cosign.bundle \
+            dist/SHA256SUMS
 
       - name: Release notes from CHANGELOG
         run: |
@@ -178,13 +207,26 @@ jobs:
           else
             echo "Pre-release \`$TAG\` for pipeline validation." > body.md
           fi
+          repo="${{ github.repository }}"
           {
             cat body.md
             echo
             echo "---"
             echo
-            echo "Static musl binaries for \`x86_64\` and \`aarch64\`."
-            echo "Verify with \`sha256sum -c SHA256SUMS\`."
+            echo "**Artifacts**"
+            echo
+            echo "- Static musl binaries for \`x86_64\` and \`aarch64\` (\`.tar.gz\`)."
+            echo "- \`SHA256SUMS\` — verify with \`sha256sum -c SHA256SUMS\`."
+            echo "- \`*-sbom.cdx.json\` — CycloneDX SBOM."
+            echo "- \`SHA256SUMS.cosign.bundle\` — cosign keyless signature over the checksums."
+            echo "- Container: \`ghcr.io/${repo}:${TAG}\` (multi-arch, cosign-signed)."
+            echo
+            echo "Verify the checksums signature:"
+            echo '```'
+            echo "cosign verify-blob --bundle SHA256SUMS.cosign.bundle \\"
+            echo "  --certificate-oidc-issuer https://token.actions.githubusercontent.com \\"
+            echo "  --certificate-identity-regexp 'release.yml@' SHA256SUMS"
+            echo '```'
           } > notes.md
 
       # Pre-release for any tag with a pre-release suffix (e.g.
@@ -205,3 +247,78 @@ jobs:
               --notes-file notes.md \
               $channel
           fi
+
+  # Multi-arch image assembled from the *prebuilt* release binaries (no
+  # recompile, no QEMU — the Dockerfile only COPYs per-arch binaries), so
+  # the image matches the standalone binaries byte-for-byte. Pushed to
+  # GHCR and signed with the same cosign keyless identity.
+  container:
+    name: container (GHCR)
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref_name }}
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: dist-*
+          merge-multiple: true
+          path: dist
+
+      # Lay the static binaries out by Docker arch so the release
+      # Dockerfile can `COPY ctx/${TARGETARCH}/siphon-ai`.
+      - name: Stage per-arch binaries
+        run: |
+          set -euo pipefail
+          mkdir -p ctx
+          for pair in \
+            "x86_64-unknown-linux-musl:amd64" \
+            "aarch64-unknown-linux-musl:arm64"; do
+            triple="${pair%%:*}"; arch="${pair##*:}"
+            tar -xzf dist/siphon-ai-*-"${triple}".tar.gz
+            mkdir -p "ctx/${arch}"
+            cp siphon-ai-*-"${triple}"/siphon-ai "ctx/${arch}/siphon-ai"
+            rm -rf siphon-ai-*-"${triple}"
+          done
+          ls -lR ctx
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      # `:latest` only for a final release, never a pre-release.
+      - name: Build + push multi-arch image
+        id: build
+        run: |
+          set -euo pipefail
+          image="ghcr.io/${{ github.repository }}"
+          tags=(-t "${image}:${TAG}")
+          if [[ "$TAG" != *-* ]]; then
+            tags+=(-t "${image}:latest")
+          fi
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            -f docker/Dockerfile.release \
+            "${tags[@]}" \
+            --metadata-file metadata.json \
+            --push ctx
+          digest="$(jq -r '.["containerimage.digest"]' metadata.json)"
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+          echo "image=${image}" >> "$GITHUB_OUTPUT"
+
+      - name: Sign the image (cosign keyless)
+        run: |
+          cosign sign --yes \
+            "${{ steps.build.outputs.image }}@${{ steps.build.outputs.digest }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with notes extracted from `CHANGELOG.md` (pre-release tags like
   `v0.16.0-rc.1` are marked accordingly, never latest). A `preflight` job
   re-asserts tag == workspace version before anything is built. Second
-  chunk of the P0 "Release & packaging" theme; signing + SBOM + GHCR
-  container and `.deb` packages follow.
+  chunk of the P0 "Release & packaging" theme; `.deb` packages follow.
+- **Release supply chain: SBOM, signatures, and a published container.**
+  Each release now ships a CycloneDX SBOM (syft), a cosign **keyless**
+  signature over `SHA256SUMS` (`SHA256SUMS.cosign.bundle`, verifiable
+  against the workflow's GitHub OIDC identity), and a multi-arch
+  (`linux/amd64` + `linux/arm64`) container at
+  `ghcr.io/thevoiceguy/siphon-ai:<tag>` (also cosign-signed; `:latest`
+  only for final releases). The image is assembled from the same prebuilt
+  static binaries that ship on the release — byte-identical, no recompile.
+  Third chunk of the P0 "Release & packaging" theme.
 
 ### Changed
+
+- **Docker dev image tracks the toolchain.** `docker/Dockerfile` now uses
+  `rust:1.95-alpine` (matching `rust-toolchain.toml`) instead of the stale
+  `rust:1.85` base, which sat below the workspace MSRV and only built
+  because `rust-toolchain.toml` forced a 1.95.0 download on top of it.
 
 - **CI: version-consistency gate.** A new `version consistency` job
   (`scripts/check-version-consistency.py`) fails the build if the

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,13 @@
 # carries an x86_64-unknown-linux-musl target via the musl libc on
 # the system, so `cargo build --target x86_64-unknown-linux-musl`
 # Just Works — no rustup target add dance required.
-FROM rust:1.85-alpine AS builder
+#
+# Track `rust-toolchain.toml` (channel 1.95.0). The previous `1.85`
+# base was below the workspace MSRV (1.89) and only built at all
+# because `rust-toolchain.toml` made rustup fetch 1.95.0 on top of it
+# — wasteful and misleading. Bump this in lockstep with the toolchain
+# file. (rustup still honors the exact pin inside the build.)
+FROM rust:1.95-alpine AS builder
 
 # Musl + the C build tools forge-codecs and friends invoke at
 # compile time. `linux-headers` is required by tokio's TCP/UDP code

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -1,0 +1,44 @@
+# Release container for the SiphonAI daemon.
+#
+# Unlike docker/Dockerfile (which builds from source for local dev),
+# this image is assembled by the release workflow from the *prebuilt*
+# static-musl binaries that ship on the GitHub release — it only COPYs
+# the right binary per arch, never compiles. That keeps the image and
+# the standalone release binary byte-identical, and lets a single
+# `docker buildx --platform linux/amd64,linux/arm64` produce a
+# multi-arch manifest without QEMU (no target code runs during build).
+#
+# Build context must contain `amd64/siphon-ai` and `arm64/siphon-ai`
+# (the release workflow stages these from the per-arch tarballs).
+
+FROM alpine:3
+
+RUN apk add --no-cache ca-certificates
+
+# Non-root user. SIP and RTP bind unprivileged ports by default
+# (5070 for SIP, 40000-40100 for RTP), so root is not needed at runtime.
+ARG UID=10001
+RUN addgroup -S -g ${UID} siphon \
+ && adduser -S -D -H -u ${UID} -G siphon siphon
+USER siphon
+
+WORKDIR /app
+
+# `TARGETARCH` is set by buildx per platform (amd64 / arm64); it selects
+# which prebuilt static binary to install.
+ARG TARGETARCH
+COPY ${TARGETARCH}/siphon-ai /usr/local/bin/siphon-ai
+
+# Default config path. Operators override via `-v ./my.toml:/app/config.toml`.
+ENV SIPHON_AI_CONFIG=/app/config.toml
+
+# Document the runtime surface (compose / k8s overrides as needed):
+#   5070/udp        — SIP signaling
+#   5070/tcp        — SIP TCP (when transports = ["tcp"])
+#   5061/tcp        — SIPS (when transports = ["tls"])
+#   9091/tcp        — Prometheus metrics + /health + /ready
+#   40000-40100/udp — RTP port pool (matches local-dev.toml default)
+EXPOSE 5070/udp 5070/tcp 5061/tcp 9091/tcp 40000-40100/udp
+
+ENTRYPOINT ["/usr/local/bin/siphon-ai"]
+CMD ["--config", "/app/config.toml"]


### PR DESCRIPTION
## Summary

Chunk 3 of the **Release & packaging** theme — supply-chain artifacts and a published container. Extends `release.yml`; nothing in chunks 1–2 changes behavior.

## What's added

**`publish` job — SBOM + signed checksums**
- CycloneDX SBOM via **syft** (`siphon-ai-<version>-sbom.cdx.json`), scanned from `Cargo.lock`.
- `SHA256SUMS` now covers the tarballs **and** the SBOM, and is signed with **cosign keyless** (GitHub OIDC) → `SHA256SUMS.cosign.bundle`. One signature vouches for everything that ships.
- Release notes document the `cosign verify-blob` command.

**`container` job (new) — multi-arch GHCR image**
- Assembles `ghcr.io/thevoiceguy/siphon-ai:<tag>` for `linux/amd64` + `linux/arm64` from the **prebuilt** release binaries — `docker/Dockerfile.release` only `COPY`s the per-arch binary via `TARGETARCH`, so **no recompile and no QEMU** (no target code runs during build), and the image is byte-identical to the standalone binary per arch.
- `:latest` only for final releases, never pre-releases.
- Image signed with the same cosign keyless identity (by digest).

**Hardening / cleanup**
- `permissions` widened: `packages: write` (GHCR) + `id-token: write` (keyless).
- `docker/Dockerfile`: `rust:1.85-alpine` → `rust:1.95-alpine` to track `rust-toolchain.toml`. The old base was *below* the 1.89 MSRV and only built because rustup fetched 1.95.0 on top of it — wasteful and misleading.

## Decisions honored (design §4)
cosign **keyless** + **syft** (decision 5), GHCR registry, container built from the prebuilt binaries.

## Verification
- `release.yml` parses; jobs = preflight / build / publish / container; permissions correct.
- Version + doc-link gates green.
- **End-to-end is a `v0.16.0-rc.1` tag after merge** (same pattern as chunk 2): confirm the SBOM + `.cosign.bundle` attach, `cosign verify-blob` succeeds, the GHCR image is a multi-arch manifest, `cosign verify` the image passes, and the rc image is **not** tagged `:latest`. The cosign/GHCR/buildx steps can only run on a real tag, so the rc is where they're proven.

## Next
4. `.deb` via cargo-deb
5. Docs + `RELEASING.md`, then cut **v0.16.0** with the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
