### PR TITLE
ci(release): Debian (.deb) packages for amd64 + arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,11 +138,26 @@ jobs:
           tar -C staging -czf "${dist}.tar.gz" "${dist}"
           ls -l "${dist}.tar.gz"
 
+      # .deb from the *same* prebuilt static binary. --no-build reuses
+      # it; --no-strip keeps the already-stripped binary (and avoids
+      # needing an aarch64-aware `strip` on the x86 runner). cargo-deb
+      # maps the Rust target to the Debian arch (amd64/arm64).
+      - name: Install cargo-deb
+        run: cargo install cargo-deb --locked
+      - name: Build .deb
+        run: |
+          cargo deb --no-build --no-strip \
+            -p siphon-ai --target ${{ matrix.target }}
+          cp target/${{ matrix.target }}/debian/*.deb .
+          ls -l ./*.deb
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: dist-${{ matrix.target }}
-          path: siphon-ai-*.tar.gz
+          path: |
+            siphon-ai-*.tar.gz
+            *.deb
           retention-days: 7
           if-no-files-found: error
 
@@ -176,12 +191,13 @@ jobs:
           syft scan dir:. \
             -o cyclonedx-json="dist/siphon-ai-${version}-sbom.cdx.json"
 
-      # SHA256SUMS covers the tarballs *and* the SBOM, so the single
-      # cosign signature below vouches for everything that ships.
+      # SHA256SUMS covers the tarballs, the .deb packages, *and* the
+      # SBOM, so the single cosign signature below vouches for everything
+      # that ships.
       - name: Checksums
         run: |
           cd dist
-          sha256sum *.tar.gz *.cdx.json | tee SHA256SUMS
+          sha256sum *.tar.gz *.deb *.cdx.json | tee SHA256SUMS
 
       # Keyless: the signature is bound to this workflow's OIDC identity
       # (verify with `cosign verify-blob --bundle SHA256SUMS.cosign.bundle
@@ -216,6 +232,7 @@ jobs:
             echo "**Artifacts**"
             echo
             echo "- Static musl binaries for \`x86_64\` and \`aarch64\` (\`.tar.gz\`)."
+            echo "- Debian packages (\`.deb\`) for \`amd64\` and \`arm64\` — \`apt install ./siphon-ai_*_amd64.deb\`."
             echo "- \`SHA256SUMS\` — verify with \`sha256sum -c SHA256SUMS\`."
             echo "- \`*-sbom.cdx.json\` — CycloneDX SBOM."
             echo "- \`SHA256SUMS.cosign.bundle\` — cosign keyless signature over the checksums."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with notes extracted from `CHANGELOG.md` (pre-release tags like
   `v0.16.0-rc.1` are marked accordingly, never latest). A `preflight` job
   re-asserts tag == workspace version before anything is built. Second
-  chunk of the P0 "Release & packaging" theme; `.deb` packages follow.
+  chunk of the P0 "Release & packaging" theme.
+- **Debian packages** (`.deb` for `amd64` + `arm64`, via cargo-deb). Each
+  release now ships installable packages built from the same prebuilt
+  static binaries: they drop the binary at `/usr/bin/siphon-ai`, a default
+  conffile at `/etc/siphon-ai/config.toml`, and a hardened systemd unit
+  (enabled but **not** started — the default config has a placeholder
+  `ws_url`), and create the `siphon-ai` service user + `/var/{lib,log}`
+  dirs in the maintainer scripts. `apt install ./siphon-ai_*_amd64.deb`.
+  Fourth chunk of the P0 "Release & packaging" theme.
 - **Release supply chain: SBOM, signatures, and a published container.**
   Each release now ships a CycloneDX SBOM (syft), a cosign **keyless**
   signature over `SHA256SUMS` (`SHA256SUMS.cosign.bundle`, verifiable

--- a/bins/siphon-ai/Cargo.toml
+++ b/bins/siphon-ai/Cargo.toml
@@ -83,3 +83,45 @@ forge-rtp.workspace    = true
 [dev-dependencies]
 tokio        = { workspace = true, features = ["macros", "rt", "time", "net", "sync"] }
 tempfile     = "3"
+
+# Debian package (`cargo deb -p siphon-ai`). Installs the static binary,
+# a default conffile, both licenses + README as docs, and a systemd unit
+# (enabled but not started — the operator edits the config first). The
+# siphon-ai service user + /var/{lib,log}/siphon-ai are created in the
+# maintainer scripts (pkg/postinst); cargo-deb injects the systemd
+# helper at each #DEBHELPER# marker.
+[package.metadata.deb]
+maintainer = "SiphonAI contributors <noreply@github.com>"
+copyright = "2026 SiphonAI contributors. Dual-licensed MIT OR Apache-2.0."
+license-file = ["../../LICENSE-APACHE", "0"]
+section = "net"
+priority = "optional"
+# Static musl binary: no shared-lib deps, so cargo-deb's $auto would
+# resolve to nothing. Depend explicitly on ca-certificates (system trust
+# roots for outbound TLS) and adduser (postinst creates the service
+# account with addgroup/adduser; no longer priority:important on Debian
+# 13, so packages that use it must depend on it).
+depends = "ca-certificates, adduser"
+extended-description = """\
+SiphonAI is a SIP-to-WebSocket media bridge. It accepts inbound SIP \
+calls (as a trunk endpoint or a registered phone), streams the call \
+audio over a WebSocket to a developer-supplied server, and plays \
+returned audio back into the call. It contains no AI code — running \
+the AI (STT/LLM/TTS) is the WebSocket server's job."""
+conf-files = ["/etc/siphon-ai/config.toml"]
+maintainer-scripts = "pkg/"
+assets = [
+    ["target/release/siphon-ai", "usr/bin/", "755"],
+    ["pkg/config.toml", "etc/siphon-ai/config.toml", "640"],
+    ["../../README.md", "usr/share/doc/siphon-ai/README.md", "644"],
+    ["../../LICENSE-APACHE", "usr/share/doc/siphon-ai/LICENSE-APACHE", "644"],
+    ["../../LICENSE-MIT", "usr/share/doc/siphon-ai/LICENSE-MIT", "644"],
+]
+
+[package.metadata.deb.systemd-units]
+unit-name = "siphon-ai"
+unit-scripts = "pkg/"
+# Enable on install so it comes up on boot, but don't start now — the
+# default config points at a placeholder ws_url.
+enable = true
+start = false

--- a/bins/siphon-ai/pkg/config.toml
+++ b/bins/siphon-ai/pkg/config.toml
@@ -1,0 +1,51 @@
+# SiphonAI default configuration (installed by the .deb package).
+#
+# This is a minimal, VALID-but-inert template: the daemon starts and
+# serves /health + /metrics on loopback, but until you set a real
+# [bridge].ws_url (your WebSocket AI server) and a [[trunk]] allowlist,
+# it won't bridge any calls. Edit this file, then:
+#
+#     sudo systemctl start siphon-ai      # first start (package enables but does not start)
+#     sudo systemctl reload siphon-ai     # apply route/gateway/webhook changes (SIGHUP)
+#
+# Full reference: /usr/share/doc/siphon-ai/ and
+# https://github.com/thevoiceguy/siphon-ai/blob/main/docs/CONFIG.md
+#
+# This is a dpkg conffile: your edits survive package upgrades.
+
+[node]
+id = "siphon-ai"
+# The address that goes into the SDP `c=` line (where callers send RTP).
+# Set this to this host's routable IP before taking real traffic.
+public_address = "127.0.0.1"
+
+[sip]
+listen = "0.0.0.0:5060"
+transports = ["udp"]
+user_agent = "SiphonAI"
+
+[media]
+codecs = ["pcmu", "pcma"]
+dtmf = "rfc2833"
+rtp_port_range = [40000, 40100]
+inactivity_timeout_secs = 60
+
+[bridge]
+# REQUIRED: the WebSocket server that runs your AI (STT/LLM/TTS).
+# Replace this placeholder before going live.
+ws_url = "ws://127.0.0.1:8080/"
+ws_connect_timeout_ms = 3000
+
+[observability]
+enabled = true
+# Loopback only by default: /metrics + /health + /ready. The admin API
+# has its own authenticated listener ([admin]); do not expose this on a
+# public interface without a fronting proxy.
+http_listen = "127.0.0.1:9091"
+
+# A default route is REQUIRED. Add [[trunk]] allowlists and more
+# specific [[route]] entries above this one (first match wins).
+[[route]]
+name = "default"
+[route.match]
+any = true

--- a/bins/siphon-ai/pkg/postinst
+++ b/bins/siphon-ai/pkg/postinst
@@ -1,0 +1,49 @@
+#!/bin/sh
+# postinst — create the service account + runtime dirs. cargo-deb
+# injects the systemd helper commands at the marker near the end.
+set -e
+
+SVC_USER=siphon-ai
+SVC_GROUP=siphon-ai
+SVC_HOME=/var/lib/siphon-ai
+LOG_DIR=/var/log/siphon-ai
+
+case "$1" in
+    configure)
+        if ! getent group "$SVC_GROUP" >/dev/null; then
+            addgroup --system "$SVC_GROUP"
+        fi
+        if ! getent passwd "$SVC_USER" >/dev/null; then
+            adduser --system --no-create-home \
+                --home "$SVC_HOME" \
+                --shell /usr/sbin/nologin \
+                --ingroup "$SVC_GROUP" \
+                "$SVC_USER"
+        fi
+
+        # State + log dirs owned by the service account.
+        for dir in "$SVC_HOME" "$LOG_DIR"; do
+            mkdir -p "$dir"
+            chown "$SVC_USER:$SVC_GROUP" "$dir"
+            chmod 0750 "$dir"
+        done
+
+        # The config may carry secrets (auth headers, passwords) — keep
+        # it readable only by root and the service group.
+        if [ -e /etc/siphon-ai/config.toml ]; then
+            chown root:"$SVC_GROUP" /etc/siphon-ai/config.toml
+            chmod 0640 /etc/siphon-ai/config.toml
+        fi
+
+        # Empty env file for ${VAR} expansion (operator fills it in).
+        if [ ! -e /etc/siphon-ai/env ]; then
+            touch /etc/siphon-ai/env
+            chown root:"$SVC_GROUP" /etc/siphon-ai/env
+            chmod 0640 /etc/siphon-ai/env
+        fi
+        ;;
+esac
+
+#DEBHELPER#
+
+exit 0

--- a/bins/siphon-ai/pkg/postrm
+++ b/bins/siphon-ai/pkg/postrm
@@ -1,0 +1,10 @@
+#!/bin/sh
+# postrm — the injected helper marker (below) handles the systemd unit
+# (daemon-reload, reset). We deliberately leave the siphon-ai user,
+# /var/log/siphon-ai, and /var/lib/siphon-ai in place on purge so
+# CDRs/recordings aren't lost; remove them by hand for a clean slate.
+set -e
+
+#DEBHELPER#
+
+exit 0

--- a/bins/siphon-ai/pkg/prerm
+++ b/bins/siphon-ai/pkg/prerm
@@ -1,0 +1,8 @@
+#!/bin/sh
+# prerm — the injected helper marker (below) stops/disables the systemd
+# unit on remove/upgrade.
+set -e
+
+#DEBHELPER#
+
+exit 0

--- a/bins/siphon-ai/pkg/siphon-ai.service
+++ b/bins/siphon-ai/pkg/siphon-ai.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=SiphonAI — SIP-to-WebSocket media bridge
+Documentation=https://github.com/thevoiceguy/siphon-ai
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=siphon-ai
+Group=siphon-ai
+# Optional secrets for ${VAR} expansion in the config (created empty by
+# the package; the `-` means "ignore if absent").
+EnvironmentFile=-/etc/siphon-ai/env
+ExecStart=/usr/bin/siphon-ai --config /etc/siphon-ai/config.toml
+# SIGHUP hot-reloads routes/gateways/webhook+CDR sinks (see CONFIG.md).
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=always
+RestartSec=5
+
+# Hardening — the daemon binds unprivileged ports (SIP 5060, RTP
+# 40000-40100) and needs no root at runtime.
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ReadWritePaths=/var/log/siphon-ai /var/lib/siphon-ai
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Chunk 4 of the **Release & packaging** theme — native Debian `.deb` packages (`amd64` + `arm64`) via cargo-deb, built from the same prebuilt static binaries as the tarballs.

## What's in here

**Packaging (`bins/siphon-ai/pkg/` + `[package.metadata.deb]`)**
- `/usr/bin/siphon-ai`, default conffile `/etc/siphon-ai/config.toml` (valid-but-inert template), both licenses + README as docs, and a hardened systemd unit.
- Unit is **enabled but not started** on install (the default `ws_url` is a placeholder — operator edits config, then `systemctl start`).
- `postinst` creates the `siphon-ai` service user + `/var/{lib,log}/siphon-ai`; `prerm`/`postrm` leave state in place on purge.
- `Depends: ca-certificates, adduser`.

**CI (`release.yml`)**
- build job builds the `.deb` per arch from the prebuilt binary: `cargo deb --no-build --no-strip --target <triple>` (reuses the zigbuild output; `--no-strip` avoids needing an aarch64 `strip` on the x86 runner).
- `.deb`s upload with the tarballs; publish folds `*.deb` into `SHA256SUMS`, so the existing **cosign signature + checksums already cover them**.
- Release notes gain an `apt install ./siphon-ai_*_amd64.deb` line.

## Validated locally end-to-end
Built `siphon-ai_0.15.0-1_amd64.deb` and installed it in `debian:stable-slim`:
- `siphon-ai` system user created; `/usr/bin/siphon-ai --version` runs; `siphon-ai check` passes on the shipped config.
- `/var/{lib,log}/siphon-ai` → `siphon-ai:siphon-ai 750`; config `root:siphon-ai 640`; conffile registered.
- unit **enabled** (wants-symlink present), **not started**; **purge is clean**.

Local testing **caught two real bugs** fixed in this PR:
1. **Duplicate systemd block** — cargo-deb substitutes the literal `#DEBHELPER#` text *everywhere*, including where I'd written it in script comments; reworded the comments so only the real marker expands.
2. **Missing `adduser` dependency** — `addgroup`/`adduser` aren't in slim bases and `adduser` is no longer priority:important on Debian 13, so the package must depend on it.

## Validation note
The aarch64 `.deb` (cross-arch cargo-deb) only runs in CI on a tag, so the **`v0.16.0-rc.1` run after merge** is where the arm64 package + checksum coverage get confirmed (same pattern as chunks 2–3).

## Next
5. Docs + `RELEASING.md`, then cut **v0.16.0** with the workflow (first auto-cut release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
