### PR TITLE
docs(release): install-from-release section + RELEASING.md runbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Docs: installing from a release + a releasing runbook.**
+  `docs/DEPLOY.md` gains an *Install from a release* section (verify
+  checksums + cosign signature, then install the binary, the `.deb`, or the
+  signed container), and a new top-level `RELEASING.md` documents the
+  "bump, then tag and push" flow the workflow automates. Final chunk of the
+  P0 "Release & packaging" theme.
 - **Automated release workflow** (`.github/workflows/release.yml`). Pushing
   a `v*` tag now builds multi-arch static-musl binaries (`x86_64` +
   `aarch64`, cross-compiled with cargo-zigbuild), packages them as

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,82 @@
+# Releasing SiphonAI
+
+Cutting a release is **"bump, then tag and push."** The
+[`release`](.github/workflows/release.yml) workflow does the rest: it builds
+multi-arch static binaries, Debian packages, an SBOM, and a signed container,
+and publishes a GitHub release. This runbook is the human half.
+
+See [`docs/design/DESIGN_RELEASE_PACKAGING.md`](docs/design/DESIGN_RELEASE_PACKAGING.md)
+for the design and the locked decisions.
+
+## The single source of truth
+
+The workspace `Cargo.toml` `[workspace.package].version` is canonical. The
+`version consistency` CI gate (on every PR/push) fails the build unless:
+
+- `README.md`'s `**Current release: vX.Y.Z**` marker equals it, and
+- `CHANGELOG.md` has a dated `## [X.Y.Z] - YYYY-MM-DD` section for it.
+
+So the three move together, in one commit, at release time — never drift.
+
+## Cutting a final release
+
+1. **Land all the work** for the release on `main` (entries accumulate under
+   `## [Unreleased]` in `CHANGELOG.md`).
+
+2. **Release-prep commit** (on a branch → PR → merge), conventionally
+   `chore(release): X.Y.Z — <headline>`:
+   - bump `[workspace.package].version` in `Cargo.toml` (and refresh
+     `Cargo.lock` with a build);
+   - in `CHANGELOG.md`, rename `## [Unreleased]` to `## [X.Y.Z] - <today>` and
+     start a fresh empty `## [Unreleased]` above it;
+   - update the `README.md` `**Current release: vX.Y.Z**` marker.
+
+   Verify locally before pushing:
+   ```sh
+   python3 scripts/check-version-consistency.py
+   python3 scripts/check-version-consistency.py --tag vX.Y.Z   # tag == version
+   python3 scripts/extract-changelog.py X.Y.Z                  # notes exist
+   ```
+
+3. **Tag the merged release commit and push:**
+   ```sh
+   git checkout main && git pull
+   git tag -a vX.Y.Z -m "vX.Y.Z — <headline>"
+   git push origin vX.Y.Z
+   ```
+
+   That's the trigger. The `release` workflow then:
+   - **preflight** — re-asserts `tag == workspace version` + a dated CHANGELOG
+     section (a mistagged commit never builds);
+   - **build** (`x86_64` + `aarch64` musl, cargo-zigbuild) → `.tar.gz`;
+   - **`.deb`** (cargo-deb, `amd64` + `arm64`);
+   - **publish** — CycloneDX SBOM (syft), `SHA256SUMS` over everything, a
+     cosign keyless signature over the checksums, and a GitHub release marked
+     **Latest**, with notes extracted from `CHANGELOG.md`;
+   - **container** — multi-arch image to `ghcr.io/thevoiceguy/siphon-ai:vX.Y.Z`
+     and `:latest`, cosign-signed.
+
+4. **Verify the published release** (see `docs/DEPLOY.md` → *Install from a
+   release*): `sha256sum -c SHA256SUMS`, `cosign verify-blob …`, and
+   `cosign verify ghcr.io/thevoiceguy/siphon-ai:vX.Y.Z …`.
+
+## Pre-releases (`-rc.N`)
+
+A tag with a pre-release suffix — `vX.Y.Z-rc.1` — exercises the whole
+pipeline **without** a version bump: preflight allows a pre-release whose base
+version is the current or a future version, the release is marked
+**pre-release** (never `:latest` / never Latest), and the notes fall back to
+the base CHANGELOG section (or a generic line). Use it to validate workflow
+changes; delete the throwaway tag/release/image afterward.
+
+## Re-running
+
+`release` also has a `workflow_dispatch` trigger taking an existing tag —
+use it to re-run publishing for a tag without re-tagging (the release is
+created if absent, or its assets/notes updated in place).
+
+## What needs no manual step
+
+Versions in crate `Cargo.toml`s (they inherit `version.workspace = true`),
+the SBOM, signatures, checksums, and the container — all produced by the
+workflow. Don't hand-build or hand-upload release artifacts.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -4,6 +4,74 @@ This is the operator's reference for running `siphon-ai` in something other
 than `cargo run`. For configuration semantics see `docs/CONFIG.md`; for the
 observability bar (the §11.8 ten questions) see `docs/OPERATIONS.md`.
 
+## Install from a release
+
+Every [GitHub release](https://github.com/thevoiceguy/siphon-ai/releases)
+ships prebuilt, **statically-linked musl** artifacts for `x86_64` and
+`aarch64` — no need to build from source. Each release carries:
+
+| Artifact | What it is |
+|---|---|
+| `siphon-ai-<ver>-<target>.tar.gz` | Standalone static binary (+ licenses, README). |
+| `siphon-ai_<ver>-1_<arch>.deb` | Debian/Ubuntu package (`amd64` / `arm64`). |
+| `ghcr.io/thevoiceguy/siphon-ai:<ver>` | Multi-arch container (`linux/amd64` + `linux/arm64`). |
+| `siphon-ai-<ver>-sbom.cdx.json` | CycloneDX SBOM. |
+| `SHA256SUMS`, `SHA256SUMS.cosign.bundle` | Checksums + a keyless [cosign](https://docs.sigstore.dev/) signature over them. |
+
+The binaries are the same artifacts the container is built from — byte-for-byte
+per arch.
+
+### Verify before installing
+
+```sh
+# Integrity: checksums cover the tarballs, the .deb packages, and the SBOM.
+sha256sum -c SHA256SUMS
+
+# Provenance: the cosign bundle is signed by the release workflow's GitHub
+# OIDC identity (keyless — no public key to distribute).
+cosign verify-blob --bundle SHA256SUMS.cosign.bundle \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp 'release\.yml@refs/tags/' \
+  SHA256SUMS
+```
+
+### Binary tarball
+
+```sh
+tar xzf siphon-ai-<ver>-x86_64-unknown-linux-musl.tar.gz
+sudo install -m255 siphon-ai-<ver>-*/siphon-ai /usr/local/bin/siphon-ai
+siphon-ai --version
+```
+
+### Debian / Ubuntu package
+
+```sh
+sudo apt install ./siphon-ai_<ver>-1_amd64.deb   # resolves ca-certificates + adduser
+```
+
+The package installs the binary to `/usr/bin/siphon-ai`, a default config to
+`/etc/siphon-ai/config.toml` (a dpkg *conffile* — your edits survive
+upgrades), and a hardened systemd unit. It creates the `siphon-ai` service
+user and `/var/{lib,log}/siphon-ai`, and **enables but does not start** the
+service — the default config points at a placeholder `[bridge].ws_url`. Edit
+the config, then `sudo systemctl start siphon-ai`. (`systemctl reload`
+hot-applies route/gateway/webhook changes via `SIGHUP`.)
+
+### Container
+
+```sh
+docker pull ghcr.io/thevoiceguy/siphon-ai:<ver>
+# Verify the image signature (same keyless identity as the blob above):
+cosign verify ghcr.io/thevoiceguy/siphon-ai:<ver> \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp 'release\.yml@refs/tags/'
+
+docker run --rm -v "$PWD/config.toml:/app/config.toml" \
+  ghcr.io/thevoiceguy/siphon-ai:<ver>
+```
+
+To build the container yourself instead, see **Container image** below.
+
 ## Build prerequisites
 
 The daemon links **libopus** (Opus codec support, 0.8.0) — built from source


### PR DESCRIPTION
Chunk 5 (docs half) of the **Release & packaging** theme.

- **`docs/DEPLOY.md` → new *Install from a release* section.** Leads with the prebuilt artifacts (per-arch musl tarballs, `.deb`, signed GHCR container), each with `sha256sum -c` + `cosign verify`/`verify-blob` steps, ahead of build-from-source. Documents the `.deb`'s enabled-but-not-started behavior and conffile.
- **New top-level `RELEASING.md`.** The maintainer runbook for the now-minimal "bump, then tag and push" flow: the version-consistency source-of-truth rule, the `chore(release)` prep commit, the tag trigger + what each job produces, `-rc.N` pre-release validation, and `workflow_dispatch` re-runs.

No code/behavior change. Version + doc-link gates green.

The other half of chunk 5 — the actual **v0.16.0 cut** (version bump → tag → first auto-cut release) — follows as a separate `chore(release)` PR once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)