### PR TITLE
chore(release): 0.16.0 — Release & packaging (automated releases)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-06-24
+
 ### Added
 
 - **Docs: installing from a release + a releasing runbook.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2937,7 +2937,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "base64",
  "bytes",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2975,7 +2975,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "regex",
  "serde",
@@ -2993,7 +2993,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3035,7 +3035,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "hmac",
  "http-body-util",
@@ -3055,7 +3055,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "thiserror 1.0.69",
  "tokio",
@@ -3088,7 +3088,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "regex",
  "serde",
@@ -3100,7 +3100,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3133,7 +3133,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3174,7 +3174,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.15.0.** Production-deployed against real carriers
+**Current release: v0.16.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a


### PR DESCRIPTION
## v0.16.0 — Release & packaging (automated releases)

Release-engineering commit, completing the **P0 Release & packaging** theme:
- workspace `0.15.0 → 0.16.0` (+ `Cargo.lock`)
- `CHANGELOG.md`: `[Unreleased]` → dated `## [0.16.0] - 2026-06-24` (fresh empty `[Unreleased]` above)
- README `Current release` marker → v0.16.0

### What v0.16.0 delivers

The whole release pipeline, built and validated chunk-by-chunk this cycle:
- **Version-consistency CI gate** (#233) — Cargo/README/CHANGELOG can't drift.
- **Automated release workflow** (#234–236) — tag `v*` → multi-arch static-musl binaries (cargo-zigbuild, `x86_64` + `aarch64`) + `SHA256SUMS` + CHANGELOG-extracted notes.
- **Supply chain + container** (#237) — CycloneDX SBOM (syft), cosign **keyless** signature over the checksums, multi-arch GHCR image (cosign-signed).
- **Debian packages** (#238) — `.deb` for `amd64` + `arm64` (cargo-deb), hardened systemd unit, service user.
- **Docs** (#239) — `DEPLOY.md` install-from-release + `RELEASING.md` runbook.

The pipeline was validated end-to-end on throwaway `v0.16.0-rc.1` tags after each chunk. **Tagging `v0.16.0` will be the first time it runs as a real release.**

### After merge
Tag `v0.16.0` on the merge commit and push → the `release` workflow publishes the Latest release (binaries + `.deb`s + SBOM + signatures) and the `ghcr.io/thevoiceguy/siphon-ai:v0.16.0` + `:latest` image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
