### PR TITLE
feat(shutdown): admin drain status, docs, SIPp + release v0.17.0 (chunk 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-06-25
+
+### Added
+
+- **Graceful shutdown & connection draining** (P0 "Production operability").
+  On `SIGTERM`/`SIGINT` the daemon now **drains** instead of dropping calls
+  mid-conversation: it flips `/ready` to not-ready, rejects new inbound
+  INVITEs with `503 Service Unavailable` + `Retry-After` (so an upstream
+  proxy/LB routes elsewhere), lets in-flight calls finish — bounded by
+  `[shutdown].drain_timeout_secs` (default `30`; `0` = pre-0.17.0 immediate
+  exit) — then **force-terminates any stragglers at the deadline with a real
+  `BYE` + WS `hangup`** rather than a silent RTP stop. In-dialog requests
+  (re-INVITE/ACK/BYE) for calls already up keep flowing so the drained calls
+  aren't broken. A **second** shutdown signal during the drain forces an
+  immediate exit (operator escape hatch). This is what makes zero-drop
+  rolling deploys possible — pair `drain_timeout_secs` with the supervisor's
+  kill grace (`terminationGracePeriodSeconds` / `TimeoutStopSec`). See
+  `docs/design/DESIGN_GRACEFUL_SHUTDOWN.md` and `docs/DEPLOY.md` →
+  *Graceful shutdown & rolling deploys*.
+- **`[shutdown]` config table** with `drain_timeout_secs` (`docs/CONFIG.md`).
+  Restart-required on SIGHUP (read once at startup).
+- **`GET /admin/v1/drain`** — live drain status
+  `{draining, active_calls, drain_timeout_secs, remaining_secs}` for deploy
+  scripts to confirm a pod entered drain and watch the countdown (readonly
+  role).
+- **Drain observability:** `siphon_ai_draining` gauge (1 while draining),
+  `siphon_ai_drain_seconds` histogram (how long the drain took), and
+  `siphon_ai_calls_drain_forced_total` counter (calls force-ended at the
+  deadline). Drain lifecycle logs throughout.
+- **SIPp coverage:** a graceful-drain phase in `test-harness/sipp-scenarios`
+  (`drain_graceful_bye.xml` + `drain_invite_503.xml`) asserts end-to-end that
+  a deadline straggler gets a real BYE, a new INVITE mid-drain is 503'd, and
+  the daemon exits within the window.
+
+### Changed
+
+- **CDR schema → version 3.** Adds the `drain_forced` `termination.cause`
+  value (calls force-ended at the drain deadline), distinct from
+  `local_shutdown`, so a deploy's forced terminations are attributable
+  per-call. Also surfaced on `siphon_ai_calls_total{cause="drain_forced"}`.
+  A new value in an existing enum field — no field added or removed.
+- The systemd unit sketch (`docs/DEPLOY.md`) gains `TimeoutStopSec=40` so the
+  default 30 s drain window fits inside systemd's stop timeout.
+
 ## [0.16.0] - 2026-06-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2937,7 +2937,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "base64",
  "bytes",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2975,7 +2975,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "regex",
  "serde",
@@ -2993,7 +2993,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3035,7 +3035,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "hmac",
  "http-body-util",
@@ -3055,7 +3055,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "thiserror 1.0.69",
  "tokio",
@@ -3088,7 +3088,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "regex",
  "serde",
@@ -3100,7 +3100,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3133,7 +3133,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3174,7 +3174,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.16.0.** Production-deployed against real carriers
+**Current release: v0.17.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -49,8 +49,9 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
@@ -92,7 +93,7 @@ use siphon_ai_sip_glue::{
 use siphon_ai_telemetry::{
     admin::{
         AdminCallRegistry, AdminConference, AdminOutbound, AdminPark, AdminState,
-        CallRegistryHandle, RegistrationRow,
+        CallRegistryHandle, DrainStatus, DrainStatusFn, RegistrationRow,
     },
     install_recorder, AdminServer, HepTelemetry, HepTelemetryBuild, HepWorkerHandle,
     LogFilterHandle, ObservabilityServer, ReadinessFlag, CALLS_DRAIN_FORCED_TOTAL, DRAINING,
@@ -150,6 +151,9 @@ pub struct Runtime {
     readiness: ReadinessFlag,
     registry: CallRegistry,
     drain_timeout: Option<Duration>,
+    /// Drain deadline (epoch-millis, `0` until drain starts). Published
+    /// by the drain phase and read by `GET /admin/v1/drain`.
+    drain_deadline_ms: Arc<AtomicU64>,
 }
 
 impl Runtime {
@@ -440,6 +444,10 @@ impl Runtime {
             .drain_timeout
             .map(|d| d.as_secs().max(1).min(u32::MAX as u64) as u32)
             .unwrap_or(5);
+        // Drain deadline as epoch-millis, published when the drain phase
+        // starts (0 = not draining). Feeds `GET /admin/v1/drain`'s
+        // `remaining_secs` countdown; shared with `drain_calls`.
+        let drain_deadline_ms = Arc::new(AtomicU64::new(0));
         let mut routing_handler_builder =
             RoutingHandler::new(Arc::clone(&route_swap), Arc::clone(&acceptor))
                 .with_dialog_terminator(dialog_terminator)
@@ -741,6 +749,28 @@ impl Runtime {
         // crashing — see telemetry::admin docs.
         let call_registry_for_admin = acceptor.registry().clone();
         let registration_mgr_for_admin = registration_mgr.clone();
+        // `GET /admin/v1/drain` status closure (0.17.0). Reads the live
+        // drain flag + registry depth + published deadline. Installed
+        // unconditionally — drain state exists regardless of `[shutdown]`.
+        let drain_status_fn: DrainStatusFn = {
+            let drain = drain.clone();
+            let registry = registry_for_drain.clone();
+            let deadline = Arc::clone(&drain_deadline_ms);
+            let timeout_secs = shutdown.drain_timeout.map(|d| d.as_secs()).unwrap_or(0);
+            Arc::new(move || {
+                let draining = drain.is_draining();
+                let remaining_secs = draining.then(|| {
+                    let deadline_ms = deadline.load(Ordering::Acquire);
+                    deadline_ms.saturating_sub(now_epoch_ms()) / 1000
+                });
+                DrainStatus {
+                    draining,
+                    active_calls: registry.len(),
+                    drain_timeout_secs: timeout_secs,
+                    remaining_secs,
+                }
+            })
+        };
         let admin_state = AdminState {
             call_registry: Some(Arc::new(RuntimeCallRegistry {
                 inner: call_registry_for_admin,
@@ -768,6 +798,7 @@ impl Runtime {
                     control_registry.clone(),
                 )) as AdminPark
             }),
+            drain: Some(drain_status_fn),
         };
         let observability_server =
             build_observability(observability, readiness.clone(), prometheus_handle).await?;
@@ -796,6 +827,7 @@ impl Runtime {
             readiness,
             registry: registry_for_drain,
             drain_timeout: shutdown.drain_timeout,
+            drain_deadline_ms,
         })
     }
 
@@ -859,7 +891,13 @@ impl Runtime {
                     self.readiness.mark_not_ready();
                     metrics::gauge!(DRAINING).set(1.0);
                 }
-                _ = drain_calls(&self.registry, &self.drain, &self.readiness, timeout) => {}
+                _ = drain_calls(
+                    &self.registry,
+                    &self.drain,
+                    &self.readiness,
+                    &self.drain_deadline_ms,
+                    timeout,
+                ) => {}
             }
         }
 
@@ -902,10 +940,11 @@ impl Runtime {
         }
 
         // Drop the UAS / TM Arcs so any per-call task that's still
-        // holding a clone tears down cleanly. We don't wait for
-        // active calls — they'll see their channels close and exit
-        // on their own. v1 doesn't have a "drain calls cleanly"
-        // story; that's a follow-up alongside SIGTERM-with-grace.
+        // holding a clone tears down cleanly. By here the drain phase
+        // (0.17.0) has already let active calls finish or force-ended
+        // them with a BYE + WS hangup; anything still holding a clone
+        // (drain disabled, force-quit, or a straggler whose BYE didn't
+        // flush in the grace window) sees its channels close and exits.
         let _ = self.transaction_mgr;
         let _ = self.uas;
         let _ = self.udp_socket;
@@ -930,6 +969,17 @@ const DRAIN_LOG_INTERVAL: Duration = Duration::from_secs(5);
 /// plenty; this is a backstop, not the common path.
 const DRAIN_FORCE_GRACE: Duration = Duration::from_secs(2);
 
+/// Wall-clock milliseconds since the UNIX epoch. Used only for the
+/// `GET /admin/v1/drain` deadline countdown (an operator-facing display
+/// value, not call logic) — the drain *wait* itself is driven by a
+/// monotonic `Instant`, immune to clock steps.
+fn now_epoch_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
 /// Outcome of the drain wait — a clean drain (registry emptied before
 /// the deadline) vs a forced one (deadline hit with calls still up).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -947,6 +997,7 @@ async fn drain_calls(
     registry: &CallRegistry,
     drain: &DrainFlag,
     readiness: &ReadinessFlag,
+    deadline_ms: &AtomicU64,
     timeout: Duration,
 ) {
     // Flip into draining BEFORE anything else so new INVITEs get 503'd
@@ -954,6 +1005,11 @@ async fn drain_calls(
     drain.begin();
     readiness.mark_not_ready();
     metrics::gauge!(DRAINING).set(1.0);
+    // Publish the deadline for `GET /admin/v1/drain`'s countdown.
+    deadline_ms.store(
+        now_epoch_ms().saturating_add(timeout.as_millis() as u64),
+        Ordering::Release,
+    );
 
     let active = registry.len();
     info!(

--- a/crates/telemetry/src/admin.rs
+++ b/crates/telemetry/src/admin.rs
@@ -23,6 +23,7 @@
 //! | GET    | `/admin/v1/parked`            | List parked calls (0.7.0)            |
 //! | POST   | `/admin/v1/calls/:id/park`    | Park a call (0.7.0)                  |
 //! | POST   | `/admin/v1/calls/:id/retrieve`| Retrieve a parked call (0.7.0)       |
+//! | GET    | `/admin/v1/drain`             | Graceful-shutdown drain status (0.17.0) |
 //!
 //! ## Threat model
 //!
@@ -75,7 +76,35 @@ pub struct AdminState {
     /// Park admin handle (0.7.0). `None` when `[park]` is disabled —
     /// the park/retrieve/parked routes then return 501.
     pub park: Option<AdminPark>,
+    /// Graceful-shutdown drain status (0.17.0). Always installed by the
+    /// runtime (drain state exists regardless of `[shutdown]`); `None`
+    /// only in partially-built test states, where `/admin/v1/drain`
+    /// then returns 503.
+    pub drain: Option<DrainStatusFn>,
 }
+
+/// Snapshot of the daemon's graceful-shutdown drain state (0.17.0),
+/// served by `GET /admin/v1/drain`. Lets an operator / deploy script
+/// confirm a pod has entered drain and watch the countdown.
+#[derive(Debug, Clone, Serialize)]
+pub struct DrainStatus {
+    /// `true` once a shutdown signal has put the daemon into drain
+    /// (new INVITEs are 503'd and `/ready` is false), until it exits.
+    pub draining: bool,
+    /// Calls still active right now (the drain waits for this to hit 0).
+    pub active_calls: usize,
+    /// Configured `[shutdown].drain_timeout_secs` (`0` = drain disabled,
+    /// immediate exit).
+    pub drain_timeout_secs: u64,
+    /// Seconds left until the drain deadline force-terminates
+    /// stragglers. `Some` only while `draining`; `None` otherwise.
+    pub remaining_secs: Option<u64>,
+}
+
+/// Closure producing a fresh [`DrainStatus`] per request. Same
+/// indirection rationale as [`CallRegistryHandle`] — keeps the drain
+/// flag / call registry types out of the telemetry crate's deps.
+pub type DrainStatusFn = Arc<dyn Fn() -> DrainStatus + Send + Sync>;
 
 /// Minimal trait surface the admin endpoints need on the call
 /// registry. Avoids a hard dep on `siphon-ai-core` here — the
@@ -296,6 +325,7 @@ pub async fn dispatch(
         (&hyper::Method::GET, "/admin/v1/conferences") => list_conferences(state),
         (&hyper::Method::POST, "/admin/v1/conferences") => create_conference(state, &body),
         (&hyper::Method::GET, "/admin/v1/parked") => list_parked(state),
+        (&hyper::Method::GET, "/admin/v1/drain") => drain_status(state),
         (m, p)
             if *m == hyper::Method::POST
                 && p.starts_with("/admin/v1/calls/")
@@ -401,6 +431,13 @@ fn list_calls(state: &AdminState) -> Response<Full<Bytes>> {
     };
     let ids = reg.snapshot_ids();
     json_response(StatusCode::OK, &json!({ "count": ids.len(), "calls": ids }))
+}
+
+fn drain_status(state: &AdminState) -> Response<Full<Bytes>> {
+    let Some(f) = state.drain.as_ref() else {
+        return service_unavailable("drain status not installed");
+    };
+    json_response(StatusCode::OK, &json!(f()))
 }
 
 fn hangup_call(state: &AdminState, sip_call_id: &str) -> Response<Full<Bytes>> {
@@ -1392,5 +1429,50 @@ mod tests {
         )
         .await;
         assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+
+    // ─── GET /admin/v1/drain (0.17.0) ────────────────────────────────
+
+    fn drain_state(status: DrainStatus) -> AdminState {
+        AdminState {
+            drain: Some(Arc::new(move || status.clone()) as DrainStatusFn),
+            ..AdminState::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn drain_503_when_not_installed() {
+        let (status, _) = conf(hyper::Method::GET, "/admin/v1/drain", "", &empty_state()).await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn drain_reports_not_draining() {
+        let state = drain_state(DrainStatus {
+            draining: false,
+            active_calls: 3,
+            drain_timeout_secs: 30,
+            remaining_secs: None,
+        });
+        let (status, v) = conf(hyper::Method::GET, "/admin/v1/drain", "", &state).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(v["draining"], serde_json::json!(false));
+        assert_eq!(v["active_calls"], serde_json::json!(3));
+        assert_eq!(v["drain_timeout_secs"], serde_json::json!(30));
+        assert_eq!(v["remaining_secs"], Value::Null);
+    }
+
+    #[tokio::test]
+    async fn drain_reports_active_drain_with_countdown() {
+        let state = drain_state(DrainStatus {
+            draining: true,
+            active_calls: 2,
+            drain_timeout_secs: 30,
+            remaining_secs: Some(18),
+        });
+        let (status, v) = conf(hyper::Method::GET, "/admin/v1/drain", "", &state).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(v["draining"], serde_json::json!(true));
+        assert_eq!(v["remaining_secs"], serde_json::json!(18));
     }
 }

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -381,6 +381,12 @@ ExecStart=/usr/local/bin/siphon-ai --config /etc/siphon-ai/siphon-ai.toml
 # SIGHUP triggers SIP/TLS cert hot-reload (0.3.0+). `systemctl
 # reload siphon-ai` invokes this — see §5 above for renewal flow.
 ExecReload=/bin/kill -HUP $MAINPID
+# On stop, systemd sends SIGTERM; the daemon drains active calls
+# (0.17.0, [shutdown].drain_timeout_secs). Give it longer than that
+# window + a couple seconds of BYE-flush grace, or systemd SIGKILLs
+# mid-drain. Default drain is 30 s → 40 s here. A second SIGTERM
+# (systemctl stop twice) forces an immediate exit.
+TimeoutStopSec=40
 Restart=always
 RestartSec=5
 NoNewPrivileges=true
@@ -420,6 +426,62 @@ the heplify collector (`heplify_*`).
 
 Both live on the `[observability]` listener.
 
+## Graceful shutdown & rolling deploys
+
+On `SIGTERM` / `SIGINT` the daemon **drains** before exiting (0.17.0,
+configured by [`[shutdown]`](CONFIG.md#shutdown)): it flips `/ready` to
+not-ready, rejects **new** inbound INVITEs with `503 Service Unavailable`
++ `Retry-After`, lets in-flight calls finish (bounded by
+`drain_timeout_secs`, default 30 s), then force-terminates any stragglers
+at the deadline with a real `BYE` + WS `hangup`. This is what makes a
+zero-drop rolling restart possible. The two signals to the outside world
+are complementary:
+
+- **`/ready` → 503** tells a load balancer / k8s readiness gate to stop
+  sending *new* calls here — but it only notices on its next poll.
+- **`503` on new INVITEs** covers the gap until then: anything an upstream
+  SIP proxy routes to this node mid-drain is rejected with a retryable
+  code so it fails over immediately.
+
+In-dialog requests (re-INVITE for hold/resume, ACK, BYE) for calls already
+up keep flowing, so the calls being drained aren't broken.
+
+**The one rule:** `drain_timeout_secs` **must be ≤** your supervisor's
+kill grace, or the supervisor `SIGKILL`s the daemon mid-drain and you lose
+the very calls you were protecting:
+
+- **systemd:** `TimeoutStopSec` (see the unit sketch above — set it a few
+  seconds *above* the drain window for the BYE-flush grace).
+- **Kubernetes:** `terminationGracePeriodSeconds` on the pod spec.
+
+### Kubernetes
+
+```yaml
+spec:
+  terminationGracePeriodSeconds: 40   # ≥ drain_timeout_secs + a few s
+  containers:
+    - name: siphon-ai
+      readinessProbe:
+        httpGet: { path: /ready, port: 9091 }
+        periodSeconds: 2
+      # No preStop hook needed: k8s sends SIGTERM directly and the daemon
+      # drains on it. (A `preStop: sleep` is only useful if your daemon
+      # ignored SIGTERM — this one doesn't.)
+```
+
+k8s removes the pod from Service endpoints and sends `SIGTERM` at the same
+time; the `503` reject path bridges the brief window before Endpoints
+propagation completes. Watch the drain with the `siphon_ai_draining` gauge
+(1 while draining), `siphon_ai_drain_seconds` (how long it took), and
+`siphon_ai_calls_drain_forced_total` (calls that didn't finish in the
+window — if this is regularly non-zero, raise `drain_timeout_secs` and the
+grace). `GET /admin/v1/drain` gives the live `{draining, active_calls,
+remaining_secs}` snapshot during a drain.
+
+Set `drain_timeout_secs = 0` to opt out and keep the pre-0.17.0 behaviour
+(immediate teardown, active calls dropped). A **second** SIGTERM/SIGINT
+during a drain forces an immediate exit (operator escape hatch).
+
 ## Admin API
 
 `/admin/*` is served **only on the dedicated `[admin]` listener**, gated by
@@ -451,6 +513,7 @@ no/invalid token → `401`.
 | GET    | `/admin/v1/parked`            | —               | readonly | **List parked calls** (0.7.0). `501` when `[park]` is disabled. |
 | POST   | `/admin/v1/calls/:id/park`    | JSON (opt.)     | operator | **Park an active call** (0.7.0). Body `{slot?}`; `202` (dispatched). `404` if no active call has that id. `501` when `[park]` is disabled. |
 | POST   | `/admin/v1/calls/:id/retrieve`| JSON (opt.)     | operator | **Retrieve a parked call** (0.7.0). Body `{ws_url?}`; `202` (dispatched). `404` unknown call, `409` if the call isn't parked. `501` when `[park]` is disabled. |
+| GET    | `/admin/v1/drain`             | —               | readonly | **Graceful-shutdown drain status** (0.17.0). Returns `{draining, active_calls, drain_timeout_secs, remaining_secs}` — `remaining_secs` is the countdown to the deadline (non-null only while draining). Lets a deploy script confirm a pod entered drain and watch it empty. |
 
 ### Admin auth & RBAC
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -19,7 +19,7 @@ evidence and flags any gaps.
 | Homer UI (`http://.../`)            | SIP call flow + RTCP + CDR + log chunks correlated by SIP `Call-ID`                    |
 | Prometheus `/metrics`               | Counters / histograms; `siphon_ai_*` for app-level, `forge_*` for media, `heplify_*` for collector  |
 | CDR (file / webhook)                | One JSON record per ended call with codec, route, termination cause, durations         |
-| `/admin/*`                          | Live state — active calls, registration status, log filter, HEP probe                  |
+| `/admin/*`                          | Live state — active calls, registration status, log filter, HEP probe, drain status     |
 
 ## The §11.8 ten questions
 
@@ -256,3 +256,30 @@ busy spans (`sip_uas`, `sip_transaction`, `sip_transport`,
 
 All of the above are reachable without restart via
 `PUT /admin/log`.
+
+## Draining for a deploy / restart (0.17.0)
+
+On `SIGTERM`/`SIGINT` the daemon drains instead of dropping calls: `/ready`
+flips false, new INVITEs get `503`, in-flight calls finish (up to
+`[shutdown].drain_timeout_secs`), then stragglers get a clean `BYE`. Full
+behaviour + k8s/systemd setup is in `DEPLOY.md` → *Graceful shutdown &
+rolling deploys*. To watch one happen:
+
+```text
+INFO drain started active_calls=7 timeout_secs=30
+INFO draining remaining=3
+INFO drain complete; all calls ended elapsed_secs=12.4
+# …or, if calls outlived the window:
+WARN drain timeout reached; force-terminating 2 straggler call(s)
+INFO signalled drain-forced teardown (BYE + WS hangup); waiting for it to flush
+```
+
+| Want to know… | Look at |
+|---------------|---------|
+| Is this pod draining right now? | `siphon_ai_draining` gauge (1), or `GET /admin/v1/drain` `{draining, active_calls, remaining_secs}` |
+| How long did the last drain take? | `siphon_ai_drain_seconds` histogram (near the timeout = calls didn't finish) |
+| Are deploys force-killing calls? | `siphon_ai_calls_drain_forced_total` — if regularly non-zero, raise `drain_timeout_secs` (and the supervisor's kill grace) |
+| Which calls were force-ended? | CDR `termination.cause == "drain_forced"` (CDR v3) |
+
+If a drain is taking too long (an operator wants out *now*), send a **second**
+`SIGTERM`/`SIGINT` — it forces immediate teardown, dropping whatever's left.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -38,17 +38,21 @@ These are the gaps that bite real deployments today.
   hardened container variant — both structured as additive follow-ups (a
   sibling packaging step / a swapped runtime base), not rework.
 
-### Graceful shutdown & zero-drop deploys
-*The remaining open P0.*
-The daemon aborts its listeners on `SIGTERM`; in-flight calls are not drained
-(`runtime.rs` explicitly notes "v1 doesn't have a 'drain calls cleanly'
-path"). Combined with `SIGHUP` reload this unlocks true rolling deploys.
+### Graceful shutdown & zero-drop deploys — ✅ delivered in v0.17.0
+*Was the remaining open P0.* Shipped over three chunks (design note
+`docs/design/DESIGN_GRACEFUL_SHUTDOWN.md`). Combined with `SIGHUP` reload this
+unlocks true rolling deploys:
 
-- On `SIGTERM`: stop accepting new INVITEs, let active calls finish, bound by
-  a configurable drain timeout, then exit.
-- A `503`/`486` posture for new inbound during drain; `/ready` flips to
-  not-ready so a load balancer stops routing.
-- Drain status surfaced on `/admin` + a metric.
+- On `SIGTERM`/`SIGINT`: flip `/ready` to not-ready, reject new INVITEs with
+  `503` + `Retry-After`, let active calls finish (bound by
+  `[shutdown].drain_timeout_secs`, default 30 s), then force-terminate
+  stragglers at the deadline with a real `BYE` + WS `hangup`. A second signal
+  forces an immediate exit.
+- Drain status on `GET /admin/v1/drain` + metrics (`siphon_ai_draining`,
+  `siphon_ai_drain_seconds`, `siphon_ai_calls_drain_forced_total`) + a
+  `drain_forced` CDR cause (CDR v3).
+
+*With both P0s delivered, the next theme is P1 (security & abuse hardening).*
 
 ---
 

--- a/docs/design/DESIGN_GRACEFUL_SHUTDOWN.md
+++ b/docs/design/DESIGN_GRACEFUL_SHUTDOWN.md
@@ -1,8 +1,8 @@
 # Design: graceful shutdown & connection draining
 
-Status: **DECISIONS LOCKED (2026-06-24) — ready to implement** (forks locked
-in §4; now chunked PRs, same cadence as config-CLI → v0.12.0 and
-release-packaging → v0.16.0).
+Status: **DELIVERED (2026-06-25) — all three chunks shipped in v0.17.0.**
+(Decisions locked 2026-06-24 in §4; chunked PRs, same cadence as config-CLI
+→ v0.12.0 and release-packaging → v0.16.0. See the ✅ markers in §6.)
 
 Theme: **P0 from `docs/ROADMAP.md`** ("Production operability → Graceful
 shutdown & zero-drop deploys") — the remaining open P0 now that release &
@@ -257,7 +257,11 @@ into `[node]`); recommend a dedicated `[shutdown]` block.
    `drain_forced` (CDR_VERSION → 3) + `calls_total{cause="drain_forced"}`, and
    the second-signal-forces escape hatch (`run()` selects a fresh
    `shutdown_signal()` against drain completion).
-3. **Surface + docs + release.** `/admin` drain status, `docs/DEPLOY.md`
-   (rolling-deploy guidance: drain ≤ `terminationGracePeriodSeconds`, the
-   `/ready` + 503 interplay, `preStop`/systemd notes), `docs/OPERATIONS.md`
-   runbook line, CHANGELOG, tag ~v0.17.0.
+3. **Surface + docs + release.** ✅ **DELIVERED.** `GET /admin/v1/drain`
+   status (`draining` / `active_calls` / `drain_timeout_secs` /
+   `remaining_secs`), `docs/DEPLOY.md` *Graceful shutdown & rolling deploys*
+   (drain ≤ `terminationGracePeriodSeconds` / `TimeoutStopSec`, the `/ready`
+   + 503 interplay, k8s/systemd notes), `docs/OPERATIONS.md` drain runbook,
+   a SIPp graceful-drain phase (`drain_graceful_bye` + `drain_invite_503`:
+   straggler BYE, mid-drain 503, daemon exits), CHANGELOG + version bump to
+   v0.17.0.

--- a/test-harness/sipp-scenarios/README.md
+++ b/test-harness/sipp-scenarios/README.md
@@ -64,6 +64,8 @@ sipp -sf basic_call_then_bye.xml -m 1 -p 5070 -s 1000 127.0.0.1:5060
 | `delayed_offer_srtp_caller.xml`      | 0.9.2 inbound delayed offer **with SRTP on the offer**: `[media].srtp = "required"`; SIPp sends an offerless INVITE and asserts (via `check_it`) SiphonAI's 200 OK carries an SDES **offer** (`a=crypto`) — we're the offerer; SIPp answers SRTP in the ACK and the keyed call bridges (**delayed_offer_srtp** phase). |
 | `outbound_delayed_dtls_uas.xml`      | 0.9.3 outbound delayed offer **with DTLS-SRTP on the answer**: gateway `srtp = "required"`; SIPp's 200 carries a `UDP/TLS/RTP/SAVPF` + `a=fingerprint` + `a=setup:actpass` DTLS **offer** and SIPp asserts (via `check_it`) the **ACK** answers DTLS (`a=fingerprint:sha-256`) — SiphonAI enabled the handshake (**outbound_delayed_dtls** phase). Signalling only; SIPp doesn't complete a real DTLS handshake. |
 | `delayed_offer_dtls_caller.xml`      | 0.9.4 inbound delayed offer **with DTLS-SRTP on the offer**: `[media].srtp = "required"` + `[media].srtp_offer = "dtls"`; SIPp sends an offerless INVITE and asserts (via `check_it`) SiphonAI's 200 OK carries a DTLS **offer** (`a=fingerprint:sha-256` + `UDP/TLS/RTP/SAVPF` + `setup:actpass`) — we're the offerer; SIPp answers DTLS in the ACK and SiphonAI enables the handshake (**delayed_offer_dtls** phase). Signalling only. |
+| `drain_graceful_bye.xml`            | 0.17.0 graceful-shutdown drain: SIPp establishes a call and idles; the harness SIGTERMs the daemon, and SIPp asserts the call is force-terminated at the deadline with a real **BYE** (not a silent RTP stop) (**graceful drain** phase) |
+| `drain_invite_503.xml`              | 0.17.0 graceful-shutdown drain: a **new** INVITE arriving mid-drain is rejected `503 Service Unavailable` (valid PCMU offer, so it can only be the drain gate, not codec/trunk rejection) (**graceful drain** phase) |
 
 `run-all.sh` also has an always-on **recording** auxiliary phase: it starts
 a daemon with `[recording].mode = "always"` writing to a temp dir, runs one
@@ -204,6 +206,17 @@ offerless INVITE and asserts (via `check_it`) the 200 OK carries
 `a=fingerprint:sha-256` (our DTLS offer), then answers DTLS in the ACK
 so SiphonAI enables the handshake. Pass = SIPp completed **and** the
 daemon logged the delayed accept. Signalling only.
+
+And an always-on **graceful drain** phase (0.17.0): a daemon with
+`[shutdown].drain_timeout_secs = 4` and a dedicated echo-ws. The runner
+backgrounds `drain_graceful_bye.xml` (a call that establishes and idles),
+waits for it to come up, then `SIGTERM`s the daemon. Three assertions: the
+idle call is a deadline straggler and gets a real **BYE** at the 4 s
+deadline (`drain_graceful_bye`); a **new** INVITE sent mid-drain is rejected
+`503` (`drain_invite_503`); and the daemon **exits on its own** within the
+drain window + grace. Covers chunks 1 + 2 of `DESIGN_GRACEFUL_SHUTDOWN.md`
+end-to-end (the unit tests cover the timing logic + mappings; this proves
+the BYE and 503 actually reach the wire).
 
 The `stir_shaken_*` scenarios run in `run-all.sh`'s always-on
 **stir_shaken** auxiliary phase. It builds + runs the

--- a/test-harness/sipp-scenarios/drain_graceful_bye.xml
+++ b/test-harness/sipp-scenarios/drain_graceful_bye.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  drain_graceful_bye — graceful-shutdown drain (0.17.0). SIPp places a
+  normal inbound call and then sits idle holding the dialog open. The
+  harness sends the daemon a SIGTERM while this call is up; with a short
+  [shutdown].drain_timeout_secs the call is a "straggler" at the deadline,
+  so the drain must force-terminate it *gracefully* — a real BYE to this
+  UAC (not a silent RTP stop). We assert that BYE arrives and 200 it.
+
+  Run with a generous -timeout (≥ the daemon's drain window + grace) so
+  the recv-BYE wait doesn't expire before the deadline fires.
+-->
+<scenario name="drain_graceful_bye">
+  <send>
+<![CDATA[
+INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+Max-Forwards: 70
+From: <sip:sipp@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:sipp@[local_ip]:[local_port]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=user1 53655765 2353687637 IN IP4 [local_ip]
+s=-
+c=IN IP4 [local_ip]
+t=0 0
+m=audio 9000 RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+]]>
+  </send>
+
+  <recv response="100" optional="true"/>
+  <recv response="180" optional="true"/>
+  <recv response="183" optional="true"/>
+
+  <recv response="200" rtd="true"/>
+
+  <send>
+<![CDATA[
+ACK sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]-ack
+Max-Forwards: 70
+From: <sip:sipp@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- Idle: hold the dialog open until the drain force-terminates it
+       with a BYE (the harness SIGTERMs the daemon while we wait). -->
+  <recv request="BYE" rtd="true"/>
+
+  <send>
+<![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+</scenario>

--- a/test-harness/sipp-scenarios/drain_invite_503.xml
+++ b/test-harness/sipp-scenarios/drain_invite_503.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  drain_invite_503 — graceful-shutdown drain (0.17.0). A *new* inbound
+  INVITE that arrives while the daemon is draining must be rejected with
+  503 Service Unavailable (+ Retry-After) so an upstream proxy routes
+  elsewhere — not accepted, and not 488/403. The offer here is a valid
+  PCMU codec, so a 503 can only come from the drain gate, not codec /
+  trunk rejection. The harness fires this right after SIGTERMing the
+  daemon, inside the drain window. ACK the non-2xx final per RFC 3261.
+-->
+<scenario name="drain_invite_503">
+  <send>
+<![CDATA[
+INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+Max-Forwards: 70
+From: <sip:sipp@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:sipp@[local_ip]:[local_port]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=user1 53655765 2353687637 IN IP4 [local_ip]
+s=-
+c=IN IP4 [local_ip]
+t=0 0
+m=audio 9000 RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+]]>
+  </send>
+
+  <recv response="100" optional="true"/>
+  <recv response="503" rtd="true"/>
+
+  <send>
+<![CDATA[
+ACK sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+Max-Forwards: 70
+From: <sip:sipp@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+Content-Length: 0
+
+]]>
+  </send>
+</scenario>

--- a/test-harness/sipp-scenarios/run-all.sh
+++ b/test-harness/sipp-scenarios/run-all.sh
@@ -1863,6 +1863,116 @@ EOF
     trap - EXIT
 fi
 
+# ─── Always-on auxiliary phase: graceful drain ────────────────────
+# Exercises the 0.17.0 SIGTERM drain end-to-end (DESIGN_GRACEFUL_SHUTDOWN
+# §5):
+#   * a call still up at the deadline is force-terminated *gracefully* —
+#     the daemon sends it a real BYE (drain_graceful_bye.xml),
+#   * a NEW INVITE arriving mid-drain is rejected 503 (drain_invite_503),
+#   * the daemon exits within the drain window + grace.
+# A short drain_timeout_secs keeps the phase quick. Self-contained echo
+# WS on its own port. The straggler SIPp uses a different local port than
+# the 503 probe so the two instances don't fight over one bind.
+echo
+echo "─── auxiliary phase: graceful drain ───────────────────"
+DRAIN_TIMEOUT_SECS=4
+DRAIN_WS_PORT=8767
+DRAIN_SIPP_PORT=5082          # straggler UAC (distinct from $SIPP_PORT)
+DRAIN_WS_LOG=$(mktemp -t echo-ws-drain.XXXXXX.log)
+DRAIN_DAEMON_LOG=$(mktemp -t siphon-ai-drain.XXXXXX.log)
+DRAIN_CONFIG=$(mktemp -t siphon-ai-drain.XXXXXX.toml)
+cat >"$DRAIN_CONFIG" <<EOF
+[node]
+id = "siphon-ai-sipp-drain"
+[sip]
+listen = "127.0.0.1:$DAEMON_PORT"
+[media]
+codecs = ["pcmu"]
+[bridge]
+ws_url = "ws://127.0.0.1:$DRAIN_WS_PORT/"
+[shutdown]
+drain_timeout_secs = $DRAIN_TIMEOUT_SECS
+[[route]]
+name = "default"
+[route.match]
+any = true
+EOF
+
+DRAIN_PYTHON="$REPO_ROOT/examples/echo-ws-server-python/.venv/bin/python"
+[[ -x "$DRAIN_PYTHON" ]] || DRAIN_PYTHON=python3
+"$DRAIN_PYTHON" \
+    "$REPO_ROOT/examples/echo-ws-server-python/server.py" \
+    --bind "127.0.0.1:$DRAIN_WS_PORT" \
+    >"$DRAIN_WS_LOG" 2>&1 &
+DRAIN_WS_PID=$!
+
+RUST_LOG=siphon_ai=info "$DAEMON_BIN" --config "$DRAIN_CONFIG" \
+    >"$DRAIN_DAEMON_LOG" 2>&1 &
+DRAIN_DAEMON_PID=$!
+drain_cleanup() {
+    kill "$DRAIN_WS_PID" "$DRAIN_DAEMON_PID" 2>/dev/null || true
+    wait "$DRAIN_WS_PID" "$DRAIN_DAEMON_PID" 2>/dev/null || true
+}
+trap drain_cleanup EXIT
+sleep 1.2
+
+# 1) Place a call that stays up — it becomes the deadline straggler.
+sipp -i 127.0.0.1 -sf "$SCRIPT_DIR/drain_graceful_bye.xml" \
+    -m 1 -timeout 20s -trace_err \
+    -p "$DRAIN_SIPP_PORT" -s 1000 \
+    "127.0.0.1:$DAEMON_PORT" >/dev/null 2>&1 &
+DRAIN_STRAGGLER_PID=$!
+sleep 1.5     # let the call establish before we pull the trigger
+
+# 2) Trigger the drain.
+echo "  sending SIGTERM to draining daemon (pid $DRAIN_DAEMON_PID)"
+kill -TERM "$DRAIN_DAEMON_PID" 2>/dev/null || true
+
+# 3) New INVITE mid-drain → 503.
+sleep 0.4
+total=$((total + 1))
+echo "─── drain_invite_503 ─────────────────────────────────"
+if sipp -i 127.0.0.1 -sf "$SCRIPT_DIR/drain_invite_503.xml" \
+        -m 1 -timeout 8s -trace_err \
+        -p "$SIPP_PORT" -s 1000 \
+        "127.0.0.1:$DAEMON_PORT" >/dev/null 2>&1; then
+    echo "  OK"
+else
+    echo "  FAIL (new INVITE not 503'd; daemon: $DRAIN_DAEMON_LOG)"
+    failures=$((failures + 1))
+fi
+
+# 4) The straggler must receive a graceful BYE at the deadline.
+total=$((total + 1))
+echo "─── drain_graceful_bye ───────────────────────────────"
+if wait "$DRAIN_STRAGGLER_PID"; then
+    echo "  OK"
+else
+    echo "  FAIL (straggler got no BYE; daemon: $DRAIN_DAEMON_LOG)"
+    failures=$((failures + 1))
+fi
+
+# 5) The daemon must exit on its own within the drain window + grace.
+total=$((total + 1))
+echo "─── drain_daemon_exits ───────────────────────────────"
+exited=0
+for _ in $(seq 1 24); do      # up to ~12s (timeout 4s + grace 2s + slack)
+    if ! kill -0 "$DRAIN_DAEMON_PID" 2>/dev/null; then
+        exited=1
+        break
+    fi
+    sleep 0.5
+done
+if (( exited == 1 )); then
+    echo "  OK"
+else
+    echo "  FAIL (daemon still alive after drain; log: $DRAIN_DAEMON_LOG)"
+    failures=$((failures + 1))
+fi
+
+drain_cleanup
+trap - EXIT
+
 echo
 if (( failures == 0 )); then
     echo "all $total scenarios passed"


### PR DESCRIPTION
**Chunk 3 of 3** of the graceful-shutdown theme (`docs/design/DESIGN_GRACEFUL_SHUTDOWN.md` §6) — the surface + docs + release chunk. **Completes the P0 theme.**

**Stacked on #244 → #243.** Merge order: #243, then #244, then this. Once all three are on `main`, push the `v0.17.0` tag to trigger the release workflow.

## Surface
- **`GET /admin/v1/drain`** → `{draining, active_calls, drain_timeout_secs, remaining_secs}` (readonly role). The runtime publishes the deadline (epoch-ms) at drain start so the endpoint shows a live countdown; the status closure reads the drain flag + registry depth.

## SIPp integration (`test-harness/sipp-scenarios`)
New graceful-drain phase in `run-all.sh`: backgrounds a call, `SIGTERM`s the daemon, and asserts:
- **(a)** the deadline straggler gets a real **BYE** (`drain_graceful_bye.xml`),
- **(b)** a **new INVITE mid-drain is `503`'d** (`drain_invite_503.xml`),
- **(c)** the daemon **exits within the window**.

Proves the BYE + 503 actually reach the wire — the unit tests across chunks 1–2 cover the timing logic + mappings; this is the end-to-end proof.

## Docs
- **DEPLOY.md:** `/admin/v1/drain` row; a *Graceful shutdown & rolling deploys* section (drain ≤ `terminationGracePeriodSeconds` / `TimeoutStopSec`, the `/ready`+503 interplay, k8s + systemd examples); `TimeoutStopSec=40` in the unit sketch; CDR cause + v3 example.
- **OPERATIONS.md:** a *Draining for a deploy* runbook (what to watch, the second-signal escape hatch).
- **CONFIG.md / design doc / ROADMAP** updated; design + ROADMAP mark the P0 theme **delivered**.

## Release prep (v0.17.0, per `RELEASING.md`)
- Workspace version `0.16.0 → 0.17.0`, README marker, dated `CHANGELOG.md` section covering all three chunks, `Cargo.lock` refreshed.
- `scripts/check-version-consistency.py` and `--tag v0.17.0` both pass.

`cargo fmt`, `clippy --workspace --all-targets -D warnings`, `cargo test --workspace` (47 groups) all clean.

## Tag
`git tag -a v0.17.0 && git push origin v0.17.0` is the manual trigger once chunks 1–3 land on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)