### PR TITLE
feat(config): resolve secrets from files & systemd credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Secret resolution from files & systemd credentials** (P1 "Security &
+  abuse hardening"; first chunk of v0.18.0). Config `${...}` references can now
+  pull a secret from outside the process environment, so plaintext secrets
+  needn't sit in env vars (visible in `/proc/<pid>/environ`, dumps, unit
+  files). Two new source prefixes, usable anywhere `${VAR}` works:
+  `${file:/path/to/secret}` (trimmed file contents — Docker/Kubernetes
+  secrets, Vault-Agent templated files) and `${cred:NAME}`
+  (`$CREDENTIALS_DIRECTORY/NAME` — systemd `LoadCredential=`). Same fail-loud
+  pass as `${VAR}`: a missing file, unset `$CREDENTIALS_DIRECTORY`, or path
+  traversal in a credential name fails the load. `${VAR}`/`${VAR:-default}`
+  behaviour is unchanged (the `:-` default operator still wins, so
+  `${file:-x}` stays an env reference). See `docs/CONFIG.md` → *Secrets &
+  variable expansion*.
+
 ## [0.17.0] - 2026-06-25
 
 ### Added

--- a/crates/config/src/env.rs
+++ b/crates/config/src/env.rs
@@ -1,25 +1,61 @@
-//! `${VAR}` and `${VAR:-default}` expansion at config load time.
+//! Config-load-time secret/variable expansion.
 //!
 //! Per `docs/DEV_PLAN.md` §6.6 every string value in the TOML can
-//! reference an environment variable. We expand before parsing TOML
-//! into raw types so missing env vars surface as a single
-//! [`EnvError`] with line context, rather than as a downstream
-//! parse failure on a half-substituted string.
+//! reference an environment variable via `${VAR}` / `${VAR:-default}`.
+//! As of v0.18.0 a reference can also pull a secret from outside the
+//! process environment, so operators don't have to put plaintext
+//! secrets in env vars (visible in `/proc/<pid>/environ`, dumps, unit
+//! files). Two source prefixes are recognised inside `${...}`:
 //!
-//! Resolved values are never logged in expanded form — see
-//! [`expand`] for the redaction approach.
+//! | Form | Resolves to |
+//! |---|---|
+//! | `${VAR}` / `${VAR:-default}` | process env (default; unchanged) |
+//! | `${file:/path/to/secret}`    | trimmed contents of that file |
+//! | `${cred:NAME}`               | `$CREDENTIALS_DIRECTORY/NAME` contents |
+//!
+//! `file:` covers Docker/Kubernetes secrets and Vault-Agent templated
+//! files; `cred:` covers systemd `LoadCredential=` / `ImportCredential=`.
+//! All three share one fail-loud pass: a missing env var, an unreadable
+//! file, or an unset `$CREDENTIALS_DIRECTORY` surfaces as a single
+//! [`EnvError`] *before* the daemon starts, never as a downstream parse
+//! failure on a half-substituted string.
+//!
+//! Disambiguation: the `:-` default operator is always an env reference
+//! (checked first), so a literal env var named `file` with a default
+//! (`${file:-x}`) is never mistaken for the `file:` prefix. A path that
+//! itself contains `:-` is the one ambiguous case and fails loudly as a
+//! malformed reference rather than resolving silently.
+//!
+//! Resolved values are never logged in expanded form.
 
 use std::borrow::Cow;
 
 use thiserror::Error;
 
-/// Looks up an environment variable. Pluggable so tests can drive
-/// expansion without touching the real environment.
+/// Resolves config references to their values. Pluggable so tests can
+/// drive expansion without touching the real environment or filesystem.
+///
+/// Only [`lookup`](EnvSource::lookup) is required; the file and
+/// credential resolvers default to the real OS and are overridden in
+/// tests for hermeticity.
 pub trait EnvSource {
+    /// Look up an environment variable (`${VAR}`).
     fn lookup(&self, name: &str) -> Option<String>;
+
+    /// Read the full contents of a secret file (`${file:PATH}`). The
+    /// caller trims trailing newlines. Default reads the real filesystem.
+    fn read_file(&self, path: &str) -> std::io::Result<String> {
+        std::fs::read_to_string(path)
+    }
+
+    /// The systemd credentials directory (`$CREDENTIALS_DIRECTORY`), the
+    /// base path for `${cred:NAME}`. Default reads the process env.
+    fn credentials_dir(&self) -> Option<String> {
+        std::env::var("CREDENTIALS_DIRECTORY").ok()
+    }
 }
 
-/// Default impl: reads from the process environment.
+/// Default impl: reads from the process environment and filesystem.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct ProcessEnv;
 
@@ -36,7 +72,23 @@ pub enum EnvError {
     #[error("environment variable {name:?} is referenced by config but not set")]
     Missing { name: String },
 
-    /// Malformed `${...}` — unterminated, empty name, etc.
+    /// `${file:PATH}` referenced a file that couldn't be read.
+    #[error("secret file {path:?} referenced by config could not be read: {message}")]
+    FileUnreadable { path: String, message: String },
+
+    /// `${cred:NAME}` referenced a systemd credential that couldn't be read.
+    #[error("systemd credential {name:?} referenced by config could not be read: {message}")]
+    CredentialUnreadable { name: String, message: String },
+
+    /// `${cred:NAME}` was used but `$CREDENTIALS_DIRECTORY` isn't set
+    /// (the daemon wasn't started with systemd `LoadCredential=`).
+    #[error(
+        "config references credential {name:?} via `${{cred:...}}` but \
+         $CREDENTIALS_DIRECTORY is not set"
+    )]
+    CredentialsDirUnset { name: String },
+
+    /// Malformed `${...}` — unterminated, empty name/path, etc.
     #[error("malformed env reference at byte {at}: {message}")]
     Malformed { at: usize, message: String },
 }
@@ -63,23 +115,7 @@ pub fn expand<E: EnvSource>(input: &str, env: &E) -> Result<String, EnvError> {
                 message: "unterminated `${`".into(),
             })?;
             let inner = &input[i + 2..close];
-            let (name, default) = match inner.split_once(":-") {
-                Some((n, d)) => (n, Some(d)),
-                None => (inner, None),
-            };
-            if !is_valid_env_name(name) {
-                return Err(EnvError::Malformed {
-                    at: start,
-                    message: format!("invalid env var name {name:?}"),
-                });
-            }
-            match env.lookup(name) {
-                Some(value) => out.push_str(&value),
-                None => match default {
-                    Some(d) => out.push_str(d),
-                    None => return Err(EnvError::Missing { name: name.into() }),
-                },
-            }
+            out.push_str(&resolve_ref(inner, env, start)?);
             i = close + 1;
         } else {
             out.push(input[i..].chars().next().expect("non-empty slice"));
@@ -91,6 +127,98 @@ pub fn expand<E: EnvSource>(input: &str, env: &E) -> Result<String, EnvError> {
         }
     }
     Ok(out)
+}
+
+/// Resolve a single `${...}` reference (the text between the braces).
+/// Dispatches on the source prefix; `at` is the byte offset of the
+/// opening `${` for error context.
+fn resolve_ref<E: EnvSource>(inner: &str, env: &E, at: usize) -> Result<String, EnvError> {
+    // The `:-` default operator is always an env reference, checked
+    // first so `${file:-x}` (env var `file`, default `x`) is never read
+    // as the `file:` prefix.
+    if let Some((name, default)) = inner.split_once(":-") {
+        return resolve_env(name, Some(default), at, env);
+    }
+    if let Some(path) = inner.strip_prefix("file:") {
+        return resolve_file(path, env, at);
+    }
+    if let Some(name) = inner.strip_prefix("cred:") {
+        return resolve_cred(name, env, at);
+    }
+    resolve_env(inner, None, at, env)
+}
+
+fn resolve_env<E: EnvSource>(
+    name: &str,
+    default: Option<&str>,
+    at: usize,
+    env: &E,
+) -> Result<String, EnvError> {
+    if !is_valid_env_name(name) {
+        return Err(EnvError::Malformed {
+            at,
+            message: format!("invalid env var name {name:?}"),
+        });
+    }
+    match env.lookup(name) {
+        Some(value) => Ok(value),
+        None => match default {
+            Some(d) => Ok(d.to_string()),
+            None => Err(EnvError::Missing { name: name.into() }),
+        },
+    }
+}
+
+fn resolve_file<E: EnvSource>(path: &str, env: &E, at: usize) -> Result<String, EnvError> {
+    if path.is_empty() {
+        return Err(EnvError::Malformed {
+            at,
+            message: "empty file path in `${file:...}`".into(),
+        });
+    }
+    match env.read_file(path) {
+        Ok(contents) => Ok(trim_secret(&contents)),
+        Err(e) => Err(EnvError::FileUnreadable {
+            path: path.into(),
+            message: e.to_string(),
+        }),
+    }
+}
+
+fn resolve_cred<E: EnvSource>(name: &str, env: &E, at: usize) -> Result<String, EnvError> {
+    if name.is_empty() {
+        return Err(EnvError::Malformed {
+            at,
+            message: "empty credential name in `${cred:...}`".into(),
+        });
+    }
+    // Credential names are flat identifiers under $CREDENTIALS_DIRECTORY;
+    // reject anything that could escape it.
+    if name.contains('/') || name.contains("..") {
+        return Err(EnvError::Malformed {
+            at,
+            message: format!("invalid credential name {name:?} (must not contain '/' or '..')"),
+        });
+    }
+    let dir = env
+        .credentials_dir()
+        .ok_or_else(|| EnvError::CredentialsDirUnset { name: name.into() })?;
+    let path = format!("{}/{}", dir.trim_end_matches('/'), name);
+    match env.read_file(&path) {
+        Ok(contents) => Ok(trim_secret(&contents)),
+        Err(e) => Err(EnvError::CredentialUnreadable {
+            name: name.into(),
+            message: e.to_string(),
+        }),
+    }
+}
+
+/// Strip trailing CR/LF from a file-sourced secret. Secret files are
+/// conventionally written with a trailing newline (`echo "..." > f`);
+/// internal and leading bytes are preserved so a secret that genuinely
+/// contains whitespace stays intact.
+fn trim_secret(contents: &str) -> String {
+    contents.trim_end_matches(['\r', '\n']).to_string()
 }
 
 fn find_close_brace(bytes: &[u8], from: usize) -> Option<usize> {
@@ -131,21 +259,44 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
-    /// Test env source backed by a HashMap.
-    struct MapEnv(HashMap<String, String>);
+    /// Test env source backed by HashMaps — hermetic across env vars,
+    /// "files" (keyed by path), and a fake `$CREDENTIALS_DIRECTORY`.
+    #[derive(Default)]
+    struct MapEnv {
+        vars: HashMap<String, String>,
+        files: HashMap<String, String>,
+        cred_dir: Option<String>,
+    }
     impl MapEnv {
         fn new<I: IntoIterator<Item = (&'static str, &'static str)>>(items: I) -> Self {
-            Self(
-                items
+            Self {
+                vars: items
                     .into_iter()
                     .map(|(k, v)| (k.to_string(), v.to_string()))
                     .collect(),
-            )
+                ..Default::default()
+            }
+        }
+        fn with_file(mut self, path: &str, contents: &str) -> Self {
+            self.files.insert(path.to_string(), contents.to_string());
+            self
+        }
+        fn with_cred_dir(mut self, dir: &str) -> Self {
+            self.cred_dir = Some(dir.to_string());
+            self
         }
     }
     impl EnvSource for MapEnv {
         fn lookup(&self, name: &str) -> Option<String> {
-            self.0.get(name).cloned()
+            self.vars.get(name).cloned()
+        }
+        fn read_file(&self, path: &str) -> std::io::Result<String> {
+            self.files.get(path).cloned().ok_or_else(|| {
+                std::io::Error::new(std::io::ErrorKind::NotFound, "no such test file")
+            })
+        }
+        fn credentials_dir(&self) -> Option<String> {
+            self.cred_dir.clone()
         }
     }
 
@@ -236,5 +387,123 @@ mod tests {
         let c = expand_cow("${X}", &env).unwrap();
         assert!(matches!(c, Cow::Owned(_)));
         assert_eq!(c, "y");
+    }
+
+    // --- file: prefix --------------------------------------------------
+
+    #[test]
+    fn file_prefix_reads_contents() {
+        let env = MapEnv::default().with_file("/run/secrets/tok", "s3cret");
+        assert_eq!(
+            expand("token=${file:/run/secrets/tok}", &env).unwrap(),
+            "token=s3cret"
+        );
+    }
+
+    #[test]
+    fn file_prefix_trims_trailing_newline() {
+        // A secret written with `echo "x" > f` has a trailing newline.
+        let env = MapEnv::default().with_file("/s", "s3cret\n");
+        assert_eq!(expand("${file:/s}", &env).unwrap(), "s3cret");
+        let env = MapEnv::default().with_file("/s", "s3cret\r\n");
+        assert_eq!(expand("${file:/s}", &env).unwrap(), "s3cret");
+    }
+
+    #[test]
+    fn file_prefix_preserves_internal_whitespace() {
+        let env = MapEnv::default().with_file("/s", "a b\tc\n");
+        assert_eq!(expand("${file:/s}", &env).unwrap(), "a b\tc");
+    }
+
+    #[test]
+    fn file_prefix_missing_file_is_an_error() {
+        let env = MapEnv::default();
+        let err = expand("${file:/nope}", &env).unwrap_err();
+        match err {
+            EnvError::FileUnreadable { path, .. } => assert_eq!(path, "/nope"),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn file_prefix_empty_path_is_malformed() {
+        let env = MapEnv::default();
+        let err = expand("${file:}", &env).unwrap_err();
+        assert!(matches!(err, EnvError::Malformed { .. }));
+    }
+
+    // --- cred: prefix --------------------------------------------------
+
+    #[test]
+    fn cred_prefix_reads_from_credentials_dir() {
+        let env = MapEnv::default()
+            .with_cred_dir("/run/creds")
+            .with_file("/run/creds/admin_token", "abc123\n");
+        assert_eq!(
+            expand("token=${cred:admin_token}", &env).unwrap(),
+            "token=abc123"
+        );
+    }
+
+    #[test]
+    fn cred_prefix_without_dir_is_an_error() {
+        let env = MapEnv::default(); // no CREDENTIALS_DIRECTORY
+        let err = expand("${cred:admin_token}", &env).unwrap_err();
+        match err {
+            EnvError::CredentialsDirUnset { name } => assert_eq!(name, "admin_token"),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cred_prefix_missing_credential_is_an_error() {
+        let env = MapEnv::default().with_cred_dir("/run/creds");
+        let err = expand("${cred:gone}", &env).unwrap_err();
+        match err {
+            EnvError::CredentialUnreadable { name, .. } => assert_eq!(name, "gone"),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cred_prefix_rejects_path_traversal() {
+        let env = MapEnv::default().with_cred_dir("/run/creds");
+        for bad in ["${cred:../etc/passwd}", "${cred:sub/dir}", "${cred:}"] {
+            let err = expand(bad, &env).unwrap_err();
+            assert!(
+                matches!(err, EnvError::Malformed { .. }),
+                "expected malformed for {bad}, got {err:?}"
+            );
+        }
+    }
+
+    // --- prefix vs env-default disambiguation --------------------------
+
+    #[test]
+    fn env_default_takes_precedence_over_file_prefix() {
+        // `${file:-x}` is env var `file` with default `x`, NOT a file ref.
+        let env = MapEnv::default();
+        assert_eq!(expand("${file:-fallback}", &env).unwrap(), "fallback");
+        let env = MapEnv::new([("file", "set")]);
+        assert_eq!(expand("${file:-fallback}", &env).unwrap(), "set");
+    }
+
+    #[test]
+    fn bare_file_name_is_an_env_lookup() {
+        // `${file}` (no colon) is a plain env var named `file`.
+        let env = MapEnv::new([("file", "v")]);
+        assert_eq!(expand("${file}", &env).unwrap(), "v");
+    }
+
+    #[test]
+    fn prefixes_mix_with_env_vars_in_one_string() {
+        let env = MapEnv::new([("HOST", "h")])
+            .with_cred_dir("/c")
+            .with_file("/c/pw", "p\n")
+            .with_file("/etc/tok", "t\n");
+        assert_eq!(
+            expand("${HOST}:${cred:pw}:${file:/etc/tok}", &env).unwrap(),
+            "h:p:t"
+        );
     }
 }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -5,8 +5,52 @@ on the daemon binary. TOML is the only supported format (CLAUDE.md §4.6); all
 validation runs at config load time, not first-use, so a bad config fails
 loudly at startup instead of mid-call.
 
-`${VAR}` and `${VAR:-default}` are expanded from the process environment
-before TOML parsing. Unset variables without a default fail the load.
+## Secrets & variable expansion
+
+`${...}` references in any string value are expanded before TOML parsing, in a
+single fail-loud pass — an unresolvable reference fails the load instead of a
+half-substituted string reaching a parser or a call. Three source forms are
+recognised:
+
+| Form | Resolves to | Use for |
+|---|---|---|
+| `${VAR}` / `${VAR:-default}` | a **process environment** variable (with optional default) | the default; simplest |
+| `${file:/path/to/secret}` | the **file's contents** (trailing CR/LF trimmed) | Docker / Kubernetes secrets, Vault-Agent templated files |
+| `${cred:NAME}` | the contents of `$CREDENTIALS_DIRECTORY/NAME` | systemd `LoadCredential=` / `ImportCredential=` |
+
+The `file:` and `cred:` forms (v0.18.0) let you keep secrets — admin tokens,
+SIP digest passwords, webhook/CDR HMAC secrets, the HEP password — **out of the
+process environment** entirely (where they'd otherwise be visible in
+`/proc/<pid>/environ`, core dumps, and supervisor unit files). They work
+anywhere `${VAR}` works.
+
+- **`${file:PATH}`** reads the whole file and trims trailing newlines (so a
+  secret written with `echo "x" > f` resolves to `x`, not `x\n`); leading and
+  internal bytes are preserved. A missing/unreadable file fails the load.
+- **`${cred:NAME}`** reads `$CREDENTIALS_DIRECTORY/NAME`. `NAME` is a flat
+  identifier (no `/` or `..`). Used with systemd:
+
+  ```ini
+  # siphon-ai.service
+  [Service]
+  LoadCredential=admin_token:/etc/siphon-ai/secrets/admin_token
+  ```
+  ```toml
+  # config.toml
+  [[admin.token]]
+  name  = "ops"
+  token = "${cred:admin_token}"
+  role  = "operator"
+  ```
+  Without `$CREDENTIALS_DIRECTORY` set, a `${cred:...}` reference fails the
+  load (you didn't start under systemd `LoadCredential=`).
+
+> **Disambiguation.** The `:-` default operator is always an env reference, so
+> `${file:-x}` means "env var `file`, default `x`", **not** a `file:` lookup.
+> Reference a file as `${file:/abs/path}` (a real path, no `:-`).
+
+Unset env variables without a default fail the load; so do unreadable files and
+credentials. Resolved secret values are never logged.
 
 ## Top-level layout
 

--- a/docs/design/DESIGN_SECURITY_HARDENING.md
+++ b/docs/design/DESIGN_SECURITY_HARDENING.md
@@ -1,0 +1,394 @@
+# Design: security & abuse hardening (P1 theme)
+
+> **Status: DECISIONS LOCKED (2026-06-25) — §5.** Same design-first cadence
+> as graceful shutdown (→ v0.17.0), admin auth (→ v0.10.0), and webhook
+> durability (→ v0.11.0): design note → locked decisions → chunked PRs →
+> tag-after-merge. The build follows §6; deviations get noted back here.
+
+Theme: **P1 from `docs/ROADMAP.md`** ("Security & abuse hardening"), now the
+top open theme since both P0s shipped (release/packaging v0.16.0, graceful
+shutdown v0.17.0). This note covers **three** of the four sub-items the
+roadmap groups here; STIR/SHAKEN **outbound signing** is explicitly **out of
+scope** (large, gated on multi-week STI-CA cert enrollment — gate on demand
+in its own theme). The three in scope:
+
+1. **Listener & secret hardening** — `[admin].tls` + secret-manager
+   integration (file-based / systemd credentials, beyond `${VAR}`).
+2. **Inbound security** — RFC 3261 §22 digest auth on inbound INVITEs +
+   per-source INVITE rate-limiting / admission control.
+3. **Signed audit-event stream** — tamper-evident admin/security events as a
+   signed webhook (and optional HEP) stream for SIEM ingestion.
+
+The headline finding from the code survey: **all three reuse plumbing we
+already ship.** None needs an upstream `forge-media` change, and inbound
+digest auth needs **no `siphon-rs` PR** — the server-side `DigestAuthenticator`
+already exists upstream (§3.2). This theme is mostly config + glue + docs.
+
+---
+
+## 1. The gaps today
+
+### 1.1 Listener & secret hardening
+
+- **Admin listener is plain HTTP.** `AdminServer::start()`
+  (`crates/telemetry/src/http.rs:223-261`) binds a bare `TcpListener` and
+  serves `hyper::server::conn::http1`. `admin.rs:37-38` says it out loud:
+  *"admin listener is plain HTTP … bind it on loopback or front it with TLS
+  termination."* A bearer token (0.10.0) over plain HTTP on any routable
+  address **leaks the token** to an on-path observer. `build_admin()`
+  (`runtime.rs:1168-1189`) already *warns* on a non-loopback bind — but warn
+  isn't a fix.
+- **Secrets must sit in the environment.** Every secret — admin tokens, SIP
+  digest passwords (`[[gateway]]`, `[[register]]`), webhook/CDR HMAC secrets,
+  the HEP capture password — flows through `${VAR}` expansion
+  (`crates/config/src/env.rs:51-93`, applied once at `lib.rs:96-99`). That
+  forces the operator to put plaintext secrets in the process environment
+  (visible in `/proc/<pid>/environ`, dumps, supervisor unit files). There is
+  no file-based or systemd-credential path.
+
+### 1.2 Inbound security
+
+- **The only inbound gate is the `[[trunk]]` allowlist.** `on_invite`
+  (`crates/sip-glue/src/handler.rs:370`) gates a new INVITE through
+  `gate.identify(request, ctx)` → `403 Forbidden` if the source isn't an
+  allowed peer (`handler.rs:425-441`), matching on `peer_addrs` (IP/CIDR) and
+  `from_hosts` (`RawTrunk`, `raw.rs:593-617`). `from_hosts` is a `From:`-URI
+  hostname match — **trivially spoofable** by an on-path attacker, and an
+  IP allowlist is impossible for a trunk without a static carrier IP.
+  `docs/CONFIG.md` already names digest auth the proper *"no trust in the
+  network"* answer and marks it post-v1.
+- **No admission control.** Nothing bounds the *rate* of new INVITEs from a
+  given source. The existing defence is the external `fail2ban` recipe
+  (`docs/SECURITY_FAIL2BAN.md`) — reactive, log-scraping, and after the fact.
+  An internet-facing trunk has no in-process DoS posture. (Note: outbound
+  *already* has a token-bucket `rate_limit_per_sec`, `[outbound]` — there's a
+  pattern to mirror.)
+
+### 1.3 Signed audit-event stream
+
+- Admin actions are **logged + metered** (`handle_admin_request`,
+  `http.rs:273-334`: `info!(actor=token.name, action, target, result, peer)` +
+  `siphon_ai_admin_requests_total{endpoint,role,result}`,
+  `metrics.rs:107`) — but the audit trail is **only local stdout/stderr**.
+  There's no tamper-evident, shippable stream a SIEM can ingest, and no
+  integrity signature, so logs are repudiable and lost on a compromised host.
+  The admin-auth design note (`DESIGN_ADMIN_AUTH.md` §4, §8) **explicitly
+  deferred** the signed audit webhook to "the theme that owns the HMAC
+  signer" — that signer shipped in 0.11.0; this is that theme.
+
+---
+
+## 2. Goals / non-goals
+
+**Goals**
+1. **TLS on the admin listener** — `[admin].tls { cert, key }`, reusing the
+   existing rustls server-config plumbing, so a routable admin bind doesn't
+   leak its bearer token. Hot-reloadable on `SIGHUP` like the SIP TLS config.
+2. **Secrets from outside the environment** — resolve config secrets from
+   files / systemd credentials, not just `${VAR}`, with the same fail-loud
+   semantics and TOML-only config.
+3. **Cryptographic inbound caller auth** — optionally challenge inbound
+   INVITEs with RFC 3261 §22 digest, verifying against configured
+   credentials, so trust no longer rests on a spoofable network identity.
+4. **In-process admission control** — per-source INVITE rate limiting that
+   sheds abusive load before it reaches route/codec work.
+5. **A tamper-evident, shippable audit trail** — admin/security events
+   emitted as an HMAC-signed stream (webhook; HEP optional) for SIEM
+   ingestion, reusing the 0.11.0 signer.
+6. **Observability for each** (CLAUDE.md §4.5) — metrics/logs ship with the
+   feature.
+
+**Non-goals (this theme)**
+- **STIR/SHAKEN outbound signing** — separate, cert-enrollment-gated theme.
+- **mTLS as an admin *auth* mechanism** — `[admin].tls` is server-side TLS
+  (confidentiality for the bearer token). Client-cert *authentication* (role
+  keyed off cert subject) stays the clean follow-up named in
+  `DESIGN_ADMIN_AUTH.md` §8.
+- **A native Vault / cloud-KMS client.** File-based + systemd-credential
+  resolution covers Vault Agent (templated files), Docker/K8s secrets, and
+  systemd `LoadCredential=` without adding a heavy dependency or network
+  call on the config path. Native Vault is a possible later additive source.
+- **OIDC / external IdP**, per-token admin rate limits — out of scope as in
+  the admin-auth theme.
+- **No protocol / CDR / config-schema break.** Everything is additive: new
+  optional `[admin.tls]`, new secret-source *syntax* (backward compatible),
+  new optional `[sip.auth]` / inbound rate-limit config, and a new optional
+  audit sink. All **off by default** — existing configs behave identically.
+
+## 3. Design
+
+### 3.1 Admin TLS (`[admin].tls`)
+
+`AdminServer::start()` (`http.rs:223-261`) loops `listener.accept()` then
+`http1::Builder::serve_connection(TokioIo::new(stream), …)`. Add an optional
+TLS acceptor in front of that stream, exactly as the SIP listener does:
+
+- **Reuse `load_rustls_server_config(cert, key)`** (the helper behind
+  `load_sip_tls_server_config`, `runtime.rs:1389-1414`, imported from the
+  `sip_transport` crate) to build an `Arc<rustls::ServerConfig>` from PEM
+  cert/key paths. Same loader the SIP TLS listener and per-route bridge TLS
+  (`crates/bridge/src/tls.rs`) use — one cert/key code path, fail-loud at
+  load.
+- When `[admin].tls` is set, wrap the accepted `TcpStream` in a
+  `tokio_rustls::TlsAcceptor` before handing it to `serve_connection`.
+- **Hot reload:** store the server config in the same `Arc<Swappable<…>>`
+  shape used for SIP TLS (`runtime.rs:501-522`) so `SIGHUP` can swap the cert
+  (renewal) without dropping the listener. (Or mark `[admin.tls]`
+  restart-required for v1 simplicity — decision 6, §5.)
+- **Config + validation** (`compile_admin`, `compile.rs:1949-1986`): add
+  `tls: Option<AdminTls { cert_path, key_path }>`; validate the PEM loads at
+  config time (parity with `[sip.tls]`). A non-loopback `[admin].listen`
+  *without* `tls` keeps today's startup **warning** (don't hard-fail — a
+  reverse-proxy-terminated deployment is still valid). Recommend escalating
+  the warning's wording to name token leakage.
+
+### 3.2 Inbound digest auth (`[sip.auth]`)
+
+**Upstream is ready — no PR.** `siphon-rs`'s `sip-auth` crate ships a
+server-side `DigestAuthenticator<S: CredentialStore>` (rev `3023963`,
+`crates/sip-auth/src/lib.rs:781`) with exactly the surface we need:
+
+- `challenge(request) -> Response` — builds `401`/`407` with
+  `WWW-Authenticate`/`Proxy-Authenticate` (nonce, realm, algorithm, qop,
+  opaque).
+- `verify(request, headers) -> Result<bool>` — validates the
+  `Authorization`/`Proxy-Authorization` header, recomputes the response hash,
+  constant-time compares; built-in `NonceManager` gives expiry + replay
+  protection.
+- `challenge_stale(request)` — `stale=true` re-challenge for expired nonces
+  (RFC 7616 §3.5).
+
+**Where it slots in.** `on_invite` (`handler.rs:370`) gates in order: drain
+(503, `409-419`) → trunk allowlist (403, `425-441`) → route dispatch
+(`443-461`). Digest auth inserts **between the trunk gate and route
+dispatch** (after we know the source isn't outright denied, before we commit
+to a route):
+
+```text
+drain? ─► trunk allowlist? ─► [NEW] digest auth? ─► route dispatch
+                                 │
+                                 ├─ no Authorization header  → challenge() → 401/407
+                                 ├─ header present, verify ok → continue
+                                 ├─ verify fails              → challenge()  (or 403)
+                                 └─ nonce stale              → challenge_stale()
+```
+
+- **`CredentialStore`** is the one piece we implement: a small adapter over
+  configured inbound credentials (`username → password`/`HA1`). Built once at
+  startup, cloned into the handler. Storing **HA1** (`MD5(user:realm:pass)`)
+  rather than the plaintext password is the better posture — decision 3, §5.
+- **Config** (`[sip.auth]`, new): `enabled`, `realm`, `algorithm`
+  (MD5/SHA-256), `qop`, and a credential table (`[[sip.auth.user]]` with
+  `username` + `password`/`ha1`, env/secret-resolved). Off by default;
+  fail-loud if `enabled` with zero users.
+- **Interaction with `[[trunk]]`:** decision 4 (§5) — recommend digest as an
+  *additional* gate (trunk allowlist AND digest, both must pass), with a
+  per-trunk `auth_required` opt-in so a static-IP carrier trunk can stay
+  allowlist-only while a roaming trunk requires digest.
+- **Applies to other in-dialog-initiating methods?** Scope v1 to **INVITE**
+  (and REGISTER if we ever act as a registrar — we don't inbound today).
+  `BYE`/`ACK`/re-INVITE inside an established dialog are not re-challenged.
+
+### 3.3 Per-source INVITE rate limiting / admission control
+
+A token-bucket keyed on **source identity** (`ctx.peer()` IP, available at
+`on_invite`; `handler.rs` via `TransportContext`), checked **before** trunk
+and digest work so abusive sources are shed as cheaply as possible.
+
+- **Mirror the outbound limiter.** `[outbound].rate_limit_per_sec` is already
+  a documented token bucket (`docs/CONFIG.md:315`); reuse the same shape for
+  consistency. New `[sip.admission]` (or `[sip.rate_limit]`): a per-source
+  `max_per_sec` (+ burst) and an optional global `max_inflight_invites`
+  admission cap.
+- **Bounded memory.** Per-IP buckets in a size-capped LRU/`DashMap` with idle
+  eviction — a rate limiter that itself leaks under a spoofed-source flood is
+  no good. Cap the table; when full, fall back to the global cap.
+- **Response when limited:** `503 Service Unavailable` + `Retry-After`
+  (consistent with the drain reject, §graceful-shutdown), or silently drop
+  (cheaper under flood, but less RFC-friendly) — decision 5, §5. Recommend
+  `503` for low-rate trips, **drop** above a hard threshold.
+- **`siphon-rs` also exposes a `RateLimiter`** coupled into
+  `DigestAuthenticator::with_rate_limiter`. That covers *auth-failure*
+  rate limiting specifically; our admission limiter is broader (pre-auth,
+  per-source) and lives siphon-ai-side. Use the upstream one *additionally*
+  for repeated bad-credential sources if cheap — decision 5.
+
+### 3.4 Signed audit-event stream
+
+Reuse the 0.11.0 signer end-to-end. `sign(secret, ts, body) -> "t=…,v1=<hmac>"`
+(`crates/http/src/lib.rs:531`) + the `X-SiphonAI-Signature` header +
+`RetryingPoster` (durable retry/spool) already power both webhook sinks. The
+audit stream is "a webhook sink that carries security events."
+
+- **Event model.** A new `SecurityEvent` / `AdminAuditEvent` type (or a
+  variant family on the existing `WebhookEvent` enum,
+  `crates/webhooks/src/event.rs`) covering: every authenticated admin action
+  (the data already at `http.rs:313-322` — actor=token name, action, target,
+  result, peer), plus auth **failures** (401/403), config reloads
+  (`siphon_ai_config_reloads_total` already exists), and — if cheap —
+  inbound-auth rejections from §3.2.
+- **Delivery.** Decision 7 (§5): a **dedicated** `[audit]` sink (its own
+  `url` + `secret` + spool) vs. folding audit events into the existing
+  lifecycle `[webhooks]` whitelist. Recommend **dedicated** — audit and
+  business-lifecycle events have different consumers (SIEM vs. app backend),
+  retention, and secrets; mixing them couples two trust domains. Both reuse
+  the same `RetryingPoster`, so "dedicated" is config + a second sink
+  instance, not new delivery code.
+- **HEP option.** The roadmap names "signed webhook / HEP stream." HEP is the
+  natural fit for Homer-centric shops; webhook for SIEM. Recommend **webhook
+  first** (direct signer reuse), HEP as an additive follow-up — decision 8.
+- **Tamper-evidence.** The HMAC over `t=<unix>,<body>` gives integrity +
+  freshness per event. A hash-chain (each event includes the prior event's
+  signature) would give *sequence* tamper-evidence (detect dropped/reordered
+  events), but adds per-sink state — recommend **out of scope v1**, note as a
+  follow-up.
+
+### 3.5 Secret-manager integration
+
+Extend the **resolver**, not the format. Today `${VAR}` expands via the
+`EnvSource` trait (`env.rs:18-29`) at one chokepoint (`lib.rs:96-99`). Add
+**source-prefixed references** inside the same `${…}` syntax so it's
+backward compatible and still a single fail-loud pass:
+
+| Syntax | Resolves to | Use case |
+|---|---|---|
+| `${VAR}` / `${VAR:-default}` | process env (today) | unchanged |
+| `${file:/run/secrets/admin_token}` | trimmed file contents | Docker/K8s secrets, Vault Agent templated files |
+| `${cred:admin_token}` | `$CREDENTIALS_DIRECTORY/admin_token` contents | systemd `LoadCredential=` / `ImportCredential=` |
+
+- One new resolver dispatching on the `prefix:` (env remains the default when
+  no known prefix) — small change at the `expand` call site, no new config
+  fields, works for **every** existing secret (admin tokens, SIP passwords,
+  HMAC secrets, HEP password) for free.
+- **Fail-loud** parity: missing file / unreadable credential / empty value →
+  `EnvError`, daemon refuses to start (matches `EnvError::Missing`).
+- **No secret logging** — same discipline as today (tokens hashed at load,
+  `auth.rs`; nothing echoes the resolved value).
+- Decision 2 (§5): exact prefix names (`file:` / `cred:`) and whether to ship
+  both or start with `file:` (which alone covers Vault-Agent + Docker/K8s).
+
+## 4. Observability / tests
+
+**Observability** (ships with each feature, CLAUDE.md §4.5):
+- **Admin TLS:** reuse existing admin metrics; log TLS handshake failures at
+  `warn` (bounded). A `tls=true/false` field on the admin-listener startup
+  log line.
+- **Digest auth:** `siphon_ai_sip_auth_total{result}` counter
+  (`challenged` / `ok` / `failed` / `stale`); `info` on accept,
+  `warn` (rate-limited) on repeated failures. Per-call: a CDR field is
+  **optional/additive** — record whether the call was digest-authenticated
+  (bumps `CDR_VERSION`; gate on whether wanted — decision 9).
+- **Rate limiting:** `siphon_ai_invite_admission_total{result}`
+  (`accepted` / `rate_limited` / `dropped`) + a gauge for the live per-source
+  table size (cardinality-safe — no IP labels). One `warn`/min max when
+  shedding, never per-drop (CLAUDE.md §4.7 discipline).
+- **Audit stream:** reuse the 0.11.0 delivery metrics
+  (`deliveries`/`attempts`/`spool_depth`/`delivery_seconds`) scoped to the
+  audit sink; the audit *events themselves* are the observability.
+
+**Tests:**
+- Unit: admin TLS config validation (good/missing/bad PEM); secret resolver
+  (`env` / `file:` / `cred:` incl. missing→error); digest `CredentialStore`
+  adapter + a `challenge`→`verify` round-trip; rate-limiter token-bucket
+  (burst, refill, eviction, table cap); audit event serialization + signature
+  round-trip (verify with the 0.11.0 verifier).
+- Integration (`test-harness/`): curl the admin listener over TLS (cert
+  trust → 2xx; plain HTTP → connection reset). A SIPp scenario: INVITE
+  without credentials → `401`, INVITE with correct digest → proceeds, wrong
+  digest → re-`401`; a flood scenario trips the rate limiter (`503`/drop) and
+  recovers. An audit-sink stub (extend `hep-collector-stub`/webhook stub)
+  asserting a signed admin action arrives and its signature verifies.
+
+## 5. Decisions — LOCKED (2026-06-25)
+
+1. **Sequencing = three minor releases**, one per sub-item, each internally
+   chunked (mirrors the per-theme cadence):
+   - **v0.18.0 — Listener & secret hardening** (admin TLS + secret resolver).
+     Smallest, pure reuse; unblocks secure routable admin binds first.
+   - **v0.19.0 — Inbound security** (digest auth + admission control).
+   - **v0.20.0 — Signed audit-event stream.**
+   (One-big-release alternative rejected — the three-way split keeps each PR
+   stack reviewable and lets v0.18.0 ship value immediately.)
+2. **Secret resolver ships both `file:` and `cred:`.** `${file:/path}` (trimmed
+   file contents — Docker/K8s secrets, Vault Agent templated files) and
+   `${cred:name}` (`$CREDENTIALS_DIRECTORY/name` — systemd `LoadCredential=`).
+   `${VAR}` stays the default when no known prefix is present. Backward
+   compatible; one resolver, one fail-loud pass.
+3. **Digest stores HA1** (`MD5(user:realm:pass)`) — never holds cleartext.
+   Config accepts `password` (hashed to HA1 at load) **or** a pre-computed
+   `ha1`.
+4. **Digest is an AND gate with the trunk allowlist**, opt-in per trunk via
+   `auth_required`. Static-IP carrier trunks stay allowlist-only; roaming /
+   no-static-IP trunks set `auth_required` and must also pass digest. Both
+   gates must pass when both apply.
+5. **Rate limiting:** per-source token bucket keyed on `ctx.peer()` IP in a
+   capped LRU with idle eviction; `503 + Retry-After` on a normal trip, hard
+   **drop** above a configurable threshold (cheaper under flood); a global
+   `max_inflight_invites` admission cap as the backstop. siphon-rs's
+   auth-failure `RateLimiter` folded into the digest path additionally if
+   cheap.
+6. **Admin TLS hot-reloads** via the SIP-TLS `Swappable` pattern (cert renewal
+   on `SIGHUP` without dropping the listener). Restart-required rejected — TLS
+   certs rotate, and SIP TLS already proves the pattern.
+7. **Audit stream = a dedicated `[audit]` sink** (its own `url` + `secret` +
+   spool), not folded into `[webhooks]`. Audit (SIEM) and lifecycle (app
+   backend) events have different consumers, retention, and trust domains;
+   both reuse the same `RetryingPoster`, so this is config + a second sink
+   instance, not new delivery code.
+8. **Audit transport = webhook first** (direct 0.11.0 signer reuse). HEP
+   transport is an additive follow-up, not in this theme.
+9. **No CDR `authenticated` field — metrics-only.** Digest outcome is captured
+   by `siphon_ai_sip_auth_total`; no `CDR_VERSION` bump. (Revisit only if an
+   operator needs per-call attribution.)
+
+**Also settled as defaults:** all sub-features **off by default**; TOML-only;
+additive config; **no protocol/CDR/schema break** (decision 9 keeps CDR at its
+current version). A non-loopback `[admin].listen` without `[admin.tls]` keeps
+today's startup *warning* (not a hard fail — reverse-proxy TLS termination
+stays valid); the warning's wording escalates to name token leakage.
+
+## 6. Implementation chunks
+
+Grouped by the three releases (decision 1). Each follows
+design→chunks→tag-after-merge.
+
+### v0.18.0 — Listener & secret hardening
+1. **Secret resolver.** Extend `expand`/`EnvSource` with `file:` (+ `cred:`)
+   prefixes; unit tests; `docs/CONFIG.md` secret-sources section. No new
+   config fields — works for every existing secret.
+2. **Admin TLS.** `[admin].tls { cert, key }` + `compile_admin` validation
+   (reuse `load_rustls_server_config`); wrap `AdminServer::start` accept loop
+   in a `TlsAcceptor`; `Swappable` for `SIGHUP` (decision 6); escalate the
+   non-loopback warning. Integration test (TLS curl). `DEPLOY.md` +
+   `CONFIG.md` + threat-model note in `admin.rs`.
+
+### v0.19.0 — Inbound security
+3. **Digest auth.** `[sip.auth]` config + `CredentialStore` adapter (HA1);
+   wire `challenge`/`verify`/`challenge_stale` into `on_invite` between trunk
+   and route; `siphon_ai_sip_auth_total` metric; SIPp 401→auth→proceed
+   scenario; `docs/CONFIG.md` + a `docs/SECURITY_*` digest section.
+4. **Admission control.** `[sip.admission]` per-source token bucket + global
+   inflight cap (capped LRU, idle eviction); `503`/drop policy;
+   `siphon_ai_invite_admission_total` metric; SIPp flood scenario;
+   `docs/CONFIG.md` + cross-link the fail2ban recipe (now defence-in-depth,
+   not the only line).
+
+### v0.20.0 — Signed audit-event stream
+5. **Audit sink core.** `SecurityEvent`/`AdminAuditEvent` model; a dedicated
+   `[audit]` sink reusing `RetryingPoster` + `sign()` +
+   `X-SiphonAI-Signature`; fire from `handle_admin_request` (success +
+   401/403) and config-reload; serialization + signature round-trip tests.
+6. **Docs + release.** `docs/DEPLOY.md` SIEM-ingestion section, payload schema
+   + signature-verification recipe, audit-sink stub in `test-harness/`,
+   CHANGELOG, tag. (HEP transport + hash-chain noted as follow-ups.)
+
+## 7. Out of scope (this theme)
+
+- **STIR/SHAKEN outbound signing** — separate cert-gated theme.
+- **mTLS admin auth**, OIDC/IdP, per-token admin rate limits — as in the
+  admin-auth theme.
+- **Native Vault / cloud-KMS client** — `file:`/`cred:` cover the templated-
+  file integration path; a native client is a later additive source.
+- **Audit hash-chaining** and **HEP audit transport** — additive follow-ups
+  after the webhook audit sink lands.
+- **Per-call digest CDR attribution** unless decision 9 opts in.


### PR DESCRIPTION
First chunk of **v0.18.0** — the opening release of the P1 *Security & abuse hardening* theme (design note `docs/design/DESIGN_SECURITY_HARDENING.md`, included here). Decisions 1 & 2 from §5.

## What

Config `${...}` references can now resolve secrets from **outside the process environment**, so plaintext secrets needn't sit in env vars (visible in `/proc/<pid>/environ`, core dumps, supervisor unit files). Two new source prefixes inside the existing single expansion pass, usable anywhere `${VAR}` works:

| Form | Resolves to | Use for |
|---|---|---|
| `${file:/path/to/secret}` | trimmed file contents | Docker/K8s secrets, Vault-Agent templated files |
| `${cred:NAME}` | `$CREDENTIALS_DIRECTORY/NAME` | systemd `LoadCredential=` |

`${VAR}` / `${VAR:-default}` are unchanged.

## Why it's low-risk

- **Backward-compatible, zero new config fields** — works for every existing secret (admin tokens, SIP digest passwords, webhook/CDR HMAC secrets, HEP password) for free.
- **`:-` default wins:** checked before prefix dispatch, so `${file:-x}` stays "env var `file`, default `x`" — never a file lookup. A path containing `:-` fails loud, not silent.
- **Fail-loud parity** with `${VAR}`: missing file → `FileUnreadable`, unset `$CREDENTIALS_DIRECTORY` → `CredentialsDirUnset`, and `/` or `..` in a credential name → `Malformed` (traversal guard).
- **Resolved secrets are never logged.**

## Tests

- `EnvSource` gains default-impl `read_file` / `credentials_dir` (real OS by default, overridden by the test `MapEnv`) so both prefixes are unit-tested hermetically — no disk access.
- 13 new env tests (both prefixes, newline trimming, internal-whitespace preservation, traversal rejection, `:-` disambiguation, mixed-in-one-string).
- `cargo test -p siphon-ai-config` → 68 unit + 97 integration green; `clippy --all-targets -D warnings` clean.

## Docs

- `docs/CONFIG.md` → new *Secrets & variable expansion* section (table + systemd `LoadCredential=` example + disambiguation note).
- `CHANGELOG.md` `[Unreleased]`.

## Next in v0.18.0

Chunk 2 — `[admin].tls` (admin listener TLS), reusing the SIP-TLS rustls loader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
