### PR TITLE
feat(admin): serve /admin over TLS with SIGHUP cert reload ([admin.tls])

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Admin listener TLS — `[admin.tls]`** (P1 "Security & abuse hardening";
+  second chunk of v0.18.0). The authenticated `[admin]` listener can now serve
+  **HTTPS** directly, so the bearer token is encrypted on the wire on a
+  routable bind without a TLS-terminating proxy. Set `[admin.tls].cert` +
+  `.key` (both required when the table is present; missing/empty → fatal at
+  load). The cert is loaded at startup (fail-loud) and **hot-reloaded on
+  `SIGHUP`** alongside `[sip.tls]` — the next connection picks up the new cert,
+  in-flight ones keep theirs, and a broken PEM keeps the previous cert
+  (nginx-style). New metric `siphon_ai_admin_tls_reload_attempts_total`
+  `{outcome=ok|failed}`. Without `[admin.tls]` a non-loopback bind still works
+  but logs a sharpened startup warning (the token travels in the clear). See
+  `docs/CONFIG.md` → `[admin.tls]`.
+
 - **Secret resolution from files & systemd credentials** (P1 "Security &
   abuse hardening"; first chunk of v0.18.0). Config `${...}` references can now
   pull a secret from outside the process environment, so plaintext secrets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3168,6 +3168,7 @@ dependencies = [
  "subtle",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-rustls",
  "tracing",
  "tracing-subscriber",
 ]

--- a/bins/siphon-ai/src/reload.rs
+++ b/bins/siphon-ai/src/reload.rs
@@ -38,7 +38,7 @@ use std::sync::Arc;
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use siphon_ai_cdr::{CdrRecord, CdrSink, CdrSinkHandle};
-use siphon_ai_config::{Config, OutboundConfig, SipTlsConfig};
+use siphon_ai_config::{AdminTlsConfig, Config, OutboundConfig, SipTlsConfig};
 use siphon_ai_core::OutboundService;
 use siphon_ai_routes::RouteSet;
 use siphon_ai_telemetry::{HepTelemetry, CONFIG_RELOADS_TOTAL};
@@ -259,6 +259,9 @@ pub struct ReloadContext {
     /// `Some` when TLS is configured — the cert is reloaded too (the
     /// prior dedicated TLS-reload behavior, folded into this handler).
     pub tls: Option<(SipTlsConfig, Arc<ArcSwap<ServerConfig>>)>,
+    /// `Some` when `[admin.tls]` is configured — the admin-listener cert
+    /// is reloaded alongside the SIP cert on each SIGHUP.
+    pub admin_tls: Option<(AdminTlsConfig, Arc<ArcSwap<ServerConfig>>)>,
     pub restart_fingerprints: Vec<(&'static str, String)>,
 }
 
@@ -299,18 +302,13 @@ pub fn spawn_reload_handler(ctx: ReloadContext) {
 
         while stream.recv().await.is_some() {
             // 1. TLS cert reload (independent of the config file).
+            //    Both SIP and admin certs rotate via the shared helpers
+            //    in `crate::runtime`.
             if let Some((tls, swap)) = &ctx.tls {
-                match crate::runtime::load_sip_tls_server_config(tls) {
-                    Ok(new_cfg) => {
-                        swap.store(new_cfg);
-                        metrics::counter!("siphon_ai_sip_tls_reload_attempts_total", "outcome" => "ok").increment(1);
-                        info!(cert = %tls.cert_path.display(), "SIP/TLS cert reloaded on SIGHUP");
-                    }
-                    Err(e) => {
-                        metrics::counter!("siphon_ai_sip_tls_reload_attempts_total", "outcome" => "failed").increment(1);
-                        error!(cert = %tls.cert_path.display(), error = %e, "SIGHUP cert reload failed; keeping previous cert");
-                    }
-                }
+                crate::runtime::reload_sip_tls_cert(tls, swap);
+            }
+            if let Some((tls, swap)) = &ctx.admin_tls {
+                crate::runtime::reload_admin_tls_cert(tls, swap);
             }
 
             // 2. Config reload.

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -75,9 +75,9 @@ use siphon_ai_cdr::{
     CdrSinkHandle, FileSink, HepCdrSink, MultiSink, NullSink, WebhookSink, WebhookSinkConfig,
 };
 use siphon_ai_config::{
-    CdrConfig, CdrFileConfig, CdrWebhookConfig, Config, HepConfig, MediaConfig, NodeConfig,
-    ObservabilityConfig, ParkTimeoutAction as ConfigParkTimeoutAction, SipConfig, SipTlsConfig,
-    SipTransport, WebhooksConfig,
+    AdminTlsConfig, CdrConfig, CdrFileConfig, CdrWebhookConfig, Config, HepConfig, MediaConfig,
+    NodeConfig, ObservabilityConfig, ParkTimeoutAction as ConfigParkTimeoutAction, SipConfig,
+    SipTlsConfig, SipTransport, WebhooksConfig,
 };
 use siphon_ai_core::{
     default_call_id_factory, BridgingAcceptor, CallControlRegistry, CallRegistry, ConferenceAdmin,
@@ -95,9 +95,9 @@ use siphon_ai_telemetry::{
         AdminCallRegistry, AdminConference, AdminOutbound, AdminPark, AdminState,
         CallRegistryHandle, DrainStatus, DrainStatusFn, RegistrationRow,
     },
-    install_recorder, AdminServer, HepTelemetry, HepTelemetryBuild, HepWorkerHandle,
-    LogFilterHandle, ObservabilityServer, ReadinessFlag, CALLS_DRAIN_FORCED_TOTAL, DRAINING,
-    DRAIN_SECONDS,
+    install_recorder, AdminServer, AdminTlsConfigFn, HepTelemetry, HepTelemetryBuild,
+    HepWorkerHandle, LogFilterHandle, ObservabilityServer, ReadinessFlag, CALLS_DRAIN_FORCED_TOTAL,
+    DRAINING, DRAIN_SECONDS,
 };
 use siphon_ai_webhooks::{
     FilteredSink as WebhookFilteredSink, HttpSink as WebhookHttpSink,
@@ -525,6 +525,24 @@ impl Runtime {
         // listeners below, so clone it for the handler here.
         let tls_for_reload = tls_server_config.clone();
 
+        // Admin listener TLS (`[admin.tls]`), same ArcSwap-for-SIGHUP
+        // shape as `[sip.tls]`. Loaded here (not in build_admin) so a
+        // bad cert/key fails at startup, and so the swap exists before
+        // the SIGHUP handler is wired up below. The swap is consumed by
+        // build_admin further down; clone it for the reloader.
+        let admin_tls_swap: Option<Arc<arc_swap::ArcSwap<tokio_rustls::rustls::ServerConfig>>> =
+            match admin.as_ref().and_then(|a| a.tls.as_ref()) {
+                Some(tls) => {
+                    let initial = load_admin_tls_server_config(tls)?;
+                    Some(Arc::new(arc_swap::ArcSwap::from(initial)))
+                }
+                None => None,
+            };
+        let admin_tls_for_reload = admin
+            .as_ref()
+            .and_then(|a| a.tls.clone())
+            .zip(admin_tls_swap.clone());
+
         // ─── Integrated UAS ────────────────────────────────────────
         let local_uri = sip_local_uri(&node, &sip);
         let contact_uri = sip.contact.as_deref().unwrap_or(&local_uri).to_string();
@@ -733,12 +751,13 @@ impl Runtime {
                     cdr_fingerprint,
                     outbound: outbound_reload,
                     tls: sip.tls.clone().zip(tls_for_reload),
+                    admin_tls: admin_tls_for_reload,
                     restart_fingerprints,
                 });
             }
             // No backing file (tests): preserve the prior TLS-cert /
             // no-op SIGHUP behavior.
-            None => spawn_sighup_handler(sip.tls.clone(), tls_for_reload),
+            None => spawn_sighup_handler(sip.tls.clone(), tls_for_reload, admin_tls_for_reload),
         }
 
         // ─── Build admin state + observability HTTP listener ──────
@@ -806,7 +825,7 @@ impl Runtime {
         // Authenticated admin listener (0.10.0), separate from the open
         // observability listener. `None` when no `[admin]` block is
         // configured — `/admin/*` is then not served at all.
-        let admin_server = build_admin(admin, admin_state).await?;
+        let admin_server = build_admin(admin, admin_state, admin_tls_swap).await?;
 
         // We're now serving SIP — let the readiness probe flip.
         readiness.mark_ready();
@@ -1161,28 +1180,38 @@ async fn build_observability(
 
 /// Spawn the **authenticated** admin HTTP server (`[admin]`). `None`
 /// when no `[admin]` block is configured — `/admin/*` is then not served
-/// at all (the secure default). Warns when the bind is not loopback: the
-/// admin listener is plain HTTP, so the bearer token would travel in the
-/// clear on a routable address (pair with a TLS-terminating proxy until
-/// native `[admin].tls` lands).
+/// at all (the secure default).
+///
+/// With `[admin.tls]` (here as a loaded, SIGHUP-swappable `ServerConfig`)
+/// the listener serves HTTPS so the bearer token is encrypted on the
+/// wire. Without it the listener is plain HTTP; we warn loudly when such
+/// a plain-HTTP listener is bound on a non-loopback address, since the
+/// bearer token would then travel in the clear.
 async fn build_admin(
     cfg: Option<siphon_ai_config::AdminConfig>,
     admin_state: AdminState,
+    tls_swap: Option<Arc<arc_swap::ArcSwap<tokio_rustls::rustls::ServerConfig>>>,
 ) -> Result<Option<AdminServer>> {
     let Some(cfg) = cfg else {
         debug!("no [admin] block; /admin/* is not served");
         return Ok(None);
     };
-    if !cfg.listen_addr.ip().is_loopback() {
+    // Live-config closure: each accepted connection reads the current
+    // cert, so a SIGHUP rotation takes effect without a restart.
+    let tls_fn: Option<AdminTlsConfigFn> = tls_swap.map(|swap| {
+        let f: AdminTlsConfigFn = Arc::new(move || swap.load_full());
+        f
+    });
+    if tls_fn.is_none() && !cfg.listen_addr.ip().is_loopback() {
         warn!(
             target: "siphon_ai_config",
             listen = %cfg.listen_addr,
-            "[admin].listen is not a loopback address and the admin listener is plain HTTP — \
-             the bearer token travels in the clear on the wire. Bind loopback or front the \
-             admin listener with a TLS-terminating proxy."
+            "[admin].listen is not a loopback address and [admin.tls] is not configured — \
+             the bearer token travels in the CLEAR on the wire. Configure [admin.tls], bind \
+             loopback, or front the admin listener with a TLS-terminating proxy."
         );
     }
-    let server = AdminServer::start(cfg.listen_addr, cfg.auth, admin_state)
+    let server = AdminServer::start(cfg.listen_addr, cfg.auth, admin_state, tls_fn)
         .await
         .with_context(|| format!("bind admin HTTP {}", cfg.listen_addr))?;
     Ok(Some(server))
@@ -1413,6 +1442,35 @@ pub(crate) fn load_sip_tls_server_config(
     Ok(cfg)
 }
 
+/// `[admin.tls]`. Same loader as `[sip.tls]` (shared
+/// `load_rustls_server_config`); failure is fatal so an operator who
+/// asked for HTTPS on the admin listener never silently gets cleartext.
+pub(crate) fn load_admin_tls_server_config(
+    tls: &AdminTlsConfig,
+) -> Result<Arc<tokio_rustls::rustls::ServerConfig>> {
+    let cert = tls
+        .cert_path
+        .to_str()
+        .ok_or_else(|| anyhow!("[admin.tls].cert path is not valid UTF-8"))?;
+    let key = tls
+        .key_path
+        .to_str()
+        .ok_or_else(|| anyhow!("[admin.tls].key path is not valid UTF-8"))?;
+    let cfg = load_rustls_server_config(cert, key).with_context(|| {
+        format!(
+            "load admin TLS cert={} key={}",
+            tls.cert_path.display(),
+            tls.key_path.display()
+        )
+    })?;
+    info!(
+        cert = %tls.cert_path.display(),
+        key = %tls.key_path.display(),
+        "admin TLS server config loaded"
+    );
+    Ok(cfg)
+}
+
 /// Install the daemon's SIGHUP handler. Always installed —
 /// claiming the signal prevents the default Unix disposition
 /// (process termination) from firing when an operator runs
@@ -1423,19 +1481,47 @@ pub(crate) fn load_sip_tls_server_config(
 /// reload to do anything) or `None` together (handler is a no-op
 /// signal consumer). Mixed states fall back to no-op with a `warn!`
 /// — they shouldn't happen, but the daemon doesn't crash if they do.
+type TlsSwap = Arc<arc_swap::ArcSwap<tokio_rustls::rustls::ServerConfig>>;
+
 fn spawn_sighup_handler(
     tls: Option<SipTlsConfig>,
-    swappable: Option<Arc<arc_swap::ArcSwap<tokio_rustls::rustls::ServerConfig>>>,
+    swappable: Option<TlsSwap>,
+    admin_tls: Option<(AdminTlsConfig, TlsSwap)>,
 ) {
-    match (tls, swappable) {
-        (Some(tls), Some(swap)) => spawn_sighup_reloader(tls, swap),
-        (None, None) => spawn_sighup_noop(),
+    let sip = match (tls, swappable) {
+        (Some(tls), Some(swap)) => Some((tls, swap)),
+        (None, None) => None,
         _ => {
             warn!(
                 "inconsistent SIGHUP wiring (one of tls/swappable is set, the other isn't); \
-                 falling back to no-op handler"
+                 ignoring SIP/TLS hot-reload"
             );
-            spawn_sighup_noop();
+            None
+        }
+    };
+    if sip.is_none() && admin_tls.is_none() {
+        spawn_sighup_noop();
+    } else {
+        spawn_sighup_reloader(sip, admin_tls);
+    }
+}
+
+/// Reload the admin-listener TLS cert into its swap (SIGHUP). Shared by
+/// the no-config reloader here and the config-file reloader in
+/// `crate::reload`, so both paths rotate the admin cert identically.
+/// A bad PEM keeps the previous cert (nginx-style), never crashes.
+pub(crate) fn reload_admin_tls_cert(tls: &AdminTlsConfig, swap: &TlsSwap) {
+    match load_admin_tls_server_config(tls) {
+        Ok(new_cfg) => {
+            swap.store(new_cfg);
+            metrics::counter!("siphon_ai_admin_tls_reload_attempts_total", "outcome" => "ok")
+                .increment(1);
+            info!(cert = %tls.cert_path.display(), "admin TLS cert reloaded on SIGHUP");
+        }
+        Err(e) => {
+            metrics::counter!("siphon_ai_admin_tls_reload_attempts_total", "outcome" => "failed")
+                .increment(1);
+            error!(cert = %tls.cert_path.display(), error = %e, "SIGHUP admin TLS reload failed; keeping previous cert");
         }
     }
 }
@@ -1463,31 +1549,27 @@ fn spawn_sighup_noop() {
     });
 }
 
-/// Install a SIGHUP handler that hot-reloads the SIP/TLS cert.
+/// Install a SIGHUP handler that hot-reloads the SIP/TLS and/or admin
+/// TLS cert (whichever are configured). Used on the no-config-file path
+/// (tests); the config-file path folds the same reloads into
+/// [`crate::reload::spawn_reload_handler`].
 ///
-/// On every `SIGHUP`, re-reads `[sip.tls].cert` + `.key` from disk,
-/// builds a fresh `rustls::ServerConfig`, and stores it into
-/// `swappable`. The next inbound TLS connection picks up the new
-/// cert; in-flight sessions keep using the cert they handshook with
-/// (RFC 5746-compliant rotation — see siphon-rs#49 for the upstream
-/// pattern).
+/// On every `SIGHUP`, re-reads each configured cert/key from disk,
+/// builds a fresh `rustls::ServerConfig`, and stores it into the
+/// relevant swap. The next connection picks up the new cert; in-flight
+/// sessions keep using the cert they handshook with (RFC 5746-compliant
+/// rotation — see siphon-rs#49).
 ///
 /// **Failure mode.** A broken PEM file on reload doesn't kill the
-/// daemon — we log `error!` and keep the old cert in place. Same
-/// shape as nginx's `nginx -s reload` semantics: if the new config
-/// is bad, the running config keeps serving.
+/// daemon — we log `error!` and keep the old cert in place (nginx-style:
+/// the running config keeps serving).
 ///
-/// **Concurrency.** One background tokio task. Lives for the
-/// daemon's lifetime (we never deregister the signal handler). The
-/// task is detached — its `JoinHandle` isn't kept anywhere because
-/// there's nothing to do with it.
-///
-/// `tls` is cloned so the task can survive the rest of `RuntimeBuilder`
-/// going out of scope; cert/key paths are owned strings in
-/// `SipTlsConfig` so this is a cheap clone.
+/// **Concurrency.** One detached background task, alive for the daemon's
+/// lifetime. Configs are cloned so the task outlives `RuntimeBuilder`;
+/// cert/key paths are owned, so the clone is cheap.
 fn spawn_sighup_reloader(
-    tls: SipTlsConfig,
-    swappable: Arc<arc_swap::ArcSwap<tokio_rustls::rustls::ServerConfig>>,
+    sip: Option<(SipTlsConfig, TlsSwap)>,
+    admin: Option<(AdminTlsConfig, TlsSwap)>,
 ) {
     use tokio::signal::unix::{signal, SignalKind};
 
@@ -1499,47 +1581,47 @@ fn spawn_sighup_reloader(
                 // is still usable — log loud and exit the task.
                 error!(
                     error = %e,
-                    "failed to install SIGHUP handler; SIP/TLS cert hot-reload disabled",
+                    "failed to install SIGHUP handler; TLS cert hot-reload disabled",
                 );
                 return;
             }
         };
         info!(
-            cert = %tls.cert_path.display(),
-            "SIP/TLS cert hot-reload installed; send SIGHUP to rotate"
+            sip_tls = sip.is_some(),
+            admin_tls = admin.is_some(),
+            "TLS cert hot-reload installed; send SIGHUP to rotate"
         );
         while stream.recv().await.is_some() {
-            match load_sip_tls_server_config(&tls) {
-                Ok(new_cfg) => {
-                    swappable.store(new_cfg);
-                    metrics::counter!(
-                        "siphon_ai_sip_tls_reload_attempts_total",
-                        "outcome" => "ok",
-                    )
-                    .increment(1);
-                    info!(
-                        cert = %tls.cert_path.display(),
-                        "SIP/TLS cert reloaded on SIGHUP"
-                    );
-                }
-                Err(e) => {
-                    metrics::counter!(
-                        "siphon_ai_sip_tls_reload_attempts_total",
-                        "outcome" => "failed",
-                    )
-                    .increment(1);
-                    error!(
-                        cert = %tls.cert_path.display(),
-                        error = %e,
-                        "SIGHUP cert reload failed; keeping previous cert"
-                    );
-                }
+            if let Some((tls, swap)) = &sip {
+                reload_sip_tls_cert(tls, swap);
+            }
+            if let Some((tls, swap)) = &admin {
+                reload_admin_tls_cert(tls, swap);
             }
         }
         // `recv()` returns `None` only on signal-handler teardown,
         // which we don't trigger. If it ever does, log so we know.
         warn!("SIGHUP signal stream ended; cert hot-reload offline");
     });
+}
+
+/// Reload the SIP-listener TLS cert into its swap (SIGHUP). Shared by
+/// the no-config reloader and `crate::reload`, mirroring
+/// [`reload_admin_tls_cert`].
+pub(crate) fn reload_sip_tls_cert(tls: &SipTlsConfig, swap: &TlsSwap) {
+    match load_sip_tls_server_config(tls) {
+        Ok(new_cfg) => {
+            swap.store(new_cfg);
+            metrics::counter!("siphon_ai_sip_tls_reload_attempts_total", "outcome" => "ok")
+                .increment(1);
+            info!(cert = %tls.cert_path.display(), "SIP/TLS cert reloaded on SIGHUP");
+        }
+        Err(e) => {
+            metrics::counter!("siphon_ai_sip_tls_reload_attempts_total", "outcome" => "failed")
+                .increment(1);
+            error!(cert = %tls.cert_path.display(), error = %e, "SIGHUP cert reload failed; keeping previous cert");
+        }
+    }
 }
 
 /// Build the lifecycle webhook sink from `[webhooks]` config.
@@ -2462,6 +2544,54 @@ mod tls_reload_tests {
         let path = base.join(format!("siphon-ai-tls-reload-test-{pid}-{seq}"));
         std::fs::create_dir_all(&path).unwrap();
         TempDir { path }
+    }
+
+    fn fixture_admin_tls_config(
+        cert: std::path::PathBuf,
+        key: std::path::PathBuf,
+    ) -> AdminTlsConfig {
+        AdminTlsConfig {
+            cert_path: cert,
+            key_path: key,
+        }
+    }
+
+    #[test]
+    fn load_admin_tls_server_config_returns_usable_config() {
+        let tmp = tempdir_for_test();
+        let (cert, key) = write_cert_a(tmp.path());
+        let tls = fixture_admin_tls_config(cert, key);
+        let cfg = load_admin_tls_server_config(&tls).expect("load admin cert A");
+        assert_eq!(Arc::strong_count(&cfg), 1);
+    }
+
+    #[test]
+    fn admin_reload_helper_swaps_cert_and_keeps_old_on_failure() {
+        let tmp = tempdir_for_test();
+        let (cert_a, key_a) = write_cert_a(tmp.path());
+        let (cert_b, key_b) = write_cert_b(tmp.path());
+
+        let tls_a = fixture_admin_tls_config(cert_a, key_a);
+        let swap = Arc::new(arc_swap::ArcSwap::from(
+            load_admin_tls_server_config(&tls_a).expect("load admin cert A"),
+        ));
+        let before = swap.load_full();
+
+        // Good reload (cert B) via the shared SIGHUP helper → new identity.
+        let tls_b = fixture_admin_tls_config(cert_b, key_b);
+        reload_admin_tls_cert(&tls_b, &swap);
+        let after = swap.load_full();
+        assert!(!Arc::ptr_eq(&before, &after), "good reload should swap");
+
+        // Bad reload (missing files) → helper keeps the previous cert.
+        let bogus =
+            fixture_admin_tls_config(tmp.path().join("nope.pem"), tmp.path().join("nope.key"));
+        reload_admin_tls_cert(&bogus, &swap);
+        let after_bad = swap.load_full();
+        assert!(
+            Arc::ptr_eq(&after, &after_bad),
+            "failed reload must keep the previous cert"
+        );
     }
 
     // Self-signed RSA-2048 cert A. Generated with:

--- a/crates/config/src/compile.rs
+++ b/crates/config/src/compile.rs
@@ -104,6 +104,17 @@ impl Default for ShutdownConfig {
 pub struct AdminConfig {
     pub listen_addr: SocketAddr,
     pub auth: siphon_ai_telemetry::AdminAuth,
+    /// `Some` when `[admin.tls]` is configured — the listener serves
+    /// HTTPS instead of plain HTTP. Loaded (and hot-reloaded on SIGHUP)
+    /// by the daemon, like `[sip.tls]`.
+    pub tls: Option<AdminTlsConfig>,
+}
+
+/// Compiled `[admin.tls]` — PEM cert/key paths for the admin listener.
+#[derive(Debug, Clone)]
+pub struct AdminTlsConfig {
+    pub cert_path: PathBuf,
+    pub key_path: PathBuf,
 }
 
 /// Compiled `[conference]` — conference rooms (0.7.0). Fail-closed:
@@ -763,6 +774,12 @@ pub enum CompileError {
         "[[admin.token]] {0:?} role is {1:?}; expected \"readonly\", \"operator\", or \"admin\""
     )]
     AdminUnknownRole(String, String),
+
+    #[error("[admin.tls] is present but [admin.tls].cert is missing or empty")]
+    AdminTlsCertRequired,
+
+    #[error("[admin.tls] is present but [admin.tls].key is missing or empty")]
+    AdminTlsKeyRequired,
 
     #[error("[webhooks].url is required when [webhooks].enabled = true")]
     WebhooksUrlRequired,
@@ -1979,9 +1996,27 @@ fn compile_admin(raw: Option<crate::raw::RawAdmin>) -> Result<Option<AdminConfig
         tokens.push(siphon_ai_telemetry::AdminToken::new(t.name, &t.token, role));
     }
 
+    // [admin.tls] (optional). When present, both cert and key are
+    // required and non-empty — fail loud rather than silently serving
+    // plain HTTP.
+    let tls = match raw.tls {
+        None => None,
+        Some(t) => {
+            let cert = t.cert.filter(|s| !s.is_empty());
+            let key = t.key.filter(|s| !s.is_empty());
+            let cert_path = cert.ok_or(CompileError::AdminTlsCertRequired)?;
+            let key_path = key.ok_or(CompileError::AdminTlsKeyRequired)?;
+            Some(AdminTlsConfig {
+                cert_path: PathBuf::from(cert_path),
+                key_path: PathBuf::from(key_path),
+            })
+        }
+    };
+
     Ok(Some(AdminConfig {
         listen_addr,
         auth: siphon_ai_telemetry::AdminAuth::new(tokens),
+        tls,
     }))
 }
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -34,7 +34,7 @@ use std::path::Path;
 use thiserror::Error;
 
 pub use compile::{
-    compile, AdminConfig, CdrConfig, CdrFileConfig, CdrWebhookConfig, CompileError,
+    compile, AdminConfig, AdminTlsConfig, CdrConfig, CdrFileConfig, CdrWebhookConfig, CompileError,
     ConferenceConfig, Config, Gateway, GatewayCredentials, HepConfig, MediaConfig, NodeConfig,
     ObservabilityConfig, OutboundConfig, ParkConfig, ParkTimeoutAction, RegisterConfig,
     SecurityConfig, ShutdownConfig, SipConfig, SipTlsConfig, SipTransport, TrunkCidr,

--- a/crates/config/src/raw.rs
+++ b/crates/config/src/raw.rs
@@ -121,6 +121,24 @@ pub struct RawAdmin {
     /// required (an admin listener with no tokens authenticates nobody).
     #[serde(default, rename = "token")]
     pub tokens: Vec<RawAdminToken>,
+    /// Optional `[admin.tls]` — serve the admin API over HTTPS so the
+    /// bearer token isn't sent in the clear on a routable bind.
+    #[serde(default)]
+    pub tls: Option<RawAdminTls>,
+}
+
+/// `[admin.tls]` — server-side TLS for the admin listener.
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawAdminTls {
+    /// PEM-encoded certificate chain (path on disk). Required when
+    /// `[admin.tls]` is present.
+    #[serde(default)]
+    pub cert: Option<String>,
+    /// PEM-encoded private key (path on disk). Required when
+    /// `[admin.tls]` is present.
+    #[serde(default)]
+    pub key: Option<String>,
 }
 
 /// One `[[admin.token]]` entry.

--- a/crates/config/tests/load.rs
+++ b/crates/config/tests/load.rs
@@ -376,6 +376,87 @@ fn admin_unknown_role_and_bad_listen_are_errors() {
 }
 
 #[test]
+fn admin_tls_compiles_with_cert_and_key() {
+    let toml = ADMIN_BASE.replace(
+        "__ADMIN__",
+        r#"
+[admin]
+listen = "0.0.0.0:9092"
+[[admin.token]]
+name = "ops"
+token = "t"
+role = "operator"
+[admin.tls]
+cert = "/etc/siphon/admin.crt"
+key = "/etc/siphon/admin.key"
+"#,
+    );
+    let cfg = load_from_str_with_env(&toml, &MapEnv::new([])).expect("compiles");
+    let tls = cfg
+        .admin
+        .expect("admin configured")
+        .tls
+        .expect("admin.tls configured");
+    assert_eq!(tls.cert_path.to_str(), Some("/etc/siphon/admin.crt"));
+    assert_eq!(tls.key_path.to_str(), Some("/etc/siphon/admin.key"));
+}
+
+#[test]
+fn admin_tls_without_cert_or_key_is_an_error() {
+    // cert present, key missing
+    let no_key = ADMIN_BASE.replace(
+        "__ADMIN__",
+        "[admin]\nlisten=\"127.0.0.1:9092\"\n[[admin.token]]\nname=\"x\"\ntoken=\"t\"\nrole=\"admin\"\n[admin.tls]\ncert=\"/c.crt\"\n",
+    );
+    assert!(
+        matches!(
+            load_from_str_with_env(&no_key, &MapEnv::new([])).unwrap_err(),
+            LoadError::Compile(_)
+        ),
+        "[admin.tls] with cert but no key must fail loud"
+    );
+
+    // empty cert string
+    let empty_cert = ADMIN_BASE.replace(
+        "__ADMIN__",
+        "[admin]\nlisten=\"127.0.0.1:9092\"\n[[admin.token]]\nname=\"x\"\ntoken=\"t\"\nrole=\"admin\"\n[admin.tls]\ncert=\"\"\nkey=\"/k.key\"\n",
+    );
+    assert!(
+        matches!(
+            load_from_str_with_env(&empty_cert, &MapEnv::new([])).unwrap_err(),
+            LoadError::Compile(_)
+        ),
+        "[admin.tls] with an empty cert path must fail loud"
+    );
+}
+
+#[test]
+fn admin_tls_paths_env_expand() {
+    let toml = ADMIN_BASE.replace(
+        "__ADMIN__",
+        "[admin]\nlisten=\"127.0.0.1:9092\"\n[[admin.token]]\nname=\"x\"\ntoken=\"t\"\nrole=\"admin\"\n[admin.tls]\ncert=\"${ADMIN_CRT}\"\nkey=\"${ADMIN_KEY}\"\n",
+    );
+    let cfg = load_from_str_with_env(
+        &toml,
+        &MapEnv::new([("ADMIN_CRT", "/x/a.crt"), ("ADMIN_KEY", "/x/a.key")]),
+    )
+    .expect("compiles");
+    let tls = cfg.admin.unwrap().tls.expect("admin.tls");
+    assert_eq!(tls.cert_path.to_str(), Some("/x/a.crt"));
+    assert_eq!(tls.key_path.to_str(), Some("/x/a.key"));
+}
+
+#[test]
+fn admin_without_tls_has_none() {
+    let toml = ADMIN_BASE.replace(
+        "__ADMIN__",
+        "[admin]\nlisten=\"127.0.0.1:9092\"\n[[admin.token]]\nname=\"x\"\ntoken=\"t\"\nrole=\"admin\"\n",
+    );
+    let cfg = load_from_str_with_env(&toml, &MapEnv::new([])).expect("compiles");
+    assert!(cfg.admin.unwrap().tls.is_none());
+}
+
+#[test]
 fn unknown_codec_is_a_compile_error() {
     let env = MapEnv::new([]);
     let toml = r#"

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -24,6 +24,10 @@ thiserror.workspace                   = true
 # Admin bearer-token auth: SHA-256 the token + constant-time compare.
 sha2.workspace                        = true
 subtle.workspace                      = true
+# Optional server-side TLS for the admin listener ([admin.tls]). The
+# cert/key are loaded (and SIGHUP-reloaded) by the daemon, which hands
+# us the live `ServerConfig`; we only build a `TlsAcceptor` per accept.
+tokio-rustls.workspace                = true
 
 # HEP3 / Homer shipping. Owned by us (github.com/thevoiceguy/hep-rs +
 # the sip-hep / forge-hep adapter crates). Telemetry assembles the

--- a/crates/telemetry/src/admin.rs
+++ b/crates/telemetry/src/admin.rs
@@ -34,8 +34,11 @@
 //! observability listener no longer serves `/admin/*`. `dispatch` itself
 //! is unauthenticated by design — it runs only after `AdminServer` has
 //! authenticated the bearer token and checked the endpoint's minimum
-//! role. The admin listener is plain HTTP, so bind it on loopback or
-//! front it with TLS termination until native `[admin].tls` lands.
+//! role. Set `[admin.tls]` (0.18.0) to serve the listener over HTTPS so
+//! the bearer token is encrypted on the wire on a routable bind; without
+//! it the listener is plain HTTP — bind it on loopback or front it with
+//! a TLS-terminating proxy (the runtime warns on a non-loopback
+//! plain-HTTP bind).
 //!
 //! ## Dependency injection
 //!

--- a/crates/telemetry/src/http.rs
+++ b/crates/telemetry/src/http.rs
@@ -15,11 +15,13 @@
 //!
 //! ## Admin transport security
 //!
-//! The admin listener is plain HTTP in this cut, so the bearer token
-//! travels in the clear on the wire — bind it on **loopback** (the
-//! default posture) or front it with a TLS-terminating proxy. A native
-//! `[admin].tls` is a follow-up; the runtime warns when the admin bind
-//! is not loopback.
+//! With `[admin.tls]` configured the listener serves **HTTPS**, so the
+//! bearer token is encrypted on the wire even on a routable bind. The
+//! daemon loads (and SIGHUP-reloads) the cert/key and hands us an
+//! [`AdminTlsConfigFn`]; we build a fresh `TlsAcceptor` per accepted
+//! connection from it. Without `[admin.tls]` the listener is plain HTTP
+//! — bind it on **loopback** or front it with a TLS-terminating proxy
+//! (the runtime warns on a non-loopback plain-HTTP bind).
 
 use std::convert::Infallible;
 use std::net::SocketAddr;
@@ -33,9 +35,20 @@ use hyper::service::service_fn;
 use hyper::{Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
 use metrics_exporter_prometheus::PrometheusHandle;
+use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
+use tokio_rustls::{rustls::ServerConfig, TlsAcceptor};
 use tracing::{debug, error, info, warn};
+
+/// Supplies the current admin-listener TLS `ServerConfig` on demand.
+///
+/// The daemon owns the cert/key (and its SIGHUP hot-reload), so it
+/// passes a closure that returns the *live* config; calling it per
+/// accepted connection is what lets a SIGHUP cert rotation take effect
+/// without dropping the listener. Kept as a closure so this crate
+/// doesn't depend on the daemon's `arc_swap` cell.
+pub type AdminTlsConfigFn = Arc<dyn Fn() -> Arc<ServerConfig> + Send + Sync>;
 
 use crate::admin::{self, AdminState};
 use crate::auth::{route_label, AdminAuth, AuthReject};
@@ -220,12 +233,23 @@ struct AdminSharedState {
 
 impl AdminServer {
     /// Bind on `addr` and start serving the gated `/admin/*` surface.
-    pub async fn start(addr: SocketAddr, auth: AdminAuth, admin: AdminState) -> Result<Self> {
+    ///
+    /// When `tls` is `Some` the listener serves HTTPS, building a fresh
+    /// `TlsAcceptor` per connection from the supplied
+    /// [`AdminTlsConfigFn`] (so a SIGHUP cert rotation is picked up by
+    /// the next connection). When `None` it serves plain HTTP.
+    pub async fn start(
+        addr: SocketAddr,
+        auth: AdminAuth,
+        admin: AdminState,
+        tls: Option<AdminTlsConfigFn>,
+    ) -> Result<Self> {
         let listener = TcpListener::bind(addr)
             .await
             .with_context(|| format!("bind admin HTTP {}", addr))?;
         let bound_addr = listener.local_addr().unwrap_or(addr);
-        info!(addr = %bound_addr, "admin HTTP listener bound (bearer-token auth)");
+        let scheme = if tls.is_some() { "https" } else { "http" };
+        info!(addr = %bound_addr, tls = tls.is_some(), "admin {scheme} listener bound (bearer-token auth)");
 
         let state = Arc::new(AdminSharedState { admin, auth });
         let listener = tokio::spawn(async move {
@@ -238,19 +262,28 @@ impl AdminServer {
                     }
                 };
                 let state = Arc::clone(&state);
-                tokio::spawn(async move {
-                    let io = TokioIo::new(stream);
-                    let svc = service_fn(move |req| {
-                        let state = Arc::clone(&state);
-                        async move { Ok::<_, Infallible>(handle_admin_request(req, state, peer).await) }
-                    });
-                    if let Err(e) = hyper::server::conn::http1::Builder::new()
-                        .serve_connection(io, svc)
-                        .await
-                    {
-                        debug!(peer = %peer, error = %e, "admin HTTP connection closed with error");
+                match &tls {
+                    Some(tls_fn) => {
+                        // Snapshot the live config so a SIGHUP rotation
+                        // takes effect on new connections.
+                        let acceptor = TlsAcceptor::from(tls_fn());
+                        tokio::spawn(async move {
+                            match acceptor.accept(stream).await {
+                                Ok(tls_stream) => serve_admin_conn(tls_stream, state, peer).await,
+                                Err(e) => {
+                                    // Handshake failures (bad SNI, plain
+                                    // HTTP to an HTTPS port, expired
+                                    // client clock) are noisy and benign;
+                                    // debug, not warn.
+                                    debug!(peer = %peer, error = %e, "admin TLS handshake failed");
+                                }
+                            }
+                        });
                     }
-                });
+                    None => {
+                        tokio::spawn(serve_admin_conn(stream, state, peer));
+                    }
+                }
             }
         });
 
@@ -267,6 +300,25 @@ impl AdminServer {
     pub async fn shutdown(self) {
         self.listener.abort();
         let _ = self.listener.await;
+    }
+}
+
+/// Serve one admin connection over `io` (plain TCP or a TLS stream).
+/// Generic so the plain-HTTP and HTTPS paths share the hyper plumbing.
+async fn serve_admin_conn<IO>(io: IO, state: Arc<AdminSharedState>, peer: SocketAddr)
+where
+    IO: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    let io = TokioIo::new(io);
+    let svc = service_fn(move |req| {
+        let state = Arc::clone(&state);
+        async move { Ok::<_, Infallible>(handle_admin_request(req, state, peer).await) }
+    });
+    if let Err(e) = hyper::server::conn::http1::Builder::new()
+        .serve_connection(io, svc)
+        .await
+    {
+        debug!(peer = %peer, error = %e, "admin HTTP connection closed with error");
     }
 }
 
@@ -377,10 +429,14 @@ mod tests {
             AdminToken::new("op", "op-tok", Role::Operator),
             AdminToken::new("ad", "ad-tok", Role::Admin),
         ]);
-        let server =
-            AdminServer::start("127.0.0.1:0".parse().unwrap(), auth, AdminState::default())
-                .await
-                .expect("admin start");
+        let server = AdminServer::start(
+            "127.0.0.1:0".parse().unwrap(),
+            auth,
+            AdminState::default(),
+            None, // plain HTTP for the test
+        )
+        .await
+        .expect("admin start");
         let url = format!("http://{}", server.bound_addr());
         (server, url)
     }

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -35,7 +35,7 @@ pub use admin::{
 };
 pub use auth::{AdminAuth, AdminToken, AuthReject, Role};
 pub use hep::{HepBuildError, HepTelemetry, HepTelemetryBuild, HepWorkerHandle};
-pub use http::{AdminServer, ObservabilityServer};
+pub use http::{AdminServer, AdminTlsConfigFn, ObservabilityServer};
 pub use log_filter::{LogFilterError, LogFilterHandle};
 
 // Re-exports for the daemon binary so it doesn't need a second

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -621,26 +621,47 @@ serves `[observability]`. Operator guide + the endpoint→role table:
 
 ```toml
 [admin]
-listen = "127.0.0.1:9092"      # dedicated listener; plain HTTP (bind loopback
-                               # or front with TLS until [admin].tls lands)
+listen = "127.0.0.1:9092"      # dedicated listener
 
 [[admin.token]]                # one block per token; at least one required
 name  = "ops-oncall"           # actor label in audit logs — NOT a secret
 token = "${SIPHON_ADMIN_OP}"   # the bearer secret; ${VAR} expansion works
 role  = "operator"             # readonly | operator | admin (roles nest)
+
+[admin.tls]                    # optional — serve /admin/* over HTTPS (0.18.0)
+cert = "${file:/etc/siphon/admin.crt}"   # PEM cert chain
+key  = "${cred:admin_tls_key}"           # PEM private key
 ```
 
 | Field            | Type        | Default        | Notes |
 |------------------|-------------|----------------|-------|
-| `listen`         | `host:port` | required if on | Where `/admin/*` is served. A non-loopback bind logs a warning (plain HTTP). |
+| `listen`         | `host:port` | required if on | Where `/admin/*` is served. A non-loopback bind **without `[admin.tls]`** logs a warning (the bearer token would travel in the clear). |
 | `token`          | table array | ≥ 1 required   | At least one `[[admin.token]]`; an `[admin]` block with no tokens is a fatal config error. |
 | `token[].name`   | string      | required       | Unique, non-empty label recorded as the audit-log actor. Duplicate names are a fatal error. |
-| `token[].token`  | string      | required       | The bearer secret (non-empty). Hashed (SHA-256) at load, compared in constant time, never logged. Use `${VAR}` to keep it out of the file. |
+| `token[].token`  | string      | required       | The bearer secret (non-empty). Hashed (SHA-256) at load, compared in constant time, never logged. Use `${VAR}` / `${file:…}` / `${cred:…}` to keep it out of the file. |
 | `token[].role`   | enum        | required       | `readonly` (GET/list) ⊂ `operator` (hangup, park/retrieve, conference CRUD) ⊂ `admin` (origination, `PUT /admin/log`, `hep/test`). Unknown value → fatal error. |
+| `tls.cert`       | path        | required if `[admin.tls]` | PEM certificate chain. Present `[admin.tls]` with a missing/empty `cert` → fatal error. |
+| `tls.key`        | path        | required if `[admin.tls]` | PEM private key. Loaded at startup (fail-loud) and **hot-reloaded on `SIGHUP`** alongside `[sip.tls]`, so cert rotation needs no restart. |
+
+### `[admin.tls]` — encrypt the admin listener (0.18.0)
+
+The bearer token authenticates the operator, but on a **plain-HTTP** listener
+it travels in the clear — fine on `127.0.0.1`, not on a routable bind. Set
+`[admin.tls]` to serve `/admin/*` over HTTPS directly (no proxy needed):
+
+- Both `cert` and `key` are required when `[admin.tls]` is present; a missing
+  or empty value fails the load.
+- The cert is **hot-reloaded on `SIGHUP`** (same mechanism as `[sip.tls]`):
+  the next connection picks up the new cert, in-flight ones keep theirs. A
+  broken PEM on reload keeps the previous cert (nginx-style), never crashes.
+  The `siphon_ai_admin_tls_reload_attempts_total{outcome}` counter tracks it.
+- Without `[admin.tls]`, a non-loopback `listen` still works but logs a
+  startup warning — bind loopback or front it with a TLS-terminating proxy.
 
 Validation is at load time (CLAUDE.md §4.6): no tokens, an empty name or
-secret, a duplicate name, an unknown role, or an unparseable `listen` all
-fail the daemon at startup rather than at first request.
+secret, a duplicate name, an unknown role, an unparseable `listen`, or
+`[admin.tls]` missing a cert/key all fail the daemon at startup rather than at
+first request.
 
 ## `[webhooks]`
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -114,7 +114,7 @@ operator's network, and the daemon container.
 | `[sip.tls].listen`| TCP    | TOML           | inbound   | TLS signaling. Defaults to the SIP IP + 5061. |
 | `[media].rtp_port_range` | UDP | TOML       | both      | RTP/RTCP. Forge allocates one even-numbered RTP port + the next odd RTCP port per call. Forward the whole range. |
 | `[observability].http_listen` | TCP | TOML  | inbound (cluster-local) | `/metrics`, `/health`, `/ready`. Unauthenticated — keep it cluster-local. Since 0.10.0 `/admin/*` is **not** served here (returns `404`); it moved to the dedicated `[admin]` listener below. |
-| `[admin].listen`  | TCP    | TOML           | inbound (cluster-local) | `/admin/*` control plane (0.10.0). Bearer-token auth + RBAC (`readonly` ⊂ `operator` ⊂ `admin`); omit `[admin]` and `/admin/*` isn't served at all. Still keep it off the public internet. |
+| `[admin].listen`  | TCP    | TOML           | inbound (cluster-local) | `/admin/*` control plane (0.10.0). Bearer-token auth + RBAC (`readonly` ⊂ `operator` ⊂ `admin`); omit `[admin]` and `/admin/*` isn't served at all. Set `[admin.tls]` (0.18.0) to serve HTTPS so the token is encrypted on a routable bind. Still keep it off the public internet. |
 | Outbound, dynamic | TCP    | `[bridge].ws_url` (per route) | outbound | WebSocket from daemon to operator's WS server. |
 | Outbound, dynamic | TCP    | `[cdr.webhook].url`, `[webhooks].url` | outbound | HTTP POSTs for CDRs and lifecycle webhooks. |
 | Outbound 9060     | UDP    | `[hep].collector` | outbound | HEP3 to Homer. UDP only in v1. |
@@ -523,8 +523,8 @@ reference in `docs/CONFIG.md` `[admin]`):
 ```toml
 [admin]
 # Dedicated listener for /admin/*. Bind to loopback (or a private
-# interface) — it is plain HTTP until native [admin].tls lands, so
-# front it with TLS termination if it must leave the host.
+# interface). On a routable bind, set [admin.tls] below so the bearer
+# token is encrypted on the wire (otherwise it's plain HTTP).
 listen = "127.0.0.1:9092"
 
 # One block per token. The secret is hashed (SHA-256) at load and
@@ -544,6 +544,14 @@ role  = "operator"
 name  = "automation"
 token = "${SIPHON_ADMIN_ADMIN}"
 role  = "admin"
+
+# Optional (0.18.0): serve /admin/* over HTTPS so the bearer token is
+# encrypted on a routable bind — no TLS-terminating proxy needed. Both
+# cert and key are required; the cert hot-reloads on SIGHUP (same as
+# [sip.tls]). Secret paths can use ${file:…}/${cred:…} too.
+[admin.tls]
+cert = "/etc/siphon-ai/admin.crt"
+key  = "/etc/siphon-ai/admin.key"
 ```
 
 Roles, lowest to highest (each inherits everything below it):
@@ -562,7 +570,7 @@ role, endpoint template, result, peer address — never the secret) and the
 A bearer token goes on every call:
 
 ```sh
-ADMIN=http://127.0.0.1:9092
+ADMIN=http://127.0.0.1:9092          # https://… when [admin.tls] is set
 curl -s -H "Authorization: Bearer $SIPHON_ADMIN_RO" $ADMIN/admin/calls
 # missing/invalid token → 401 + WWW-Authenticate: Bearer
 # token below the endpoint's min role → 403
@@ -986,6 +994,7 @@ on the metrics crate's defaults (CLAUDE.md §7.4).
 | `siphon_ai_rtp_packet_loss_ratio`       | histogram | —                                     | Packet-loss ratio (0.0-1.0) recorded on every `rtp_stats` emission. |
 | `siphon_ai_rtp_rtt_ms`                  | histogram | —                                     | RTCP-derived round-trip time (ms) per received Receiver Report (RFC 3550 §A.7). Populated since 0.3.2 (forge originates SRs); explicit buckets 10ms–1s. Records a sample roughly every RTCP cycle (~5s) once bidirectional RTCP is flowing. |
 | `siphon_ai_sip_tls_reload_attempts_total` | counter | `outcome=ok\|failed`                  | One tick per SIGHUP cert-reload attempt. `failed` means a broken cert/key on disk; the listener keeps serving the previous cert. |
+| `siphon_ai_admin_tls_reload_attempts_total` | counter | `outcome=ok\|failed`                | Same as above for the `[admin.tls]` listener cert (0.18.0). One tick per SIGHUP admin-cert reload; `failed` keeps the previous cert. Only emitted when `[admin.tls]` is configured. |
 | `siphon_ai_config_reloads_total`        | counter   | `result=applied\|no_change\|failed`   | SIGHUP config-file reloads (0.12.0). `applied` = a changed config loaded and the hot-reloadable sections (routes, webhook/CDR sinks) were swapped; `no_change` = the file was byte-identical to the last load; `failed` = the new config didn't load/compile and the running config was kept. Alert on `failed` after a deploy. |
 | `siphon_ai_conference_joins_total`      | counter   | `result=joined\|disabled\|too_many_rooms\|room_full\|rate_mismatch\|already_joined\|error` | Conference joins attempted (0.7.0). Every non-`joined` row leaves the call on its direct caller↔WS pair. |
 | `siphon_ai_conferences_active`          | gauge     | —                                     | Live conference rooms (0.7.0). A room spawns on first join and exits when its last member leaves. |


### PR DESCRIPTION
Second chunk of **v0.18.0** (P1 *Security & abuse hardening* theme; design note `docs/design/DESIGN_SECURITY_HARDENING.md`, decisions 6). Builds on the secret resolver (#246).

## What

The authenticated `[admin]` listener can now serve **HTTPS** directly, so the bearer token is encrypted on the wire on a routable bind — no TLS-terminating proxy required.

```toml
[admin]
listen = "0.0.0.0:9092"
[[admin.token]]
name = "ops"; token = "${cred:admin_token}"; role = "operator"
[admin.tls]                      # optional; off → plain HTTP as before
cert = "${file:/etc/siphon/admin.crt}"
key  = "/etc/siphon/admin.key"
```

## How

- **Config** — `[admin.tls] { cert, key }`. Both required when the table is present; missing/empty → fatal at load (`AdminTlsCertRequired`/`AdminTlsKeyRequired`). Paths expand like any string, so `${file:…}`/`${cred:…}` from #246 work for the key too.
- **Telemetry** — `AdminServer::start` takes an optional `AdminTlsConfigFn` (a closure returning the *live* `ServerConfig`). The accept loop builds a fresh `TlsAcceptor` per connection from it, so a SIGHUP cert rotation is picked up by the next connection. Plain-HTTP and HTTPS share a generic `serve_admin_conn`. Adds `tokio-rustls` to the crate (already a workspace dep); the closure keeps `arc_swap` out of telemetry. Handshake failures are `debug`, not `warn`.
- **Runtime** — `[admin.tls]` loads into an `Arc<ArcSwap<ServerConfig>>` at startup (fail-loud, before the SIGHUP handler is wired), the same shape as `[sip.tls]`. `build_admin` builds the live-config closure and only warns on a non-loopback bind when TLS is **absent**. SIGHUP folds admin-cert reload in next to SIP via shared `reload_{sip,admin}_tls_cert` helpers (both the config-file reloader and the no-config path). A broken PEM on reload keeps the previous cert (nginx-style).

## Decision honored

Decision 6 (§5): **hot-reload via the SIP-TLS `Swappable` pattern**, not restart-required.

## Observability

New `siphon_ai_admin_tls_reload_attempts_total{outcome=ok|failed}` counter (only when `[admin.tls]` is set). Listener startup log carries `tls=true/false`.

## Tests

- Config: cert+key present / key-missing / empty-cert / env-expanded / absent (5 new).
- Runtime: `load_admin_tls_server_config` returns a usable config; the shared `reload_admin_tls_cert` helper swaps on a good cert and **keeps the old cert on a failed reload** — reusing the existing TLS fixtures.
- Full workspace `clippy --all-targets -D warnings` + `cargo test` green; `fmt --check` clean.

## Docs

`docs/CONFIG.md` `[admin.tls]` section + field table; `docs/DEPLOY.md` admin-auth example, listener table, metric; `admin.rs` threat model; `CHANGELOG`.

## Next

This completes the v0.18.0 feature surface (secret resolver + admin TLS). Next is the **release chunk** — version bump to 0.18.0, `CHANGELOG` finalize, tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
