### PR TITLE
chore(release): 0.18.0 — admin TLS + file/systemd secret sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-06-26
+
 ### Added
 
 - **Admin listener TLS — `[admin.tls]`** (P1 "Security & abuse hardening";

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2937,7 +2937,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "base64",
  "bytes",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2975,7 +2975,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "regex",
  "serde",
@@ -2993,7 +2993,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3035,7 +3035,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "hmac",
  "http-body-util",
@@ -3055,7 +3055,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "thiserror 1.0.69",
  "tokio",
@@ -3088,7 +3088,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "regex",
  "serde",
@@ -3100,7 +3100,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3133,7 +3133,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3175,7 +3175,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.17.0.** Production-deployed against real carriers
+**Current release: v0.18.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a


### PR DESCRIPTION
Release-prep for **v0.18.0** — the first release of the P1 *Security & abuse hardening* theme (design note `docs/design/DESIGN_SECURITY_HARDENING.md`).

Moves the workspace version `0.17.0 → 0.18.0` across the three sources the consistency gate checks, in one commit:
- `Cargo.toml` `[workspace.package].version` (+ `Cargo.lock` refresh, 14 crates),
- `CHANGELOG.md` — `## [Unreleased]` → `## [0.18.0] - 2026-06-26` (+ fresh empty `[Unreleased]`),
- `README.md` `**Current release: v0.18.0**` marker.

## What ships in 0.18.0

- **Secret resolution from files & systemd credentials** (#246) — config `${file:/path}` / `${cred:NAME}` references keep secrets out of the process environment.
- **Admin listener TLS, `[admin.tls]`** (#247) — serve `/admin/*` over HTTPS with SIGHUP cert hot-reload; the bearer token is encrypted on a routable bind without a proxy.

Both off by default; no protocol / CDR / config-schema break.

## Gates (verified locally)

```
$ python3 scripts/check-version-consistency.py            # Version consistent: 0.18.0.
$ python3 scripts/check-version-consistency.py --tag v0.18.0  # tag == version
$ python3 scripts/extract-changelog.py 0.18.0             # notes present
```

## After merge

Tag `v0.18.0` on the merged commit and push → the `release` workflow builds the multi-arch musl binaries + `.deb`s, SBOM, checksums, cosign signatures, the GitHub release (Latest), and the signed GHCR container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
