### PR TITLE
chore(release): 0.20.0 — signed audit-event stream ([audit])

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-07-01
+
+### Added
+
+- **Signed audit-event stream — `[audit]`** (P1 "Security & abuse
+  hardening"; the last sub-item of the theme). A tamper-evident trail of
+  admin and security decisions for SIEM ingestion — *who did what* on the
+  `[admin]` surface and *what the daemon refused* on the SIP surface —
+  distinct from `[webhooks]` (ops automation) and `[cdr]` (billing).
+  Ships to an append-only JSONL **file** (`[audit.file]`, for a log
+  shipper) and/or an HMAC-signed **webhook** (`[audit.webhook]`, for a
+  SIEM collector); enable either or both. The webhook reuses the 0.11.0
+  delivery transport, so the `X-SiphonAI-Signature` HMAC (the
+  tamper-evidence), `X-SiphonAI-Event-Id` idempotency, durable spool, and
+  the `siphon_ai_webhook_*` delivery metrics (label `sink="audit"`) all
+  behave identically. Six event types — `admin_request`, `sip_auth`,
+  `invite_rejected`, `attestation_rejected`, `config_reload`,
+  `cert_reload` — with an `events` allowlist. Emission is deliberately
+  signal-first: `invite_rejected` records admission `rate_limited` /
+  `no_trunk` / `draining` but **not** the per-packet silent flood-drop
+  (auditing that DoS-shedding fast path would amplify the attack), and
+  `sip_auth` records `failed` / `stale` but **not** the normal per-call
+  `challenged` / `ok`. Off by default; hot-reloadable on `SIGHUP` when
+  enabled at startup (enabling from off is restart-required). Best-effort
+  and off the call path — a slow SIEM never blocks an admin request or a
+  SIP transaction. New `docs/AUDIT.md`; see also `docs/CONFIG.md` →
+  `[audit]`. Completes the P1 security & abuse hardening theme.
+
 ## [0.19.0] - 2026-06-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2938,7 +2938,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2954,7 +2954,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "base64",
  "bytes",
@@ -2975,7 +2975,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2992,7 +2992,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "regex",
  "serde",
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3053,7 +3053,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "hmac",
  "http-body-util",
@@ -3073,7 +3073,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "thiserror 1.0.69",
  "tokio",
@@ -3106,7 +3106,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "regex",
  "serde",
@@ -3118,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3127,7 +3127,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3154,7 +3154,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.19.0.** Production-deployed against real carriers
+**Current release: v0.20.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -79,12 +79,17 @@ internet-facing daemons (especially trunks without a static carrier IP):
 - **Per-source INVITE rate limits + admission control** — a DoS posture
   beyond the allowlist, complementing the existing fail2ban recipe.
 
-### Signed audit-event stream
-Admin requests are logged + metered, but there's no tamper-evident, shippable
-audit trail. (Explicitly deferred from the admin-auth theme.)
+### Signed audit-event stream — ✅ delivered in v0.20.0
+Admin requests were logged + metered, but there was no tamper-evident,
+shippable audit trail. (Explicitly deferred from the admin-auth theme.)
 
-- Emit admin/security events as a signed webhook / HEP stream for SIEM
-  ingestion (reuse the 0.11.0 HMAC signer).
+- **Delivered:** `[audit]` — admin/security events (`admin_request`,
+  `sip_auth`, `invite_rejected`, `attestation_rejected`, `config_reload`,
+  `cert_reload`) emitted to an append-only JSONL file and/or an HMAC-signed
+  webhook for SIEM ingestion, reusing the 0.11.0 signer. A HEP audit stream
+  remains a possible follow-up. **This completes the P1 security & abuse
+  hardening theme** — only STIR/SHAKEN outbound signing (below) remains, and
+  it's scoped as its own demand-gated effort.
 
 ### STIR/SHAKEN outbound signing
 SiphonAI *verifies* inbound attestation (0.4.0) but cannot *sign* outbound


### PR DESCRIPTION
Release-prep for **v0.20.0** (the signed audit-event stream landed in #252).

Moves the three version-locked files together (the `version consistency` CI gate requires it) plus the roadmap:

- `Cargo.toml` `[workspace.package].version` → `0.20.0` (+ `Cargo.lock` refresh)
- `CHANGELOG.md` — date the `## [0.20.0] - 2026-07-01` section, open a fresh `## [Unreleased]`
- `README.md` — `**Current release: v0.20.0**`
- `docs/ROADMAP.md` — mark the audit-event stream **delivered**, which **completes the P1 security & abuse hardening theme** (only STIR/SHAKEN outbound signing remains, scoped separately)

Preflight verified locally:
- `check-version-consistency.py` → `Version consistent: 0.20.0`
- `check-version-consistency.py --tag v0.20.0` → consistent
- `extract-changelog.py 0.20.0` → notes present

After merge: tag `v0.20.0` on the merged commit and push to trigger the release pipeline (per `RELEASING.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)