### PR TITLE
feat(observability): dashboards & alerts as code (v0.21.0)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,25 @@ jobs:
       - name: Check version consistency
         run: python3 scripts/check-version-consistency.py
 
+  observability-artifacts:
+    name: observability artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Anti-drift: every siphon_ai_* metric referenced in the shipped
+      # Prometheus rules / Grafana dashboards under examples/observability/
+      # must be a metric the daemon actually emits, so a metric rename can't
+      # ship silently-broken artifacts. Pure Python (stdlib).
+      - name: Check observability metric names
+        run: python3 scripts/check-observability-metrics.py
+      # Validate the reference Prometheus config + rules parse (real PromQL
+      # + rule-structure check) using promtool from the Prometheus image.
+      - name: promtool check rules + config
+        run: |
+          docker run --rm -v "$PWD/examples/observability":/work -w /work \
+            --entrypoint promtool prom/prometheus:latest \
+            check config prometheus.yml
+
   lint-and-test:
     name: fmt + clippy + cargo test
     runs-on: ubuntu-latest

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -970,6 +970,14 @@ should be incrementing across calls.
 All histograms have sensible default buckets defined explicitly — no reliance
 on the metrics crate's defaults (CLAUDE.md §7.4).
 
+> **Dashboards & alerts as code (0.21.0).** You don't have to author these
+> from scratch: [`examples/observability/`](../examples/observability/) ships
+> a runnable Prometheus + Grafana stack — recording rules, starting-point
+> alerting rules, and two Grafana dashboards (Fleet Overview + Call Quality)
+> built against the metrics below. `docker compose -f
+> examples/observability/compose.yaml up`. A CI check keeps the metric names
+> in those artifacts in sync with this table.
+
 | Metric                                  | Type      | Labels                                | What it measures |
 |-----------------------------------------|-----------|---------------------------------------|------------------|
 | `siphon_ai_invites_total`               | counter   | `result=accepted\|rejected\|rejected_attestation\|no_match` | INVITEs by acceptance outcome. `rejected_attestation` is a STIR/SHAKEN policy reject (`min_attestation` gate or `require_identity`) — separately alertable from ordinary routing/media `rejected`. |

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -18,8 +18,31 @@ evidence and flags any gaps.
 | `tracing` spans                     | Per-call latency between `on_invite` → `on_matched` → `accept_inbound` → `start_session` |
 | Homer UI (`http://.../`)            | SIP call flow + RTCP + CDR + log chunks correlated by SIP `Call-ID`                    |
 | Prometheus `/metrics`               | Counters / histograms; `siphon_ai_*` for app-level, `forge_*` for media, `heplify_*` for collector  |
+| Grafana dashboards                  | Fleet Overview + Call Quality — shipped in [`examples/observability/`](../examples/observability/) (rates, ratios, latency percentiles) |
 | CDR (file / webhook)                | One JSON record per ended call with codec, route, termination cause, durations         |
 | `/admin/*`                          | Live state — active calls, registration status, log filter, HEP probe, drain status     |
+
+## Dashboards & alerts as code
+
+[`examples/observability/`](../examples/observability/) ships a runnable
+Prometheus + Grafana stack — recording rules, alerting rules, and two Grafana
+dashboards — so the metrics below come with visualizations and pages out of
+the box (`docker compose -f examples/observability/compose.yaml up`). Where a
+question below is answerable from metrics, the worked PromQL and the panel /
+alert that covers it are called out. **Prometheus/Grafana for the aggregate
+(rates, ratios, latency percentiles); Homer for the individual call** (SIP
+flow + per-stream RTP quality); the daemon log for the per-call *why*.
+
+Symptom → where to look first:
+
+| Symptom | Dashboard / alert | Then |
+|---|---|---|
+| Callers turned away | `SiphonAIHighInviteRejectRate`; Fleet → *INVITE rate by outcome* | break down `siphon_ai_invites_total` by `result`; Q1 |
+| Dead air at answer | `SiphonAISlowWsConnect`; Call Quality → *WS connect latency* | WS server health; Q5 |
+| Choppy / laggy audio | `SiphonAIHighRtpRtt` / `SiphonAIHighPacketLoss`; Call Quality → RTP panels | Homer RTP-QoS per leg; Q6 |
+| Not receiving calls | `SiphonAIRegistrationDown` / `SiphonAINoInboundCalls` | Q10; upstream trunk |
+| Events not reaching a SIEM/billing | `SiphonAIWebhookSpoolBacklog` / `SiphonAIWebhookDeliveryFailing`; Fleet → delivery panels | receiver health |
+| Rough deploy | `SiphonAIDrainForced` | lengthen `[shutdown].drain_timeout_secs` |
 
 ## The §11.8 ten questions
 
@@ -103,8 +126,18 @@ For systemic latency tracking the daemon exposes:
 - `siphon_ai_ws_connect_seconds` (histogram)
 - `siphon_ai_call_duration_seconds` (histogram of total call wall time)
 
-Pipe to Grafana; `histogram_quantile(0.99, ...)` per stage gives
-the headline numbers.
+The shipped rules pre-compute the percentiles — query the recorded series
+(no `histogram_quantile` in the panel):
+
+```promql
+siphon_ai:ws_connect_seconds:p99      # bridge to WS handshake + start
+siphon_ai:sdp_negotiate_seconds:p99   # SDP parse + port alloc + tap attach
+siphon_ai:call_duration_seconds:p95
+```
+
+The **Call Quality** dashboard (`examples/observability/`) plots all three.
+Raw form if you need an ad-hoc quantile:
+`histogram_quantile(0.99, sum by (le) (rate(siphon_ai_ws_connect_seconds_bucket[5m])))`.
 
 ### 5. Was the WS server slow to respond?
 
@@ -117,7 +150,9 @@ INFO connect_and_run{call_id=… ws_url=ws://echo-ws:8765/}:
 
 The histogram captures the time from `connect_and_run` start to
 "bridge connected." For per-call rather than aggregate, subtract
-log timestamps.
+log timestamps. The `SiphonAISlowWsConnect` alert fires on
+`siphon_ai:ws_connect_seconds:p99 > 1` for 10m — a slow WS server (or the
+network to it) means callers hear dead air at answer.
 
 **Gap:** The CDR doesn't carry `first_audio_out_ms` — the time
 from `bridge connected` to the first audio frame from the WS
@@ -145,6 +180,17 @@ look at the QoS panel."
 Prometheus also exposes `forge_rtcp_packet_loss_fraction`,
 `forge_rtcp_packets_lost_total` (gauges over the most recent
 RR), and `forge_rtcp_jitter_ms` for dashboards.
+
+For the aggregate view, SiphonAI's own histograms drive the **Call Quality**
+dashboard and two alerts:
+
+```promql
+siphon_ai:rtp_rtt_ms:p95              # SiphonAIHighRtpRtt        (> 300ms/10m)
+siphon_ai:rtp_packet_loss_ratio:p95   # SiphonAIHighPacketLoss    (> 5%/10m)
+```
+
+These tell you *a fleet-wide quality problem is happening*; drop to Homer's
+per-leg RTP-QoS panel to see *which stream*.
 
 ### 7. What did the SIP exchange actually look like?
 
@@ -218,8 +264,11 @@ WARN registration drive task ended with error error=…
 ```
 
 The Prometheus gauge `siphon_ai_register_state{name="…", state="…"}`
-tracks the current row of every `[[register]]` block; alert on
-`failed` or `disabled` to catch outages.
+tracks the current row of every `[[register]]` block; the shipped
+`SiphonAIRegistrationDown` alert fires when a name has not been in the
+`registered` state for 5m (`max by (name) (siphon_ai_register_state{state="registered"}) < 1`),
+and the **Fleet Overview** dashboard shows the registered count. Inbound
+calls to a non-registered AOR won't arrive, so this is a `critical`.
 
 The question's premise belongs to a B2BUA model where one
 mis-routed call could break a downstream registration. SiphonAI

--- a/examples/observability/README.md
+++ b/examples/observability/README.md
@@ -1,0 +1,68 @@
+# SiphonAI observability example — Prometheus + Grafana
+
+Shipped, ready-to-run **dashboards and alerts as code** for a SiphonAI fleet.
+SiphonAI exposes 40-plus `siphon_ai_*` Prometheus metrics on its
+`[observability]` listener (`/metrics`, default `127.0.0.1:9091`); this
+directory turns them into recording rules, alerts, and two Grafana dashboards
+you can drop into an existing stack or run standalone.
+
+For per-call SIP flow and per-stream RTP quality, pair this with
+[`../homer-stack/`](../homer-stack/) (HEP → Homer). Rule of thumb: **Prometheus
++ Grafana here for rates, ratios, and latency percentiles; Homer for the
+individual call.** The `docs/OPERATIONS.md` "ten questions" runbook says which
+to open for a given symptom.
+
+## What's here
+
+```
+prometheus.yml                 reference scrape config (+ loads the rules)
+rules/recording.yml            pre-aggregated rates / ratios / latency percentiles
+rules/alerting.yml             starting-point alerts (availability, calls, latency,
+                               delivery, security, shutdown)
+grafana/
+  provisioning/                datasource (uid siphonai-prom) + dashboard provider
+  dashboards/
+    siphon-ai-fleet.json       Fleet Overview — volume, outcomes, routes,
+                               registrations, delivery health, drain
+    siphon-ai-call-quality.json  Call Quality — WS/SDP/duration latency, RTP RTT
+                               & loss, conference mixer health
+compose.yaml                   Prometheus + auto-provisioned Grafana
+```
+
+## Run it
+
+```sh
+docker compose -f examples/observability/compose.yaml up
+```
+
+- **Grafana** → http://127.0.0.1:3000 (`admin` / `admin`) — both dashboards
+  are pre-loaded under the `siphon-ai` tag.
+- **Prometheus** → http://127.0.0.1:9090 — check *Status → Rules* and *Alerts*.
+
+By default Prometheus scrapes a daemon at `siphon-ai:9091` (mapped to the
+host gateway, so a daemon running on the host is reachable). Point it at your
+own daemon(s) by editing [`prometheus.yml`](prometheus.yml).
+
+Reference-only: ports are published on loopback, credentials are defaults,
+and there's no storage persistence. Harden before any shared use.
+
+## Tuning
+
+Thresholds and `for:` windows in `rules/alerting.yml` are conservative
+defaults — set them to your SLOs and traffic shape. The recording rules use
+`[5m]` windows; widen for quieter fleets. Wire your own Alertmanager under
+`prometheus.yml`'s `alerting:` block (intentionally omitted here).
+
+## Kept honest by CI
+
+`scripts/check-observability-metrics.py` (run in CI) asserts every
+`siphon_ai_*` metric referenced in these rules and dashboards is a metric the
+daemon actually emits, and `promtool check config` validates the PromQL — so
+a metric rename can't ship silently-broken artifacts. If you add a panel or
+rule for a new metric, both run locally too:
+
+```sh
+python3 scripts/check-observability-metrics.py
+docker run --rm -v "$PWD/examples/observability":/work -w /work \
+  --entrypoint promtool prom/prometheus:latest check config prometheus.yml
+```

--- a/examples/observability/compose.yaml
+++ b/examples/observability/compose.yaml
@@ -1,0 +1,50 @@
+# Reference metrics stack for SiphonAI: Prometheus + Grafana, auto-provisioned
+# with the recording/alerting rules and dashboards in this directory.
+#
+#   docker compose -f examples/observability/compose.yaml up
+#
+# Then open Grafana at http://127.0.0.1:3000 (admin / admin — change it, or
+# it's fine for a throwaway lab). The two SiphonAI dashboards are pre-loaded.
+#
+# This stack scrapes a daemon at `siphon-ai:9091` by default (see
+# prometheus.yml). Point it at your daemon by editing prometheus.yml, or run
+# a daemon reachable on that name (e.g. add it to this compose, or use
+# `extra_hosts` / a shared network). It composes cleanly alongside
+# examples/homer-stack/ — Prometheus/Grafana for rates + latency, Homer for
+# per-call SIP flow + per-stream RTP quality.
+#
+# Reference-only: loopback-published ports, default creds, no persistence.
+
+name: siphon-ai-observability
+
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.retention.time=7d
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./rules:/etc/prometheus/rules:ro
+    ports:
+      - "127.0.0.1:9090:9090"
+    # Let the daemon on the host be scraped as `siphon-ai:9091` when it runs
+    # outside compose. Harmless if you instead add a siphon-ai service here.
+    extra_hosts:
+      - "siphon-ai:host-gateway"
+
+  grafana:
+    image: grafana/grafana:latest
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      # Reference lab only — do not expose this to a network.
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+    ports:
+      - "127.0.0.1:3000:3000"
+    depends_on:
+      - prometheus

--- a/examples/observability/grafana/dashboards/siphon-ai-call-quality.json
+++ b/examples/observability/grafana/dashboards/siphon-ai-call-quality.json
@@ -1,0 +1,85 @@
+{
+  "uid": "siphonai-call-quality",
+  "title": "SiphonAI — Call Quality & Latency",
+  "tags": ["siphon-ai"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "editable": true,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": { "text": "Prometheus", "value": "siphonai-prom" },
+        "hide": 0
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "WS connect latency (p50 / p99)",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "siphon_ai:ws_connect_seconds:p50", "legendFormat": "p50" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "siphon_ai:ws_connect_seconds:p99", "legendFormat": "p99" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "SDP negotiate latency (p99)",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "siphon_ai:sdp_negotiate_seconds:p99", "legendFormat": "p99" } ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Call duration (p50 / p95)",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "siphon_ai:call_duration_seconds:p50", "legendFormat": "p50" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "siphon_ai:call_duration_seconds:p95", "legendFormat": "p95" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "RTP round-trip time p95 (ms)",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "ms", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "siphon_ai:rtp_rtt_ms:p95", "legendFormat": "p95 RTT" } ]
+    },
+    {
+      "type": "timeseries",
+      "title": "RTP packet-loss ratio p95",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "siphon_ai:rtp_packet_loss_ratio:p95", "legendFormat": "p95 loss" } ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Conference mix tick lag p99",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "siphon_ai:room_tick_lag_seconds:p99", "legendFormat": "p99 lag" } ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Conference room frames dropped",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum by (stage, side) (rate(siphon_ai_room_frames_dropped_total[5m]))", "legendFormat": "{{stage}}/{{side}}" } ]
+    }
+  ]
+}

--- a/examples/observability/grafana/dashboards/siphon-ai-fleet.json
+++ b/examples/observability/grafana/dashboards/siphon-ai-fleet.json
@@ -1,0 +1,119 @@
+{
+  "uid": "siphonai-fleet",
+  "title": "SiphonAI — Fleet Overview",
+  "tags": ["siphon-ai"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "editable": true,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": { "text": "Prometheus", "value": "siphonai-prom" },
+        "hide": 0
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Active calls",
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "color": "green", "value": null } ] } }, "overrides": [] },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(siphon_ai_calls_active)" } ]
+    },
+    {
+      "type": "stat",
+      "title": "Outbound active",
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(siphon_ai_outbound_calls_active)" } ]
+    },
+    {
+      "type": "stat",
+      "title": "INVITE reject ratio (5m)",
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1, "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 0.1 }, { "color": "red", "value": 0.2 } ] } }, "overrides": [] },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "siphon_ai:invite_reject_ratio:5m" } ]
+    },
+    {
+      "type": "stat",
+      "title": "Registrations registered",
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(siphon_ai_register_state{state=\"registered\"})" } ]
+    },
+    {
+      "type": "stat",
+      "title": "Draining nodes",
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "color": "green", "value": null }, { "color": "orange", "value": 1 } ] } }, "overrides": [] },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(siphon_ai_draining)" } ]
+    },
+    {
+      "type": "stat",
+      "title": "Active conferences",
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(siphon_ai_conferences_active)" } ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Inbound INVITE rate by outcome",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 15, "stacking": { "mode": "normal" } } }, "overrides": [] },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "siphon_ai:invites:rate5m", "legendFormat": "{{result}}" } ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Ended calls by cause",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 15, "stacking": { "mode": "normal" } } }, "overrides": [] },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "siphon_ai:calls:rate5m", "legendFormat": "{{cause}}" } ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Call rate by route",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "siphon_ai:route_match:rate5m", "legendFormat": "{{route}}" } ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Outbound call outcomes",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "siphon_ai:outbound_calls:rate5m", "legendFormat": "{{result}}" } ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Webhook/CDR/audit delivery success ratio",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 20 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1, "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "siphon_ai:webhook_delivery_success_ratio:5m", "legendFormat": "{{sink}}" } ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Delivery spool depth by sink",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 20 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "max by (sink) (siphon_ai_webhook_spool_depth)", "legendFormat": "{{sink}}" } ]
+    }
+  ]
+}

--- a/examples/observability/grafana/provisioning/dashboards/dashboards.yml
+++ b/examples/observability/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,13 @@
+# Loads every dashboard JSON under /var/lib/grafana/dashboards on startup.
+apiVersion: 1
+
+providers:
+  - name: siphon-ai
+    orgId: 1
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/examples/observability/grafana/provisioning/datasources/prometheus.yml
+++ b/examples/observability/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,12 @@
+# Provisions the Prometheus datasource the bundled dashboards reference by a
+# fixed uid (`siphonai-prom`), so they load without any manual wiring.
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: siphonai-prom
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true

--- a/examples/observability/prometheus.yml
+++ b/examples/observability/prometheus.yml
@@ -1,0 +1,36 @@
+# Reference Prometheus scrape config for SiphonAI.
+#
+# SiphonAI exposes Prometheus metrics on the [observability] listener
+# (`[observability].http_listen`, default 127.0.0.1:9091) at /metrics —
+# unauthenticated by design (metrics/health are safe to scrape; the
+# privileged surface is the separate authenticated [admin] listener).
+#
+# This is a starting point: set the target(s) to your daemon(s), tune the
+# scrape interval to your retention budget, and load the rule files. The
+# recording/alerting rules and the Grafana dashboards in this directory are
+# authored against the metric names this config scrapes.
+
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+rule_files:
+  - rules/recording.yml
+  - rules/alerting.yml
+
+scrape_configs:
+  - job_name: siphon-ai
+    metrics_path: /metrics
+    static_configs:
+      # One entry per daemon. In the bundled compose stack the daemon is
+      # reachable as `siphon-ai:9091`; for a host-run daemon use
+      # 127.0.0.1:9091 (or the [observability].http_listen you configured).
+      - targets: ["siphon-ai:9091"]
+        labels:
+          # `instance` is set from the target by default; add any fleet
+          # dimensions you slice on (region, pool, node) here.
+          service: siphon-ai
+
+# Alertmanager is intentionally omitted from this reference — wire your own
+# under `alerting:` / `alertmanagers:`. The alerting rules fire regardless;
+# without an Alertmanager they're visible in Prometheus' Alerts page.

--- a/examples/observability/rules/alerting.yml
+++ b/examples/observability/rules/alerting.yml
@@ -1,0 +1,191 @@
+# SiphonAI alerting rules — reference.
+#
+# Starting-point alerts for the signals an operator actually gets paged on.
+# Thresholds and `for:` durations are deliberately conservative defaults —
+# tune them to your SLOs and traffic. Each alert links to the relevant
+# docs/OPERATIONS.md question so the responder knows where to look first.
+#
+# These reference recorded series from recording.yml where it keeps the
+# expression readable, and raw metrics otherwise. Metric names are checked
+# against crates/telemetry/src/metrics.rs by CI
+# (scripts/check-observability-metrics.py).
+
+groups:
+  - name: siphon_ai.availability
+    rules:
+      - alert: SiphonAITargetDown
+        expr: up{job="siphon-ai"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "SiphonAI /metrics target {{ $labels.instance }} is down"
+          description: >
+            Prometheus cannot scrape {{ $labels.instance }}. The daemon may be
+            down, or its [observability] listener unreachable. Check /health
+            and /ready on the same listener, and the process/unit status.
+
+      - alert: SiphonAIRegistrationDown
+        # A [[register]] endpoint stuck out of the "registered" state. The
+        # gauge is 1 for a name's current state; alert when a known name has
+        # been non-registered for a while.
+        expr: max by (name) (siphon_ai_register_state{state="registered"}) < 1
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "SiphonAI registration {{ $labels.name }} is not registered"
+          description: >
+            The [[register]] endpoint {{ $labels.name }} has not been in the
+            `registered` state for 5m — inbound calls to that AOR won't arrive.
+            See OPERATIONS.md Q10 (registration state) and the daemon's
+            register-state transition logs.
+
+  - name: siphon_ai.calls
+    rules:
+      - alert: SiphonAIHighInviteRejectRate
+        expr: siphon_ai:invite_reject_ratio:5m > 0.2
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "SiphonAI is rejecting {{ $value | humanizePercentage }} of INVITEs"
+          description: >
+            Over 20% of inbound INVITEs have been refused for 10m
+            (admission / trunk allowlist / attestation / no-route). Break down
+            by `result` on siphon_ai_invites_total. See OPERATIONS.md Q1
+            (routing) and the [sip.admission] / [[trunk]] / [security] config.
+
+      - alert: SiphonAINoInboundCalls
+        # Dead-air: the daemon is up but has taken no INVITEs. Only meaningful
+        # for always-on inbound deployments — disable or lengthen `for:` for
+        # bursty / outbound-only nodes.
+        expr: sum(rate(siphon_ai_invites_total[5m])) == 0 and on() up{job="siphon-ai"} == 1
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "SiphonAI has received no INVITEs for 15m"
+          description: >
+            The daemon is up but has seen no inbound INVITEs for 15m. Expected
+            for an outbound-only or off-hours node; on an always-on inbound
+            trunk it usually means upstream (carrier / SBC / DNS) is not
+            delivering calls.
+
+  - name: siphon_ai.latency
+    rules:
+      - alert: SiphonAISlowWsConnect
+        # The bridge is slow to reach the developer's WS server + send `start`.
+        expr: siphon_ai:ws_connect_seconds:p99 > 1
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "SiphonAI WS-connect p99 is {{ $value | humanizeDuration }}"
+          description: >
+            p99 time from bridge spawn to WS handshake + `start` exceeds 1s for
+            10m — callers hear dead air at answer. Check the WS server's health
+            and the network path. See OPERATIONS.md Q5 (WS server slow?).
+
+      - alert: SiphonAIHighRtpRtt
+        expr: siphon_ai:rtp_rtt_ms:p95 > 300
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "SiphonAI RTP RTT p95 is {{ $value }}ms"
+          description: >
+            RTCP-derived round-trip time p95 exceeds 300ms for 10m — likely
+            audible latency / talk-over. For per-stream loss & jitter, see the
+            Homer RTP-QoS view (OPERATIONS.md Q6, audio quality).
+
+      - alert: SiphonAIHighPacketLoss
+        expr: siphon_ai:rtp_packet_loss_ratio:p95 > 0.05
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "SiphonAI RTP packet-loss p95 is {{ $value | humanizePercentage }}"
+          description: >
+            RTP packet-loss ratio p95 over 5% for 10m — degraded audio. Usually
+            a network-path problem toward the far end. Cross-check the Homer
+            RTP-QoS view for the affected legs (OPERATIONS.md Q6).
+
+  - name: siphon_ai.security
+    rules:
+      - alert: SiphonAISipAuthFailures
+        # Sustained bad digest credentials — brute-force or a misconfigured
+        # peer. Only emitted when [sip.auth] is enabled.
+        expr: sum(rate(siphon_ai_sip_auth_total{result="failed"}[5m])) > 1
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "SiphonAI inbound digest-auth failures at {{ $value | humanize }}/s"
+          description: >
+            Sustained inbound digest-auth failures for 10m — a brute-force
+            attempt or a peer with stale credentials. Pair with the fail2ban
+            recipe and the audit stream (sip_auth events). See CONFIG.md
+            [sip.auth].
+
+      - alert: SiphonAIAdmissionFlooding
+        # A source pushed past drop_after and is being silently dropped —
+        # an active flood. Only emitted when [sip.admission] is on.
+        expr: sum(rate(siphon_ai_invite_admission_total{result="dropped"}[5m])) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "SiphonAI is silently dropping flooding INVITEs"
+          description: >
+            Admission control has been hard-dropping INVITEs (past drop_after)
+            for 5m — a sustained flood from one or more sources. The node is
+            shedding load as designed; investigate the source(s) upstream.
+            See CONFIG.md [sip.admission].
+
+  - name: siphon_ai.delivery
+    rules:
+      - alert: SiphonAIWebhookSpoolBacklog
+        # Durable-spool depth rising = deliveries failing and backing up on disk.
+        expr: max by (sink) (siphon_ai_webhook_spool_depth) > 100
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "SiphonAI {{ $labels.sink }} spool depth is {{ $value }}"
+          description: >
+            The {{ $labels.sink }} delivery spool has held >100 entries for
+            15m — the receiver is unreachable or erroring. Healthy is 0. Check
+            the receiver endpoint and the delivery-attempt outcomes.
+
+      - alert: SiphonAIWebhookDeliveryFailing
+        expr: >
+          sum by (sink) (rate(siphon_ai_webhook_deliveries_total{result=~"dropped|rejected"}[10m]))
+          /
+          clamp_min(sum by (sink) (rate(siphon_ai_webhook_deliveries_total[10m])), 1e-9)
+          > 0.1
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "SiphonAI {{ $labels.sink }} deliveries {{ $value | humanizePercentage }} failing"
+          description: >
+            Over 10% of {{ $labels.sink }} deliveries dropped/rejected for 10m.
+            `rejected` = non-retryable 4xx (bad URL/auth/signature mismatch);
+            `dropped` = retry/spool budget exhausted or payload unserializable.
+
+  - name: siphon_ai.shutdown
+    rules:
+      - alert: SiphonAIDrainForced
+        # Calls were force-terminated at the drain deadline on shutdown — the
+        # drain window is too short for the call volume, or a deploy is racing it.
+        expr: increase(siphon_ai_calls_drain_forced_total[10m]) > 0
+        labels:
+          severity: warning
+        annotations:
+          summary: "SiphonAI force-terminated {{ $value }} call(s) at drain deadline"
+          description: >
+            One or more calls were cut at the [shutdown].drain_timeout deadline
+            rather than ending naturally. Lengthen the drain window (≤ the
+            orchestrator's terminationGracePeriodSeconds) or investigate stuck
+            calls.

--- a/examples/observability/rules/recording.yml
+++ b/examples/observability/rules/recording.yml
@@ -1,0 +1,93 @@
+# SiphonAI recording rules — reference.
+#
+# These pre-aggregate the raw `siphon_ai_*` metrics into the rates, ratios,
+# and latency percentiles the dashboards and alerts consume, so a query runs
+# once here instead of on every dashboard refresh / alert eval.
+#
+# Naming follows the Prometheus convention `level:metric:operation`, loosely:
+# the recorded series carry a `siphon_ai:` prefix so they're easy to spot.
+# The `[5m]` windows are a starting point — widen for quieter fleets.
+#
+# Metric names are validated against crates/telemetry/src/metrics.rs by
+# scripts/check-observability-metrics.py (CI). If you add a rule referencing
+# a new metric, that check keeps this file honest.
+
+groups:
+  - name: siphon_ai.calls.recording
+    interval: 15s
+    rules:
+      # Inbound INVITE rate by outcome (accepted|rejected|rejected_attestation|no_match).
+      - record: siphon_ai:invites:rate5m
+        expr: sum by (result) (rate(siphon_ai_invites_total[5m]))
+
+      # Fraction of inbound INVITEs refused (any non-accepted outcome). The
+      # headline "are we turning callers away?" number.
+      - record: siphon_ai:invite_reject_ratio:5m
+        expr: >
+          sum(rate(siphon_ai_invites_total{result=~"rejected|rejected_attestation"}[5m]))
+          /
+          clamp_min(sum(rate(siphon_ai_invites_total[5m])), 1e-9)
+
+      # Completed calls by termination cause.
+      - record: siphon_ai:calls:rate5m
+        expr: sum by (cause) (rate(siphon_ai_calls_total[5m]))
+
+      # Per-route call rate (route is a bounded label — operator routes).
+      - record: siphon_ai:route_match:rate5m
+        expr: sum by (route) (rate(siphon_ai_route_match_total[5m]))
+
+      # Outbound call outcomes (answered|busy|declined|no_answer|rejected|unreachable|failed).
+      - record: siphon_ai:outbound_calls:rate5m
+        expr: sum by (result) (rate(siphon_ai_outbound_calls_total[5m]))
+
+  - name: siphon_ai.latency.recording
+    interval: 15s
+    rules:
+      # End-to-end call-setup / bridge latencies (seconds). p50/p95/p99.
+      - record: siphon_ai:ws_connect_seconds:p99
+        expr: histogram_quantile(0.99, sum by (le) (rate(siphon_ai_ws_connect_seconds_bucket[5m])))
+      - record: siphon_ai:ws_connect_seconds:p50
+        expr: histogram_quantile(0.50, sum by (le) (rate(siphon_ai_ws_connect_seconds_bucket[5m])))
+      - record: siphon_ai:sdp_negotiate_seconds:p99
+        expr: histogram_quantile(0.99, sum by (le) (rate(siphon_ai_sdp_negotiate_seconds_bucket[5m])))
+      - record: siphon_ai:call_duration_seconds:p50
+        expr: histogram_quantile(0.50, sum by (le) (rate(siphon_ai_call_duration_seconds_bucket[5m])))
+      - record: siphon_ai:call_duration_seconds:p95
+        expr: histogram_quantile(0.95, sum by (le) (rate(siphon_ai_call_duration_seconds_bucket[5m])))
+
+      # RTCP round-trip time (milliseconds — note the _ms suffix / bucket unit).
+      - record: siphon_ai:rtp_rtt_ms:p95
+        expr: histogram_quantile(0.95, sum by (le) (rate(siphon_ai_rtp_rtt_ms_bucket[5m])))
+
+      # RTP packet-loss ratio (0.0-1.0) p95, sampled per rtp_stats emission.
+      # Prometheus-side audio-quality signal; Homer/HEP has per-stream detail.
+      - record: siphon_ai:rtp_packet_loss_ratio:p95
+        expr: histogram_quantile(0.95, sum by (le) (rate(siphon_ai_rtp_packet_loss_ratio_bucket[5m])))
+
+      # Conference mixer tick jitter past the 20ms cadence (seconds).
+      - record: siphon_ai:room_tick_lag_seconds:p99
+        expr: histogram_quantile(0.99, sum by (le) (rate(siphon_ai_room_tick_lag_seconds_bucket[5m])))
+
+  - name: siphon_ai.delivery.recording
+    interval: 15s
+    rules:
+      # Webhook / CDR / audit delivery success ratio, per sink
+      # (sink=lifecycle|cdr|audit). "delivered" over all terminal outcomes.
+      - record: siphon_ai:webhook_delivery_success_ratio:5m
+        expr: >
+          sum by (sink) (rate(siphon_ai_webhook_deliveries_total{result="delivered"}[5m]))
+          /
+          clamp_min(sum by (sink) (rate(siphon_ai_webhook_deliveries_total[5m])), 1e-9)
+
+      # Delivery latency p99 (seconds), per sink.
+      - record: siphon_ai:webhook_delivery_seconds:p99
+        expr: histogram_quantile(0.99, sum by (le, sink) (rate(siphon_ai_webhook_delivery_seconds_bucket[5m])))
+
+  - name: siphon_ai.registration.recording
+    interval: 15s
+    rules:
+      # Number of [[register]] endpoints currently in each state. The gauge
+      # is 1 for a name's current state and 0 for the others, so summing the
+      # `state` label gives a per-state count across the fleet.
+      - record: siphon_ai:register_endpoints:by_state
+        expr: sum by (state) (siphon_ai_register_state)

--- a/scripts/check-observability-metrics.py
+++ b/scripts/check-observability-metrics.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Anti-drift guard for the shipped observability artifacts.
+
+Every `siphon_ai_*` metric name referenced in the reference Prometheus rules
+and Grafana dashboards under `examples/observability/` must actually be a
+metric the daemon emits. A metric rename that forgets to update the
+rules/dashboards would otherwise ship silently-broken artifacts; this check
+(run in CI, same spirit as the version-consistency gate) fails loud instead.
+
+The "emitted" set is every `"siphon_ai_..."` string literal across the Rust
+workspace — not just the constants in `crates/telemetry/src/metrics.rs`,
+because several metrics (e.g. `siphon_ai_sip_auth_total`,
+`siphon_ai_invite_admission_total`, `siphon_ai_rtp_packet_loss_ratio`) are
+emitted with inline string literals from other crates. Scanning the whole
+workspace keeps the set a safe superset (a stray non-metric literal like a
+log target only makes the check more lenient, never wrongly failing).
+
+What it does NOT catch: PromQL/JSON semantics, label typos, or renames that
+update both sides wrongly. It only asserts referenced base metric names are
+real. Recorded-rule series (`siphon_ai:...`, with a colon) are defined by the
+rules themselves and are intentionally ignored.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+RUST_DIRS = [REPO / "crates", REPO / "bins"]
+OBS_DIR = REPO / "examples" / "observability"
+
+# Metric-name string literals anywhere in the Rust source: `"siphon_ai_foo"`.
+DEFINED_RE = re.compile(r'"(siphon_ai_[a-z0-9_]+)"')
+# References in YAML/JSON: underscore names only (colon recorded-series and
+# Prometheus built-ins like `up` are excluded by construction).
+REFERENCED_RE = re.compile(r"\bsiphon_ai_[a-z0-9_]+\b")
+
+# metrics-exporter-prometheus renders a histogram as three series; strip the
+# suffix back to the base name registered in metrics.rs.
+HISTOGRAM_SUFFIXES = ("_bucket", "_sum", "_count")
+
+
+def defined_metrics() -> set[str]:
+    names: set[str] = set()
+    for root in RUST_DIRS:
+        for path in root.rglob("*.rs"):
+            names.update(DEFINED_RE.findall(path.read_text()))
+    return names
+
+
+def base_name(name: str) -> str:
+    for suffix in HISTOGRAM_SUFFIXES:
+        if name.endswith(suffix):
+            return name[: -len(suffix)]
+    return name
+
+
+def referenced_metrics() -> dict[str, list[str]]:
+    """Map metric base-name -> list of files referencing it."""
+    refs: dict[str, set[str]] = {}
+    for path in sorted(OBS_DIR.rglob("*")):
+        if path.suffix.lower() not in {".yml", ".yaml", ".json"}:
+            continue
+        rel = path.relative_to(REPO).as_posix()
+        for raw in REFERENCED_RE.findall(path.read_text()):
+            refs.setdefault(base_name(raw), set()).add(rel)
+    return {name: sorted(files) for name, files in refs.items()}
+
+
+def main() -> int:
+    if not OBS_DIR.exists():
+        print(f"error: {OBS_DIR} not found", file=sys.stderr)
+        return 2
+
+    defined = defined_metrics()
+    if not defined:
+        print("error: no siphon_ai_ metric literals found in the workspace", file=sys.stderr)
+        return 2
+
+    referenced = referenced_metrics()
+    unknown = {name: files for name, files in referenced.items() if name not in defined}
+
+    if unknown:
+        print("Observability artifacts reference unknown metric(s):", file=sys.stderr)
+        for name, files in sorted(unknown.items()):
+            print(f"  - {name}  (in {', '.join(files)})", file=sys.stderr)
+        print(
+            "\nEither the metric was renamed/removed in the Rust source, or the "
+            "reference is a typo. Update examples/observability/ to match.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"Observability metrics consistent: "
+        f"{len(referenced)} referenced, all emitted "
+        f"({len(defined)} siphon_ai_ literals in the workspace)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
First sub-item of the **observability completeness** theme (design note: #254). Ships the consumer artifacts for the metrics we already emit — **no daemon code, no new deps, no protocol touch**.

### What's shipped
`examples/observability/` — a runnable Prometheus + Grafana stack:
- **`prometheus.yml`** — reference scrape config.
- **`rules/recording.yml`** (16 rules) — per-route call rates, INVITE reject ratio, latency percentiles (WS-connect / SDP-negotiate / call-duration / RTP-RTT / packet-loss / room-tick-lag), webhook delivery success ratio, registration state counts.
- **`rules/alerting.yml`** (12 alerts) — target down, registration down, high reject rate, dead air, slow WS connect, high RTP RTT / packet loss, spool backlog, delivery failing, admission flooding, sip-auth brute force, drain forced. Each links to the relevant `OPERATIONS.md` question.
- **`grafana/`** — provisioned datasource + two dashboards: **Fleet Overview** and **Call Quality & Latency**.
- **`compose.yaml`** — `docker compose -f examples/observability/compose.yaml up`.

### Anti-drift
- `scripts/check-observability-metrics.py` + a new CI job assert every `siphon_ai_*` metric referenced in the rules/dashboards is actually emitted by the daemon (scans the whole workspace — several metrics are literal-emitted outside `metrics.rs`), and `promtool check config` validates the PromQL. A metric rename can't ship silently-broken artifacts.

### Docs
- `DEPLOY.md` metrics section points to the stack.
- `OPERATIONS.md` "ten questions" gain worked PromQL + the covering dashboard/alert for each metrics-answerable one, plus a symptom→dashboard table. Boundary stated: Prometheus/Grafana for the aggregate, Homer for the individual call.

### Verified locally
- `promtool check config` → 16 recording + 12 alerting rules valid.
- Brought the stack up: Prometheus loaded all 10 rule groups; Grafana provisioned the datasource + both dashboards (confirmed via API); no provisioning errors for the shipped artifacts.
- Anti-drift check (22 metrics referenced, all emitted) + doc-links check green.

### Not in this PR
Version bump to 0.21.0 — held for the release-prep PR. OTLP tracing is v0.22.0+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)