### PR TITLE
chore(release): 0.21.0 — dashboards & alerts as code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-07-01
+
+### Added
+
+- **Dashboards & alerts as code** (P1 "Observability completeness"; first
+  sub-item of the theme). A runnable Prometheus + Grafana stack under
+  [`examples/observability/`](examples/observability/) — the consumer
+  artifacts for the metrics the daemon already emits, no daemon code. Ships
+  a reference scrape config, **16 recording rules** (per-route call rates,
+  INVITE reject ratio, latency percentiles for WS-connect / SDP-negotiate /
+  call-duration / RTP-RTT / packet-loss / room-tick-lag, webhook delivery
+  success ratio, registration state), **12 alerting rules** (target/
+  registration down, high reject rate, dead air, slow WS connect, high RTP
+  RTT / packet loss, spool backlog, delivery failing, admission flooding,
+  sip-auth brute force, drain forced), and **two provisioned Grafana
+  dashboards** (Fleet Overview + Call Quality). `docker compose -f
+  examples/observability/compose.yaml up` stands the whole stack up.
+- **Observability anti-drift CI check.** `scripts/check-observability-metrics.py`
+  (new `observability artifacts` CI job) asserts every `siphon_ai_*` metric
+  referenced in the shipped rules/dashboards is actually emitted by the
+  daemon, and `promtool check config` validates the PromQL — so a metric
+  rename can't ship silently-broken artifacts (same spirit as the version
+  gate).
+
+### Changed
+
+- **`docs/OPERATIONS.md` made concrete.** The §11.8 "ten questions" now carry
+  the worked PromQL and the covering dashboard/alert for each metrics-
+  answerable one, plus a symptom → dashboard table. `docs/DEPLOY.md`'s metrics
+  section points to the shipped stack. (Prometheus/Grafana for the aggregate;
+  Homer for the individual call.)
+
 ## [0.20.0] - 2026-07-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2938,7 +2938,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2954,7 +2954,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "base64",
  "bytes",
@@ -2975,7 +2975,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2992,7 +2992,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "regex",
  "serde",
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3053,7 +3053,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "hmac",
  "http-body-util",
@@ -3073,7 +3073,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "thiserror 1.0.69",
  "tokio",
@@ -3106,7 +3106,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "regex",
  "serde",
@@ -3118,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3127,7 +3127,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3154,7 +3154,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.20.0.** Production-deployed against real carriers
+**Current release: v0.21.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -102,15 +102,20 @@ calls. Regulatory-driven for some operators; large.
 
 ## P1 — Observability completeness
 
-The metrics/logs/HEP primitives are rich, but there are no shipped consumer
-artifacts and no distributed tracing.
+The metrics/logs/HEP primitives are rich; the gap is shipped consumer
+artifacts and distributed tracing. Scoped in
+[`docs/design/DESIGN_OBSERVABILITY.md`](design/DESIGN_OBSERVABILITY.md).
 
-- **Dashboards & alerts as code** — shipped Grafana dashboard JSON +
-  Prometheus recording/alerting rules + the `docs/OPERATIONS.md` "ten
-  questions" runbook made concrete.
+- **Dashboards & alerts as code** — ✅ **delivered in v0.21.0.** Runnable
+  Prometheus + Grafana stack in [`examples/observability/`](../examples/observability/)
+  (recording + alerting rules + Fleet Overview / Call Quality dashboards),
+  `docs/OPERATIONS.md` "ten questions" made concrete, and an anti-drift CI
+  check keeping metric names honest.
 - **OpenTelemetry / OTLP traces** — today tracing is structured logs + HEP
   correlation only; OTLP spans would let operators trace a call across the
-  daemon + their WS server in one view.
+  daemon + their WS server in one view. Next up: v0.22.0 (daemon-side export)
+  then v0.23.0 (W3C trace-context propagation to the WS server). Deps + the
+  additive protocol change are approved (DESIGN_OBSERVABILITY §5).
 
 ---
 


### PR DESCRIPTION
Release-prep for **v0.21.0** (dashboards & alerts as code landed in #255).

Moves the three version-locked files together (the `version consistency` CI gate requires it) plus the roadmap:

- `Cargo.toml` `[workspace.package].version` → `0.21.0` (+ `Cargo.lock` refresh)
- `CHANGELOG.md` — date the `## [0.21.0] - 2026-07-01` section, open a fresh `## [Unreleased]`
- `README.md` — `**Current release: v0.21.0**`
- `docs/ROADMAP.md` — mark "dashboards & alerts as code" **delivered**; OTLP traces (v0.22.0+) remain the observability work

Preflight verified locally:
- `check-version-consistency.py` → `Version consistent: 0.21.0`
- `check-version-consistency.py --tag v0.21.0` → consistent
- `extract-changelog.py 0.21.0` → notes present
- `check-doc-links.py` → all links resolve

After merge: tag `v0.21.0` on the merged commit and push to trigger the release pipeline (per `RELEASING.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)