### PR TITLE
feat(sip): [sip].tcp_idle_timeout_secs — keep live TCP/TLS trunks open

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2668,7 +2668,7 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 [[package]]
 name = "sip-auth"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3023963ba83a#3023963ba83a0428b28133d1d1dada7cca78db8f"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d#83523662848da594d4bee8271c06ee6c65a7df0a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2691,7 +2691,7 @@ dependencies = [
 [[package]]
 name = "sip-core"
 version = "0.7.6"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3023963ba83a#3023963ba83a0428b28133d1d1dada7cca78db8f"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d#83523662848da594d4bee8271c06ee6c65a7df0a"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2704,7 +2704,7 @@ dependencies = [
 [[package]]
 name = "sip-dialog"
 version = "0.3.3"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3023963ba83a#3023963ba83a0428b28133d1d1dada7cca78db8f"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d#83523662848da594d4bee8271c06ee6c65a7df0a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2722,7 +2722,7 @@ dependencies = [
 [[package]]
 name = "sip-dns"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3023963ba83a#3023963ba83a0428b28133d1d1dada7cca78db8f"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d#83523662848da594d4bee8271c06ee6c65a7df0a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2736,7 +2736,7 @@ dependencies = [
 [[package]]
 name = "sip-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3023963ba83a#3023963ba83a0428b28133d1d1dada7cca78db8f"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d#83523662848da594d4bee8271c06ee6c65a7df0a"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -2747,7 +2747,7 @@ dependencies = [
 [[package]]
 name = "sip-identity"
 version = "0.1.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3023963ba83a#3023963ba83a0428b28133d1d1dada7cca78db8f"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d#83523662848da594d4bee8271c06ee6c65a7df0a"
 dependencies = [
  "base64",
  "ring",
@@ -2760,7 +2760,7 @@ dependencies = [
 [[package]]
 name = "sip-observe"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3023963ba83a#3023963ba83a0428b28133d1d1dada7cca78db8f"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d#83523662848da594d4bee8271c06ee6c65a7df0a"
 dependencies = [
  "once_cell",
  "tracing",
@@ -2769,7 +2769,7 @@ dependencies = [
 [[package]]
 name = "sip-parse"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3023963ba83a#3023963ba83a0428b28133d1d1dada7cca78db8f"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d#83523662848da594d4bee8271c06ee6c65a7df0a"
 dependencies = [
  "bytes",
  "httpdate",
@@ -2783,7 +2783,7 @@ dependencies = [
 [[package]]
 name = "sip-ratelimit"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3023963ba83a#3023963ba83a0428b28133d1d1dada7cca78db8f"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d#83523662848da594d4bee8271c06ee6c65a7df0a"
 dependencies = [
  "dashmap 5.5.3",
  "parking_lot",
@@ -2803,7 +2803,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3023963ba83a#3023963ba83a0428b28133d1d1dada7cca78db8f"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d#83523662848da594d4bee8271c06ee6c65a7df0a"
 dependencies = [
  "nom",
  "smol_str",
@@ -2812,7 +2812,7 @@ dependencies = [
 [[package]]
 name = "sip-transaction"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3023963ba83a#3023963ba83a0428b28133d1d1dada7cca78db8f"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d#83523662848da594d4bee8271c06ee6c65a7df0a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2831,7 +2831,7 @@ dependencies = [
 [[package]]
 name = "sip-transport"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3023963ba83a#3023963ba83a0428b28133d1d1dada7cca78db8f"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d#83523662848da594d4bee8271c06ee6c65a7df0a"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2851,7 +2851,7 @@ dependencies = [
 [[package]]
 name = "sip-uac"
 version = "0.4.2"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3023963ba83a#3023963ba83a0428b28133d1d1dada7cca78db8f"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d#83523662848da594d4bee8271c06ee6c65a7df0a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2864,7 +2864,7 @@ dependencies = [
  "sip-dialog",
  "sip-dns",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=3023963ba83a)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -2876,7 +2876,7 @@ dependencies = [
 [[package]]
 name = "sip-uas"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3023963ba83a#3023963ba83a0428b28133d1d1dada7cca78db8f"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d#83523662848da594d4bee8271c06ee6c65a7df0a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2886,7 +2886,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=3023963ba83a)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -3029,7 +3029,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=3023963ba83a)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d)",
  "sip-transaction",
  "sip-uac",
  "sip-uas",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,24 +112,24 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 # main branch and replace the rev hashes here (see CLAUDE.md §7.5).
 
 # siphon-rs — RFC 3261 SIP stack
-sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3023963ba83a" }
-sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3023963ba83a" }
-sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3023963ba83a", features = ["tls"] }
-sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3023963ba83a" }
-sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3023963ba83a" }
-sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3023963ba83a" }
-sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3023963ba83a" }
-sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3023963ba83a" }
-sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3023963ba83a" }
+sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "83523662848d" }
+sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "83523662848d" }
+sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "83523662848d", features = ["tls"] }
+sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "83523662848d" }
+sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "83523662848d" }
+sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "83523662848d" }
+sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "83523662848d" }
+sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "83523662848d" }
+sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "83523662848d" }
 # sip-sdp — the SAME sip-sdp sip-uac's SdpAnswerGenerator trait speaks
 # (distinct from forge-media's pinned sip-sdp). Used by the outbound
 # delayed-offer answer generator to hand the UAC a SessionDescription it
 # accepts. Must stay on the same siphon-rs rev as the rest below.
-sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3023963ba83a" }
-sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3023963ba83a" }
+sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "83523662848d" }
+sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "83523662848d" }
 # sip-identity — STIR/SHAKEN Identity-header parsing + PASSporT verification
 # (ES256 + X.509 chain validation). Consumed by the stir-shaken verifier crate.
-sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3023963ba83a" }
+sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "83523662848d" }
 
 # forge-media — RTP / codecs / SDP / DTMF / engine.
 #

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -557,6 +557,22 @@ impl Runtime {
         let routing_handler = Arc::new(routing_handler_builder);
 
         // ─── SIP transports + transaction manager ──────────────────
+        // Established-connection idle timeout for inbound SIP-over-TCP/TLS.
+        // A SIP trunk (e.g. CUCM) keeps its signaling connection open for a
+        // call's whole life while sending no SIP — RTP is out-of-band — so
+        // the transport must not reap it as "idle" mid-call (that drops
+        // in-dialog re-INVITEs/BYEs and wedges the trunk). Set before any
+        // listener accepts. UDP is connectionless and unaffected.
+        sip_transport::set_established_idle_timeout(sip.tcp_idle_timeout_secs);
+        if sip.tcp_idle_timeout_secs == 0 {
+            info!("inbound SIP TCP/TLS established idle-close disabled ([sip].tcp_idle_timeout_secs = 0)");
+        } else {
+            info!(
+                secs = sip.tcp_idle_timeout_secs,
+                "inbound SIP TCP/TLS established idle timeout set"
+            );
+        }
+
         // Bind UDP eagerly so a port-busy error surfaces here, not
         // after we log "ready". TCP / TLS listeners spawn inside
         // spawn_listeners; their accept loops own the bind.

--- a/crates/config/src/compile.rs
+++ b/crates/config/src/compile.rs
@@ -555,6 +555,11 @@ pub struct SipConfig {
     /// `Some` when `[sip.admission]` enables a per-source rate limit
     /// and/or a global concurrency cap. `None` ⇒ off.
     pub admission: Option<SipAdmissionConfig>,
+    /// Idle timeout (seconds) for an established inbound SIP-over-TCP/TLS
+    /// connection (`[sip].tcp_idle_timeout_secs`). Default 1800; `0`
+    /// disables the idle close. Wired to `sip_transport::set_established_idle_timeout`
+    /// at startup. UDP is unaffected.
+    pub tcp_idle_timeout_secs: u64,
 }
 
 /// Compiled `[sip.admission]` — inbound INVITE admission control.
@@ -1194,6 +1199,7 @@ fn compile_sip(raw: RawSip) -> Result<SipConfig, CompileError> {
         allow_delayed_offer: raw.allow_delayed_offer,
         auth,
         admission,
+        tcp_idle_timeout_secs: raw.tcp_idle_timeout_secs.unwrap_or(1800),
     })
 }
 

--- a/crates/config/src/raw.rs
+++ b/crates/config/src/raw.rs
@@ -236,6 +236,16 @@ pub struct RawSip {
     /// concurrency cap. Unset / all-zero ⇒ off.
     #[serde(default)]
     pub admission: Option<RawSipAdmission>,
+    /// Idle timeout (seconds) for an **established** inbound SIP-over-TCP/TLS
+    /// connection — one that has completed at least one SIP message. A SIP
+    /// trunk (e.g. CUCM) holds this connection open for a call's whole life
+    /// while sending no SIP (RTP is out-of-band), so this must exceed your
+    /// longest SIP-quiet period. Default 1800 (matches typical session
+    /// timers). `0` disables the idle close entirely. Does NOT shorten the
+    /// separate Slowloris window for connections that never complete a
+    /// request. UDP is connectionless and unaffected.
+    #[serde(default)]
+    pub tcp_idle_timeout_secs: Option<u64>,
 }
 
 /// `[sip.admission]` — inbound INVITE admission control. A per-source

--- a/crates/config/tests/load.rs
+++ b/crates/config/tests/load.rs
@@ -195,6 +195,37 @@ ws_url = "wss://${HOST:-fallback.example.com}/ws"
 }
 
 #[test]
+fn tcp_idle_timeout_defaults_to_1800() {
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[bridge]
+ws_url = "wss://x/y"
+"#;
+    let cfg = load_from_str_with_env(toml, &MapEnv::new([])).expect("compiles");
+    assert_eq!(cfg.sip.tcp_idle_timeout_secs, 1800);
+}
+
+#[test]
+fn tcp_idle_timeout_custom_and_zero() {
+    for (val, want) in [("300", 300u64), ("0", 0)] {
+        let toml = format!(
+            r#"
+[sip]
+listen = "127.0.0.1:5060"
+tcp_idle_timeout_secs = {val}
+
+[bridge]
+ws_url = "wss://x/y"
+"#
+        );
+        let cfg = load_from_str_with_env(&toml, &MapEnv::new([])).expect("compiles");
+        assert_eq!(cfg.sip.tcp_idle_timeout_secs, want);
+    }
+}
+
+#[test]
 fn public_address_falls_back_to_listen_ip_when_unset() {
     let env = MapEnv::new([]);
     let toml = r#"

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -92,6 +92,7 @@ credentials. Resolved secret values are never logged.
 | `user_agent` | string           | unset      | Set to brand the `User-Agent` and `Server` headers. |
 | `contact`    | string           | derived    | Override the `Contact` URI; otherwise built from `[node].public_address` + the bound port. |
 | `allow_delayed_offer` | bool    | `true`     | Accept an inbound INVITE with **no SDP** (RFC 3264 delayed offer): SiphonAI offers in the 200 OK and reads the peer's answer from the ACK. Needed for CUCM trunks/phones without a forced MTP. `false` rejects an offerless INVITE with `488`. Early-offer INVITEs are unaffected either way. |
+| `tcp_idle_timeout_secs` | integer | `1800`  | Idle timeout for an **established** inbound SIP-over-**TCP/TLS** connection — one that has completed at least one SIP message. A SIP trunk (e.g. CUCM) holds this connection open for a call's whole life while sending **no SIP** (RTP is out-of-band), so this must exceed your longest SIP-quiet period, or the connection is reaped mid-call and in-dialog re-INVITEs/BYEs are lost (wedging the trunk → `503` on new calls). Default `1800` (matches common session timers). `0` disables the idle close. Does **not** shorten the short Slowloris window for connections that never complete a request. **UDP is connectionless and unaffected.** |
 
 ### `[sip.tls]`
 


### PR DESCRIPTION
Host-side of the CUCM/TCP-trunk idle-close fix. **Paired with siphon-rs PR thevoiceguy/siphon-rs#60** — merge that first, then this PR needs a `siphon-rs` pin bump before it compiles (see below).

## Problem
A SIP trunk (e.g. CUCM) holds its TCP/TLS signaling connection open for a call's whole life while sending no SIP (RTP is out-of-band). siphon-rs reaped it after 60s idle, dropping mid-call re-INVITEs/BYEs and wedging the trunk → `503` on new calls. Diagnosis + fix detail in siphon-rs#60.

## This change
- New **`[sip].tcp_idle_timeout_secs`** (default `1800`, `0` = disabled) on `RawSip` → `SipConfig`.
- Wired in `runtime.rs` to `sip_transport::set_established_idle_timeout(...)` **before any listener accepts**; logs the value at startup. UDP is connectionless and unaffected.
- `docs/CONFIG.md` `[sip]` table row; load tests (`tcp_idle_timeout_defaults_to_1800`, `_custom_and_zero`).

## Validation
Built siphon-ai against the fixed siphon-rs via a temporary local `[patch]` (reverted, not committed) — daemon boots and logs `inbound SIP TCP/TLS established idle timeout set secs=300`. Config-layer tests pass standalone.

## ⚠️ Blocked on pin bump
The daemon binary calls `sip_transport::set_established_idle_timeout`, which only exists after siphon-rs#60. **Landing order:**
1. Merge siphon-rs#60 → get the merged commit hash.
2. Bump `siphon-rs` `rev` in the workspace `Cargo.toml` (currently `3023963ba83a`; all ~14 `sip-*` crates share the one rev) to that hash + refresh `Cargo.lock`.
3. This PR then compiles and CI goes green.

I'll push the pin-bump commit onto this branch once siphon-rs#60 is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)