### PR TITLE
chore(release): 0.21.1 — fix SIP-over-TCP/TLS trunk idle-close (CUCM)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.1] - 2026-07-01
+
+### Fixed
+
+- **SIP-over-TCP/TLS trunks no longer wedge after ~60s of a call**
+  (CUCM and any persistent-connection trunk). The SIP stack closed an
+  inbound TCP/TLS connection after 60s with no inbound SIP — but a trunk
+  keeps its signaling connection open for a call's whole life while
+  sending **no SIP at all** (RTP is out-of-band), so 60s idle was hit by
+  essentially every call. The reaped connection then dropped mid-call
+  re-INVITEs and BYEs (they got no response — the socket was gone before
+  the transaction layer saw them), leaving the peer's dialogs stuck and
+  its trunk health-check failing → `503` on new calls. The idle timeout
+  is now two-phase: a short Slowloris window until a connection completes
+  its first SIP message, then a long, configurable **established** timeout
+  (new `[sip].tcp_idle_timeout_secs`, default `1800`; `0` disables). UDP
+  is connectionless and was never affected. Requires the paired siphon-rs
+  transport fix (bumped here). See `docs/CONFIG.md` → `[sip]`.
+
 ## [0.21.0] - 2026-07-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2938,7 +2938,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2954,7 +2954,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "base64",
  "bytes",
@@ -2975,7 +2975,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2992,7 +2992,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "regex",
  "serde",
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3053,7 +3053,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "hmac",
  "http-body-util",
@@ -3073,7 +3073,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "thiserror 1.0.69",
  "tokio",
@@ -3106,7 +3106,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "regex",
  "serde",
@@ -3118,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3127,7 +3127,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3154,7 +3154,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "base64",
  "rcgen",
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.21.0"
+version = "0.21.1"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.21.0.** Production-deployed against real carriers
+**Current release: v0.21.1.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a


### PR DESCRIPTION
Patch release for the carrier-interop fix landed in #257 (paired with siphon-rs #60).

- `Cargo.toml` `[workspace.package].version` → `0.21.1` (+ `Cargo.lock` refresh)
- `CHANGELOG.md` — dated `## [0.21.1] - 2026-07-01` `### Fixed` section, fresh `## [Unreleased]`
- `README.md` — `**Current release: v0.21.1**`

**What it fixes:** SIP-over-TCP/TLS trunks (CUCM et al.) no longer wedge after ~60s of a call — the SIP stack was reaping the idle-but-live signaling connection, dropping mid-call re-INVITEs/BYEs and 503'ing new calls. Now a two-phase idle timeout keeps established trunk connections open (`[sip].tcp_idle_timeout_secs`, default 1800).

Preflight verified locally: version-consistency (plain + `--tag v0.21.1`), changelog extract, doc-links all green.

After merge: tag `v0.21.1` and push to trigger the release pipeline (per `RELEASING.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)