### PR TITLE
feat(observability): daemon-side OTLP tracing ([observability.otlp]) — v0.22.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,7 +601,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1301,6 +1301,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1317,7 +1330,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1514,6 +1527,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1910,6 +1932,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+ "tonic-types",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.4",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1947,6 +2031,26 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2042,6 +2146,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "quanta"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2069,7 +2205,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2106,7 +2242,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -2411,7 +2547,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2908,6 +3044,7 @@ dependencies = [
  "forge-engine",
  "forge-rtp",
  "metrics 0.23.1",
+ "opentelemetry",
  "rustls",
  "rustls-pemfile",
  "sip-core",
@@ -2932,6 +3069,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "webpki-roots 1.0.7",
 ]
@@ -3182,6 +3320,9 @@ dependencies = [
  "hyper-util",
  "metrics 0.23.1",
  "metrics-exporter-prometheus",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "serde",
  "serde_json",
  "sha2",
@@ -3554,7 +3695,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3689,6 +3830,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3759,6 +3911,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3766,11 +3966,15 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3844,6 +4048,22 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -4211,7 +4431,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/bins/siphon-ai/Cargo.toml
+++ b/bins/siphon-ai/Cargo.toml
@@ -80,6 +80,8 @@ arc-swap = "1"
 forge-core.workspace   = true
 forge-engine.workspace = true
 forge-rtp.workspace    = true
+opentelemetry = "0.32.0"
+tracing-opentelemetry = "0.33.0"
 
 [dev-dependencies]
 tokio        = { workspace = true, features = ["macros", "rt", "time", "net", "sync"] }

--- a/bins/siphon-ai/src/lib.rs
+++ b/bins/siphon-ai/src/lib.rs
@@ -4,8 +4,10 @@
 //! library form exists so integration tests in `tests/` can build
 //! the same runtime without spawning a child process.
 
+pub mod otel;
 pub mod registration;
 pub mod reload;
 pub mod runtime;
 
+pub use otel::OtelActivation;
 pub use runtime::Runtime;

--- a/bins/siphon-ai/src/main.rs
+++ b/bins/siphon-ai/src/main.rs
@@ -13,9 +13,9 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Context, Result};
 use clap::{Parser, Subcommand};
-use siphon_ai::Runtime;
+use siphon_ai::{OtelActivation, Runtime};
 use siphon_ai_config::Config;
-use siphon_ai_telemetry::LogFilterHandle;
+use siphon_ai_telemetry::{LogFilterHandle, OTEL_SCOPE};
 use tracing::info;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
@@ -124,7 +124,7 @@ async fn main() -> Result<()> {
     // SRTP-key-in-cleartext footgun); without a subscriber those are
     // silently dropped and the preflight is less informative than a real
     // boot.
-    let log_filter = init_tracing(cli.log.as_deref());
+    let (log_filter, otel_activation) = init_tracing(cli.log.as_deref());
 
     // Read-only subcommands dispatch here and exit — no socket binding,
     // no runtime (but tracing is live, so config warnings show).
@@ -182,9 +182,10 @@ async fn main() -> Result<()> {
 
     // Pass the path so SIGHUP (`systemctl reload`) can re-read it for
     // hot reload of the reload-safe sections.
-    let runtime = Runtime::build_with_reload(config, Some(config_path), log_filter)
-        .await
-        .context("runtime build failed")?;
+    let runtime =
+        Runtime::build_with_reload(config, Some(config_path), log_filter, Some(otel_activation))
+            .await
+            .context("runtime build failed")?;
 
     runtime.run(shutdown_signal()).await
 }
@@ -361,7 +362,7 @@ fn print_check_summary(path: &Path, config: &Config) {
 /// shorthand `tracing_subscriber::fmt()` builder, because the
 /// shorthand doesn't expose a reload handle. The layered form is
 /// the canonical way to make `EnvFilter` mutable at runtime.
-fn init_tracing(cli_filter: Option<&str>) -> LogFilterHandle {
+fn init_tracing(cli_filter: Option<&str>) -> (LogFilterHandle, OtelActivation) {
     const DEFAULT: &str = "siphon_ai=info,siphon_ai_core=info,siphon_ai_media_glue=info,\
          siphon_ai_sip_glue=info,siphon_ai_bridge=info,siphon_ai_routes=info,\
          siphon_ai_config=info,sip_uas=warn,sip_transaction=warn,\
@@ -373,6 +374,19 @@ fn init_tracing(cli_filter: Option<&str>) -> LogFilterHandle {
     };
 
     let (filter_layer, reload_handle) = tracing_subscriber::reload::Layer::new(env_filter);
+
+    // OTLP trace layer, reloadable and installed **inactive** (`None`). The
+    // real OTLP tracer isn't known until config loads (it carries the
+    // endpoint), and `init_tracing` runs before that so config-load warnings
+    // still print. `None` is a genuine no-op layer — zero per-span cost while
+    // OTLP is disabled (the common case). The runtime installs the global
+    // OTLP provider and then calls `OtelActivation::activate`, which swaps in
+    // a live layer bound to `opentelemetry::global::tracer` (which must be
+    // obtained *after* the provider is set, hence the deferred build).
+    let otel_layer: Option<
+        tracing_opentelemetry::OpenTelemetryLayer<_, opentelemetry::global::BoxedTracer>,
+    > = None;
+    let (otel_reload_layer, otel_handle) = tracing_subscriber::reload::Layer::new(otel_layer);
     // `fmt::layer()` defaults to ANSI on regardless of stdout type
     // — unlike the higher-level `fmt::Subscriber::builder()` which
     // does tty auto-detection. Without the explicit `with_ansi`
@@ -391,10 +405,19 @@ fn init_tracing(cli_filter: Option<&str>) -> LogFilterHandle {
     // the subscriber, not a global cell.
     let _ = tracing_subscriber::registry()
         .with(filter_layer)
+        .with(otel_reload_layer)
         .with(fmt_layer)
         .try_init();
 
-    LogFilterHandle::new(reload_handle)
+    // Deferred activation: build the live layer *at activation time* so
+    // `global::tracer` binds to whatever provider is installed then (the real
+    // OTLP one). The runtime calls this after installing the OTLP provider.
+    let activation = OtelActivation::new(Box::new(move || {
+        let tracer = opentelemetry::global::tracer(OTEL_SCOPE);
+        otel_handle.reload(Some(tracing_opentelemetry::layer().with_tracer(tracer)))
+    }));
+
+    (LogFilterHandle::new(reload_handle), activation)
 }
 
 /// Resolve when SIGINT (Ctrl-C) or SIGTERM is received. On Windows

--- a/bins/siphon-ai/src/otel.rs
+++ b/bins/siphon-ai/src/otel.rs
@@ -1,0 +1,40 @@
+//! Deferred activation of the OTLP tracing layer (0.22.0).
+//!
+//! `main::init_tracing` installs a reloadable OTLP layer **inactive** (a
+//! no-op `None`) before config is loaded, so config-load warnings still
+//! print. The [`Runtime`](crate::Runtime), which has the config and installs
+//! the process-global OTLP provider, then calls [`OtelActivation::activate`]
+//! to swap in a live layer bound to `opentelemetry::global::tracer`. When
+//! `[observability.otlp]` is disabled, `activate` is simply never called and
+//! the layer stays a zero-cost no-op.
+//!
+//! The activation is a boxed closure so the concrete `reload::Handle<...>`
+//! type (which names the whole subscriber-layer stack) stays inside
+//! `init_tracing` and never has to be spelled out here or on `Runtime`.
+
+use tracing::warn;
+
+/// A one-shot handle that turns the inactive OTLP tracing layer live. Built by
+/// `init_tracing`, consumed by the runtime after the OTLP provider is set.
+pub struct OtelActivation {
+    reload: Box<dyn FnOnce() -> Result<(), tracing_subscriber::reload::Error> + Send>,
+}
+
+impl OtelActivation {
+    /// Wrap the layer-reload closure. The closure must build the live OTLP
+    /// layer from the *current* global tracer and swap it in — so it has to
+    /// run after the global OTLP provider is installed.
+    pub fn new(
+        reload: Box<dyn FnOnce() -> Result<(), tracing_subscriber::reload::Error> + Send>,
+    ) -> Self {
+        Self { reload }
+    }
+
+    /// Swap the inactive OTLP layer for a live one bound to the current global
+    /// tracer. Best-effort — a reload error is logged, never fatal.
+    pub fn activate(self) {
+        if let Err(e) = (self.reload)() {
+            warn!(error = %e, "failed to activate OTLP tracing layer; spans will not export");
+        }
+    }
+}

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -142,6 +142,9 @@ pub struct Runtime {
     /// The HEP UDP worker JoinHandle. Held for the daemon's
     /// lifetime; aborted on shutdown.
     hep_worker: Option<HepWorkerHandle>,
+    /// OTLP trace exporter (0.22.0). `Some` when `[observability.otlp]` is
+    /// enabled; held so teardown can flush pending spans before exit.
+    otel: Option<siphon_ai_telemetry::OtelTelemetry>,
     /// Per-`[[register]]` background tasks. v1's tasks are no-ops
     /// (UAC drive lands in a follow-up); we still own the handles
     /// so shutdown awaits them cleanly.
@@ -167,7 +170,7 @@ impl Runtime {
     /// Binds the UDP socket eagerly so a "port already in use" error
     /// surfaces during startup, not after we've logged "ready".
     pub async fn build(config: Config, log_filter: LogFilterHandle) -> Result<Self> {
-        Self::build_with_reload(config, None, log_filter).await
+        Self::build_with_reload(config, None, log_filter, None).await
     }
 
     /// Like [`build`](Self::build) but with the `--config` path so a
@@ -179,6 +182,7 @@ impl Runtime {
         config: Config,
         config_path: Option<PathBuf>,
         log_filter: LogFilterHandle,
+        otel_activation: Option<crate::OtelActivation>,
     ) -> Result<Self> {
         // Fingerprint the restart-required sections before the config
         // is destructured, so a later SIGHUP reload can detect changes
@@ -223,6 +227,34 @@ impl Runtime {
         let (hep_telemetry, hep_worker) = match hep_built {
             Some((t, w)) => (Some(t), Some(w)),
             None => (None, None),
+        };
+
+        // ─── OpenTelemetry / OTLP trace export (0.22.0) ─────────────
+        // Build the OTLP provider (installs the process-global tracer
+        // provider), then activate the deferred tracing layer so per-call
+        // spans export. Off when `[observability.otlp]` is absent — the
+        // layer stays a no-op and OTLP has zero cost. Best-effort: a bad
+        // endpoint fails loud here (§4.6), but a collector that's merely
+        // down never blocks a call (spans batch + drop in the background).
+        let otel = match &observability.otlp {
+            Some(otlp) => {
+                let telemetry =
+                    siphon_ai_telemetry::OtelTelemetry::build(siphon_ai_telemetry::OtelConfig {
+                        endpoint: otlp.endpoint.clone(),
+                        timeout: otlp.timeout,
+                        sample_ratio: otlp.sample_ratio,
+                        service_name: otlp.service_name.clone(),
+                        node_id: node.id.clone(),
+                        extra_attributes: otlp.attributes.clone(),
+                    })
+                    .map_err(|e| anyhow!("OTLP trace export build failed: {e}"))?;
+                // Provider is now the process global; make the layer live.
+                if let Some(activation) = otel_activation {
+                    activation.activate();
+                }
+                Some(telemetry)
+            }
+            None => None,
         };
 
         // Whether a durable spool is active — captured before the
@@ -955,6 +987,7 @@ impl Runtime {
             admin: admin_server,
             hep_telemetry,
             hep_worker,
+            otel,
             registration_mgr,
             registration_listeners,
             drain,
@@ -1071,6 +1104,17 @@ impl Runtime {
         // scope at function end).
         if let Some(worker) = self.hep_worker {
             worker.shutdown().await;
+        }
+
+        // Flush + shut down the OTLP exporter so batched per-call spans reach
+        // the collector before exit (best-effort, bounded window). Runs on a
+        // blocking thread — the SDK's shutdown is synchronous and must not be
+        // called from within the async batch worker's runtime context.
+        if let Some(otel) = self.otel {
+            let _ = tokio::task::spawn_blocking(move || {
+                otel.shutdown(Duration::from_secs(5));
+            })
+            .await;
         }
 
         // Drop the UAS / TM Arcs so any per-call task that's still

--- a/crates/config/src/compile.rs
+++ b/crates/config/src/compile.rs
@@ -429,6 +429,26 @@ pub struct WebhooksConfig {
 pub struct ObservabilityConfig {
     pub enabled: bool,
     pub http_listen: Option<SocketAddr>,
+    /// `Some` when `[observability.otlp].enabled` — OTLP/gRPC trace export
+    /// (0.22.0). Independent of `enabled`/`http_listen` (traces without
+    /// metrics scraping is a valid setup). The daemon maps this to
+    /// `siphon_ai_telemetry::OtelConfig`.
+    pub otlp: Option<OtlpConfig>,
+}
+
+/// Resolved OTLP trace-export plan (`[observability.otlp]`, 0.22.0).
+#[derive(Debug, Clone)]
+pub struct OtlpConfig {
+    /// OTLP/gRPC endpoint (default `http://localhost:4317`).
+    pub endpoint: String,
+    /// Head sampling ratio in `[0.0, 1.0]`.
+    pub sample_ratio: f64,
+    /// Per-export gRPC timeout.
+    pub timeout: Duration,
+    /// `service.name` resource attribute.
+    pub service_name: String,
+    /// Extra resource attributes (`key`, `value`).
+    pub attributes: Vec<(String, String)>,
 }
 
 /// Resolved HEP3 (Homer) plan. The daemon binary builds a real
@@ -864,6 +884,9 @@ pub enum CompileError {
 
     #[error("[observability].http_listen is required when [observability].enabled = true")]
     ObservabilityListenRequired,
+
+    #[error("[observability.otlp].sample_ratio {0} is out of range; must be between 0.0 and 1.0")]
+    OtlpBadSampleRatio(f64),
 
     #[error("[admin].listen {0:?} is not a valid socket address: {1}")]
     BadAdminListen(String, std::net::AddrParseError),
@@ -2193,12 +2216,21 @@ fn parse_register_server(
 }
 
 fn compile_observability(raw: RawObservability) -> Result<ObservabilityConfig, CompileError> {
+    // OTLP trace export is independent of the metrics HTTP listener — like
+    // HEP vs `[cdr]`, you can export traces without scraping metrics — so
+    // compile it regardless of the `enabled` master switch.
+    let otlp = compile_otlp(raw.otlp)?;
+
     if !raw.enabled {
         // Disabled means "don't spawn the HTTP server" — sub-block
         // misconfig is tolerated (same shape as [cdr] master switch
         // — operators can flip enabled = false to silence a flaky
         // listener without re-editing every field).
-        return Ok(ObservabilityConfig::default());
+        return Ok(ObservabilityConfig {
+            enabled: false,
+            http_listen: None,
+            otlp,
+        });
     }
     let listen_str = raw
         .http_listen
@@ -2212,7 +2244,33 @@ fn compile_observability(raw: RawObservability) -> Result<ObservabilityConfig, C
     Ok(ObservabilityConfig {
         enabled: true,
         http_listen: Some(http_listen),
+        otlp,
     })
+}
+
+fn compile_otlp(raw: crate::raw::RawObservabilityOtlp) -> Result<Option<OtlpConfig>, CompileError> {
+    if !raw.enabled {
+        return Ok(None);
+    }
+    let endpoint = raw
+        .endpoint
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "http://localhost:4317".to_string());
+    let sample_ratio = raw.sample_ratio.unwrap_or(1.0);
+    if !(0.0..=1.0).contains(&sample_ratio) {
+        return Err(CompileError::OtlpBadSampleRatio(sample_ratio));
+    }
+    let service_name = raw
+        .service_name
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "siphon-ai".to_string());
+    Ok(Some(OtlpConfig {
+        endpoint,
+        sample_ratio,
+        timeout: Duration::from_millis(raw.timeout_ms.unwrap_or(5000)),
+        service_name,
+        attributes: raw.attributes.unwrap_or_default().into_iter().collect(),
+    }))
 }
 
 fn compile_admin(raw: Option<crate::raw::RawAdmin>) -> Result<Option<AdminConfig>, CompileError> {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -36,8 +36,8 @@ use thiserror::Error;
 pub use compile::{
     compile, AdminConfig, AdminTlsConfig, AuditConfig, AuditFileConfig, AuditWebhookConfig,
     CdrConfig, CdrFileConfig, CdrWebhookConfig, CompileError, ConferenceConfig, Config, Gateway,
-    GatewayCredentials, HepConfig, MediaConfig, NodeConfig, ObservabilityConfig, OutboundConfig,
-    ParkConfig, ParkTimeoutAction, RegisterConfig, SecurityConfig, ShutdownConfig,
+    GatewayCredentials, HepConfig, MediaConfig, NodeConfig, ObservabilityConfig, OtlpConfig,
+    OutboundConfig, ParkConfig, ParkTimeoutAction, RegisterConfig, SecurityConfig, ShutdownConfig,
     SipAdmissionConfig, SipAuthConfig, SipAuthUser, SipConfig, SipTlsConfig, SipTransport,
     TrunkCidr, TrunkCidrParseError, TrunkConfig, WebhooksConfig,
 };

--- a/crates/config/src/raw.rs
+++ b/crates/config/src/raw.rs
@@ -846,6 +846,38 @@ pub struct RawObservability {
     /// Required when `enabled = true`.
     #[serde(default)]
     pub http_listen: Option<String>,
+    /// `[observability.otlp]` — OpenTelemetry OTLP trace export (0.22.0).
+    /// Independent of the metrics HTTP server above — you can export traces
+    /// without scraping metrics, and vice versa. Off by default.
+    #[serde(default)]
+    pub otlp: RawObservabilityOtlp,
+}
+
+/// `[observability.otlp]` — export per-call spans over OTLP/gRPC to a
+/// collector (Tempo / Jaeger / an OpenTelemetry Collector). Off by default;
+/// best-effort (a slow/unreachable collector never blocks a call).
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawObservabilityOtlp {
+    #[serde(default)]
+    pub enabled: bool,
+    /// OTLP/gRPC endpoint. Default `http://localhost:4317`.
+    #[serde(default)]
+    pub endpoint: Option<String>,
+    /// Head sampling ratio in `[0.0, 1.0]`. Default `1.0` (sample all).
+    /// Parent-based: a sampled parent keeps its children.
+    #[serde(default)]
+    pub sample_ratio: Option<f64>,
+    /// Per-export gRPC timeout (ms). Default `5000`.
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
+    /// `service.name` resource attribute. Default `siphon-ai`.
+    #[serde(default)]
+    pub service_name: Option<String>,
+    /// Extra resource attributes (e.g. `deployment.environment = "prod"`),
+    /// attached to every exported span.
+    #[serde(default)]
+    pub attributes: Option<std::collections::BTreeMap<String, String>>,
 }
 
 /// `[hep]` — HEP3 (Homer) shipping. Off by default; when

--- a/crates/config/tests/load.rs
+++ b/crates/config/tests/load.rs
@@ -226,6 +226,76 @@ ws_url = "wss://x/y"
 }
 
 #[test]
+fn otlp_disabled_by_default_and_independent_of_metrics_listener() {
+    // No [observability] block at all → otlp is None.
+    let toml = "[sip]\nlisten = \"127.0.0.1:5060\"\n[bridge]\nws_url = \"wss://x/y\"\n";
+    let cfg = load_from_str_with_env(toml, &MapEnv::new([])).expect("compiles");
+    assert!(cfg.observability.otlp.is_none());
+
+    // OTLP enabled WITHOUT the metrics HTTP server — a valid setup.
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+[bridge]
+ws_url = "wss://x/y"
+[observability.otlp]
+enabled = true
+"#;
+    let cfg = load_from_str_with_env(toml, &MapEnv::new([])).expect("compiles");
+    assert!(!cfg.observability.enabled, "metrics listener stays off");
+    let otlp = cfg.observability.otlp.expect("otlp compiled");
+    assert_eq!(otlp.endpoint, "http://localhost:4317");
+    assert_eq!(otlp.sample_ratio, 1.0);
+    assert_eq!(otlp.service_name, "siphon-ai");
+}
+
+#[test]
+fn otlp_custom_fields_and_attributes() {
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+[bridge]
+ws_url = "wss://x/y"
+[observability.otlp]
+enabled = true
+endpoint = "http://collector:4317"
+sample_ratio = 0.25
+timeout_ms = 2000
+service_name = "siphon-edge"
+[observability.otlp.attributes]
+"deployment.environment" = "prod"
+region = "us-east"
+"#;
+    let cfg = load_from_str_with_env(toml, &MapEnv::new([])).expect("compiles");
+    let otlp = cfg.observability.otlp.expect("otlp compiled");
+    assert_eq!(otlp.endpoint, "http://collector:4317");
+    assert_eq!(otlp.sample_ratio, 0.25);
+    assert_eq!(otlp.timeout.as_millis(), 2000);
+    assert_eq!(otlp.service_name, "siphon-edge");
+    assert!(otlp
+        .attributes
+        .contains(&("deployment.environment".to_string(), "prod".to_string())));
+}
+
+#[test]
+fn otlp_bad_sample_ratio_fails_load() {
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+[bridge]
+ws_url = "wss://x/y"
+[observability.otlp]
+enabled = true
+sample_ratio = 1.5
+"#;
+    let err = load_from_str_with_env(toml, &MapEnv::new([])).unwrap_err();
+    assert!(
+        format!("{err}").contains("sample_ratio"),
+        "expected sample_ratio range error, got: {err}"
+    );
+}
+
+#[test]
 fn public_address_falls_back_to_listen_ip_when_unset() {
     let env = MapEnv::new([]);
     let toml = r#"

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -3064,72 +3064,81 @@ impl BridgingAcceptor {
         let dialog_handles = Arc::clone(&self.dialog_handles);
         let cleanup_session_timer_key = session_timer_key;
 
-        tokio::spawn(async move {
-            let run_result = controller.run().await;
-            let view = CallTerminationView::from_run_result(run_result);
-            info!(
-                call_id = %bridge_call_id,
-                cause = ?view.cause,
-                "call ended"
-            );
-            // Stop the RFC 4028 timer and drop the handle map entry
-            // first — otherwise a `SessionExpired` racing the
-            // controller exit would try to shutdown an already-gone
-            // controller. Cheap when no timer was negotiated.
-            if let Some(dialog_id) = cleanup_session_timer_key.as_ref() {
-                session_timer_manager.stop_timer(dialog_id);
-                dialog_handles.write().remove(dialog_id);
-            }
-            // Send outbound BYE if the peer didn't already drive it.
-            // Order: BYE first, registry remove second, forge stop
-            // third. That way a follow-up BYE retransmit from the
-            // peer (which would be racing our outbound BYE in the
-            // wild) still finds the entry and gets a 200 OK instead
-            // of "unknown dialog".
-            if !cleanup_handle.remote_bye_received() {
-                send_outbound_bye(teardown.as_ref(), &sip_call_id, bridge_call_id.as_str()).await;
-            }
-            registry.remove(&sip_call_id);
-            control_registry.remove(bridge_call_id.as_str());
-            if let Err(e) = media.session_manager().stop_session(&forge_call_id).await {
-                warn!(
+        // Link the controller task to the accept span so the whole call —
+        // INVITE handling, the controller, the WS bridge and media — is one
+        // OTLP trace instead of a separate root per task (0.22.0).
+        tokio::spawn(tracing::Instrument::instrument(
+            async move {
+                let run_result = controller.run().await;
+                let view = CallTerminationView::from_run_result(run_result);
+                info!(
                     call_id = %bridge_call_id,
-                    error = %e,
-                    "forge session teardown failed"
+                    cause = ?view.cause,
+                    "call ended"
                 );
-            }
+                // Stop the RFC 4028 timer and drop the handle map entry
+                // first — otherwise a `SessionExpired` racing the
+                // controller exit would try to shutdown an already-gone
+                // controller. Cheap when no timer was negotiated.
+                if let Some(dialog_id) = cleanup_session_timer_key.as_ref() {
+                    session_timer_manager.stop_timer(dialog_id);
+                    dialog_handles.write().remove(dialog_id);
+                }
+                // Send outbound BYE if the peer didn't already drive it.
+                // Order: BYE first, registry remove second, forge stop
+                // third. That way a follow-up BYE retransmit from the
+                // peer (which would be racing our outbound BYE in the
+                // wild) still finds the entry and gets a 200 OK instead
+                // of "unknown dialog".
+                if !cleanup_handle.remote_bye_received() {
+                    send_outbound_bye(teardown.as_ref(), &sip_call_id, bridge_call_id.as_str())
+                        .await;
+                }
+                registry.remove(&sip_call_id);
+                control_registry.remove(bridge_call_id.as_str());
+                if let Err(e) = media.session_manager().stop_session(&forge_call_id).await {
+                    warn!(
+                        call_id = %bridge_call_id,
+                        error = %e,
+                        "forge session teardown failed"
+                    );
+                }
 
-            let ended_at = Utc::now();
-            let duration_ms = (ended_at - call_start.started_at).num_milliseconds().max(0) as u64;
-            let duration_secs = duration_ms as f64 / 1000.0;
-            metrics::gauge!(CALLS_ACTIVE).decrement(1.0);
-            metrics::counter!(
-                CALLS_TOTAL,
-                "cause" => termination_label(view.cause),
-            )
-            .increment(1);
-            metrics::histogram!(CALL_DURATION_SECONDS).record(duration_secs);
-            if let Some(rec) = view.recording.as_ref() {
-                metrics::counter!(RECORDINGS_TOTAL, "result" => rec.result.as_str()).increment(1);
-            }
+                let ended_at = Utc::now();
+                let duration_ms =
+                    (ended_at - call_start.started_at).num_milliseconds().max(0) as u64;
+                let duration_secs = duration_ms as f64 / 1000.0;
+                metrics::gauge!(CALLS_ACTIVE).decrement(1.0);
+                metrics::counter!(
+                    CALLS_TOTAL,
+                    "cause" => termination_label(view.cause),
+                )
+                .increment(1);
+                metrics::histogram!(CALL_DURATION_SECONDS).record(duration_secs);
+                if let Some(rec) = view.recording.as_ref() {
+                    metrics::counter!(RECORDINGS_TOTAL, "result" => rec.result.as_str())
+                        .increment(1);
+                }
 
-            let end_event = WebhookEvent::CallEnd(CallEndEvent {
-                version: WEBHOOK_VERSION,
-                call_id: call_start.bridge_call_id.as_str().to_string(),
-                sip_call_id: call_start.sip_call_id.clone(),
-                timestamp: ended_at,
-                from: call_start.from.clone(),
-                to: call_start.to.clone(),
-                route: call_start.route.clone(),
-                ws_url: call_start.ws_url.clone(),
-                duration_ms,
-                termination_cause: termination_label(view.cause).to_string(),
-            });
+                let end_event = WebhookEvent::CallEnd(CallEndEvent {
+                    version: WEBHOOK_VERSION,
+                    call_id: call_start.bridge_call_id.as_str().to_string(),
+                    sip_call_id: call_start.sip_call_id.clone(),
+                    timestamp: ended_at,
+                    from: call_start.from.clone(),
+                    to: call_start.to.clone(),
+                    route: call_start.route.clone(),
+                    ws_url: call_start.ws_url.clone(),
+                    duration_ms,
+                    termination_cause: termination_label(view.cause).to_string(),
+                });
 
-            let record = call_start.into_record(ended_at, &view);
-            cdr_sink.emit(record).await;
-            webhook_sink.emit(end_event).await;
-        })
+                let record = call_start.into_record(ended_at, &view);
+                cdr_sink.emit(record).await;
+                webhook_sink.emit(end_event).await;
+            },
+            tracing::Span::current(),
+        ))
     }
 }
 

--- a/crates/core/src/call.rs
+++ b/crates/core/src/call.rs
@@ -82,7 +82,7 @@ use siphon_ai_webhooks::{
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot, Notify};
 use tokio::task::JoinHandle;
-use tracing::{debug, info, instrument, warn};
+use tracing::{debug, info, instrument, warn, Instrument};
 
 use crate::transfer::{plan_refer, ReferPlan, TransferContext, TransferOutcome};
 use siphon_ai_telemetry::{
@@ -622,7 +622,13 @@ impl CallController {
     ///
     /// Returns when all sub-tasks have terminated. The returned
     /// [`CallOutcome`] is the source of truth for what happened.
-    #[instrument(skip(self), fields(call_id = %self.cfg.call_id))]
+    #[instrument(skip(self), fields(
+        call_id = %self.cfg.call_id,
+        sip_call_id = %self.cfg.start.sip.call_id,
+        direction = ?self.cfg.start.direction,
+        from = %self.cfg.start.from,
+        to = %self.cfg.start.to,
+    ))]
     pub async fn run(self) -> Result<CallOutcome, CallError> {
         let CallController {
             cfg,
@@ -725,7 +731,11 @@ impl CallController {
             rec_path = Some(setup.path.clone());
             let writer =
                 RecordingWriter::new(setup.path, media_tap.sample_rate(), setup.auto_start);
-            recording_task = Some(tokio::spawn(writer.run(rec_rx, ctrl_rx, evt_tx)));
+            recording_task = Some(tokio::spawn(
+                writer
+                    .run(rec_rx, ctrl_rx, evt_tx)
+                    .instrument(tracing::Span::current()),
+            ));
             rec_ctrl_tx = Some(ctrl_tx);
             rec_evt_rx = Some(evt_rx);
             rec_drops = Some(Arc::clone(&drops));
@@ -734,20 +744,28 @@ impl CallController {
             media_tap
         };
 
-        let mut bridge_task: JoinHandle<Result<DisconnectReason, BridgeError>> =
-            tokio::spawn(connect_and_run(bridge, start, channels));
+        // Spawned tasks don't inherit the current span, so a call would
+        // otherwise fragment into sibling traces. Instrument each with the
+        // controller's `run` span so the WS-bridge, media-tap, and recording
+        // spans nest under it — one trace per call in OTLP (0.22.0).
+        let mut bridge_task: JoinHandle<Result<DisconnectReason, BridgeError>> = tokio::spawn(
+            connect_and_run(bridge, start, channels).instrument(tracing::Span::current()),
+        );
         // The tap forwards out-of-band events (currently DTMF) onto
         // the same control stream the bridge reads. Cloning the
         // sender means tap and controller are independent producers
         // — bridge teardown closes the receiver, both producers see
         // the same EOF.
-        let mut tap_task: JoinHandle<Result<TapDisconnect, MediaTapError>> =
-            tokio::spawn(media_tap.run(
-                caller_audio_tx,
-                playout_audio_rx,
-                control_out_tx.clone(),
-                tap_cmd_rx,
-            ));
+        let mut tap_task: JoinHandle<Result<TapDisconnect, MediaTapError>> = tokio::spawn(
+            media_tap
+                .run(
+                    caller_audio_tx,
+                    playout_audio_rx,
+                    control_out_tx.clone(),
+                    tap_cmd_rx,
+                )
+                .instrument(tracing::Span::current()),
+        );
 
         // We don't wait for the bridge handshake to declare
         // Active; the moment both tasks are spawned, audio plumbing

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -42,6 +42,9 @@ tokio-rustls.workspace                = true
 hep-rs       = { workspace = true }
 sip-hep      = { workspace = true }
 forge-hep    = { workspace = true }
+opentelemetry = "0.32.0"
+opentelemetry_sdk = { version = "0.32.1", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.32.0", default-features = false, features = ["grpc-tonic", "trace"] }
 
 [dev-dependencies]
 hyper-util = { workspace = true, features = ["client", "client-legacy", "http1"] }

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -25,6 +25,7 @@ pub mod hep;
 pub mod http;
 pub mod log_filter;
 pub mod metrics;
+pub mod otel;
 pub mod readiness;
 
 pub use admin::{
@@ -37,6 +38,7 @@ pub use auth::{AdminAuth, AdminToken, AuthReject, Role};
 pub use hep::{HepBuildError, HepTelemetry, HepTelemetryBuild, HepWorkerHandle};
 pub use http::{AdminServer, AdminTlsConfigFn, ObservabilityServer};
 pub use log_filter::{LogFilterError, LogFilterHandle};
+pub use otel::{OtelConfig, OtelError, OtelTelemetry, OTEL_SCOPE};
 
 // Re-exports for the daemon binary so it doesn't need a second
 // direct dep on `metrics-exporter-prometheus`.

--- a/crates/telemetry/src/otel.rs
+++ b/crates/telemetry/src/otel.rs
@@ -1,0 +1,124 @@
+//! OpenTelemetry OTLP trace export (0.22.0).
+//!
+//! Builds an OTLP/gRPC span exporter + a batch-exporting `SdkTracerProvider`
+//! and installs it as the process-global tracer provider, so the
+//! `tracing-opentelemetry` layer wired in the daemon binary ships per-call
+//! spans to a collector (Tempo / Jaeger / an OTel Collector).
+//!
+//! Off by default. **Best-effort**, mirroring the HEP worker (CLAUDE.md §4.7):
+//! spans batch on a background worker and drop on overflow; a slow or
+//! unreachable collector never blocks the call path. Config is passed as
+//! primitives (not `siphon-ai-config`) to keep the dep graph minimal, same as
+//! [`crate::hep::HepTelemetry::build`].
+
+use std::time::Duration;
+
+use opentelemetry::KeyValue;
+use opentelemetry_otlp::{SpanExporter, WithExportConfig};
+use opentelemetry_sdk::trace::{Sampler, SdkTracerProvider};
+use opentelemetry_sdk::Resource;
+use thiserror::Error;
+use tracing::{info, warn};
+
+/// The instrumentation-scope name the daemon's `tracing-opentelemetry` layer
+/// uses (`opentelemetry::global::tracer(OTEL_SCOPE)`); kept here so the
+/// producer and the exporter agree on one name.
+pub const OTEL_SCOPE: &str = "siphon-ai";
+
+#[derive(Debug, Error)]
+pub enum OtelError {
+    #[error("failed to build OTLP span exporter for {endpoint}: {detail}")]
+    Exporter { endpoint: String, detail: String },
+}
+
+/// Resolved OTLP export plan. Primitives so `siphon-ai-config` isn't a dep here.
+#[derive(Debug, Clone)]
+pub struct OtelConfig {
+    /// OTLP/gRPC collector endpoint, e.g. `http://localhost:4317`.
+    pub endpoint: String,
+    /// Per-export gRPC timeout.
+    pub timeout: Duration,
+    /// Head sampling ratio in `[0.0, 1.0]`; `>= 1.0` = always sample.
+    pub sample_ratio: f64,
+    /// `service.name` resource attribute.
+    pub service_name: String,
+    /// `service.instance.id` resource attribute (the node id).
+    pub node_id: String,
+    /// Extra `key=value` resource attributes (e.g. `deployment.environment`).
+    pub extra_attributes: Vec<(String, String)>,
+}
+
+/// A live OTLP tracer provider. Held for the process lifetime; call
+/// [`OtelTelemetry::shutdown`] on daemon shutdown to flush pending spans.
+#[derive(Clone)]
+pub struct OtelTelemetry {
+    provider: SdkTracerProvider,
+}
+
+impl OtelTelemetry {
+    /// Build the OTLP/gRPC exporter + batch provider and install it as the
+    /// process-global tracer provider. After this returns, a
+    /// `tracing-opentelemetry` layer built from
+    /// `opentelemetry::global::tracer(`[`OTEL_SCOPE`]`)` exports to
+    /// `cfg.endpoint`. Fails only if the exporter can't be constructed (bad
+    /// endpoint / TLS backend) — surfaced at startup so a misconfig fails loud
+    /// (CLAUDE.md §4.6). A collector that's merely *down* is not an error:
+    /// the batch worker retries/drops in the background.
+    pub fn build(cfg: OtelConfig) -> Result<Self, OtelError> {
+        let exporter = SpanExporter::builder()
+            .with_tonic()
+            .with_endpoint(cfg.endpoint.clone())
+            .with_timeout(cfg.timeout)
+            .build()
+            .map_err(|e| OtelError::Exporter {
+                endpoint: cfg.endpoint.clone(),
+                detail: e.to_string(),
+            })?;
+
+        let mut attrs = vec![
+            KeyValue::new("service.name", cfg.service_name.clone()),
+            KeyValue::new("service.instance.id", cfg.node_id.clone()),
+        ];
+        for (k, v) in cfg.extra_attributes {
+            attrs.push(KeyValue::new(k, v));
+        }
+        let resource = Resource::builder().with_attributes(attrs).build();
+
+        // ParentBased so a sampled parent keeps its children — and so a future
+        // inbound W3C traceparent from the WS server (v0.23.0) is honoured.
+        let ratio = cfg.sample_ratio.clamp(0.0, 1.0);
+        let sampler = if ratio >= 1.0 {
+            Sampler::ParentBased(Box::new(Sampler::AlwaysOn))
+        } else {
+            Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(ratio)))
+        };
+
+        let provider = SdkTracerProvider::builder()
+            .with_batch_exporter(exporter)
+            .with_sampler(sampler)
+            .with_resource(resource)
+            .build();
+
+        // Install as the process global so `global::tracer()` (called by the
+        // daemon's tracing layer once it activates) routes here.
+        opentelemetry::global::set_tracer_provider(provider.clone());
+
+        info!(
+            endpoint = %cfg.endpoint,
+            sample_ratio = ratio,
+            "OTLP trace export active"
+        );
+        Ok(Self { provider })
+    }
+
+    /// Flush + shut down the provider, giving batched spans a bounded window to
+    /// reach the collector. Best-effort — errors are logged, never fatal.
+    pub fn shutdown(&self, timeout: Duration) {
+        match self.provider.shutdown_with_timeout(timeout) {
+            Ok(()) => info!("OTLP tracer flushed + shut down"),
+            Err(e) => {
+                warn!(error = %e, "OTLP tracer shutdown/flush error; some spans may be lost")
+            }
+        }
+    }
+}

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -707,6 +707,47 @@ This listener is unauthenticated by design (metrics/health are safe to
 scrape). The privileged `/admin/*` surface lives on its own
 [`[admin]`](#admin) listener.
 
+### `[observability.otlp]` — OpenTelemetry trace export (0.22.0)
+
+Export per-call **distributed traces** over OTLP/gRPC to a collector (Tempo /
+Jaeger / an OpenTelemetry Collector). Each call is one trace — INVITE handling
+→ controller → WS bridge → media — with the SIP `Call-ID`, direction, and
+from/to on the root. **Off by default**, and **independent of the metrics
+listener above**: you can export traces without `enabled = true` (and vice
+versa), the same way HEP is independent of `[cdr]`.
+
+Best-effort, like HEP (CLAUDE.md §4.7): spans batch on a background worker and
+drop on overflow, so a slow or unreachable collector never blocks a call. A
+bad *endpoint* fails loud at startup; a collector that's merely *down* does
+not.
+
+```toml
+[observability.otlp]
+enabled      = true
+endpoint     = "http://localhost:4317"   # OTLP/gRPC collector
+sample_ratio = 1.0                        # parent-based head sampling, [0.0, 1.0]
+timeout_ms   = 5000                       # per-export gRPC timeout
+service_name = "siphon-ai"                # service.name resource attribute
+
+[observability.otlp.attributes]           # extra resource attributes
+"deployment.environment" = "prod"
+region                   = "us-east-1"
+```
+
+| Field          | Type       | Default                   | Notes |
+|----------------|------------|---------------------------|-------|
+| `enabled`      | bool       | `false`                   | Master switch. Off ⇒ the tracing layer is a zero-cost no-op. |
+| `endpoint`     | URL        | `http://localhost:4317`   | OTLP/**gRPC** collector endpoint. |
+| `sample_ratio` | float      | `1.0`                     | Head sampling ratio in `[0.0, 1.0]`; parent-based, so a sampled parent keeps its children. Out of range → fatal at load. |
+| `timeout_ms`   | integer    | `5000`                    | Per-export gRPC timeout. |
+| `service_name` | string     | `siphon-ai`               | `service.name` resource attribute. The node id is set as `service.instance.id`. |
+| `attributes`   | table      | none                      | Extra resource attributes attached to every span. |
+
+The daemon logs `OTLP trace export active` at startup when enabled, and
+flushes pending spans on shutdown. See `docs/OPERATIONS.md` and
+`examples/observability/` for the metrics/dashboards side; W3C trace-context
+propagation to your WS server is a follow-up (v0.23.0).
+
 ## `[admin]`
 
 Authenticated admin API listener (0.10.0). Serves `/admin/*` (hangup,

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -15,7 +15,7 @@ evidence and flags any gaps.
 | Source                              | What's there                                                                           |
 |-------------------------------------|----------------------------------------------------------------------------------------|
 | Daemon log (stdout / journald)      | Lifecycle events, state transitions, errors, registration drive output                 |
-| `tracing` spans                     | Per-call latency between `on_invite` → `on_matched` → `accept_inbound` → `start_session` |
+| `tracing` spans                     | Per-call latency between `on_invite` → `on_matched` → `accept_inbound` → `start_session`. With `[observability.otlp]` (0.22.0) these export as one OTLP trace per call (root carries the SIP `Call-ID`, direction, from/to) to Tempo / Jaeger. |
 | Homer UI (`http://.../`)            | SIP call flow + RTCP + CDR + log chunks correlated by SIP `Call-ID`                    |
 | Prometheus `/metrics`               | Counters / histograms; `siphon_ai_*` for app-level, `forge_*` for media, `heplify_*` for collector  |
 | Grafana dashboards                  | Fleet Overview + Call Quality — shipped in [`examples/observability/`](../examples/observability/) (rates, ratios, latency percentiles) |


### PR DESCRIPTION
Second sub-item of the **observability completeness** theme (design note: `docs/design/DESIGN_OBSERVABILITY.md` §3.1). Adds OpenTelemetry/OTLP distributed tracing so operators can trace a call through the daemon. **Off by default.**

### What it does
- **`crates/telemetry/src/otel.rs`** — `OtelTelemetry::build` builds an OTLP/gRPC span exporter + batch-exporting `SdkTracerProvider` (parent-based ratio sampler, `service.name`/`service.instance.id` + extra resource attrs), installs it as the process-global tracer provider, and flushes on shutdown. Off the call path, best-effort (mirrors the HEP worker). New deps: opentelemetry 0.32, opentelemetry_sdk 0.32, opentelemetry-otlp 0.32 (grpc-tonic), tracing-opentelemetry 0.33, tonic 0.14 — approved in the design note §5.
- **`[observability.otlp]` config** (`enabled`/`endpoint`/`sample_ratio`/`timeout_ms`/`service_name`/`attributes`), independent of the metrics HTTP listener; fail-loud on a bad `sample_ratio`.
- **`init_tracing`** installs a reloadable OTLP layer **inactive** (`None`) before config loads — so config-load warnings still print and disabled = zero per-span cost — then the runtime installs the global provider and flips the layer live via `OtelActivation`.
- **One trace per call**: the `CallController::run` root span gains `sip_call_id` / `direction` / `from` / `to`; the spawned WS-bridge, media-tap, and recording tasks are `.instrument()`-ed under it, and the controller spawn is linked to the accept span — so `on_invite → on_matched → accept_inbound → run → { connect_and_run, media }` is **one trace**.

### Verified end to end
Against a real Jaeger (OTLP :4317) with a SIPp `basic_call_then_bye`: a single 6-span trace with the correct parent/child hierarchy and the root attributes populated; `OTLP trace export active` on boot, clean flush on SIGTERM (no panic); disabled default is a no-op. 807 workspace tests pass; clippy + fmt clean.

### Not in this PR
Version bump to 0.22.0 — held for release-prep. W3C trace-context propagation to the WS server is v0.23.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)