### PR TITLE
chore(release): 0.22.0 — daemon-side OTLP tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-07-03
+
+### Added
+
+- **OpenTelemetry / OTLP distributed tracing — `[observability.otlp]`** (P1
+  "Observability completeness"; second sub-item of the theme). Export
+  per-call traces over OTLP/gRPC to a collector (Tempo / Jaeger / an
+  OpenTelemetry Collector). Each call is **one trace** — `on_invite →
+  on_matched → accept_inbound → run → { WS bridge, media }` — with the SIP
+  `Call-ID`, direction, and from/to on the root span, so an operator can see
+  where a call spent its time across the daemon. Config knobs: `endpoint`
+  (default `http://localhost:4317`), parent-based `sample_ratio`,
+  `timeout_ms`, `service_name`, and extra resource `attributes`; independent
+  of the metrics HTTP listener (traces without metrics scraping is a valid
+  setup). **Off by default** and **best-effort** (CLAUDE.md §4.7): spans batch
+  on a background worker and drop on overflow, so a slow or unreachable
+  collector never blocks a call; a bad endpoint fails loud at startup, a
+  collector that's merely down does not. When disabled the tracing layer is a
+  zero-cost no-op. Pending spans flush on shutdown. See `docs/CONFIG.md` →
+  `[observability.otlp]`. W3C trace-context propagation to the WS server is a
+  follow-up (v0.23.0).
+
 ## [0.21.1] - 2026-07-01
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3032,7 +3032,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3076,7 +3076,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3092,7 +3092,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "base64",
  "bytes",
@@ -3113,7 +3113,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3130,7 +3130,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "regex",
  "serde",
@@ -3148,7 +3148,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3191,7 +3191,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "hmac",
  "http-body-util",
@@ -3211,7 +3211,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3235,7 +3235,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "thiserror 1.0.69",
  "tokio",
@@ -3244,7 +3244,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "regex",
  "serde",
@@ -3256,7 +3256,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3265,7 +3265,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3292,7 +3292,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -3310,7 +3310,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3338,7 +3338,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.21.1"
+version = "0.22.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.21.1.** Production-deployed against real carriers
+**Current release: v0.22.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -111,11 +111,12 @@ artifacts and distributed tracing. Scoped in
   (recording + alerting rules + Fleet Overview / Call Quality dashboards),
   `docs/OPERATIONS.md` "ten questions" made concrete, and an anti-drift CI
   check keeping metric names honest.
-- **OpenTelemetry / OTLP traces** — today tracing is structured logs + HEP
-  correlation only; OTLP spans would let operators trace a call across the
-  daemon + their WS server in one view. Next up: v0.22.0 (daemon-side export)
-  then v0.23.0 (W3C trace-context propagation to the WS server). Deps + the
-  additive protocol change are approved (DESIGN_OBSERVABILITY §5).
+- **OpenTelemetry / OTLP traces** — daemon-side export ✅ **delivered in
+  v0.22.0** (`[observability.otlp]`): one OTLP trace per call across the
+  daemon (INVITE handling → controller → WS bridge → media), off by default,
+  best-effort. Remaining: **v0.23.0** — W3C trace-context propagation to the
+  WS server so the developer's server joins the same trace (additive, protocol
+  stays v1; approved in DESIGN_OBSERVABILITY §5).
 
 ---
 


### PR DESCRIPTION
Release-prep for **v0.22.0** (daemon-side OTLP tracing landed in #259).

- `Cargo.toml` `[workspace.package].version` → `0.22.0` (+ `Cargo.lock` refresh)
- `CHANGELOG.md` — dated `## [0.22.0] - 2026-07-03` `### Added` section, fresh `## [Unreleased]`
- `README.md` — `**Current release: v0.22.0**`
- `docs/ROADMAP.md` — OTLP daemon-side export marked **delivered**; v0.23.0 WS trace-context propagation remains

Preflight verified locally: version-consistency (plain + `--tag v0.22.0`), changelog extract, doc-links all green.

After merge: tag `v0.22.0` and push to trigger the release pipeline (per `RELEASING.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)