### PR TITLE
chore(release): 0.23.0 — W3C trace propagation to the WS server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-07-08
+
+### Added
+
+- **W3C trace-context propagation to the WS server** (P1 "Observability
+  completeness"; final sub-item — the theme is complete). When
+  `[observability.otlp]` is enabled, the WS upgrade request now carries
+  [`traceparent`](https://www.w3.org/TR/trace-context/) (+ `tracestate` when
+  non-empty), and the `start` message carries the same values in a new
+  additive `trace_context` field for servers whose WS library hides upgrade
+  headers. A WS server that continues the trace from either place appears in
+  the **same waterfall** as the daemon's SIP/media spans — one distributed
+  trace per call across both services. The span-id propagated is the daemon's
+  call-root span; park-retrieve and WS-reconnect sessions stay in the same
+  trace. **The protocol stays v1**: the field is absent whenever OTLP is
+  disabled (the default), so existing servers see an unchanged `start` shape.
+  No new knob — OTLP on ⇒ headers + field, off ⇒ neither. The reference echo
+  and OpenAI-Realtime example servers show the continuation pattern. See
+  `docs/PROTOCOL.md` §3.1 and `docs/CONFIG.md` → `[observability.otlp]`.
+
+### Fixed
+
+- **OTel span-context extraction now reaches the OTLP layer.** The 0.22.0
+  init installed the OTLP tracing layer behind `tracing_subscriber::reload`,
+  whose downcast barrier made the layer invisible to
+  `OpenTelemetrySpanExt::context()` — span *export* worked, but anything
+  asking a live span for its trace context got nothing (this would have
+  silently disabled 0.23.0's propagation). The layer is now installed
+  concrete with a reloadable per-layer filter (`OFF` until `[observability.otlp]`
+  activates it), preserving the zero-cost-when-disabled property.
+
 ## [0.22.0] - 2026-07-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3032,7 +3032,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3076,7 +3076,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3092,7 +3092,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "base64",
  "bytes",
@@ -3113,7 +3113,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3130,7 +3130,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "regex",
  "serde",
@@ -3148,7 +3148,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3191,7 +3191,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "hmac",
  "http-body-util",
@@ -3211,7 +3211,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3235,7 +3235,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "thiserror 1.0.69",
  "tokio",
@@ -3244,7 +3244,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "regex",
  "serde",
@@ -3256,7 +3256,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3265,7 +3265,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3292,7 +3292,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -3310,7 +3310,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3339,7 +3339,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.22.0.** Production-deployed against real carriers
+**Current release: v0.23.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a


### PR DESCRIPTION
Release-prep per RELEASING.md: workspace version → 0.23.0, CHANGELOG section dated 2026-07-08 (fresh empty Unreleased above), README marker updated, Cargo.lock refreshed.

Verified locally: `check-version-consistency.py` (plain + `--tag v0.23.0`) and `extract-changelog.py 0.23.0` all pass.

After merge: tag `v0.23.0` on the merge commit → release workflow does the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)