### PR TITLE
feat(recording): encryption at rest — [recording.encryption] (v0.24.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3060,6 +3060,7 @@ dependencies = [
  "siphon-ai-config",
  "siphon-ai-core",
  "siphon-ai-media-glue",
+ "siphon-ai-recording",
  "siphon-ai-routes",
  "siphon-ai-sip-glue",
  "siphon-ai-stir-shaken",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3237,9 +3237,11 @@ dependencies = [
 name = "siphon-ai-recording"
 version = "0.23.0"
 dependencies = [
+ "aes-gcm",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,10 +64,14 @@ bytes  = "1"
 base64 = "0.22"
 
 # Crypto (HMAC for webhook signing; SHA-256 + constant-time eq for
-# admin token auth)
+# admin token auth; AES-GCM + zeroize for recording encryption-at-rest —
+# both already in-tree transitively via rustls, promoted to direct for
+# DESIGN_RECORDING_COMPLIANCE §2)
 hmac = "0.12"
 sha2 = "0.10"
 subtle = "2"
+aes-gcm = "0.10"
+zeroize = "1"
 
 # WebSocket
 tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }

--- a/bins/siphon-ai/Cargo.toml
+++ b/bins/siphon-ai/Cargo.toml
@@ -34,6 +34,7 @@ siphon-ai-cdr.workspace        = true
 siphon-ai-config.workspace     = true
 siphon-ai-core.workspace       = true
 siphon-ai-media-glue.workspace = true
+siphon-ai-recording.workspace  = true
 siphon-ai-routes.workspace     = true
 siphon-ai-sip-glue.workspace   = true
 siphon-ai-stir-shaken.workspace = true

--- a/bins/siphon-ai/src/main.rs
+++ b/bins/siphon-ai/src/main.rs
@@ -91,6 +91,28 @@ enum Command {
         #[arg(long = "header", short = 'H')]
         headers: Vec<String>,
     },
+
+    /// Decrypt an encrypted recording (`.wava`, 0.24.0) into a playable
+    /// WAV and exit. Offline tooling — needs the KEK file only, not the
+    /// daemon config.
+    DecryptRecording {
+        /// The `.wava` file to decrypt (a crashed capture's
+        /// `.wava.part` works with `--allow-unfinalized`).
+        file: PathBuf,
+        /// File holding the KEK as 64 hex chars — the same secret
+        /// `[recording.encryption].kek` references.
+        #[arg(long = "kek-file")]
+        kek_file: PathBuf,
+        /// Output path. Defaults to the input with a `.wav` extension.
+        #[arg(long, short)]
+        out: Option<PathBuf>,
+        /// Recover an unfinalized capture: accept a generation-0 chunk 0.
+        /// The output WAV then has placeholder (zero) size fields in its
+        /// header; most tools still play it after `ffmpeg -i in.wav out.wav`
+        /// or similar re-muxing.
+        #[arg(long)]
+        allow_unfinalized: bool,
+    },
 }
 
 /// The config path, from `--config` or `$SIPHON_AI_CONFIG`. A clap
@@ -129,6 +151,17 @@ async fn main() -> Result<()> {
     // Read-only subcommands dispatch here and exit — no socket binding,
     // no runtime (but tracing is live, so config warnings show).
     if let Some(command) = &cli.command {
+        // decrypt-recording is pure offline tooling: it takes its key
+        // material directly and must work on a box with no daemon config.
+        if let Command::DecryptRecording {
+            file,
+            kek_file,
+            out,
+            allow_unfinalized,
+        } = command
+        {
+            run_decrypt_recording(file, kek_file, out.as_deref(), *allow_unfinalized);
+        }
         let path = config_path(&cli)?;
         match command {
             Command::Check => run_check(&path),
@@ -161,6 +194,8 @@ async fn main() -> Result<()> {
                     headers: parse_headers(headers)?,
                 },
             ),
+            // Dispatched above, before the config-path requirement.
+            Command::DecryptRecording { .. } => unreachable!("handled before config load"),
         }
     }
 
@@ -226,6 +261,77 @@ fn run_route_test(path: &Path, input: inspect::RouteTestInput) -> ! {
     let config = load_or_exit(path);
     print!("{}", inspect::route_test(&config, &input));
     std::process::exit(0);
+}
+
+/// `siphon-ai decrypt-recording` — unseal a `.wava` into a playable WAV
+/// and exit (0.24.0 tooling; format spec in `docs/RECORDING.md`).
+fn run_decrypt_recording(
+    file: &Path,
+    kek_file: &Path,
+    out: Option<&Path>,
+    allow_unfinalized: bool,
+) -> ! {
+    match decrypt_recording(file, kek_file, out, allow_unfinalized) {
+        Ok((out_path, bytes)) => {
+            println!(
+                "decrypted {} → {} ({bytes} WAV bytes)",
+                file.display(),
+                out_path.display()
+            );
+            std::process::exit(0);
+        }
+        Err(err) => {
+            eprintln!("error: {err:#}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn decrypt_recording(
+    file: &Path,
+    kek_file: &Path,
+    out: Option<&Path>,
+    allow_unfinalized: bool,
+) -> Result<(PathBuf, u64)> {
+    use std::io::{Seek, SeekFrom, Write};
+
+    let kek_hex = std::fs::read_to_string(kek_file)
+        .with_context(|| format!("read KEK file {}", kek_file.display()))?;
+    let mut input = std::io::BufReader::new(
+        std::fs::File::open(file).with_context(|| format!("open {}", file.display()))?,
+    );
+    // The container names the KEK that wrapped it; surface that id in
+    // errors (so the operator knows *which* retired KEK to fetch) and use
+    // it for the supplied key.
+    let key_id = siphon_ai_recording::peek_key_id(&mut input)
+        .with_context(|| format!("{} is not a readable encrypted recording", file.display()))?;
+    input.seek(SeekFrom::Start(0)).context("rewind input")?;
+    let kek = siphon_ai_recording::Kek::from_hex(&kek_hex, key_id.clone()).with_context(|| {
+        format!(
+            "KEK file {} (recording needs key_id {key_id:?})",
+            kek_file.display()
+        )
+    })?;
+
+    let out_path = out
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| file.with_extension("wav"));
+    if out_path == file {
+        return Err(anyhow!("output path equals input; pass --out"));
+    }
+    let mut out_file = std::io::BufWriter::new(
+        std::fs::File::create(&out_path)
+            .with_context(|| format!("create {}", out_path.display()))?,
+    );
+    let bytes = siphon_ai_recording::decrypt(input, &mut out_file, &kek, allow_unfinalized)
+        .with_context(|| {
+            format!(
+                "decrypt {} (wrapped with key_id {key_id:?})",
+                file.display()
+            )
+        })?;
+    out_file.flush().context("flush output")?;
+    Ok((out_path, bytes))
 }
 
 /// Parse `--header 'Name: Value'` flags into `(name, value)` pairs.

--- a/bins/siphon-ai/tests/decrypt_recording.rs
+++ b/bins/siphon-ai/tests/decrypt_recording.rs
@@ -1,0 +1,99 @@
+//! End-to-end test of `siphon-ai decrypt-recording` (0.24.0): seal a WAV
+//! through the recording writer exactly as the daemon does, then decrypt it
+//! back with the real binary.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use siphon_ai_recording::{Kek, RecControl, RecEvent, RecFrame, RecordingWriter};
+use tokio::sync::mpsc;
+
+fn temp_dir(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("siphon_cli_dec_{}_{}", std::process::id(), tag));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+const KEK_HEX: &str = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+
+fn kek() -> Kek {
+    Kek::from_hex(KEK_HEX, "cli-test-key".into()).unwrap()
+}
+
+/// Record a short encrypted call and return the `.wava` path.
+async fn record_encrypted(dir: &Path) -> PathBuf {
+    let path = dir.join("call.wava");
+    let (atx, arx) = mpsc::channel(64);
+    let (_ctx, crx) = mpsc::channel::<RecControl>(8);
+    let (etx, mut erx) = mpsc::channel(8);
+    let task = tokio::spawn(
+        RecordingWriter::new(path.clone(), 8000, true)
+            .with_encryption(Some(kek()))
+            .run(arx, crx, etx),
+    );
+    assert!(matches!(erx.recv().await, Some(RecEvent::Started)));
+    for _ in 0..5 {
+        atx.send(RecFrame::Caller(vec![0x0F; 320])).await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    drop(atx);
+    task.await.unwrap().unwrap().unwrap();
+    path
+}
+
+#[tokio::test]
+async fn decrypt_recording_cli_roundtrip() {
+    let dir = temp_dir("roundtrip");
+    let wava = record_encrypted(&dir).await;
+    let kek_file = dir.join("kek.hex");
+    std::fs::write(&kek_file, format!("{KEK_HEX}\n")).unwrap();
+
+    let out = dir.join("out.wav");
+    let status = Command::new(env!("CARGO_BIN_EXE_siphon-ai"))
+        .args([
+            "decrypt-recording",
+            wava.to_str().unwrap(),
+            "--kek-file",
+            kek_file.to_str().unwrap(),
+            "--out",
+            out.to_str().unwrap(),
+        ])
+        .status()
+        .expect("run siphon-ai decrypt-recording");
+    assert!(status.success(), "decrypt-recording must exit 0");
+
+    let wav = std::fs::read(&out).unwrap();
+    assert_eq!(&wav[0..4], b"RIFF");
+    assert_eq!(&wav[8..12], b"WAVE");
+    let data = u32::from_le_bytes(wav[40..44].try_into().unwrap()) as usize;
+    assert_eq!(wav.len(), 44 + data, "header sizes must be patched");
+    assert!(data > 0, "payload must be non-empty");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn decrypt_recording_cli_wrong_key_fails() {
+    let dir = temp_dir("wrongkey");
+    let wava = record_encrypted(&dir).await;
+    let kek_file = dir.join("kek.hex");
+    std::fs::write(&kek_file, "ff".repeat(32)).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_siphon-ai"))
+        .args([
+            "decrypt-recording",
+            wava.to_str().unwrap(),
+            "--kek-file",
+            kek_file.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run siphon-ai decrypt-recording");
+    assert!(!output.status.success(), "wrong KEK must exit non-zero");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("cli-test-key"),
+        "error must name the key_id the recording needs, got: {stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/cdr/src/file.rs
+++ b/crates/cdr/src/file.rs
@@ -174,6 +174,7 @@ mod tests {
             verstat_passed: None,
             recording_id: None,
             recording_path: None,
+            recording_encrypted: None,
             park: None,
             hold: None,
             reconnect: None,

--- a/crates/cdr/src/hep.rs
+++ b/crates/cdr/src/hep.rs
@@ -141,6 +141,7 @@ mod tests {
             verstat_passed: None,
             recording_id: None,
             recording_path: None,
+            recording_encrypted: None,
             park: None,
             hold: None,
             reconnect: None,

--- a/crates/cdr/src/schema.rs
+++ b/crates/cdr/src/schema.rs
@@ -102,6 +102,12 @@ pub struct CdrRecord {
     /// Filesystem path of the recording, when one was written.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub recording_path: Option<String>,
+    /// `true` when the recording is sealed at rest under
+    /// `[recording.encryption]` (0.24.0) — the file at `recording_path` is
+    /// a `.wava` envelope, not a playable WAV. Omitted when the call wasn't
+    /// recorded. Additive optional field → CDR schema version unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recording_encrypted: Option<bool>,
 
     /// Park summary (0.7.0), present when the call was parked at least
     /// once. Omitted otherwise. Additive optional field → CDR schema
@@ -270,6 +276,7 @@ mod tests {
             verstat_passed: None,
             recording_id: None,
             recording_path: None,
+            recording_encrypted: None,
             park: None,
             hold: None,
             reconnect: None,

--- a/crates/cdr/src/sink.rs
+++ b/crates/cdr/src/sink.rs
@@ -120,6 +120,7 @@ mod tests {
             verstat_passed: None,
             recording_id: None,
             recording_path: None,
+            recording_encrypted: None,
             park: None,
             hold: None,
             reconnect: None,

--- a/crates/config/src/compile.rs
+++ b/crates/config/src/compile.rs
@@ -796,6 +796,21 @@ pub enum CompileError {
     #[error("[recording].dir {path:?} could not be created: {err}")]
     RecordingDirInvalid { path: String, err: String },
 
+    #[error(
+        "[recording.encryption].kek is required when enabled — 64 hex chars, \
+         via ${{file:...}} or ${{cred:...}}"
+    )]
+    RecordingKekRequired,
+
+    #[error("[recording.encryption].kek is invalid: {0} (expected 64 hex chars = 32 bytes)")]
+    RecordingKekInvalid(String),
+
+    #[error("[recording.encryption].key_id is required when enabled (1–255 bytes)")]
+    RecordingKeyIdRequired,
+
+    #[error("[recording.encryption].key_id must be 1–255 bytes, got {0}")]
+    RecordingKeyIdInvalid(usize),
+
     #[error("[route.recording].mode on route {route:?} is {value:?}; expected \"off\", \"always\", or \"on_demand\"")]
     RouteRecordingModeInvalid { route: String, value: String },
 
@@ -1563,7 +1578,31 @@ fn compile_recording(
             err: err.to_string(),
         })?;
     }
-    Ok(RecordingConfig { mode, dir })
+
+    // `[recording.encryption]` (0.24.0). Fail-loud at load (§4.6): a bad
+    // or missing KEK/key_id must never surface as per-call recording
+    // failures. The `kek` value arrives already resolved (`${file:}` /
+    // `${cred:}` expand before parse), so it must be hex — raw key bytes
+    // wouldn't survive the TOML splice.
+    let encryption = match raw.encryption {
+        Some(enc) if enc.enabled.unwrap_or(false) => {
+            let key_id = enc.key_id.ok_or(CompileError::RecordingKeyIdRequired)?;
+            if key_id.is_empty() || key_id.len() > 255 {
+                return Err(CompileError::RecordingKeyIdInvalid(key_id.len()));
+            }
+            let kek_hex = enc.kek.ok_or(CompileError::RecordingKekRequired)?;
+            let kek = siphon_ai_recording::Kek::from_hex(&kek_hex, key_id)
+                .map_err(|e| CompileError::RecordingKekInvalid(e.to_string()))?;
+            Some(kek)
+        }
+        _ => None,
+    };
+
+    Ok(RecordingConfig {
+        mode,
+        dir,
+        encryption,
+    })
 }
 
 /// Compile `[outbound]` and `[[gateway]]`. Gateways resolve to a uniform
@@ -2766,6 +2805,19 @@ mod recording_tests {
         RawRecording {
             mode: mode.map(str::to_string),
             dir: dir.map(str::to_string),
+            encryption: None,
+        }
+    }
+
+    fn raw_enc(
+        enabled: bool,
+        kek: Option<&str>,
+        key_id: Option<&str>,
+    ) -> crate::raw::RawRecordingEncryption {
+        crate::raw::RawRecordingEncryption {
+            enabled: Some(enabled),
+            kek: kek.map(str::to_string),
+            key_id: key_id.map(str::to_string),
         }
     }
 
@@ -2802,6 +2854,76 @@ mod recording_tests {
         assert!(matches!(
             compile_recording(raw(Some("always"), None)),
             Err(CompileError::RecordingDirRequired)
+        ));
+    }
+
+    #[test]
+    fn encryption_compiles_and_flips_extension() {
+        let dir = std::env::temp_dir().join("siphon_rec_cfg_enc_test");
+        let mut r = raw(Some("always"), dir.to_str());
+        r.encryption = Some(raw_enc(true, Some(&"ab".repeat(32)), Some("k-2026")));
+        let c = compile_recording(r).unwrap();
+        let kek = c.encryption.as_ref().expect("encryption compiled");
+        assert_eq!(kek.key_id(), "k-2026");
+        assert!(c
+            .path_for("call1")
+            .to_string_lossy()
+            .ends_with("call1.wava"));
+    }
+
+    #[test]
+    fn encryption_disabled_section_is_inert() {
+        let dir = std::env::temp_dir().join("siphon_rec_cfg_enc_test");
+        let mut r = raw(Some("always"), dir.to_str());
+        // enabled = false → no KEK/key_id required, plaintext output.
+        r.encryption = Some(raw_enc(false, None, None));
+        let c = compile_recording(r).unwrap();
+        assert!(c.encryption.is_none());
+        assert!(c.path_for("call1").to_string_lossy().ends_with("call1.wav"));
+    }
+
+    #[test]
+    fn encryption_validation_fails_loud() {
+        let dir = std::env::temp_dir().join("siphon_rec_cfg_enc_test");
+        let d = dir.to_str();
+
+        let mut r = raw(Some("always"), d);
+        r.encryption = Some(raw_enc(true, Some(&"ab".repeat(32)), None));
+        assert!(matches!(
+            compile_recording(r),
+            Err(CompileError::RecordingKeyIdRequired)
+        ));
+
+        let mut r = raw(Some("always"), d);
+        r.encryption = Some(raw_enc(true, None, Some("k")));
+        assert!(matches!(
+            compile_recording(r),
+            Err(CompileError::RecordingKekRequired)
+        ));
+
+        let mut r = raw(Some("always"), d);
+        r.encryption = Some(raw_enc(true, Some("too-short"), Some("k")));
+        assert!(matches!(
+            compile_recording(r),
+            Err(CompileError::RecordingKekInvalid(_))
+        ));
+
+        let mut r = raw(Some("always"), d);
+        r.encryption = Some(raw_enc(true, Some(&"zz".repeat(32)), Some("k")));
+        assert!(matches!(
+            compile_recording(r),
+            Err(CompileError::RecordingKekInvalid(_))
+        ));
+
+        let mut r = raw(Some("always"), d);
+        r.encryption = Some(raw_enc(
+            true,
+            Some(&"ab".repeat(32)),
+            Some(&"x".repeat(256)),
+        ));
+        assert!(matches!(
+            compile_recording(r),
+            Err(CompileError::RecordingKeyIdInvalid(256))
         ));
     }
 

--- a/crates/config/src/raw.rs
+++ b/crates/config/src/raw.rs
@@ -491,6 +491,26 @@ pub struct RawRecording {
     /// Directory recordings are written to. Required when `mode != "off"`.
     #[serde(default)]
     pub dir: Option<String>,
+    /// `[recording.encryption]` (0.24.0) — envelope encryption at rest.
+    #[serde(default)]
+    pub encryption: Option<RawRecordingEncryption>,
+}
+
+/// `[recording.encryption]` — seal recordings into `.wava` envelopes
+/// (0.24.0). Off by default (`enabled = false`), mirroring
+/// `[observability.otlp]`.
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct RawRecordingEncryption {
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    /// The KEK as 64 hex chars — reference a secret with `${file:}` /
+    /// `${cred:}`, never inline it.
+    #[serde(default)]
+    pub kek: Option<String>,
+    /// Identifier stamped into recording headers; names which KEK wrapped
+    /// each recording so keys can rotate.
+    #[serde(default)]
+    pub key_id: Option<String>,
 }
 
 /// `[conference]` — conference rooms (0.7.0). Fail-closed like

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -2076,6 +2076,7 @@ impl CallStart {
                 .recording
                 .as_ref()
                 .map(|r| r.path.display().to_string()),
+            recording_encrypted: outcome.recording.as_ref().map(|r| r.encrypted),
             park: outcome.park.map(|p| siphon_ai_cdr::ParkInfo {
                 count: p.count,
                 total_ms: p.total_ms,
@@ -2217,6 +2218,7 @@ fn build_delayed_failure_cdr(
         verstat_passed: None,
         recording_id: None,
         recording_path: None,
+        recording_encrypted: None,
         park: None,
         hold: None,
         reconnect: None,
@@ -3486,10 +3488,12 @@ impl BridgingAcceptor {
             RecordingMode::Always => Some(RecordingSetup {
                 path: self.recording.path_for(bridge_call_id.as_str()),
                 auto_start: true,
+                encryption: self.recording.encryption.clone(),
             }),
             RecordingMode::OnDemand => Some(RecordingSetup {
                 path: self.recording.path_for(bridge_call_id.as_str()),
                 auto_start: false,
+                encryption: self.recording.encryption.clone(),
             }),
             RecordingMode::Off => None,
         };
@@ -3768,10 +3772,12 @@ impl BridgingAcceptor {
             RecordingMode::Always => Some(RecordingSetup {
                 path: self.recording.path_for(bridge_call_id.as_str()),
                 auto_start: true,
+                encryption: self.recording.encryption.clone(),
             }),
             RecordingMode::OnDemand => Some(RecordingSetup {
                 path: self.recording.path_for(bridge_call_id.as_str()),
                 auto_start: false,
+                encryption: self.recording.encryption.clone(),
             }),
             RecordingMode::Off => None,
         };

--- a/crates/core/src/call.rs
+++ b/crates/core/src/call.rs
@@ -284,6 +284,8 @@ pub struct ReconnectSummary {
 pub struct RecordingSummary {
     pub path: std::path::PathBuf,
     pub result: RecordingResult,
+    /// Sealed at rest under `[recording.encryption]` (0.24.0).
+    pub encrypted: bool,
 }
 
 /// How a recording finished — the `result` label on `siphon_ai_recordings_total`.
@@ -735,6 +737,9 @@ impl CallController {
         // recording `degraded`. `None` when recording is off for the call.
         let mut rec_drops: Option<Arc<AtomicU64>> = None;
         let mut rec_path: Option<std::path::PathBuf> = None;
+        // Whether this call's recording is sealed at rest (0.24.0) — feeds
+        // the CDR `recording_encrypted` flag.
+        let mut rec_encrypted = false;
         // One recording per call in this revision → recording_id = call_id.
         let recording_id = call_id.as_str().to_string();
         let media_tap = if let Some(setup) = recording {
@@ -743,8 +748,10 @@ impl CallController {
             let (evt_tx, evt_rx) = mpsc::channel::<RecEvent>(CONTROL_CHANNEL_CAPACITY);
             let drops = Arc::new(AtomicU64::new(0));
             rec_path = Some(setup.path.clone());
+            rec_encrypted = setup.encryption.is_some();
             let writer =
-                RecordingWriter::new(setup.path, media_tap.sample_rate(), setup.auto_start);
+                RecordingWriter::new(setup.path, media_tap.sample_rate(), setup.auto_start)
+                    .with_encryption(setup.encryption);
             recording_task = Some(tokio::spawn(
                 writer
                     .run(rec_rx, ctrl_rx, evt_tx)
@@ -1881,6 +1888,7 @@ impl CallController {
                     Some(RecordingSummary {
                         path: stats.path,
                         result,
+                        encrypted: rec_encrypted,
                     })
                 }
                 // on-demand recording that was never started.
@@ -1893,6 +1901,7 @@ impl CallController {
                     Some(RecordingSummary {
                         path: failed_path(),
                         result: RecordingResult::Failed,
+                        encrypted: rec_encrypted,
                     })
                 }
                 Ok(Err(join_err)) => {
@@ -1900,6 +1909,7 @@ impl CallController {
                     Some(RecordingSummary {
                         path: failed_path(),
                         result: RecordingResult::Failed,
+                        encrypted: rec_encrypted,
                     })
                 }
                 Err(_) => {
@@ -1909,6 +1919,7 @@ impl CallController {
                     Some(RecordingSummary {
                         path: failed_path(),
                         result: RecordingResult::Failed,
+                        encrypted: rec_encrypted,
                     })
                 }
             }

--- a/crates/core/src/outbound_service.rs
+++ b/crates/core/src/outbound_service.rs
@@ -570,6 +570,7 @@ fn build_outbound_record(
         verstat_passed: None,
         recording_id: None,
         recording_path: None,
+        recording_encrypted: None,
         // Outbound bots can park too (0.7.0); carry the accounting.
         park: view.park.map(|p| siphon_ai_cdr::ParkInfo {
             count: p.count,

--- a/crates/recording/Cargo.toml
+++ b/crates/recording/Cargo.toml
@@ -12,6 +12,8 @@ repository.workspace   = true
 tokio     = { workspace = true }
 tracing.workspace   = true
 thiserror.workspace = true
+aes-gcm.workspace   = true
+zeroize.workspace   = true
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/recording/src/config.rs
+++ b/crates/recording/src/config.rs
@@ -2,6 +2,8 @@
 
 use std::path::PathBuf;
 
+use crate::kek::Kek;
+
 /// When to record.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum RecordingMode {
@@ -21,6 +23,9 @@ pub struct RecordingConfig {
     pub mode: RecordingMode,
     /// Directory recordings are written to (required when `mode != Off`).
     pub dir: PathBuf,
+    /// `[recording.encryption]` (0.24.0): seal recordings into `.wava`
+    /// envelopes under this KEK. `None` = plaintext WAV.
+    pub encryption: Option<Kek>,
 }
 
 impl Default for RecordingConfig {
@@ -28,15 +33,22 @@ impl Default for RecordingConfig {
         Self {
             mode: RecordingMode::Off,
             dir: PathBuf::new(),
+            encryption: None,
         }
     }
 }
 
 impl RecordingConfig {
-    /// The output path for `call_id` under this config's directory.
-    /// (Templating beyond `<dir>/<call_id>.wav` is a later chunk.)
+    /// The output path for `call_id` under this config's directory —
+    /// `<dir>/<call_id>.wav`, or `.wava` when encryption is on.
+    /// (Templating beyond that is a later chunk.)
     pub fn path_for(&self, call_id: &str) -> PathBuf {
-        self.dir.join(format!("{call_id}.wav"))
+        let ext = if self.encryption.is_some() {
+            "wava"
+        } else {
+            "wav"
+        };
+        self.dir.join(format!("{call_id}.{ext}"))
     }
 }
 
@@ -49,4 +61,6 @@ pub struct RecordingSetup {
     /// `true` (mode `always`) → start recording immediately. `false` (mode
     /// `on_demand`) → wait for a `StartRecording` from the WS server.
     pub auto_start: bool,
+    /// Encrypt at rest under this KEK (0.24.0); `None` = plaintext WAV.
+    pub encryption: Option<Kek>,
 }

--- a/crates/recording/src/envelope.rs
+++ b/crates/recording/src/envelope.rs
@@ -1,0 +1,507 @@
+//! The `.wava` encrypted-recording container (DESIGN_RECORDING_COMPLIANCE §2).
+//!
+//! Envelope encryption: a fresh random 256-bit DEK per recording encrypts
+//! the payload in independent AES-256-GCM chunks; the DEK travels in the
+//! header, wrapped by the operator's KEK (see [`crate::kek`]). The inner
+//! payload is a byte-exact standard WAV, so `decrypt` output is playable
+//! as-is.
+//!
+//! ## On-disk layout (all integers little-endian)
+//!
+//! ```text
+//! header:  magic "SAIWAVA1"
+//!          key_id_len u8 | key_id (utf-8)
+//!          wrapped_dek_len u16 | wrapped_dek        (see kek::wrap_dek)
+//!          chunk_size u32                           (plaintext bytes/chunk)
+//! chunk i: generation u32 | ct_len u32 | ciphertext (plaintext + 16-byte tag)
+//! ```
+//!
+//! Chunk `i`'s GCM nonce is `chunk_index u64 || generation u32` (12 bytes),
+//! and the AAD for every chunk is the full serialized header — a chunk
+//! can't be replayed into a different recording or under a different key id.
+//!
+//! ## The chunk-0 rewrite
+//!
+//! WAV finalize back-patches the RIFF sizes at offsets 4 and 40 — inside a
+//! sealed stream that's impossible, so finalize **rewrites chunk 0**: the
+//! writer retains chunk 0's plaintext, patches the sizes, and re-seals it
+//! with `generation = 1`. Bumping the generation changes the nonce (GCM
+//! nonce reuse is catastrophic), and because the plaintext length is
+//! unchanged the ciphertext overwrites in place. A finalized file therefore
+//! has `generation == 1` on chunk 0 and `0` everywhere else — the decoder
+//! enforces exactly that, so a truncated/unfinalized capture (a crashed
+//! `.part`) is distinguishable and an attacker can't swap the placeholder
+//! chunk 0 back in.
+
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use aes_gcm::aead::{Aead, KeyInit, Payload};
+use aes_gcm::{Aes256Gcm, Nonce};
+use thiserror::Error;
+use tokio::fs::File;
+use tokio::io::{AsyncSeekExt, AsyncWriteExt, BufWriter};
+use zeroize::Zeroizing;
+
+use crate::kek::Kek;
+
+/// Container magic; the trailing `1` is the format version.
+pub const MAGIC: &[u8; 8] = b"SAIWAVA1";
+/// Plaintext bytes per chunk. Matches the writer's flush cadence (~1 s of
+/// stereo 16 kHz audio) so steady-state writes seal whole chunks.
+pub const CHUNK_SIZE: usize = 64 * 1024;
+/// GCM tag length.
+const TAG_LEN: usize = 16;
+/// Per-chunk on-disk framing: `generation u32 | ct_len u32`.
+const CHUNK_FRAME_LEN: usize = 8;
+
+#[derive(Debug, Error)]
+pub enum EnvelopeError {
+    #[error("envelope I/O failed for {path:?}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("not a SiphonAI encrypted recording (bad magic)")]
+    BadMagic,
+    #[error("malformed envelope header: {0}")]
+    BadHeader(&'static str),
+    #[error("DEK unwrap failed: {0}")]
+    Kek(#[from] crate::kek::KekError),
+    #[error("chunk {index}: {reason}")]
+    BadChunk { index: u64, reason: &'static str },
+    #[error(
+        "chunk 0 is unfinalized (generation 0) — the recording was cut off \
+         before finalize; its WAV header sizes are placeholders"
+    )]
+    Unfinalized,
+    #[error("chunk {index} failed authentication (wrong key or tampered data)")]
+    Auth { index: u64 },
+}
+
+impl EnvelopeError {
+    fn io(path: &Path, source: std::io::Error) -> Self {
+        Self::Io {
+            path: path.to_path_buf(),
+            source,
+        }
+    }
+}
+
+/// `chunk_index || generation` → the 12-byte GCM nonce.
+fn nonce_for(index: u64, generation: u32) -> [u8; 12] {
+    let mut n = [0u8; 12];
+    n[..8].copy_from_slice(&index.to_le_bytes());
+    n[8..].copy_from_slice(&generation.to_le_bytes());
+    n
+}
+
+/// Serialized header for a new envelope; also the AAD for every chunk.
+fn build_header(key_id: &str, wrapped_dek: &[u8]) -> Vec<u8> {
+    let mut h = Vec::with_capacity(MAGIC.len() + 1 + key_id.len() + 2 + wrapped_dek.len() + 4);
+    h.extend_from_slice(MAGIC);
+    h.push(key_id.len() as u8);
+    h.extend_from_slice(key_id.as_bytes());
+    h.extend_from_slice(&(wrapped_dek.len() as u16).to_le_bytes());
+    h.extend_from_slice(wrapped_dek);
+    h.extend_from_slice(&(CHUNK_SIZE as u32).to_le_bytes());
+    h
+}
+
+/// Streaming encrypting writer. Feed plaintext with [`Self::write`]; call
+/// [`Self::finalize`] with the WAV header patches to seal the container.
+///
+/// Owns the output `File` (the caller creates it — typically a `.part`
+/// path it renames after finalize). Retains chunk 0's plaintext (≤ 64 KiB,
+/// per-call, off the hot path) for the finalize rewrite.
+pub struct EnvelopeWriter {
+    path: PathBuf,
+    out: BufWriter<File>,
+    cipher: Aes256Gcm,
+    header: Vec<u8>,
+    /// Plaintext staged for the next chunk (< CHUNK_SIZE between writes).
+    pending: Vec<u8>,
+    /// Chunk 0's plaintext, kept for the finalize rewrite.
+    first_chunk: Option<Vec<u8>>,
+    /// File offset where chunk 0's frame begins (== header length).
+    chunks_start: u64,
+    next_index: u64,
+}
+
+impl EnvelopeWriter {
+    /// Wrap a fresh random DEK with `kek` and write the container header.
+    pub async fn create(path: &Path, file: File, kek: &Kek) -> Result<Self, EnvelopeError> {
+        let dek: Zeroizing<[u8; 32]> = crate::kek::fresh_dek();
+        let wrapped = kek.wrap_dek(&dek)?;
+        let header = build_header(kek.key_id(), &wrapped);
+        let dek_bytes: &[u8; 32] = &dek;
+        let cipher = Aes256Gcm::new(dek_bytes.into());
+        let mut out = BufWriter::new(file);
+        out.write_all(&header)
+            .await
+            .map_err(|e| EnvelopeError::io(path, e))?;
+        Ok(Self {
+            path: path.to_path_buf(),
+            chunks_start: header.len() as u64,
+            out,
+            cipher,
+            header,
+            pending: Vec::with_capacity(CHUNK_SIZE),
+            first_chunk: None,
+            next_index: 0,
+        })
+    }
+
+    /// Append plaintext; seals and writes a chunk each time a full
+    /// `CHUNK_SIZE` accumulates.
+    pub async fn write(&mut self, mut data: &[u8]) -> Result<(), EnvelopeError> {
+        while !data.is_empty() {
+            let take = (CHUNK_SIZE - self.pending.len()).min(data.len());
+            self.pending.extend_from_slice(&data[..take]);
+            data = &data[take..];
+            if self.pending.len() == CHUNK_SIZE {
+                self.seal_pending().await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn seal_pending(&mut self) -> Result<(), EnvelopeError> {
+        let index = self.next_index;
+        let plain = std::mem::replace(&mut self.pending, Vec::with_capacity(CHUNK_SIZE));
+        let ct = self.seal(index, 0, &plain)?;
+        self.write_chunk_frame(0, &ct).await?;
+        if index == 0 {
+            self.first_chunk = Some(plain);
+        }
+        self.next_index += 1;
+        Ok(())
+    }
+
+    fn seal(&self, index: u64, generation: u32, plain: &[u8]) -> Result<Vec<u8>, EnvelopeError> {
+        self.cipher
+            .encrypt(
+                Nonce::from_slice(&nonce_for(index, generation)),
+                Payload {
+                    msg: plain,
+                    aad: &self.header,
+                },
+            )
+            .map_err(|_| EnvelopeError::BadChunk {
+                index,
+                reason: "encryption failed",
+            })
+    }
+
+    async fn write_chunk_frame(&mut self, generation: u32, ct: &[u8]) -> Result<(), EnvelopeError> {
+        let mut frame = [0u8; CHUNK_FRAME_LEN];
+        frame[..4].copy_from_slice(&generation.to_le_bytes());
+        frame[4..].copy_from_slice(&(ct.len() as u32).to_le_bytes());
+        self.out
+            .write_all(&frame)
+            .await
+            .map_err(|e| EnvelopeError::io(&self.path, e))?;
+        self.out
+            .write_all(ct)
+            .await
+            .map_err(|e| EnvelopeError::io(&self.path, e))?;
+        Ok(())
+    }
+
+    /// Seal the trailing partial chunk, apply the WAV size patches to chunk
+    /// 0, and rewrite it with `generation = 1`. `patches` are
+    /// `(plaintext_offset, value)` pairs — both WAV size fields sit inside
+    /// chunk 0 (offsets 4 and 40 ≪ CHUNK_SIZE).
+    pub async fn finalize(mut self, patches: &[(usize, u32)]) -> Result<(), EnvelopeError> {
+        if !self.pending.is_empty() || self.next_index == 0 {
+            self.seal_pending().await?;
+        }
+        let mut chunk0 = self.first_chunk.take().ok_or(EnvelopeError::BadChunk {
+            index: 0,
+            reason: "no chunk 0 to finalize",
+        })?;
+        for &(offset, value) in patches {
+            if offset + 4 > chunk0.len() {
+                return Err(EnvelopeError::BadChunk {
+                    index: 0,
+                    reason: "patch offset outside chunk 0",
+                });
+            }
+            chunk0[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
+        }
+        // Same plaintext length ⇒ same ciphertext length ⇒ in-place
+        // overwrite; generation 1 ⇒ a fresh nonce for the rewrite.
+        let ct = self.seal(0, 1, &chunk0)?;
+        self.out
+            .flush()
+            .await
+            .map_err(|e| EnvelopeError::io(&self.path, e))?;
+        self.out
+            .seek(std::io::SeekFrom::Start(self.chunks_start))
+            .await
+            .map_err(|e| EnvelopeError::io(&self.path, e))?;
+        self.write_chunk_frame(1, &ct).await?;
+        self.out
+            .flush()
+            .await
+            .map_err(|e| EnvelopeError::io(&self.path, e))?;
+        Ok(())
+    }
+}
+
+/// Decrypt a `.wava` container into `out`, returning the payload byte
+/// count. Synchronous — used by the `decrypt-recording` subcommand and
+/// tests, never on a call path.
+///
+/// `allow_unfinalized` accepts a chunk-0 `generation` of 0 (a crashed
+/// `.part` capture) — the recovered WAV then has placeholder (zero) size
+/// fields the caller must expect.
+pub fn decrypt<R: Read, W: Write>(
+    mut input: R,
+    out: &mut W,
+    kek: &Kek,
+    allow_unfinalized: bool,
+) -> Result<u64, EnvelopeError> {
+    let err_io = |e: std::io::Error| EnvelopeError::Io {
+        path: PathBuf::from("<input>"),
+        source: e,
+    };
+
+    // Header — reconstructed byte-for-byte, since it is every chunk's AAD.
+    let mut magic = [0u8; 8];
+    input.read_exact(&mut magic).map_err(err_io)?;
+    if &magic != MAGIC {
+        return Err(EnvelopeError::BadMagic);
+    }
+    let mut len1 = [0u8; 1];
+    input.read_exact(&mut len1).map_err(err_io)?;
+    let mut key_id = vec![0u8; len1[0] as usize];
+    input.read_exact(&mut key_id).map_err(err_io)?;
+    let key_id = String::from_utf8(key_id).map_err(|_| EnvelopeError::BadHeader("key_id utf8"))?;
+    let mut len2 = [0u8; 2];
+    input.read_exact(&mut len2).map_err(err_io)?;
+    let mut wrapped = vec![0u8; u16::from_le_bytes(len2) as usize];
+    input.read_exact(&mut wrapped).map_err(err_io)?;
+    let mut cs = [0u8; 4];
+    input.read_exact(&mut cs).map_err(err_io)?;
+    let chunk_size = u32::from_le_bytes(cs) as usize;
+    if chunk_size == 0 || chunk_size > 16 * 1024 * 1024 {
+        return Err(EnvelopeError::BadHeader("unreasonable chunk_size"));
+    }
+    let header = build_header(&key_id, &wrapped);
+
+    let dek = kek.unwrap_dek(&key_id, &wrapped)?;
+    let dek_bytes: &[u8; 32] = &dek;
+    let cipher = Aes256Gcm::new(dek_bytes.into());
+
+    let mut index = 0u64;
+    let mut total = 0u64;
+    loop {
+        let mut frame = [0u8; CHUNK_FRAME_LEN];
+        match input.read_exact(&mut frame) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof && index > 0 => break,
+            Err(e) => return Err(err_io(e)),
+        }
+        let generation = u32::from_le_bytes(frame[..4].try_into().expect("4 bytes"));
+        let ct_len = u32::from_le_bytes(frame[4..].try_into().expect("4 bytes")) as usize;
+        if ct_len < TAG_LEN || ct_len > chunk_size + TAG_LEN {
+            return Err(EnvelopeError::BadChunk {
+                index,
+                reason: "ciphertext length out of range",
+            });
+        }
+        match (index, generation) {
+            (0, 1) => {}
+            (0, 0) if allow_unfinalized => {}
+            (0, 0) => return Err(EnvelopeError::Unfinalized),
+            (_, 0) if index > 0 => {}
+            _ => {
+                return Err(EnvelopeError::BadChunk {
+                    index,
+                    reason: "unexpected generation",
+                })
+            }
+        }
+        let mut ct = vec![0u8; ct_len];
+        input.read_exact(&mut ct).map_err(err_io)?;
+        let plain = cipher
+            .decrypt(
+                Nonce::from_slice(&nonce_for(index, generation)),
+                Payload {
+                    msg: &ct,
+                    aad: &header,
+                },
+            )
+            .map_err(|_| EnvelopeError::Auth { index })?;
+        if index > 0 && plain.len() != chunk_size && {
+            // Only the final chunk may be short — peek for more data.
+            let mut probe = [0u8; 1];
+            match input.read_exact(&mut probe) {
+                Ok(()) => true, // more chunks follow a short one → malformed
+                Err(_) => false,
+            }
+        } {
+            return Err(EnvelopeError::BadChunk {
+                index,
+                reason: "short chunk before end of file",
+            });
+        }
+        out.write_all(&plain).map_err(err_io)?;
+        total += plain.len() as u64;
+        if plain.len() != chunk_size {
+            break; // final (short) chunk
+        }
+        index += 1;
+    }
+    Ok(total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kek::Kek;
+
+    fn test_kek() -> Kek {
+        Kek::new_static([7u8; 32], "test-key".into())
+    }
+
+    fn temp_file(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("siphon_env_{}_{}", std::process::id(), tag));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir.join("r.wava")
+    }
+
+    async fn write_envelope(path: &Path, kek: &Kek, payload: &[u8], patches: &[(usize, u32)]) {
+        let file = File::create(path).await.unwrap();
+        let mut w = EnvelopeWriter::create(path, file, kek).await.unwrap();
+        // Write in awkward sizes to exercise chunk-boundary slicing.
+        for piece in payload.chunks(CHUNK_SIZE / 3 + 11) {
+            w.write(piece).await.unwrap();
+        }
+        w.finalize(patches).await.unwrap();
+    }
+
+    fn decrypt_file(
+        path: &Path,
+        kek: &Kek,
+        allow_unfinalized: bool,
+    ) -> Result<Vec<u8>, EnvelopeError> {
+        let f = std::fs::File::open(path).unwrap();
+        let mut out = Vec::new();
+        decrypt(std::io::BufReader::new(f), &mut out, kek, allow_unfinalized)?;
+        Ok(out)
+    }
+
+    #[tokio::test]
+    async fn roundtrip_multi_chunk_with_patches() {
+        let path = temp_file("roundtrip");
+        let kek = test_kek();
+        // 2.5 chunks of recognizable data.
+        let payload: Vec<u8> = (0..CHUNK_SIZE * 5 / 2).map(|i| (i % 251) as u8).collect();
+        write_envelope(&path, &kek, &payload, &[(4, 0xAABBCCDD), (40, 0x11223344)]).await;
+
+        let plain = decrypt_file(&path, &kek, false).unwrap();
+        let mut expected = payload.clone();
+        expected[4..8].copy_from_slice(&0xAABBCCDDu32.to_le_bytes());
+        expected[40..44].copy_from_slice(&0x11223344u32.to_le_bytes());
+        assert_eq!(plain, expected, "decrypt must yield patched payload");
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[tokio::test]
+    async fn tiny_payload_single_chunk() {
+        let path = temp_file("tiny");
+        let kek = test_kek();
+        let payload = vec![0x5A; 100]; // < one chunk, still gets patched + finalized
+        write_envelope(&path, &kek, &payload, &[(4, 56)]).await;
+        let plain = decrypt_file(&path, &kek, false).unwrap();
+        assert_eq!(plain.len(), 100);
+        assert_eq!(&plain[4..8], &56u32.to_le_bytes());
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[tokio::test]
+    async fn wrong_kek_fails_auth_not_panics() {
+        let path = temp_file("wrongkey");
+        let kek = test_kek();
+        write_envelope(&path, &kek, &vec![1u8; 500], &[]).await;
+        let other = Kek::new_static([9u8; 32], "test-key".into());
+        match decrypt_file(&path, &other, false) {
+            Err(EnvelopeError::Kek(_)) => {}
+            other => panic!("expected KEK unwrap failure, got {other:?}"),
+        }
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[tokio::test]
+    async fn tampered_ciphertext_fails_auth() {
+        let path = temp_file("tamper");
+        let kek = test_kek();
+        write_envelope(&path, &kek, &vec![3u8; CHUNK_SIZE + 300], &[]).await;
+        // Flip one byte late in the file (inside chunk 1's ciphertext).
+        let mut bytes = std::fs::read(&path).unwrap();
+        let n = bytes.len();
+        bytes[n - 10] ^= 0xFF;
+        std::fs::write(&path, &bytes).unwrap();
+        match decrypt_file(&path, &kek, false) {
+            Err(EnvelopeError::Auth { index: 1 }) => {}
+            other => panic!("expected auth failure on chunk 1, got {other:?}"),
+        }
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[tokio::test]
+    async fn unfinalized_rejected_unless_allowed() {
+        let path = temp_file("unfinal");
+        let kek = test_kek();
+        // Write without finalize: chunk 0 keeps generation 0.
+        let file = File::create(&path).await.unwrap();
+        let mut w = EnvelopeWriter::create(&path, file, &kek).await.unwrap();
+        w.write(&vec![8u8; CHUNK_SIZE]).await.unwrap(); // seals chunk 0 (gen 0)
+        w.out.flush().await.unwrap();
+        drop(w);
+
+        match decrypt_file(&path, &kek, false) {
+            Err(EnvelopeError::Unfinalized) => {}
+            other => panic!("expected Unfinalized, got {other:?}"),
+        }
+        let plain = decrypt_file(&path, &kek, true).unwrap();
+        assert_eq!(plain, vec![8u8; CHUNK_SIZE]);
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[tokio::test]
+    async fn chunk0_placeholder_swap_is_rejected() {
+        // An attacker restoring the pre-finalize chunk 0 (generation 0)
+        // into a finalized file must be caught by the generation rule.
+        let path = temp_file("swap");
+        let kek = test_kek();
+
+        // Capture the pre-finalize bytes of chunk 0 by writing one chunk,
+        // flushing, and snapshotting the file before finalize.
+        let file = File::create(&path).await.unwrap();
+        let mut w = EnvelopeWriter::create(&path, file, &kek).await.unwrap();
+        w.write(&vec![4u8; CHUNK_SIZE + 32]).await.unwrap();
+        w.out.flush().await.unwrap();
+        let before = std::fs::read(&path).unwrap();
+        w.finalize(&[(4, 999)]).await.unwrap();
+        let mut after = std::fs::read(&path).unwrap();
+
+        // Splice the old (gen 0) chunk-0 frame back over the finalized one.
+        // `before` = header + chunk-0 frame only (the 32 trailing bytes were
+        // still pending), so chunk 0 ends exactly at `before.len()`.
+        let chunk0_frame_len = CHUNK_FRAME_LEN + CHUNK_SIZE + TAG_LEN;
+        let start = before.len() - chunk0_frame_len;
+        after[start..start + chunk0_frame_len]
+            .copy_from_slice(&before[start..start + chunk0_frame_len]);
+        std::fs::write(&path, &after).unwrap();
+
+        match decrypt_file(&path, &kek, false) {
+            Err(EnvelopeError::Unfinalized) => {}
+            other => panic!("expected Unfinalized on swapped chunk 0, got {other:?}"),
+        }
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+}

--- a/crates/recording/src/envelope.rs
+++ b/crates/recording/src/envelope.rs
@@ -257,18 +257,12 @@ impl EnvelopeWriter {
 /// `allow_unfinalized` accepts a chunk-0 `generation` of 0 (a crashed
 /// `.part` capture) — the recovered WAV then has placeholder (zero) size
 /// fields the caller must expect.
-pub fn decrypt<R: Read, W: Write>(
-    mut input: R,
-    out: &mut W,
-    kek: &Kek,
-    allow_unfinalized: bool,
-) -> Result<u64, EnvelopeError> {
+/// Parse a container header: `(key_id, wrapped_dek, chunk_size)`.
+fn read_header<R: Read>(input: &mut R) -> Result<(String, Vec<u8>, usize), EnvelopeError> {
     let err_io = |e: std::io::Error| EnvelopeError::Io {
         path: PathBuf::from("<input>"),
         source: e,
     };
-
-    // Header — reconstructed byte-for-byte, since it is every chunk's AAD.
     let mut magic = [0u8; 8];
     input.read_exact(&mut magic).map_err(err_io)?;
     if &magic != MAGIC {
@@ -289,6 +283,28 @@ pub fn decrypt<R: Read, W: Write>(
     if chunk_size == 0 || chunk_size > 16 * 1024 * 1024 {
         return Err(EnvelopeError::BadHeader("unreasonable chunk_size"));
     }
+    Ok((key_id, wrapped, chunk_size))
+}
+
+/// Read just the `key_id` a container names — lets tooling tell the
+/// operator *which* KEK a recording needs without attempting decryption.
+pub fn peek_key_id<R: Read>(mut input: R) -> Result<String, EnvelopeError> {
+    read_header(&mut input).map(|(key_id, _, _)| key_id)
+}
+
+pub fn decrypt<R: Read, W: Write>(
+    mut input: R,
+    out: &mut W,
+    kek: &Kek,
+    allow_unfinalized: bool,
+) -> Result<u64, EnvelopeError> {
+    let err_io = |e: std::io::Error| EnvelopeError::Io {
+        path: PathBuf::from("<input>"),
+        source: e,
+    };
+
+    // Header — reconstructed byte-for-byte, since it is every chunk's AAD.
+    let (key_id, wrapped, chunk_size) = read_header(&mut input)?;
     let header = build_header(&key_id, &wrapped);
 
     let dek = kek.unwrap_dek(&key_id, &wrapped)?;

--- a/crates/recording/src/kek.rs
+++ b/crates/recording/src/kek.rs
@@ -41,10 +41,16 @@ pub enum KekError {
     UnwrapAuth,
     #[error("DEK wrap failed")]
     WrapFailed,
+    #[error("bad KEK encoding: {0}")]
+    BadEncoding(&'static str),
 }
 
 /// A key-encryption key + its identifier.
-#[derive(Clone)]
+///
+/// `PartialEq` exists for config-diffing on reload — it compares key bytes
+/// non-constant-time, which is fine there (both sides are our own config,
+/// never attacker-supplied guesses).
+#[derive(Clone, PartialEq, Eq)]
 pub enum Kek {
     /// A 32-byte KEK held in memory (resolved from `${file:}` / `${cred:}`
     /// at config load). Zeroized on drop.
@@ -72,6 +78,24 @@ impl Kek {
             key: Zeroizing::new(key),
             key_id,
         }
+    }
+
+    /// Parse a KEK from its 64-hex-char encoding — the `[recording.
+    /// encryption].kek` value and the `decrypt-recording` key file. Hex
+    /// (not raw bytes) because config secret references splice the value
+    /// into TOML text. Surrounding whitespace is tolerated.
+    pub fn from_hex(hex: &str, key_id: String) -> Result<Self, KekError> {
+        let hex = hex.trim();
+        if hex.len() != 64 {
+            return Err(KekError::BadEncoding("expected 64 hex characters"));
+        }
+        let mut key = Zeroizing::new([0u8; 32]);
+        for (i, byte) in key.iter_mut().enumerate() {
+            let pair = &hex[i * 2..i * 2 + 2];
+            *byte = u8::from_str_radix(pair, 16)
+                .map_err(|_| KekError::BadEncoding("non-hex character"))?;
+        }
+        Ok(Kek::Static { key, key_id })
     }
 
     /// The identifier stamped into container headers.

--- a/crates/recording/src/kek.rs
+++ b/crates/recording/src/kek.rs
@@ -1,0 +1,195 @@
+//! Key-encryption-key sources for recording encryption
+//! (DESIGN_RECORDING_COMPLIANCE §2).
+//!
+//! Envelope encryption splits keys in two: each recording gets a fresh
+//! random **DEK** (data-encryption key) that encrypts the audio, and the
+//! DEK itself is stored in the container header **wrapped** by the
+//! operator's **KEK**. Rotating the KEK never re-encrypts audio — new
+//! recordings just name the new `key_id`.
+//!
+//! [`Kek`] is the provider seam. v0.24.0 ships the static (file/`${cred:}`
+//! resolved) variant; the AWS-KMS variant lands with the SigV4 client in
+//! v0.25.0 as a new enum arm. (The design note sketched this seam as a
+//! trait; an enum keeps it dyn-compatible with async wrap calls once KMS —
+//! a network hop — joins, and config compiles to a closed set anyway.)
+//!
+//! Wrap format (`wrapped_dek` header field): `nonce (12) || AES-256-GCM
+//! ciphertext+tag (48)`, AAD = the `key_id` — a wrapped DEK can't be
+//! replayed under a different key id.
+
+use aes_gcm::aead::rand_core::RngCore;
+use aes_gcm::aead::{Aead, KeyInit, OsRng, Payload};
+use aes_gcm::{Aes256Gcm, Nonce};
+use thiserror::Error;
+use zeroize::Zeroizing;
+
+/// Wrapped-DEK length: 12-byte nonce + 32-byte DEK + 16-byte tag.
+pub const WRAPPED_DEK_LEN: usize = 12 + 32 + 16;
+
+#[derive(Debug, Error)]
+pub enum KekError {
+    #[error(
+        "recording was wrapped with KEK '{recording}' but the configured key_id is '{configured}'"
+    )]
+    KeyIdMismatch {
+        recording: String,
+        configured: String,
+    },
+    #[error("malformed wrapped DEK (expected {WRAPPED_DEK_LEN} bytes)")]
+    MalformedWrap,
+    #[error("DEK unwrap failed authentication (wrong KEK?)")]
+    UnwrapAuth,
+    #[error("DEK wrap failed")]
+    WrapFailed,
+}
+
+/// A key-encryption key + its identifier.
+#[derive(Clone)]
+pub enum Kek {
+    /// A 32-byte KEK held in memory (resolved from `${file:}` / `${cred:}`
+    /// at config load). Zeroized on drop.
+    Static {
+        key: Zeroizing<[u8; 32]>,
+        key_id: String,
+    },
+}
+
+impl std::fmt::Debug for Kek {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never Debug-print key material.
+        match self {
+            Kek::Static { key_id, .. } => f
+                .debug_struct("Kek::Static")
+                .field("key_id", key_id)
+                .finish_non_exhaustive(),
+        }
+    }
+}
+
+impl Kek {
+    pub fn new_static(key: [u8; 32], key_id: String) -> Self {
+        Kek::Static {
+            key: Zeroizing::new(key),
+            key_id,
+        }
+    }
+
+    /// The identifier stamped into container headers.
+    pub fn key_id(&self) -> &str {
+        match self {
+            Kek::Static { key_id, .. } => key_id,
+        }
+    }
+
+    /// Wrap a DEK for storage in a container header.
+    pub fn wrap_dek(&self, dek: &[u8; 32]) -> Result<Vec<u8>, KekError> {
+        match self {
+            Kek::Static { key, key_id } => {
+                let key_bytes: &[u8; 32] = key;
+                let cipher = Aes256Gcm::new(key_bytes.into());
+                let mut nonce = [0u8; 12];
+                OsRng.fill_bytes(&mut nonce);
+                let ct = cipher
+                    .encrypt(
+                        Nonce::from_slice(&nonce),
+                        Payload {
+                            msg: dek,
+                            aad: key_id.as_bytes(),
+                        },
+                    )
+                    .map_err(|_| KekError::WrapFailed)?;
+                let mut out = Vec::with_capacity(WRAPPED_DEK_LEN);
+                out.extend_from_slice(&nonce);
+                out.extend_from_slice(&ct);
+                Ok(out)
+            }
+        }
+    }
+
+    /// Unwrap a DEK read from a container header. `recording_key_id` is the
+    /// id the container names; it must match this KEK's.
+    pub fn unwrap_dek(
+        &self,
+        recording_key_id: &str,
+        wrapped: &[u8],
+    ) -> Result<Zeroizing<[u8; 32]>, KekError> {
+        match self {
+            Kek::Static { key, key_id } => {
+                if recording_key_id != key_id {
+                    return Err(KekError::KeyIdMismatch {
+                        recording: recording_key_id.to_string(),
+                        configured: key_id.clone(),
+                    });
+                }
+                if wrapped.len() != WRAPPED_DEK_LEN {
+                    return Err(KekError::MalformedWrap);
+                }
+                let key_bytes: &[u8; 32] = key;
+                let cipher = Aes256Gcm::new(key_bytes.into());
+                let plain = cipher
+                    .decrypt(
+                        Nonce::from_slice(&wrapped[..12]),
+                        Payload {
+                            msg: &wrapped[12..],
+                            aad: key_id.as_bytes(),
+                        },
+                    )
+                    .map_err(|_| KekError::UnwrapAuth)?;
+                let mut dek = Zeroizing::new([0u8; 32]);
+                dek.copy_from_slice(&plain);
+                // `plain` holds the raw DEK too — wipe it.
+                drop(Zeroizing::new(plain));
+                Ok(dek)
+            }
+        }
+    }
+}
+
+/// A fresh random 256-bit DEK.
+pub fn fresh_dek() -> Zeroizing<[u8; 32]> {
+    let mut dek = Zeroizing::new([0u8; 32]);
+    OsRng.fill_bytes(&mut *dek);
+    dek
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wrap_unwrap_roundtrip() {
+        let kek = Kek::new_static([1u8; 32], "k-1".into());
+        let dek = fresh_dek();
+        let wrapped = kek.wrap_dek(&dek).unwrap();
+        assert_eq!(wrapped.len(), WRAPPED_DEK_LEN);
+        let back = kek.unwrap_dek("k-1", &wrapped).unwrap();
+        assert_eq!(*back, *dek);
+    }
+
+    #[test]
+    fn wrong_kek_or_key_id_fails() {
+        let kek = Kek::new_static([1u8; 32], "k-1".into());
+        let wrapped = kek.wrap_dek(&fresh_dek()).unwrap();
+
+        let other = Kek::new_static([2u8; 32], "k-1".into());
+        assert!(matches!(
+            other.unwrap_dek("k-1", &wrapped),
+            Err(KekError::UnwrapAuth)
+        ));
+
+        let renamed = Kek::new_static([1u8; 32], "k-2".into());
+        assert!(matches!(
+            renamed.unwrap_dek("k-1", &wrapped),
+            Err(KekError::KeyIdMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn distinct_deks_and_nonces_every_time() {
+        let kek = Kek::new_static([1u8; 32], "k".into());
+        let (d1, d2) = (fresh_dek(), fresh_dek());
+        assert_ne!(*d1, *d2, "fresh DEKs must differ");
+        let (w1, w2) = (kek.wrap_dek(&d1).unwrap(), kek.wrap_dek(&d1).unwrap());
+        assert_ne!(w1, w2, "wrap must use a fresh nonce every time");
+    }
+}

--- a/crates/recording/src/lib.rs
+++ b/crates/recording/src/lib.rs
@@ -15,10 +15,14 @@
 
 mod config;
 mod control;
+mod envelope;
 mod frame;
+mod kek;
 mod writer;
 
 pub use config::{RecordingConfig, RecordingMode, RecordingSetup};
 pub use control::{RecControl, RecEvent};
+pub use envelope::{decrypt, EnvelopeError};
 pub use frame::RecFrame;
+pub use kek::{Kek, KekError};
 pub use writer::{RecordingError, RecordingStats, RecordingWriter};

--- a/crates/recording/src/lib.rs
+++ b/crates/recording/src/lib.rs
@@ -22,7 +22,7 @@ mod writer;
 
 pub use config::{RecordingConfig, RecordingMode, RecordingSetup};
 pub use control::{RecControl, RecEvent};
-pub use envelope::{decrypt, EnvelopeError};
+pub use envelope::{decrypt, peek_key_id, EnvelopeError};
 pub use frame::RecFrame;
 pub use kek::{Kek, KekError};
 pub use writer::{RecordingError, RecordingStats, RecordingWriter};

--- a/crates/recording/src/writer.rs
+++ b/crates/recording/src/writer.rs
@@ -17,7 +17,7 @@
 //! caller reads a card number"); `Resume` continues; `Stop` finalizes early.
 
 use std::io::SeekFrom;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use thiserror::Error;
@@ -27,7 +27,9 @@ use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
 use crate::control::{RecControl, RecEvent};
+use crate::envelope::EnvelopeWriter;
 use crate::frame::RecFrame;
+use crate::kek::Kek;
 
 /// Recording cadence — one stereo frame per 20 ms, matching the bridge.
 const FRAME_MS: u64 = 20;
@@ -71,6 +73,7 @@ pub struct RecordingWriter {
     path: PathBuf,
     sample_rate: u32,
     auto_start: bool,
+    encryption: Option<Kek>,
 }
 
 impl RecordingWriter {
@@ -81,7 +84,16 @@ impl RecordingWriter {
             path,
             sample_rate,
             auto_start,
+            encryption: None,
         }
+    }
+
+    /// Encrypt the recording at rest: seal the WAV payload into a `.wava`
+    /// envelope under a per-recording DEK wrapped by `kek` (0.24.0).
+    /// `None` (the default) keeps plaintext WAV output.
+    pub fn with_encryption(mut self, kek: Option<Kek>) -> Self {
+        self.encryption = kek;
+        self
     }
 
     /// Run until `audio_rx` closes (call ended). `ctrl_rx` drives the
@@ -124,7 +136,7 @@ impl RecordingWriter {
         }
 
         if self.auto_start {
-            match Open::create(&self.path, self.sample_rate).await {
+            match Open::create(&self.path, self.sample_rate, self.encryption.as_ref()).await {
                 Ok(o) => {
                     open = Some(o);
                     status = Status::Recording;
@@ -147,7 +159,7 @@ impl RecordingWriter {
                 },
                 maybe = ctrl_rx.recv(), if ctrl_open => match maybe {
                     Some(RecControl::Start) if status == Status::Idle => {
-                        match Open::create(&self.path, self.sample_rate).await {
+                        match Open::create(&self.path, self.sample_rate, self.encryption.as_ref()).await {
                             Ok(o) => {
                                 open = Some(o);
                                 status = Status::Recording;
@@ -216,29 +228,78 @@ impl RecordingWriter {
     }
 }
 
-/// An open WAV file mid-recording.
+/// The in-progress path: `<final>.part`, renamed onto the final path only
+/// by a successful finalize — so a bare `.wav`/`.wava` on disk is always a
+/// complete recording, and a crash leaves only a `.part` (0.24.0, §6 D5).
+fn part_path(path: &Path) -> PathBuf {
+    let mut os = path.as_os_str().to_os_string();
+    os.push(".part");
+    PathBuf::from(os)
+}
+
+/// Where the WAV bytes go: straight to disk, or sealed into an encrypted
+/// envelope first. Plaintext keeps the seek-back header patch; the envelope
+/// patches via its chunk-0 rewrite instead (no seeking into ciphertext).
+enum Output {
+    Plain(BufWriter<File>),
+    Sealed(Box<EnvelopeWriter>),
+}
+
+/// An open recording mid-write (WAV, possibly enveloped).
 struct Open {
     path: PathBuf,
+    part: PathBuf,
     sample_rate: u32,
-    out: BufWriter<File>,
+    out: Output,
     buf: Vec<u8>,
     frames: u64,
     data_bytes: u64,
 }
 
 impl Open {
-    async fn create(path: &PathBuf, sample_rate: u32) -> std::io::Result<Self> {
-        let file = File::create(path).await?;
-        let mut out = BufWriter::new(file);
-        out.write_all(&wav_header(sample_rate, 0)).await?; // placeholder
+    async fn create(
+        path: &Path,
+        sample_rate: u32,
+        encryption: Option<&Kek>,
+    ) -> std::io::Result<Self> {
+        let part = part_path(path);
+        let file = File::create(&part).await?;
+        let out = match encryption {
+            None => {
+                let mut out = BufWriter::new(file);
+                out.write_all(&wav_header(sample_rate, 0)).await?; // placeholder
+                Output::Plain(out)
+            }
+            Some(kek) => {
+                let mut env = EnvelopeWriter::create(&part, file, kek)
+                    .await
+                    .map_err(std::io::Error::other)?;
+                env.write(&wav_header(sample_rate, 0)) // placeholder, patched at finalize
+                    .await
+                    .map_err(std::io::Error::other)?;
+                Output::Sealed(Box::new(env))
+            }
+        };
         Ok(Self {
-            path: path.clone(),
+            path: path.to_path_buf(),
+            part,
             sample_rate,
             out,
             buf: Vec::with_capacity(FLUSH_BYTES * 2),
             frames: 0,
             data_bytes: 0,
         })
+    }
+
+    async fn flush_buf(&mut self) -> std::io::Result<()> {
+        let buf = std::mem::take(&mut self.buf);
+        match &mut self.out {
+            Output::Plain(out) => out.write_all(&buf).await?,
+            Output::Sealed(env) => env.write(&buf).await.map_err(std::io::Error::other)?,
+        }
+        self.buf = buf;
+        self.buf.clear();
+        Ok(())
     }
 
     async fn write_frame(
@@ -251,28 +312,33 @@ impl Open {
         self.frames += 1;
         self.data_bytes += (mono_bytes * 2) as u64;
         if self.buf.len() >= FLUSH_BYTES {
-            let buf = std::mem::take(&mut self.buf);
-            self.out.write_all(&buf).await?;
-            self.buf = buf;
-            self.buf.clear();
+            self.flush_buf().await?;
         }
         Ok(())
     }
 
     async fn finalize(mut self) -> std::io::Result<RecordingStats> {
         if !self.buf.is_empty() {
-            let buf = std::mem::take(&mut self.buf);
-            self.out.write_all(&buf).await?;
+            self.flush_buf().await?;
         }
-        self.out.flush().await?;
         let data_u32 = u32::try_from(self.data_bytes).unwrap_or(u32::MAX);
-        self.out.seek(SeekFrom::Start(4)).await?;
-        self.out
-            .write_all(&36u32.wrapping_add(data_u32).to_le_bytes())
-            .await?;
-        self.out.seek(SeekFrom::Start(40)).await?;
-        self.out.write_all(&data_u32.to_le_bytes()).await?;
-        self.out.flush().await?;
+        let riff_u32 = 36u32.wrapping_add(data_u32);
+        match self.out {
+            Output::Plain(mut out) => {
+                out.flush().await?;
+                out.seek(SeekFrom::Start(4)).await?;
+                out.write_all(&riff_u32.to_le_bytes()).await?;
+                out.seek(SeekFrom::Start(40)).await?;
+                out.write_all(&data_u32.to_le_bytes()).await?;
+                out.flush().await?;
+            }
+            Output::Sealed(env) => {
+                env.finalize(&[(4, riff_u32), (40, data_u32)])
+                    .await
+                    .map_err(std::io::Error::other)?;
+            }
+        }
+        tokio::fs::rename(&self.part, &self.path).await?;
         debug!(path = %self.path.display(), frames = self.frames, data_bytes = self.data_bytes, "recording finalized");
         if self.data_bytes > u32::MAX as u64 {
             warn!(path = %self.path.display(), "recording exceeded 4 GiB; WAV header sizes saturated");
@@ -421,6 +487,62 @@ mod tests {
         let stats = h.await.unwrap().unwrap().unwrap();
         assert!(stats.frames >= 2);
         assert_eq!(read_data_len(&path) as u64, stats.data_bytes);
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[tokio::test]
+    async fn part_file_until_finalize_then_bare_path() {
+        let path = temp_path("part");
+        let (atx, arx) = mpsc::channel(64);
+        let (_ctx, crx) = mpsc::channel(8);
+        let (etx, mut erx) = mpsc::channel(8);
+        let h = tokio::spawn(RecordingWriter::new(path.clone(), 8000, true).run(arx, crx, etx));
+        assert!(matches!(erx.recv().await, Some(RecEvent::Started)));
+        // Mid-recording: only the .part exists (0.24.0 finalize atomicity).
+        atx.send(RecFrame::Caller(vec![1u8; 320])).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(part_path(&path).exists(), ".part must exist mid-recording");
+        assert!(!path.exists(), "final path must not exist mid-recording");
+        drop(atx);
+        h.await.unwrap().unwrap().unwrap();
+        assert!(path.exists(), "final path must exist after finalize");
+        assert!(!part_path(&path).exists(), ".part must be renamed away");
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[tokio::test]
+    async fn encrypted_recording_decrypts_to_valid_wav() {
+        let path = temp_path("encrypted").with_extension("wava");
+        let kek = crate::kek::Kek::new_static([5u8; 32], "unit-kek".into());
+        let (atx, arx) = mpsc::channel(64);
+        let (_ctx, crx) = mpsc::channel(8);
+        let (etx, mut erx) = mpsc::channel(8);
+        let h = tokio::spawn(
+            RecordingWriter::new(path.clone(), 8000, true)
+                .with_encryption(Some(kek.clone()))
+                .run(arx, crx, etx),
+        );
+        assert!(matches!(erx.recv().await, Some(RecEvent::Started)));
+        for _ in 0..5 {
+            atx.send(RecFrame::Caller(vec![0x11; 320])).await.unwrap();
+            atx.send(RecFrame::Bot(vec![0x22; 320])).await.unwrap();
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        drop(atx);
+        let stats = h.await.unwrap().unwrap().unwrap();
+
+        // The file on disk is an envelope, not a WAV.
+        let raw = std::fs::read(&path).unwrap();
+        assert_eq!(&raw[..8], b"SAIWAVA1");
+
+        // Decrypting yields a well-formed WAV with patched sizes.
+        let mut wav = Vec::new();
+        crate::envelope::decrypt(std::io::Cursor::new(raw), &mut wav, &kek, false).unwrap();
+        assert_eq!(&wav[0..4], b"RIFF");
+        assert_eq!(&wav[8..12], b"WAVE");
+        let data = u32::from_le_bytes(wav[40..44].try_into().unwrap()) as u64;
+        assert_eq!(data, stats.data_bytes);
+        assert_eq!(wav.len() as u64, WAV_HEADER_LEN as u64 + data);
         let _ = std::fs::remove_dir_all(path.parent().unwrap());
     }
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -632,12 +632,20 @@ writer can never stall live audio. **Full guide: `docs/RECORDING.md`.**
 [recording]
 mode = "always"            # "off" (default) | "always" | "on_demand"
 dir  = "/var/lib/siphon-ai/recordings"
+
+[recording.encryption]                 # optional — encrypt at rest (0.24.0)
+enabled = true                         # default false
+kek     = "${file:/etc/siphon-ai/recording-kek.hex}"   # 64 hex chars
+key_id  = "rec-2026-07"                # stamped into each recording
 ```
 
 | Field | Type | Default | Notes |
 |---|---|---|---|
 | `mode` | string | `"off"` | `"off"` = no recording (zero behaviour change). `"always"` = record every accepted call for its full duration. `"on_demand"` = the WS server drives recording with `start_recording` / `stop_recording` / `pause_recording` / `resume_recording` (see `docs/PROTOCOL.md` §4.7); SiphonAI emits `recording_started` / `recording_stopped` / `recording_failed` back. (Per-route overrides land in a later 0.5.0 chunk.) |
-| `dir` | string | — | Directory recordings are written to as `<dir>/<call_id>.wav`. **Required when `mode != "off"`**; created at startup (a bad path fails loud at load). A `pause` omits the paused span from the file (the audio is dropped, not silenced). |
+| `dir` | string | — | Directory recordings are written to as `<dir>/<call_id>.wav` (`.wava` when encryption is on). **Required when `mode != "off"`**; created at startup (a bad path fails loud at load). A `pause` omits the paused span from the file (the audio is dropped, not silenced). In-progress recordings are `<name>.part` and are renamed on finalize (0.24.0) — a bare `.wav`/`.wava` is always a complete file. |
+| `encryption.enabled` | bool | `false` | Seal recordings into encrypted `.wava` envelopes (per-recording AES-256-GCM data key, wrapped by your `kek`). Decrypt offline with `siphon-ai decrypt-recording` — see `docs/RECORDING.md` §8 for the model, key rotation, and the container format. |
+| `encryption.kek` | string | — | The key-encryption key as **64 hex characters** (32 bytes). Reference a secret — `${file:…}` or `${cred:…}` — never inline it. Required when `enabled`; validated at load (fail-loud). Generate one with `openssl rand -hex 32`. |
+| `encryption.key_id` | string | — | Identifier (1–255 bytes) stamped into every recording's header, naming which KEK wrapped it — this is what makes rotation possible. Required when `enabled`. |
 
 **Per-route override.** A `[route.recording]` block overrides the global
 `mode` for calls that match that route (strict override — the route value
@@ -660,9 +668,11 @@ mode = "always"                      # …but always record the support line
 
 Operational notes: recordings are uncompressed PCM16 stereo (≈115 MB/hour
 at 16 kHz; ≈58 MB/hour at 8 kHz) — size your disk and **manage retention
-yourself** (the daemon does not delete recordings). Recording consent and
-any "this call is recorded" announcement are the operator's responsibility
-(see `docs/SECURITY_STIR_SHAKEN.md` for the analogous trust-model framing).
+yourself** (the daemon does not delete recordings). Plaintext WAV at rest
+is fine for a lab; regulated deployments should turn on
+`[recording.encryption]` (0.24.0). Recording consent and any "this call is
+recorded" announcement are the operator's responsibility (see
+`docs/SECURITY_STIR_SHAKEN.md` for the analogous trust-model framing).
 
 ## `[cdr]`
 

--- a/docs/RECORDING.md
+++ b/docs/RECORDING.md
@@ -61,10 +61,17 @@ mode = "always"                       # …but always record the support line
 | Sample format | PCM16, little-endian |
 | Channels | 2 (stereo) — **L = caller, R = bot/WS** |
 | Sample rate | The call's negotiated rate (8 kHz or 16 kHz) |
-| Path | `<dir>/<call_id>.wav` |
+| Path | `<dir>/<call_id>.wav` — `<dir>/<call_id>.wava` with encryption on (§8) |
 
 The `call_id` in the path is the same one on the WS `start` message and the
 CDR, so a recording correlates 1:1 with its call.
+
+**In-progress files are `<name>.part`** (0.24.0): the writer streams into
+the `.part` and renames it onto the final path only when finalize succeeds.
+A bare `.wav`/`.wava` on disk is therefore always a *complete* recording —
+safe for a watcher/uploader to pick up — and a crash leaves only a `.part`.
+(Before 0.24.0 the file appeared at its final name immediately, with
+placeholder header sizes until the call ended.)
 
 ---
 
@@ -103,8 +110,9 @@ needed there (a `start_recording` on an already-recording call is a no-op).
 ## 4. Observability
 
 - **CDR** (`docs/DEPLOY.md`): a recorded call's CDR carries `recording_id`
-  and `recording_path`. Both are omitted when the call wasn't recorded, so
-  the CDR schema stays at version 1.
+  and `recording_path`, plus `recording_encrypted: true` when the file is a
+  sealed `.wava` (§8). All are omitted when the call wasn't recorded —
+  additive fields, no CDR version bump.
 - **Metric:** `siphon_ai_recordings_total{result="ok"|"degraded"|"failed"}`
   ticks once per recorded call.
   - `ok` — written cleanly.
@@ -130,14 +138,13 @@ call. A recording is always best-effort; it never degrades call quality.
 
 ## 6. Operating
 
-- **Recordings are plaintext at rest — even for encrypted calls.** Recording
-  works on SRTP calls (the recorder taps the *decoded* audio — forge already
-  decrypts the media to bridge it to your WS server), so the WAV on disk is
-  always cleartext PCM regardless of `[media].srtp`. SRTP protects the media
-  *in transit*; it does nothing for the recording *at rest*. Treat the
-  recording directory as sensitive PII/PCI: protect it with volume
-  encryption, filesystem permissions, and access controls. SiphonAI does not
-  encrypt recordings.
+- **At-rest protection.** SRTP/WSS protect media *in transit*; the recorder
+  taps the *decoded* audio, so by default the WAV on disk is cleartext PCM
+  regardless of `[media].srtp`. For PCI/HIPAA-grade deployments turn on
+  **`[recording.encryption]`** (§8) so nothing plaintext ever touches disk.
+  Either way, treat the recording directory as sensitive PII/PCI:
+  filesystem permissions and access controls still apply (encryption
+  protects stolen disks and stale backups, not a compromised live box).
 - **Disk sizing:** recordings are uncompressed — ≈115 MB/hour at 16 kHz,
   ≈58 MB/hour at 8 kHz (stereo PCM16). With `mode = "always"`, size the disk
   for your peak concurrent-call-hours.
@@ -151,15 +158,86 @@ call. A recording is always best-effort; it never degrades call quality.
 
 ---
 
-## 7. Limitations (v0.5.0)
+## 7. Limitations
 
 - One recording per call (`recording_id == call_id`).
-- Path is `<dir>/<call_id>.wav` — no templating yet.
-- WAV/PCM16 only; no compressed (Opus) format yet.
-- Local-file sink only; no object-storage (S3) sink yet.
+- Path is `<dir>/<call_id>.wav[a]` — no templating yet (planned for the
+  object-storage release, `docs/design/DESIGN_RECORDING_COMPLIANCE.md` §3).
+- WAV/PCM16 only; no compressed (Opus) format yet (planned, same design
+  note §5).
+- Local-file sink only; no object-storage (S3) sink yet (planned, §3).
+- Inbound calls only; outbound-leg recording is planned (§5).
 - WAV `data`/`RIFF` sizes are 32-bit, so a single recording over ~4 GiB
   (many hours of 16 kHz stereo) saturates the header sizes — not a concern
   for normal call lengths.
 
-The compressed-format and object-storage sinks are tracked as 0.5.x
-stretch items (see `docs/design/DEV_PLAN_0.5.0.md` §4).
+---
+
+## 8. Encryption at rest (`[recording.encryption]`, 0.24.0)
+
+```toml
+[recording.encryption]
+enabled = true
+kek     = "${file:/etc/siphon-ai/recording-kek.hex}"   # 64 hex chars
+key_id  = "rec-2026-07"
+```
+
+With encryption on, recordings are written as **`.wava` envelopes** —
+nothing plaintext ever touches disk. The model is standard **envelope
+encryption**:
+
+- Every recording gets a **fresh random 256-bit data key (DEK)** that
+  encrypts the audio in independent 64 KiB AES-256-GCM chunks.
+- The DEK is stored in the file's header, **wrapped by your KEK** (the
+  32-byte key `kek` references). The KEK itself never appears in any
+  recording.
+- The header names your `key_id`, so **rotation is cheap**: deploy a new
+  KEK + `key_id` and new recordings use it; old recordings still name the
+  old id — keep retired KEKs in a secure archive to read them. No
+  re-encryption of existing audio, ever.
+
+Generate a KEK with `openssl rand -hex 32`, deliver it via `${file:}` (mode
+`0400`) or systemd `LoadCredential` + `${cred:}`. Validation is at config
+load — a missing/malformed KEK or `key_id` fails startup, never a call. If
+wrapping fails at runtime the *recording* fails (`recording_failed`,
+`siphon_ai_recordings_total{result="failed"}`); the call continues.
+
+### Decrypting
+
+```sh
+siphon-ai decrypt-recording /var/lib/siphon-ai/recordings/<call_id>.wava \
+    --kek-file /etc/siphon-ai/recording-kek.hex
+# → <call_id>.wav next to the input (or --out PATH)
+```
+
+The subcommand is offline tooling — it needs only the KEK file, not the
+daemon config. A wrong key fails loud and prints the `key_id` the recording
+was wrapped with, so you know which archived KEK to fetch. A crashed
+capture (`.wava.part`) can be recovered with `--allow-unfinalized`; its WAV
+header sizes are placeholders (re-mux with `ffmpeg -i out.wav fixed.wav` if
+a tool refuses it).
+
+### Container format (`SAIWAVA1`)
+
+For third-party decrypt implementations. All integers little-endian:
+
+```
+header:  magic "SAIWAVA1"
+         key_id_len u8 | key_id (utf-8)
+         wrapped_dek_len u16 | wrapped_dek
+         chunk_size u32                       # plaintext bytes per chunk
+chunk i: generation u32 | ct_len u32 | ciphertext (plaintext + 16-byte tag)
+```
+
+- `wrapped_dek` = `nonce (12) || AES-256-GCM(KEK, DEK)` with the `key_id`
+  bytes as AAD.
+- Chunk `i`'s cipher is AES-256-GCM under the DEK with nonce
+  `chunk_index u64 || generation u32` and the full serialized header as
+  AAD (a chunk can't be replayed into another recording).
+- The decrypted payload is a byte-exact standard WAV.
+- **Generation rule:** finalize rewrites chunk 0 with the patched WAV
+  header sizes under `generation = 1` (a fresh nonce — the plaintext
+  length is unchanged so it overwrites in place). A valid finalized file
+  has generation 1 on chunk 0 and 0 on every other chunk; anything else
+  (including generation 0 on chunk 0 — an unfinalized capture) must be
+  rejected by default.


### PR DESCRIPTION
First release of the P1 **recording compliance & storage** theme (design: `docs/design/DESIGN_RECORDING_COMPLIANCE.md`, decisions locked 2026-07-08, PR #263). Closes the RECORDING.md §6 compliance blocker: recordings are no longer forcibly plaintext at rest.

## What

- **`[recording.encryption]` {enabled=false, kek, key_id}** — envelope encryption: each recording gets a fresh random 256-bit DEK sealing the WAV payload into independent 64 KiB AES-256-GCM chunks (`.wava` container); the DEK travels in the header, wrapped by the operator's KEK (64 hex chars via `${file:}`/`${cred:}`, validated fail-loud at load). `key_id` is stamped into every header → KEK rotation never re-encrypts audio.
- **The WAV-finalize-inside-a-sealed-stream problem**: finalize rewrites chunk 0 with the patched RIFF sizes under `generation = 1` (fresh nonce — GCM nonce reuse is catastrophic; same plaintext length → in-place overwrite). The decoder enforces gen 1 on chunk 0 / gen 0 elsewhere, so unfinalized captures are detectable and placeholder-swap attacks fail. Every chunk's AAD is the serialized header (no cross-recording replay).
- **Finalize atomicity for both paths (§6 D5)**: plaintext and encrypted recordings now write `<name>.part` and rename on finalize — a bare `.wav`/`.wava` is always a complete file (safe for watchers/uploaders); a crash leaves only `.part`. *Behavior change for plaintext WAV consumers watching the dir — CHANGELOG-flagged at release.*
- **`siphon-ai decrypt-recording <file> --kek-file <hex> [--out] [--allow-unfinalized]`** — offline tooling, no daemon config needed; a wrong key names the `key_id` the recording was wrapped with. `--allow-unfinalized` recovers crashed `.part` captures.
- **CDR**: additive `recording_encrypted` flag (no version bump). Kek provider is an enum seam (`Static` now, AWS-KMS arm lands with v0.25.0's SigV4 client — noted deviation from the design note's trait sketch).
- **Deps**: `aes-gcm` + `zeroize` promoted transitive→direct (both RustCrypto, already in `Cargo.lock` — no new vendor). Key material is `Zeroizing` and Debug-redacted.
- **Docs**: CONFIG.md field table; RECORDING.md §8 — model, rotation, decrypt usage, and the full `SAIWAVA1` container spec for third-party implementations.

## Verification

- **Live (SIPp + echo server)**: encrypted config → call → on-disk file is `SAIWAVA1` (not RIFF), CDR carries `recording_encrypted: true` + the `.wava` path, `decrypt-recording` emits a `file`-recognized stereo PCM WAV with consistent header sizes, no `.part` leftovers. **kill -9 mid-call** → only a `.part` remains; strict decrypt refuses it; `--allow-unfinalized` recovers the sealed audio.
- **Tests**: 16 recording-crate tests (multi-chunk roundtrip w/ patches, tamper/wrong-KEK auth failures, unfinalized + chunk-0-swap rejection, `.part` lifecycle, encrypted end-to-end), config-compile validation matrix, CLI integration tests against the real binary. Workspace suite + clippy `-D warnings` + fmt green.

Protocol stays v1 (no WS changes); CDR stays v3 (additive field only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
