### PR TITLE
chore(release): 0.24.0 — recording encryption at rest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-07-08
+
+### Added
+
+- **Recording encryption at rest — `[recording.encryption]`** (P1 "Recording
+  compliance & storage", first sub-item; design note
+  `docs/design/DESIGN_RECORDING_COMPLIANCE.md`). With `enabled = true`, a
+  `kek` (64 hex chars, referenced via `${file:}`/`${cred:}`) and a `key_id`,
+  recordings are written as encrypted **`.wava` envelopes** instead of
+  plaintext WAV — nothing plaintext ever touches disk. Envelope encryption:
+  a fresh random 256-bit data key per recording seals the audio in
+  independent AES-256-GCM chunks; the data key travels in the file header,
+  wrapped by your KEK. The header names the `key_id` that wrapped it, so
+  **rotating the KEK never re-encrypts audio**. Config is validated
+  fail-loud at startup; a runtime wrap failure fails the *recording*
+  (`recording_failed`), never the call. The CDR gains an additive
+  `recording_encrypted` flag (schema version unchanged). Decrypt offline
+  with the new **`siphon-ai decrypt-recording <file> --kek-file <hex>`**
+  subcommand — needs no daemon config; a wrong key names the `key_id` the
+  recording requires; `--allow-unfinalized` recovers a crashed capture. The
+  `SAIWAVA1` container format is documented in `docs/RECORDING.md` §8 for
+  third-party implementations. **Off by default.** Deps: `aes-gcm` +
+  `zeroize` promoted from transitive to direct (RustCrypto; no new vendor).
+
+### Changed
+
+- **Recordings now appear as `<name>.part` while in progress** and are
+  renamed to their final `.wav`/`.wava` name only when finalized — for
+  *plaintext* recordings too. A bare `.wav` on disk is now always a
+  complete file (safe for a watcher/uploader to pick up), and a daemon
+  crash leaves only a `.part` instead of a WAV with placeholder header
+  sizes. **If you watch the recording directory, match the final names and
+  ignore `*.part`.**
+
 ## [0.23.0] - 2026-07-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3032,7 +3032,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3077,7 +3077,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3093,7 +3093,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "base64",
  "bytes",
@@ -3114,7 +3114,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3131,7 +3131,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "regex",
  "serde",
@@ -3149,7 +3149,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3192,7 +3192,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "hmac",
  "http-body-util",
@@ -3212,7 +3212,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "aes-gcm",
  "thiserror 1.0.69",
@@ -3247,7 +3247,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "regex",
  "serde",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3268,7 +3268,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3295,7 +3295,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -3313,7 +3313,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3342,7 +3342,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.23.0.** Production-deployed against real carriers
+**Current release: v0.24.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a


### PR DESCRIPTION
Release-prep per RELEASING.md: workspace version → 0.24.0, CHANGELOG dated 2026-07-08 (includes the **Changed** entry flagging the `.part` finalize behavior change), README marker, Cargo.lock refreshed.

Verified locally: `check-version-consistency.py` (plain + `--tag v0.24.0`) and `extract-changelog.py 0.24.0` pass.

After merge: tag `v0.24.0` on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)