### PR TITLE
chore(release): 0.25.0 — recording object storage, KMS KEK + Opus format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-07-08
+
+### Added
+
+- **Object-storage upload — `[recording.storage]`** (P1 "Recording
+  compliance & storage", second release). Finalized recordings upload to
+  any S3-compatible bucket (AWS, MinIO, Cloudflare R2, Backblaze B2 —
+  path-style, hand-rolled SigV4, **no AWS SDK**). Durable by design: a
+  small job file lands in `spool_dir` at call teardown (atomic, survives
+  restarts) and a background worker uploads with retries; a job that keeps
+  failing is dropped with a metric rather than wedging the spool, and the
+  local file is deleted only after a durable upload (opt-in
+  `delete_local_after_upload`). `key_template` names objects with
+  `{call_id}` / `{date}` / `{route}` / `{direction}`. The CDR gains an
+  additive `recording_url` (`s3://bucket/key`, stamped at enqueue) and a
+  new **`recording_uploaded`** lifecycle webhook (after `call_end`)
+  confirms arrival with `size_bytes`. New metrics:
+  `siphon_ai_recording_uploads_total{result}`,
+  `siphon_ai_recording_upload_spool_depth`,
+  `siphon_ai_recording_upload_seconds`. Retention/TTL stays the bucket
+  lifecycle policy's job (worked recipe in `docs/RECORDING.md` §9). Pair
+  with `[recording.encryption]` so the bucket only ever holds ciphertext.
+  **Off by default.**
+- **AWS KMS as the recording KEK — `[recording.encryption.kms]`**. The KMS
+  hook the 0.24.0 envelope design reserved: each recording's data key is
+  wrapped by KMS `Encrypt` (the KEK never exists outside KMS; every unwrap
+  is IAM-auditable), on the same SigV4 client — still no AWS SDK. Exactly
+  one of `kek` / `kms`; `endpoint` override supports KMS-compatible
+  emulators. `siphon-ai decrypt-recording` gains `--kms-region` /
+  `--kms-endpoint` (credentials via `AWS_ACCESS_KEY_ID` /
+  `AWS_SECRET_ACCESS_KEY`); symmetric-KMS blobs name their own key, so no
+  key ARN is needed to decrypt. **Off by default.**
+- **Ogg-Opus recording format — `[recording].format = "opus"`**. ~10×
+  smaller than WAV for voice, encoded with the same libopus the media path
+  already uses and playable by ffmpeg/VLC/browsers. Streaming-native
+  (RFC 7845), so nothing needs a finalize back-patch — including inside an
+  encrypted envelope. Extensions: `.opus` plaintext, `.opusa` sealed.
+  Adds the `ogg` crate (the theme's one new small dependency). **Default
+  stays WAV.**
+
 ## [0.24.0] - 2026-07-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3044,7 +3044,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3090,7 +3090,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3106,7 +3106,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "base64",
  "bytes",
@@ -3127,7 +3127,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3144,7 +3144,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "regex",
  "serde",
@@ -3163,7 +3163,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "base64",
  "hmac",
@@ -3230,7 +3230,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3254,7 +3254,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "aes-gcm",
  "audiopus",
@@ -3268,7 +3268,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "regex",
  "serde",
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3289,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3316,7 +3316,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -3334,7 +3334,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3363,7 +3363,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.24.0"
+version = "0.25.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.24.0.** Production-deployed against real carriers
+**Current release: v0.25.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a


### PR DESCRIPTION
Release-prep per RELEASING.md: workspace version → 0.25.0, CHANGELOG dated 2026-07-08, README marker, Cargo.lock refreshed.

Verified locally: `check-version-consistency.py` (plain + `--tag v0.25.0`) and `extract-changelog.py 0.25.0` pass.

After merge: tag `v0.25.0` on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)