### PR TITLE
chore(release): 0.26.0 — recording consent + outbound recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.0] - 2026-07-09
+
+### Added
+
+- **Recording consent announcement — `[recording.announcement]`** (P1
+  "Recording compliance & storage", final release — the theme is
+  complete). Point `file` at a "this call may be recorded" WAV and the
+  daemon plays it to the caller right after answer; **capture starts only
+  when the prompt finishes**. The WS session connects in parallel
+  (announce-then-bridge); the bot can't talk over the prompt, and nothing
+  the caller says during it reaches the recording *or* the server. With
+  `mode = "on_demand"`, a `start_recording` arriving mid-prompt is
+  deferred to prompt completion. **Fail-closed**: if the prompt can't play
+  (missing file, wrong sample rate), the call is *not* recorded — and the
+  CDR shows `consent.announced = false`. Applies to inbound and outbound
+  legs. **Off by default.**
+- **Consent audit trail on the CDR** — additive
+  `consent { announced, announcement_ms, server }` object (schema version
+  unchanged). `announced`/`announcement_ms` come from the daemon-played
+  prompt; `server` from the new **`set_recording_consent`** WS control
+  message (`{ "type": "set_recording_consent", "call_id", "note"? }`) —
+  a stamp for consent your server captured itself (DTMF press-1, verbal
+  yes). A stamp, not a gate: capture gating stays `on_demand` +
+  `start_recording`. Protocol stays **v1**.
+- **Outbound-leg recording.** Originated calls (`POST /admin/v1/calls`)
+  can record exactly like inbound ones — same `[recording]`
+  dir/encryption/format, same on-demand WS controls, same object-storage
+  upload spool. Per-gateway default (`[[gateway]].recording = "off"
+  (default) | "always" | "on_demand"`, validated at load) plus a
+  per-originate `"recording"` override (`400` for bad values, rejected
+  before a toll-fraud concurrency permit is consumed). Recording an
+  outbound leg is config/API opt-in, never implied. **Off by default.**
+
 ## [0.25.0] - 2026-07-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3044,7 +3044,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3090,7 +3090,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3106,7 +3106,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "base64",
  "bytes",
@@ -3127,7 +3127,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3144,7 +3144,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "regex",
  "serde",
@@ -3163,7 +3163,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "base64",
  "hmac",
@@ -3230,7 +3230,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3254,7 +3254,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "aes-gcm",
  "audiopus",
@@ -3268,7 +3268,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "regex",
  "serde",
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3289,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3316,7 +3316,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -3334,7 +3334,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3363,7 +3363,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.25.0"
+version = "0.26.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.25.0.** Production-deployed against real carriers
+**Current release: v0.26.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a

--- a/docs/design/DESIGN_RECORDING_COMPLIANCE.md
+++ b/docs/design/DESIGN_RECORDING_COMPLIANCE.md
@@ -1,6 +1,15 @@
 # Design: recording compliance & storage (P1 theme)
 
-> **Status: DECISIONS LOCKED (2026-07-08) — §6.** Same design-first cadence
+> **Status: SHIPPED — theme complete.** v0.24.0 (encryption at rest) +
+> v0.25.0 (object storage, KMS KEK, Opus) + v0.26.0 (consent + outbound)
+> released 2026-07-08/09. Deviations from the plan: the KEK seam is an
+> enum, not a trait (async-KMS-friendly, closed set); S3 multipart was
+> dropped (single-PUT + fail-loud 5 GiB cap — unreachable, WAV saturates
+> at 4 GiB); an unusable announcement FAIL-CLOSES recording (stronger
+> than the note's sketch); local-path templating stayed out (the
+> object-storage `key_template` covers naming).
+>
+> Original status line: DECISIONS LOCKED (2026-07-08) — §6. Same design-first cadence
 > as observability (→ v0.21–0.23) and security hardening (→ v0.18–0.20):
 > design note → locked decisions → chunked PRs → tag-after-merge. The build
 > follows §7; deviations get noted back here.


### PR DESCRIPTION
Release-prep per RELEASING.md: workspace version → 0.26.0, CHANGELOG dated 2026-07-09, README marker, Cargo.lock refreshed — plus the theme-retrospective status update in `DESIGN_RECORDING_COMPLIANCE.md` (shipped + deviations), completing the P1 recording-compliance theme.

Verified locally: `check-version-consistency.py` (plain + `--tag v0.26.0`) and `extract-changelog.py 0.26.0` pass.

After merge: tag `v0.26.0` on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)