### PR TITLE
chore(release): 0.27.0 — machine-readable protocol schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0] - 2026-07-09
+
+### Added
+
+- **Machine-readable protocol schema — `schemas/siphon-ai.v1.json`** (P1
+  "Protocol SDKs & machine-readable schemas", first release; design note
+  `docs/design/DESIGN_PROTOCOL_SDKS.md`). The complete WS protocol
+  contract as JSON Schema draft 2020-12, **generated from the Rust wire
+  types** in `crates/bridge`: `$defs/BridgeOut` (21 daemon→server
+  messages) + `$defs/BridgeIn` (17 server→daemon), doc comments as
+  descriptions, and an `x-binary-frames` annotation describing the audio
+  half (raw PCM16-LE, 320 B @ 8 kHz / 640 B @ 16 kHz, 20 ms). Point your
+  editor, validator, or code generator at it. The top level is `anyOf`
+  (not `oneOf`): `hold`/`resume`/`mark` exist in both directions, so
+  validate against the direction-specific union when you know who sent
+  the frame. A new CI gate regenerates the schema and diffs it on every
+  PR, **and validates every JSON example in `docs/PROTOCOL.md` against
+  it** (39 today) — the protocol docs, Rust types, and schema can no
+  longer drift apart silently. Generation is behind a dev-only
+  `json-schema` cargo feature (`schemars`); the daemon binary is
+  unchanged. Protocol stays **v1**.
+
 ## [0.26.0] - 2026-07-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3106,7 +3106,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3152,7 +3152,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3168,7 +3168,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "base64",
  "bytes",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "regex",
  "serde",
@@ -3226,7 +3226,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3270,7 +3270,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "base64",
  "hmac",
@@ -3293,7 +3293,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "aes-gcm",
  "audiopus",
@@ -3331,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "regex",
  "serde",
@@ -3343,7 +3343,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "schemars",
  "serde",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3380,7 +3380,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3427,7 +3427,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.26.0.** Production-deployed against real carriers
+**Current release: v0.27.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a


### PR DESCRIPTION
Release-prep per RELEASING.md: workspace version → 0.27.0, CHANGELOG dated 2026-07-09, README marker, Cargo.lock refreshed.

Verified locally: `check-version-consistency.py` (plain + `--tag v0.27.0`) passes.

After merge: tag `v0.27.0` on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)