### PR TITLE
feat(sdks): Python + TypeScript server SDKs; echo servers rewritten on them (0.28.0)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,6 +75,30 @@ jobs:
             --entrypoint promtool prom/prometheus:latest \
             check config prometheus.yml
 
+  sdk-tests:
+    name: server SDK unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Both SDK suites (sdks/python, sdks/typescript) parse every
+      # PROTOCOL.md example into typed events and validate every command
+      # the SDK can emit against schemas/siphon-ai.v1.json — the SDKs
+      # can't drift from the protocol silently. No cargo needed: the
+      # committed schema is the contract (lint-and-test regenerates and
+      # diffs it separately).
+      - name: Python SDK tests
+        run: |
+          pip install --quiet jsonschema websockets pytest
+          python3 -m pytest sdks/python/tests -q
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: TypeScript SDK tests
+        run: |
+          cd sdks/typescript
+          npm install --no-audit --no-fund
+          npm test
+
   lint-and-test:
     name: fmt + clippy + cargo test
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,9 +56,12 @@ siphon-ai/
 │   └── telemetry/                # tracing + metrics + HEP wiring + admin/health endpoints
 ├── bins/
 │   └── siphon-ai/                # The daemon binary
+├── sdks/
+│   ├── python/                   # Server SDK (siphon-ai-server on PyPI-style layout)
+│   └── typescript/               # Server SDK (siphon-ai-server npm-style layout)
 ├── examples/
-│   ├── echo-ws-server-python/    # Reference WS server (echo)
-│   ├── echo-ws-server-node/      # Same in Node
+│   ├── echo-ws-server-python/    # Reference WS server (echo) — built on sdks/python
+│   ├── echo-ws-server-node/      # Same in Node — built on sdks/typescript
 │   ├── openai-realtime-bridge-py/  # Reference: OpenAI Realtime bridge
 │   └── homer-stack/              # Local Homer + dashboards via docker-compose
 ├── docker/
@@ -90,6 +93,7 @@ siphon-ai/
 | New config field | `crates/config/src/` + update `docs/CONFIG.md` + example TOML in `docs/` |
 | New CDR field | `crates/cdr/src/schema.rs` + bump CDR `version` + update `docs/` |
 | New webhook event type | `crates/webhooks/src/events.rs` + update `docs/` |
+| Server SDK change (typed events, `Call` commands, framing) | `sdks/python` + `sdks/typescript` — keep both in lockstep; their tests validate against `schemas/siphon-ai.v1.json` + `docs/PROTOCOL.md` |
 | New HEP chunk emission | `crates/telemetry/src/hep.rs` (uses `hep-rs` crate) |
 | New metric | `crates/telemetry/src/metrics.rs` + document in `docs/DEPLOY.md` |
 | New admin endpoint | `crates/telemetry/src/admin.rs` + document in `docs/DEPLOY.md` |
@@ -323,8 +327,9 @@ info!(target: "siphon_ai::call", from = %invite.from, "received invite");
 5. Add integration test in `test-harness/` if it touches SIP or audio
 6. **Document it in `docs/PROTOCOL.md`** (this is not optional)
 7. **Regenerate the protocol schema**: `cargo run -p siphon-ai-bridge --example gen_schema --features json-schema > schemas/siphon-ai.v1.json` (CI diffs it and validates the PROTOCOL.md examples against it)
-8. **Update example WS servers** in `examples/` to demonstrate or at least handle the new message
-9. If the message is a breaking addition (changes existing behavior), bump protocol version
+8. **Update the server SDKs** in `sdks/python` + `sdks/typescript` (typed message classes + `Call` method for BridgeIn commands; their test suites assert full coverage of the schema's unions, so CI fails if you skip this)
+9. **Update example WS servers** in `examples/` to demonstrate or at least handle the new message
+10. If the message is a breaking addition (changes existing behavior), bump protocol version
 
 ### 7.2 Adding a New WS Event (SiphonAI → Server)
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ The reference bot in `examples/deepgram-llm-bot-node/` is a working demo
 of the protocol, not the product. Tune it for your deployment or replace
 it entirely with your own WS server in any language.
 
+Writing that server in Python or TypeScript? The **server SDKs** in
+[`sdks/`](sdks/) handle the wire protocol for you — typed events, paced
+20 ms audio framing, and connection lifecycle — so you write handlers,
+not wire code. The protocol itself is also machine-readable:
+[`schemas/siphon-ai.v1.json`](schemas/siphon-ai.v1.json).
+
 ## Quickstart (Docker)
 
 The fastest way to see SiphonAI work end-to-end is the local demo
@@ -200,6 +206,7 @@ journal — grep `turn_summary` for SLO numbers. See
 | `crates/config/`      | TOML config + validation + SIGHUP reload |
 | `crates/telemetry/`   | tracing + metrics + HEP wiring + admin API (auth + RBAC) |
 | `bins/siphon-ai/`     | The daemon binary |
+| `sdks/`               | Server SDKs (Python + TypeScript) for the WS protocol |
 | `examples/`           | Reference WS servers and the local Homer stack |
 | `scripts/`            | Idempotent Debian 13 install scripts (daemon + bot) |
 | `test-harness/`       | SIPp scenarios, load tooling, HEP collector stub |

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -31,6 +31,12 @@ editor, validator, or code generator at it. Notes: messages are
 discriminated by `type`; validate against `$defs/BridgeOut`
 (SiphonAI→server) or `$defs/BridgeIn` (server→SiphonAI) when you know the
 direction — three discriminators (`hold`, `resume`, `mark`) exist in both.
+
+**Server SDKs (0.28.0).** Writing your server in Python or TypeScript?
+The SDKs in [`sdks/`](../sdks/) implement this protocol — typed events,
+paced 20 ms audio framing, close semantics — so you write handlers, not
+wire code. Their test suites validate against the schema and every
+example in this document, so they track the spec release-for-release.
 The binary audio framing is described by the schema's `x-binary-frames`
 annotation.
 

--- a/examples/echo-ws-server-node/.gitignore
+++ b/examples/echo-ws-server-node/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+yarn.lock

--- a/examples/echo-ws-server-node/README.md
+++ b/examples/echo-ws-server-node/README.md
@@ -1,0 +1,31 @@
+# echo-ws-server-node
+
+Reference echo WS server for the SiphonAI bridge protocol v1, built on the
+in-repo TypeScript SDK ([`sdks/typescript`](../../sdks/typescript)). It
+echoes every audio frame back to the caller — point a softphone at SiphonAI
+and you hear yourself.
+
+This is the Node twin of
+[`examples/echo-ws-server-python`](../../examples/echo-ws-server-python)
+(which carries the SIPp test-harness knobs; this one stays minimal).
+
+## Run
+
+```bash
+npm install     # builds the in-repo SDK via its prepare script
+node server.mjs --bind 0.0.0.0:8080
+```
+
+Then point a SiphonAI route at `ws://your-host:8080/` and place a call
+(see the repo root README for the full local stack).
+
+## Options
+
+| Flag | Meaning |
+|---|---|
+| `--bind HOST:PORT` | address to listen on (default `0.0.0.0:8080`) |
+| `--auth-token TOK` | require `Authorization: Bearer <TOK>` on the upgrade |
+| `--echo-marks` | send a `mark` event back after `start` (protocol smoke tests) |
+| `--delay-ms MS` | echo each audio frame back after this many ms |
+
+`GET /healthz` returns 200 for container probes.

--- a/examples/echo-ws-server-node/package.json
+++ b/examples/echo-ws-server-node/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "echo-ws-server-node",
+  "private": true,
+  "version": "0.28.0",
+  "description": "Reference echo WS server for the SiphonAI bridge protocol v1, built on the TypeScript server SDK.",
+  "type": "module",
+  "engines": { "node": ">=20" },
+  "scripts": {
+    "start": "node server.mjs"
+  },
+  "dependencies": {
+    "siphon-ai-server": "file:../../sdks/typescript"
+  }
+}

--- a/examples/echo-ws-server-node/server.mjs
+++ b/examples/echo-ws-server-node/server.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/**
+ * Reference echo WS server for the SiphonAI bridge protocol v1.
+ *
+ * Echoes every audio frame back to the caller — point a softphone at
+ * SiphonAI and you hear yourself. Built on the **`siphon-ai-server` SDK**
+ * (`sdks/typescript/`), so this file is the canonical example of writing
+ * a SiphonAI bot server in Node with typed events instead of hand-rolled
+ * wire code. The Python twin (`examples/echo-ws-server-python`) carries
+ * the SIPp test-harness knobs; this one stays minimal.
+ *
+ * Run:
+ *   npm install          # builds the in-repo SDK via its prepare script
+ *   node server.mjs --bind 0.0.0.0:8080
+ */
+
+import { parseArgs } from "node:util";
+
+import { SiphonServer, SUBPROTOCOL } from "siphon-ai-server";
+
+const { values: args } = parseArgs({
+  options: {
+    bind: { type: "string", default: "0.0.0.0:8080" },
+    "auth-token": { type: "string" },
+    "echo-marks": { type: "boolean", default: false },
+    "delay-ms": { type: "string", default: "0" },
+    help: { type: "boolean", short: "h", default: false },
+  },
+});
+
+if (args.help) {
+  console.log(`usage: node server.mjs [options]
+
+  --bind HOST:PORT   address to listen on (default: 0.0.0.0:8080)
+  --auth-token TOK   require Authorization: Bearer <TOK> on the upgrade
+  --echo-marks       send a \`mark\` event back after \`start\`
+                     (used by protocol smoke tests)
+  --delay-ms MS      echo each audio frame back after this many ms`);
+  process.exit(0);
+}
+
+const [host, port] = args.bind.split(":");
+if (!port) {
+  console.error("--bind must be HOST:PORT");
+  process.exit(2);
+}
+const delayMs = Number(args["delay-ms"]);
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const server = new SiphonServer(
+  async (call) => {
+    const start = call.start;
+    console.log(
+      `start call_id=${start.call_id} version=${start.version}` +
+        ` from=${start.from} to=${start.to}` +
+        ` rate=${start.audio.sample_rate} ch=${start.audio.channels}` +
+        ` frame_ms=${start.audio.frame_ms} sip_call_id=${start.sip.call_id}`,
+    );
+    if (start.reconnected) {
+      console.log(`start call_id=${start.call_id} is a reconnected call`);
+    }
+    if (args["echo-marks"]) call.mark("echo_ready");
+
+    let framesEchoed = 0;
+    for await (const item of call) {
+      if (item.type === "audio") {
+        if (delayMs > 0) await sleep(delayMs);
+        // Echo 1:1, mirroring the daemon's own 20 ms cadence — for
+        // generated audio use call.sendAudio, the SDK's paced re-framer.
+        call.sendAudioFrame(item.pcm);
+        framesEchoed += 1;
+      } else if (item.type === "stop") {
+        console.log(`stop call_id=${start.call_id} reason=${item.reason}`);
+        break;
+      } else if (item.type === "unknown") {
+        console.warn(`unknown text message type=${item.raw?.type}`);
+      } else {
+        console.log(`${item.type}:`, item);
+      }
+    }
+    console.log(
+      `done call_id=${start.call_id} frames_echoed=${framesEchoed}`,
+    );
+  },
+  { host, port: Number(port), authToken: args["auth-token"] },
+);
+
+await server.listen();
+console.log(
+  `listening on ws://${host}:${port}  (subprotocol=${SUBPROTOCOL},` +
+    ` auth=${args["auth-token"] ? "on" : "off"}, delay_ms=${delayMs})`,
+);
+
+for (const sig of ["SIGINT", "SIGTERM"]) {
+  process.on(sig, async () => {
+    console.log(`received ${sig}, shutting down`);
+    await server.close();
+    process.exit(0);
+  });
+}

--- a/examples/echo-ws-server-python/requirements.txt
+++ b/examples/echo-ws-server-python/requirements.txt
@@ -1,1 +1,5 @@
 websockets>=13
+# The SiphonAI server SDK (sdks/python). Path is relative to the pip
+# invocation CWD — install from the repo root (as CI does); a bare
+# `python3 server.py` also works with no install (repo-path fallback).
+./sdks/python

--- a/examples/echo-ws-server-python/server.py
+++ b/examples/echo-ws-server-python/server.py
@@ -1,45 +1,48 @@
 #!/usr/bin/env python3
-"""
-Reference echo WebSocket server for the SiphonAI bridge protocol v1.
+"""Reference echo WS server for the SiphonAI bridge protocol v1.
 
-What it does
-------------
-- Accepts a SiphonAI WebSocket upgrade (subprotocol ``siphon-ai.v1``).
-- Reads the ``start`` text message and logs the call's audio format.
-- Echoes every binary audio frame back into the same connection.
-- Logs incoming text messages (DTMF, marks, speech events).
-- Cleans up on ``stop`` or when SiphonAI closes the connection.
+Echoes every audio frame back to the caller — point a softphone at
+SiphonAI and you hear yourself. Built on the **`siphon-ai-server` SDK**
+(`sdks/python/`), so this file is the canonical example of writing a
+SiphonAI bot server with typed events instead of hand-rolled wire code.
+(It is also the SIPp CI fixture: every daemon PR drives real calls
+through this server — and therefore through the SDK.)
 
-What it does NOT do
--------------------
-- Run any AI logic. This is the reference for the *transport* — building a
-  real assistant on top of it is the developer's job.
-- Send ``hangup``, ``transfer``, ``mark``, or ``send_dtmf``. (See the
-  ``--echo-marks`` flag for a tiny exception used in protocol tests.)
+By default the server is silent on the control channel: it never sends
+commands unless one of the `--auto-*` test-harness flags asks it to.
 
-Run
----
+Run:
     python3 server.py --bind 0.0.0.0:8080
 
-Wire format
------------
-See ``docs/PROTOCOL.md`` in the SiphonAI repo. This file is intentionally
-the simplest possible compliant server.
+The SDK is imported from the repo checkout automatically; installing it
+(`pip install ./sdks/python` from the repo root) also works.
 """
 
 from __future__ import annotations
 
 import argparse
 import asyncio
-import json
 import logging
 import signal
+import sys
 from dataclasses import dataclass
-from typing import Any
+from pathlib import Path
 
-import websockets
-from websockets.asyncio.server import ServerConnection, serve
-from websockets.http11 import Request, Response
+# Prefer an installed siphon-ai-server; fall back to the in-repo SDK so a
+# bare `python3 server.py` works from a checkout with no pip step.
+try:
+    import siphon_ai_server  # noqa: F401
+except ImportError:  # pragma: no cover
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "sdks" / "python" / "src"))
+
+from siphon_ai_server import (  # noqa: E402
+    AudioFrame,
+    Call,
+    SiphonServer,
+    Start,
+    Stop,
+    UnknownEvent,
+)
 
 LOG = logging.getLogger("echo-ws")
 SUBPROTOCOL = "siphon-ai.v1"
@@ -53,375 +56,179 @@ class Options:
     auth_token: str | None
     echo_marks: bool
     log_level: str
-    # Test-harness knob: after the `start` message, wait this long and
-    # then send a `transfer` message with `target=auto_transfer_target`.
-    # Disabled when either field is None — keeps the reference server
-    # silent on the control channel by default (see file docstring).
+    # Test-harness knobs (see --help): each drives one SIPp scenario.
     auto_transfer_target: str | None
     auto_transfer_delay_ms: int
-    # Test-harness knob: after `start`, wait this long and then send a
-    # `hangup`. Lets the outbound SIPp scenario end the call from the
-    # WS side (the callee just waits for our BYE). None = disabled.
     auto_hangup_after_ms: int | None
-    # Test-harness knob: after `start`, send an ATTENDED transfer
-    # naming this consult call id (`replaces_call_id`). Reuses
-    # auto_transfer_delay_ms for the pause. None = disabled.
     auto_transfer_replaces: str | None
-    # Test-harness knob: after `start`, wait auto_transfer_delay_ms and
-    # then `conference_join` into this room. Lets two SIPp callers be
-    # mixed in one room without a human driving the control channel.
-    # None = disabled.
     auto_conference_join: str | None
-    # Test-harness knob: after `start`, wait auto_transfer_delay_ms and
-    # then `park` this call (optionally labelling the lot). SiphonAI
-    # replies `stop { reason: "park" }` and closes the WS; an operator
-    # retrieves the call later via the admin API. None = disabled.
-    auto_park_slot: str | None
-    # Sentinel distinguishing "--auto-park with no slot" (park, unlabeled)
-    # from "--auto-park absent" (don't park). Set alongside auto_park_slot.
     auto_park: bool
-    # Test-harness knob: after `start`, wait auto_transfer_delay_ms and then
-    # `hold` this call, hold it for ~1s, `resume` it, then `hangup`. Drives
-    # the bot-initiated hold/resume SIPp scenario (the caller asserts it
-    # receives a sendonly re-INVITE then a sendrecv one). None = disabled.
+    auto_park_slot: str | None
     auto_hold: bool
-    # Test-harness knob: drop the **first** connection's socket this many ms
-    # after `start` (an unexpected WS drop), to exercise SiphonAI's WS
-    # reconnect (0.7.3). With `[bridge].ws_reconnect_enabled = true` SiphonAI
-    # re-dials; the redial's `start` carries `reconnected: true`, and this
-    # server ends that resumed call with a `hangup`. `_dropped_once` (mutated
-    # at runtime) makes the drop fire only on the first connection so the
-    # redial succeeds. None = disabled.
+    # Drop the FIRST connection's socket this many ms after `start` (an
+    # unexpected WS drop) to exercise 0.7.3 reconnect; the redial's
+    # `start` carries reconnected:true and gets hung up instead.
     drop_after_ms: int | None
     _dropped_once: bool = False
 
 
-# ─── HTTP-side concerns: auth + subprotocol ─────────────────────────────────
-
-
-def make_request_handler(opts: Options):
-    """Build a websockets ``process_request`` hook that enforces bearer auth.
-
-    Returning a ``Response`` here aborts the upgrade with that response.
-    Returning ``None`` lets the upgrade proceed.
-    """
-
-    def process_request(connection: ServerConnection, request: Request) -> Response | None:
-        # Cheap healthcheck endpoint. We short-circuit before the
-        # websockets handshake validation runs, so periodic
-        # `curl http://.../healthz` from a Docker / k8s probe
-        # doesn't show up as an `InvalidUpgrade` error in the log.
-        if request.path == "/healthz":
-            return connection.respond(200, "ok\n")
-
-        if opts.auth_token is None:
-            return None
-        header = request.headers.get("Authorization", "")
-        expected = f"Bearer {opts.auth_token}"
-        if header != expected:
-            LOG.warning("rejecting upgrade: bad/missing Authorization header")
-            return connection.respond(401, "Unauthorized\n")
-        return None
-
-    return process_request
-
-
-# ─── Connection handler ─────────────────────────────────────────────────────
-
-
-async def handle(connection: ServerConnection, opts: Options) -> None:
-    peer = connection.remote_address
-    call_id: str | None = None
-    frames_echoed = 0
-    bytes_echoed = 0
-
-    LOG.info("connect peer=%s subprotocol=%r", peer, connection.subprotocol)
-
-    if connection.subprotocol != SUBPROTOCOL:
-        LOG.warning("client did not negotiate %r; proceeding optimistically", SUBPROTOCOL)
-
-    # W3C trace context (PROTOCOL.md §2, 0.23.0): present on the upgrade
-    # request when the daemon runs with [observability.otlp] enabled. A real
-    # server would hand this to its OpenTelemetry SDK — e.g.
-    #   ctx = TraceContextTextMapPropagator().extract(dict(request.headers))
-    #   with tracer.start_as_current_span("handle-call", context=ctx): ...
-    # — so its spans join the daemon's per-call trace in one waterfall. The
-    # reference server has no OTel dependency, so it just logs the value.
-    # (The same context is mirrored on `start.trace_context` below, for
-    # stacks whose WS library hides upgrade headers.)
-    if connection.request is not None:
-        traceparent = connection.request.headers.get("traceparent")
-        if traceparent:
-            LOG.info("trace context: traceparent=%s", traceparent)
-
-    try:
-        async for message in connection:
-            if isinstance(message, bytes):
-                # Binary = audio. Echo it back unchanged.
-                if opts.delay_ms > 0:
-                    await asyncio.sleep(opts.delay_ms / 1000.0)
-                await connection.send(message)
-                frames_echoed += 1
-                bytes_echoed += len(message)
-                if frames_echoed % 50 == 0:
-                    # Log once a second at 50 fps so the operator sees life
-                    # without being drowned in per-frame chatter.
-                    LOG.debug(
-                        "echoed %d frames / %d bytes (call_id=%s)",
-                        frames_echoed,
-                        bytes_echoed,
-                        call_id,
-                    )
-                continue
-
-            # Text frame: parse and dispatch.
-            try:
-                msg = json.loads(message)
-            except json.JSONDecodeError as e:
-                LOG.warning("invalid JSON on text frame: %s — ignoring", e)
-                continue
-
-            mtype = msg.get("type")
-            if mtype == "start":
-                call_id = msg.get("call_id")
-                version = msg.get("version")
-                audio = msg.get("audio", {})
-                sip = msg.get("sip", {})
-                LOG.info(
-                    "start call_id=%s version=%s from=%s to=%s "
-                    "rate=%s ch=%s frame_ms=%s sip_call_id=%s",
-                    call_id,
-                    version,
-                    msg.get("from"),
-                    msg.get("to"),
-                    audio.get("sample_rate"),
-                    audio.get("channels"),
-                    audio.get("frame_ms"),
-                    sip.get("call_id"),
-                )
-                if version != "1":
-                    LOG.error("unsupported protocol version %r; closing", version)
-                    await connection.close(code=1003, reason="unsupported version")
-                    return
-                if msg.get("trace_context"):
-                    # Mirror of the `traceparent` upgrade header (PROTOCOL.md
-                    # §3.1, 0.23.0) — either place works for continuing the
-                    # daemon's per-call OTLP trace. Absent unless the daemon
-                    # runs with [observability.otlp] enabled.
-                    LOG.info(
-                        "start call_id=%s trace_context=%s",
-                        call_id,
-                        msg["trace_context"],
-                    )
-                if msg.get("retrieved"):
-                    # This session is picking up a previously parked call
-                    # (PROTOCOL.md §3.1 / §4.9), not a fresh inbound one.
-                    LOG.info("start call_id=%s is a retrieved (parked) call", call_id)
-                if msg.get("reconnected"):
-                    # SiphonAI re-dialed after an unexpected WS drop (0.7.3,
-                    # PROTOCOL.md §5.7). End this resumed call so the harness
-                    # caller completes — proving the reconnect recovered.
-                    LOG.info("start call_id=%s is a reconnected (resumed) call", call_id)
-                    if call_id:
-                        asyncio.create_task(
-                            _send_after(
-                                connection, 300, {"type": "hangup", "call_id": call_id}
-                            )
-                        )
-                elif opts.drop_after_ms is not None and not opts._dropped_once:
-                    # First connection: drop the socket after a beat to
-                    # simulate an unexpected WS failure mid-call.
-                    opts._dropped_once = True
-                    asyncio.create_task(_drop_after(connection, opts.drop_after_ms))
-                if opts.echo_marks:
-                    # Optional behavior used by SiphonAI's protocol smoke
-                    # tests: round-trip a `mark` to verify the control
-                    # path. Disabled by default; the reference echo
-                    # server is supposed to be silent on the control
-                    # channel.
-                    await connection.send(
-                        json.dumps({
-                            "type": "mark",
-                            "call_id": call_id,
-                            "name": "echo_ready",
-                        })
-                    )
-
-                if opts.auto_transfer_target and call_id:
-                    # Test-harness behaviour: drive a blind transfer
-                    # without a human in the loop. The delay lets the
-                    # SIP side reach ESTABLISHED before REFER lands.
-                    target = opts.auto_transfer_target
-                    delay_ms = opts.auto_transfer_delay_ms
-                    cid = call_id
-                    asyncio.create_task(
-                        _send_after(
-                            connection,
-                            delay_ms,
-                            {"type": "transfer", "call_id": cid, "target": target},
-                        )
-                    )
-
-                if opts.auto_transfer_replaces and call_id:
-                    # Test-harness behaviour: complete an attended
-                    # transfer against a consult call the harness
-                    # placed via POST /admin/v1/calls. No `target` —
-                    # SiphonAI derives the Refer-To from the consult
-                    # dialog's Contact (PROTOCOL.md §4.4).
-                    asyncio.create_task(
-                        _send_after(
-                            connection,
-                            opts.auto_transfer_delay_ms,
-                            {
-                                "type": "transfer",
-                                "call_id": call_id,
-                                "replaces_call_id": opts.auto_transfer_replaces,
-                            },
-                        )
-                    )
-
-                if opts.auto_conference_join and call_id:
-                    # Test-harness behaviour: join a conference room so
-                    # two SIPp callers land in the same mix. The delay
-                    # lets the SIP side reach ESTABLISHED first.
-                    asyncio.create_task(
-                        _send_after(
-                            connection,
-                            opts.auto_transfer_delay_ms,
-                            {
-                                "type": "conference_join",
-                                "call_id": call_id,
-                                "room_id": opts.auto_conference_join,
-                            },
-                        )
-                    )
-
-                if opts.auto_park and call_id:
-                    # Test-harness behaviour: park the call from the WS
-                    # side. SiphonAI detaches this session (`stop{park}`
-                    # + close); the call lives on hold music until an
-                    # operator retrieves it. The hook for the 0.7.0
-                    # park→retrieve SIPp scenario.
-                    park_msg: dict[str, Any] = {"type": "park", "call_id": call_id}
-                    if opts.auto_park_slot:
-                        park_msg["slot"] = opts.auto_park_slot
-                    asyncio.create_task(
-                        _send_after(connection, opts.auto_transfer_delay_ms, park_msg)
-                    )
-
-                if opts.auto_hold and call_id:
-                    # Test-harness behaviour: drive a full bot-initiated
-                    # hold cycle — hold the caller, keep them held for ~1s,
-                    # resume, then hang up. SiphonAI re-INVITEs the caller
-                    # sendonly then sendrecv; the SIPp scenario asserts both
-                    # and replies `held`/`resumed` come back. The hangup at
-                    # the end lets the caller's scenario complete.
-                    asyncio.create_task(_auto_hold_cycle(connection, call_id, opts))
-
-                if opts.auto_hangup_after_ms is not None and call_id:
-                    # Test-harness behaviour: end the call from the WS
-                    # side after a beat. Used by the outbound SIPp
-                    # scenario, where SIPp (the callee) answers and then
-                    # waits for SiphonAI's BYE.
-                    asyncio.create_task(
-                        _send_after(
-                            connection,
-                            opts.auto_hangup_after_ms,
-                            {"type": "hangup", "call_id": call_id},
-                        )
-                    )
-
-            elif mtype == "stop":
-                LOG.info("stop call_id=%s reason=%s", call_id, msg.get("reason"))
-                # SiphonAI closes the connection right after `stop`; we
-                # simply drop out of the loop.
-                break
-
-            elif mtype in {
-                "speech_started",
-                "speech_stopped",
-                "dtmf",
-                "mark",
-                "hold",
-                "resume",
-                "held",
-                "resumed",
-                "error",
-                "conference_joined",
-                "conference_left",
-                "participant_joined",
-                "participant_left",
-            }:
-                LOG.info("%s: %s", mtype, _redact(msg))
-
-            else:
-                LOG.warning("unknown text message type=%r", mtype)
-
-    except websockets.exceptions.ConnectionClosedError as e:
-        LOG.info("connection closed unexpectedly: %s", e)
-    except websockets.exceptions.ConnectionClosedOK:
-        LOG.info("connection closed cleanly")
-    finally:
+async def handle(call: Call, opts: Options) -> None:
+    start = call.start
+    LOG.info(
+        "start call_id=%s version=%s from=%s to=%s rate=%s ch=%s frame_ms=%s sip_call_id=%s",
+        start.call_id,
+        start.version,
+        start.from_,
+        start.to,
+        start.audio.sample_rate,
+        start.audio.channels,
+        start.audio.frame_ms,
+        start.sip.call_id,
+    )
+    if start.trace_context:
+        # Mirror of the `traceparent` upgrade header (PROTOCOL.md §3.1) —
+        # a real server would hand this to its OpenTelemetry SDK so its
+        # spans join the daemon's per-call trace.
         LOG.info(
-            "done peer=%s call_id=%s frames_echoed=%d bytes_echoed=%d",
-            peer,
-            call_id,
-            frames_echoed,
-            bytes_echoed,
+            "start call_id=%s trace_context=%s", start.call_id, start.trace_context
+        )
+    if start.retrieved:
+        LOG.info("start call_id=%s is a retrieved (parked) call", start.call_id)
+
+    if start.reconnected:
+        # SiphonAI re-dialed after an unexpected WS drop (0.7.3). End the
+        # resumed call so the harness caller completes — proving the
+        # reconnect recovered.
+        LOG.info("start call_id=%s is a reconnected (resumed) call", start.call_id)
+        asyncio.get_running_loop().create_task(_send_after(300, call.hangup()))
+    elif opts.drop_after_ms is not None and not opts._dropped_once:
+        opts._dropped_once = True
+        asyncio.get_running_loop().create_task(_drop_after(call, opts.drop_after_ms))
+
+    if opts.echo_marks:
+        # Used by protocol smoke tests to verify the control round-trip.
+        await call.mark("echo_ready")
+
+    # ── test-harness one-shots (each drives one SIPp scenario) ──
+    loop = asyncio.get_running_loop()
+    if opts.auto_transfer_target:
+        loop.create_task(
+            _harness(
+                _send_after(
+                    opts.auto_transfer_delay_ms,
+                    call.transfer(opts.auto_transfer_target),
+                ),
+                "transfer",
+            )
+        )
+    if opts.auto_transfer_replaces:
+        loop.create_task(
+            _harness(
+                _send_after(
+                    opts.auto_transfer_delay_ms,
+                    call.transfer(replaces_call_id=opts.auto_transfer_replaces),
+                ),
+                "attended transfer",
+            )
+        )
+    if opts.auto_conference_join:
+        loop.create_task(
+            _harness(
+                _send_after(
+                    opts.auto_transfer_delay_ms,
+                    call.conference_join(opts.auto_conference_join),
+                ),
+                "conference_join",
+            )
+        )
+    if opts.auto_park:
+        loop.create_task(
+            _harness(
+                _send_after(
+                    opts.auto_transfer_delay_ms, call.park(opts.auto_park_slot)
+                ),
+                "park",
+            )
+        )
+    if opts.auto_hold:
+        loop.create_task(_auto_hold_cycle(call, opts))
+    if opts.auto_hangup_after_ms is not None:
+        loop.create_task(
+            _harness(_send_after(opts.auto_hangup_after_ms, call.hangup()), "hangup")
         )
 
+    # ── the echo loop ──
+    frames_echoed = 0
+    bytes_echoed = 0
+    async for item in call:
+        if isinstance(item, AudioFrame):
+            if opts.delay_ms > 0:
+                await asyncio.sleep(opts.delay_ms / 1000.0)
+            # Echo 1:1, mirroring the daemon's own 20 ms cadence — no
+            # re-pacing needed (for generated audio use call.send_audio,
+            # the SDK's paced re-framer).
+            await call.send_audio_frame(item.pcm)
+            frames_echoed += 1
+            bytes_echoed += len(item.pcm)
+            if frames_echoed % 50 == 0:
+                LOG.debug(
+                    "echoed %d frames / %d bytes (call_id=%s)",
+                    frames_echoed,
+                    bytes_echoed,
+                    start.call_id,
+                )
+        elif isinstance(item, Stop):
+            LOG.info("stop call_id=%s reason=%s", start.call_id, item.reason)
+            break
+        elif isinstance(item, UnknownEvent):
+            LOG.warning("unknown text message type=%r", item.type)
+        else:
+            LOG.info("%s: %s", item.type, item)
 
-def _redact(msg: dict[str, Any]) -> dict[str, Any]:
-    """Strip noisy fields when logging known control messages."""
-    return {k: v for k, v in msg.items() if k != "type"}
+    LOG.info(
+        "done call_id=%s frames_echoed=%d bytes_echoed=%d",
+        start.call_id,
+        frames_echoed,
+        bytes_echoed,
+    )
 
 
-async def _send_after(
-    connection: ServerConnection, delay_ms: int, payload: dict[str, Any]
-) -> None:
-    """Sleep, then send a JSON payload. Swallows close errors so a
-    race with WS teardown doesn't crash the task."""
+async def _send_after(delay_ms: int, command) -> None:
     await asyncio.sleep(delay_ms / 1000.0)
+    await command
+
+
+async def _harness(coro, label: str) -> None:
+    """Run a delayed test-harness command; a race with WS teardown is
+    logged, never fatal (Call commands already swallow closed sockets)."""
     try:
-        await connection.send(json.dumps(payload))
-        LOG.info("test-harness sent: %s", _redact(payload))
-    except websockets.exceptions.ConnectionClosed:
-        LOG.debug("auto-send dropped: connection closed before delay elapsed")
+        await coro
+        LOG.info("test-harness sent: %s", label)
+    except Exception as e:  # pragma: no cover
+        LOG.debug("test-harness %s dropped: %s", label, e)
 
 
-async def _drop_after(connection: ServerConnection, delay_ms: int) -> None:
-    """Test-harness only: after `delay_ms`, abruptly close the socket to
-    simulate an unexpected WS drop (no `stop`/`hangup`). Drives 0.7.3
-    reconnect. Closes with a non-1000 code so it reads as a failure."""
+async def _drop_after(call: Call, delay_ms: int) -> None:
+    """Abruptly close the socket (no hangup) to trigger 0.7.3 reconnect."""
     await asyncio.sleep(delay_ms / 1000.0)
     LOG.info("test-harness: dropping WS connection to trigger reconnect")
-    try:
-        await connection.close(code=1011, reason="harness drop")
-    except websockets.exceptions.ConnectionClosed:
-        pass
+    await call.abort()
 
 
-async def _auto_hold_cycle(
-    connection: ServerConnection, call_id: str, opts: Options
-) -> None:
-    """Test-harness only: hold → wait → resume → hangup. Drives the
-    bot-initiated hold/resume SIPp scenario. Swallows close errors."""
+async def _auto_hold_cycle(call: Call, opts: Options) -> None:
+    """hold → ~1 s → resume → hangup, driving the 0.7.2 SIPp scenario."""
     try:
         await asyncio.sleep(opts.auto_transfer_delay_ms / 1000.0)
-        await connection.send(json.dumps({"type": "hold", "call_id": call_id}))
+        await call.hold()
         LOG.info("test-harness sent: hold")
         await asyncio.sleep(1.0)
-        await connection.send(json.dumps({"type": "resume", "call_id": call_id}))
+        await call.resume()
         LOG.info("test-harness sent: resume")
-        # Give the resume re-INVITE a beat to complete, then end the call.
         await asyncio.sleep(0.5)
-        await connection.send(json.dumps({"type": "hangup", "call_id": call_id}))
+        await call.hangup()
         LOG.info("test-harness sent: hangup")
-    except websockets.exceptions.ConnectionClosed:
-        LOG.debug("auto-hold dropped: connection closed mid-cycle")
-
-
-# ─── Entrypoint ──────────────────────────────────────────────────────────────
+    except Exception as e:  # pragma: no cover
+        LOG.debug("auto-hold dropped: %s", e)
 
 
 def parse_args(argv: list[str] | None = None) -> Options:
@@ -566,20 +373,13 @@ def parse_args(argv: list[str] | None = None) -> Options:
 
 
 async def main(opts: Options) -> None:
-    async def handler(connection: ServerConnection) -> None:
-        await handle(connection, opts)
-
-    async with serve(
-        handler,
+    server = SiphonServer(
+        lambda call: handle(call, opts),
         host=opts.bind_host,
         port=opts.bind_port,
-        subprotocols=[SUBPROTOCOL],
-        process_request=make_request_handler(opts),
-        # 256 KiB matches PROTOCOL.md §2.1.
-        max_size=256 * 1024,
-        ping_interval=15,
-        ping_timeout=10,
-    ) as server:
+        auth_token=opts.auth_token,
+    )
+    async with server.listen():
         LOG.info(
             "listening on ws://%s:%d  (subprotocol=%s, auth=%s, delay_ms=%d)",
             opts.bind_host,
@@ -588,18 +388,12 @@ async def main(opts: Options) -> None:
             "on" if opts.auth_token else "off",
             opts.delay_ms,
         )
-
-        # Wait for SIGINT / SIGTERM.
         loop = asyncio.get_running_loop()
         stop = loop.create_future()
         for sig in (signal.SIGINT, signal.SIGTERM):
             loop.add_signal_handler(sig, lambda s=sig: stop.set_result(s))
-        try:
-            sig = await stop
-            LOG.info("received signal %s, shutting down", sig.name if hasattr(sig, "name") else sig)
-        finally:
-            server.close()
-            await server.wait_closed()
+        sig = await stop
+        LOG.info("received signal %s, shutting down", getattr(sig, "name", sig))
 
 
 if __name__ == "__main__":

--- a/examples/echo-ws-server-python/test_smoke.py
+++ b/examples/echo-ws-server-python/test_smoke.py
@@ -55,18 +55,15 @@ def _start_msg(call_id: str = "smoke-1", sample_rate: int = 8000) -> dict:
 async def running_server(opts: srv.Options):
     """Start the echo server on a background task; cancel it on exit."""
 
-    async def handler(connection):
-        await srv.handle(connection, opts)
-
-    async with websockets.asyncio.server.serve(
-        handler,
+    sdk_server = srv.SiphonServer(
+        lambda call: srv.handle(call, opts),
         host=opts.bind_host,
         port=opts.bind_port,
-        subprotocols=[srv.SUBPROTOCOL],
-        process_request=srv.make_request_handler(opts),
-        max_size=256 * 1024,
+        auth_token=opts.auth_token,
         ping_interval=None,  # disable pings in tests; we want deterministic IO
-    ) as server:
+        ping_timeout=None,
+    )
+    async with sdk_server.listen() as server:
         yield server
 
 

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -1,0 +1,83 @@
+# siphon-ai-server (Python)
+
+Server SDK for the [SiphonAI](https://github.com/thevoiceguy/siphon-ai)
+WebSocket bridge protocol v1: typed events, paced 20 ms audio framing, and
+connection lifecycle — write handlers, not wire code.
+
+**This SDK contains no AI code.** SiphonAI streams call audio to your server
+and plays back whatever you send; STT/LLM/TTS are your handler's business.
+
+## Install
+
+Not yet on PyPI — install from the repo (vendorable):
+
+```bash
+pip install ./sdks/python
+# or from a checkout URL:
+pip install "siphon-ai-server @ git+https://github.com/thevoiceguy/siphon-ai#subdirectory=sdks/python"
+```
+
+Requires Python ≥ 3.10. Sole runtime dependency: `websockets`.
+
+## Quickstart
+
+```python
+import asyncio
+from siphon_ai_server import AudioFrame, Dtmf, SiphonServer
+
+
+async def handle(call):
+    print("call from", call.start.from_, "to", call.start.to)
+    async for item in call:
+        if isinstance(item, AudioFrame):
+            await call.send_audio_frame(item.pcm)   # echo it back
+        elif isinstance(item, Dtmf) and item.digit == "0":
+            await call.hangup()
+
+
+asyncio.run(SiphonServer(handle, port=8080).serve_forever())
+```
+
+Point a SiphonAI route at `ws://your-host:8080/` and place a call.
+
+## What you get
+
+- **`SiphonServer(handler, host, port)`** — accepts WS connections, echoes
+  the `siphon-ai.v1` subprotocol, waits for `start`, and invokes your
+  handler with a `Call`. One task per call; handler exceptions tear down
+  only that call.
+- **`Call`** — async-iterate it to receive `AudioFrame` (binary PCM) and
+  typed events (`Dtmf`, `SpeechStarted`, `Mark`, `RtpStats`, `Stop`, …).
+  Iteration ends when the call does.
+- **Commands** — one method per protocol v1 command: `send_audio` /
+  `send_audio_frame`, `clear`, `mark`, `hangup`, `transfer`, `send_dtmf`,
+  `mute`/`unmute`, `start_recording`/`stop_recording`/`pause_recording`/
+  `resume_recording`, `set_recording_consent`, `park`, `hold`/`resume`,
+  `conference_join`/`conference_leave`, `abort`.
+- **`send_audio(pcm)`** takes arbitrary byte lengths and re-frames to exact
+  20 ms frames (320 B @ 8 kHz, 640 B @ 16 kHz — per `call.start.audio`),
+  paced at 50 frames/s. `send_audio_frame` sends one pre-framed frame.
+- **Close semantics** per PROTOCOL §5.7: end a call with `hangup()`; a bare
+  close is treated as a drop (and triggers daemon-side reconnect if
+  enabled). `call.start.reconnected` tells you a session is a resumption.
+- **Tolerant parsing** — unknown event types arrive as `UnknownEvent`,
+  unknown fields are ignored, so older SDKs keep working as the daemon
+  grows.
+
+## Conformance
+
+The test suite parses every canonical example in `docs/PROTOCOL.md` into
+typed events and validates every command the SDK can emit against
+`schemas/siphon-ai.v1.json`:
+
+```bash
+pip install ./sdks/python[test] pytest
+pytest sdks/python/tests
+```
+
+The canonical spec is [`docs/PROTOCOL.md`](../../docs/PROTOCOL.md); the
+machine-readable contract is
+[`schemas/siphon-ai.v1.json`](../../schemas/siphon-ai.v1.json).
+
+A complete working server built on this SDK:
+[`examples/echo-ws-server-python`](../../examples/echo-ws-server-python).

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "siphon-ai-server"
+version = "0.28.0"
+description = "Server SDK for the SiphonAI WebSocket bridge protocol v1: typed events, 20 ms audio framing, and connection lifecycle — write handlers, not wire code."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT OR Apache-2.0" }
+keywords = ["siphon-ai", "sip", "voice", "websocket", "telephony"]
+dependencies = [
+    "websockets>=13",
+]
+
+[project.urls]
+Homepage = "https://github.com/thevoiceguy/siphon-ai"
+Documentation = "https://github.com/thevoiceguy/siphon-ai/blob/main/docs/PROTOCOL.md"
+
+[project.optional-dependencies]
+test = ["jsonschema>=4"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/siphon_ai_server"]

--- a/sdks/python/src/siphon_ai_server/__init__.py
+++ b/sdks/python/src/siphon_ai_server/__init__.py
@@ -1,0 +1,99 @@
+"""Server SDK for the SiphonAI WebSocket bridge protocol v1.
+
+Write handlers, not wire code:
+
+```python
+import asyncio
+from siphon_ai_server import AudioFrame, Dtmf, SiphonServer
+
+
+async def handle(call):
+    print("call from", call.start.from_)
+    async for item in call:
+        if isinstance(item, AudioFrame):
+            await call.send_audio_frame(item.pcm)   # echo
+        elif isinstance(item, Dtmf) and item.digit == "0":
+            await call.hangup()
+
+
+asyncio.run(SiphonServer(handle, port=8080).serve_forever())
+```
+
+The canonical protocol spec is ``docs/PROTOCOL.md``; the machine-readable
+contract is ``schemas/siphon-ai.v1.json`` (this SDK's test suite validates
+against both). **This SDK contains no AI code** — STT/LLM/TTS are your
+handler's business.
+"""
+
+from .audio import FRAME_MS, AudioSender, frame_bytes
+from .call import Call
+from .events import (
+    AudioFormat,
+    AudioFrame,
+    ConferenceJoined,
+    ConferenceLeft,
+    DeadAirDetected,
+    Dtmf,
+    Error,
+    Event,
+    FarEndHold,
+    FarEndResume,
+    Held,
+    Mark,
+    ParticipantJoined,
+    ParticipantLeft,
+    RecordingFailed,
+    RecordingStarted,
+    RecordingStopped,
+    Resumed,
+    RtpStats,
+    SilenceDetected,
+    SipMeta,
+    SpeechStarted,
+    SpeechStopped,
+    Start,
+    Stop,
+    TraceContext,
+    UnknownEvent,
+    parse_event,
+)
+from .server import SUBPROTOCOL, SiphonServer
+
+__version__ = "0.28.0"
+
+__all__ = [
+    "AudioFormat",
+    "AudioFrame",
+    "AudioSender",
+    "Call",
+    "ConferenceJoined",
+    "ConferenceLeft",
+    "DeadAirDetected",
+    "Dtmf",
+    "Error",
+    "Event",
+    "FarEndHold",
+    "FarEndResume",
+    "FRAME_MS",
+    "frame_bytes",
+    "Held",
+    "Mark",
+    "ParticipantJoined",
+    "ParticipantLeft",
+    "parse_event",
+    "RecordingFailed",
+    "RecordingStarted",
+    "RecordingStopped",
+    "Resumed",
+    "RtpStats",
+    "SilenceDetected",
+    "SipMeta",
+    "SpeechStarted",
+    "SpeechStopped",
+    "Start",
+    "Stop",
+    "SUBPROTOCOL",
+    "SiphonServer",
+    "TraceContext",
+    "UnknownEvent",
+]

--- a/sdks/python/src/siphon_ai_server/audio.py
+++ b/sdks/python/src/siphon_ai_server/audio.py
@@ -1,0 +1,113 @@
+"""Outbound audio framing: arbitrary PCM byte pushes → exact 20 ms frames.
+
+SiphonAI requires every binary WS frame to be exactly one 20 ms PCM16-LE
+mono chunk (320 bytes @ 8 kHz, 640 @ 16 kHz) — the piece every integrator
+hand-rolls. :class:`AudioSender` buffers whatever a TTS engine produces and
+emits spec-sized frames, **paced at real time** (one frame per 20 ms) so a
+fast synthesizer can't flood the daemon's bounded playout queue and blunt
+barge-in `clear`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Awaitable, Callable
+
+FRAME_MS = 20
+SUPPORTED_RATES = (8000, 16000)
+
+
+def frame_bytes(sample_rate: int) -> int:
+    """Bytes per 20 ms PCM16-LE mono frame at `sample_rate`."""
+    if sample_rate not in SUPPORTED_RATES:
+        raise ValueError(f"unsupported sample rate {sample_rate} (8000 or 16000)")
+    return sample_rate // 1000 * FRAME_MS * 2
+
+
+class AudioSender:
+    """Paced 20 ms re-framer over a raw ``send(bytes)`` coroutine.
+
+    ``push()`` never blocks on the wire; a background task drains the
+    buffer one frame per 20 ms. ``clear()`` drops everything buffered
+    (barge-in); ``flush()`` waits until the buffer has fully played out,
+    zero-padding the final partial frame so the tail is audible.
+    """
+
+    def __init__(
+        self,
+        send: Callable[[bytes], Awaitable[None]],
+        sample_rate: int,
+    ) -> None:
+        self._send = send
+        self._frame_bytes = frame_bytes(sample_rate)
+        self._buffer = bytearray()
+        self._wakeup = asyncio.Event()
+        self._closed = False
+        self._task: asyncio.Task[None] | None = None
+
+    def push(self, pcm: bytes) -> None:
+        """Queue PCM16-LE mono bytes of any length for paced sending."""
+        if self._closed:
+            return
+        self._buffer.extend(pcm)
+        self._wakeup.set()
+        if self._task is None:
+            self._task = asyncio.get_running_loop().create_task(self._run())
+
+    def clear(self) -> int:
+        """Drop all buffered audio (local half of barge-in). Returns the
+        number of bytes dropped — pair with sending the daemon a
+        ``clear`` to flush its side too."""
+        dropped = len(self._buffer)
+        self._buffer.clear()
+        return dropped
+
+    async def flush(self) -> None:
+        """Wait until everything pushed so far has been sent. The final
+        partial frame (if any) is zero-padded to spec size."""
+        if self._buffer:
+            pad = -len(self._buffer) % self._frame_bytes
+            self._buffer.extend(b"\x00" * pad)
+            self._wakeup.set()
+        while self._buffer and not self._closed:
+            await asyncio.sleep(FRAME_MS / 1000)
+
+    async def aclose(self) -> None:
+        self._closed = True
+        self._buffer.clear()
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+
+    async def _run(self) -> None:
+        loop = asyncio.get_running_loop()
+        next_at = loop.time()
+        while not self._closed:
+            if len(self._buffer) < self._frame_bytes:
+                self._wakeup.clear()
+                # Idle: no whole frame ready — wait for more audio and
+                # re-anchor the clock (no "catch-up burst" after silence).
+                await self._wakeup.wait()
+                next_at = loop.time()
+                continue
+            frame = bytes(self._buffer[: self._frame_bytes])
+            del self._buffer[: self._frame_bytes]
+            try:
+                await self._send(frame)
+            except Exception:
+                # The connection owns error reporting; a dead socket just
+                # stops the pacer.
+                self._closed = True
+                return
+            next_at += FRAME_MS / 1000
+            delay = next_at - loop.time()
+            if delay > 0:
+                await asyncio.sleep(delay)
+            else:
+                # Fell behind (slow event loop) — re-anchor rather than
+                # bursting frames to catch up.
+                next_at = loop.time()

--- a/sdks/python/src/siphon_ai_server/call.py
+++ b/sdks/python/src/siphon_ai_server/call.py
@@ -1,0 +1,167 @@
+"""One bridged call: typed event stream + command senders."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, AsyncIterator, Union
+
+from websockets.asyncio.server import ServerConnection
+from websockets.exceptions import ConnectionClosed
+
+from .audio import AudioSender
+from .events import AudioFrame, Event, Start, parse_event
+
+__all__ = ["Call"]
+
+logger = logging.getLogger("siphon_ai_server")
+
+
+class Call:
+    """A live SiphonAI bridge session.
+
+    Iterate it to receive :class:`AudioFrame` (caller audio, one 20 ms
+    frame each) interleaved with typed protocol events. The iterator ends
+    when the daemon closes the session (normally right after a ``stop``
+    event).
+
+    Command methods mirror `docs/PROTOCOL.md` §4. Ending a call is
+    :meth:`hangup` — per §5.7 a bare WS close is treated as an unexpected
+    drop, not a hangup.
+    """
+
+    def __init__(self, ws: ServerConnection, start: Start) -> None:
+        self._ws = ws
+        self.start = start
+        self.call_id = start.call_id
+        self.audio_out = AudioSender(ws.send, start.audio.sample_rate)
+
+    # ─── receiving ────────────────────────────────────────────────
+
+    def __aiter__(self) -> AsyncIterator[Union[AudioFrame, Event]]:
+        return self._events()
+
+    async def _events(self) -> AsyncIterator[Union[AudioFrame, Event]]:
+        try:
+            async for message in self._ws:
+                if isinstance(message, bytes):
+                    yield AudioFrame(pcm=message)
+                else:
+                    try:
+                        yield parse_event(message)
+                    except ValueError as e:
+                        # The daemon never sends malformed JSON; if
+                        # something on the path does, a robust server
+                        # logs and keeps the call alive.
+                        logger.warning(
+                            "call %s: ignoring bad text frame: %s",
+                            self.call_id,
+                            e,
+                        )
+        except ConnectionClosed:
+            return
+        finally:
+            await self.audio_out.aclose()
+
+    # ─── audio ────────────────────────────────────────────────────
+
+    def send_audio(self, pcm: bytes) -> None:
+        """Queue PCM16-LE mono bytes (any length) — re-framed to exact
+        20 ms frames and paced at real time."""
+        self.audio_out.push(pcm)
+
+    async def send_audio_frame(self, frame: bytes) -> None:
+        """Send one already-exact 20 ms frame immediately (no pacing) —
+        for echo/replay servers that mirror the daemon's own cadence."""
+        await self._ws.send(frame)
+
+    async def clear(self) -> None:
+        """Barge-in: drop locally buffered audio AND tell the daemon to
+        flush everything already queued on its side."""
+        self.audio_out.clear()
+        await self._command({"type": "clear"})
+
+    # ─── commands (PROTOCOL.md §4) ────────────────────────────────
+
+    async def mark(self, name: str) -> None:
+        await self._command({"type": "mark", "name": name})
+
+    async def hangup(self, cause: str = "normal") -> None:
+        await self._command({"type": "hangup", "cause": cause})
+
+    async def transfer(
+        self,
+        target: str | None = None,
+        *,
+        replaces_call_id: str | None = None,
+    ) -> None:
+        msg: dict[str, Any] = {"type": "transfer"}
+        if target is not None:
+            msg["target"] = target
+        if replaces_call_id is not None:
+            msg["replaces_call_id"] = replaces_call_id
+        await self._command(msg)
+
+    async def send_dtmf(self, digit: str, duration_ms: int = 160) -> None:
+        await self._command(
+            {"type": "send_dtmf", "digit": digit, "duration_ms": duration_ms}
+        )
+
+    async def mute(self) -> None:
+        await self._command({"type": "mute"})
+
+    async def unmute(self) -> None:
+        await self._command({"type": "unmute"})
+
+    async def start_recording(self) -> None:
+        await self._command({"type": "start_recording"})
+
+    async def stop_recording(self) -> None:
+        await self._command({"type": "stop_recording"})
+
+    async def pause_recording(self) -> None:
+        await self._command({"type": "pause_recording"})
+
+    async def resume_recording(self) -> None:
+        await self._command({"type": "resume_recording"})
+
+    async def set_recording_consent(self, note: str | None = None) -> None:
+        msg: dict[str, Any] = {"type": "set_recording_consent"}
+        if note is not None:
+            msg["note"] = note
+        await self._command(msg)
+
+    async def park(self, slot: str | None = None) -> None:
+        msg: dict[str, Any] = {"type": "park"}
+        if slot is not None:
+            msg["slot"] = slot
+        await self._command(msg)
+
+    async def conference_join(self, room_id: str) -> None:
+        await self._command({"type": "conference_join", "room_id": room_id})
+
+    async def conference_leave(self) -> None:
+        await self._command({"type": "conference_leave"})
+
+    async def hold(self) -> None:
+        await self._command({"type": "hold"})
+
+    async def resume(self) -> None:
+        await self._command({"type": "resume"})
+
+    # ─── lifecycle ────────────────────────────────────────────────
+
+    async def abort(self) -> None:
+        """Hard-drop the socket without a hangup — the daemon treats this
+        as an unexpected WS drop (reconnect/teardown per its config).
+        Test harnesses use this; bots want :meth:`hangup`."""
+        await self.audio_out.aclose()
+        await self._ws.close(code=1011, reason="aborted")
+
+    async def _command(self, msg: dict[str, Any]) -> None:
+        msg.setdefault("call_id", self.call_id)
+        try:
+            await self._ws.send(json.dumps(msg))
+        except ConnectionClosed:
+            # Commands racing teardown are best-effort by contract.
+            pass

--- a/sdks/python/src/siphon_ai_server/events.py
+++ b/sdks/python/src/siphon_ai_server/events.py
@@ -1,0 +1,404 @@
+"""Typed events for the SiphonAI WS protocol v1 (daemon → server).
+
+One frozen dataclass per `BridgeOut` message, plus :class:`AudioFrame` for
+the binary half. Shapes mirror ``schemas/siphon-ai.v1.json`` exactly — the
+SDK test suite validates this module against the schema and every example
+in ``docs/PROTOCOL.md``.
+
+Parsing is **tolerant by contract**: unknown JSON fields are ignored and an
+unknown ``type`` becomes :class:`UnknownEvent` (the protocol is additive
+within v1 — a server must keep working when the daemon learns new tricks).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, fields
+from typing import Any, Mapping, Union
+
+__all__ = [
+    "AudioFrame",
+    "AudioFormat",
+    "SipMeta",
+    "TraceContext",
+    "Start",
+    "SpeechStarted",
+    "SpeechStopped",
+    "FarEndHold",
+    "FarEndResume",
+    "SilenceDetected",
+    "DeadAirDetected",
+    "RtpStats",
+    "Dtmf",
+    "Mark",
+    "RecordingStarted",
+    "RecordingStopped",
+    "RecordingFailed",
+    "ConferenceJoined",
+    "ConferenceLeft",
+    "ParticipantJoined",
+    "ParticipantLeft",
+    "Held",
+    "Resumed",
+    "Stop",
+    "Error",
+    "UnknownEvent",
+    "Event",
+    "parse_event",
+]
+
+
+@dataclass(frozen=True)
+class AudioFrame:
+    """One WS binary frame: raw PCM16-LE mono, exactly 20 ms of audio.
+
+    Not a JSON message — yielded by :class:`~siphon_ai_server.Call`'s
+    iterator alongside the typed events below.
+    """
+
+    pcm: bytes
+
+    @property
+    def sample_count(self) -> int:
+        return len(self.pcm) // 2
+
+
+# ─── nested objects ──────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class AudioFormat:
+    encoding: str
+    sample_rate: int
+    channels: int
+    frame_ms: int
+
+
+@dataclass(frozen=True)
+class SipMeta:
+    call_id: str
+    headers: Mapping[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class TraceContext:
+    traceparent: str
+    tracestate: str | None = None
+
+
+# ─── events (BridgeOut) ──────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Start:
+    """First message of every session. ``from_`` is the wire's ``from``."""
+
+    type = "start"
+    version: str
+    call_id: str
+    seq: int
+    from_: str
+    to: str
+    direction: str
+    audio: AudioFormat
+    sip: SipMeta
+    srtp: Mapping[str, Any] | None = None
+    verstat: Mapping[str, Any] | None = None
+    trace_context: TraceContext | None = None
+    retrieved: bool = False
+    reconnected: bool = False
+
+
+@dataclass(frozen=True)
+class SpeechStarted:
+    type = "speech_started"
+    call_id: str
+    seq: int
+    ts_ms: int
+
+
+@dataclass(frozen=True)
+class SpeechStopped:
+    type = "speech_stopped"
+    call_id: str
+    seq: int
+    ts_ms: int
+    duration_ms: int
+
+
+@dataclass(frozen=True)
+class FarEndHold:
+    """Wire ``type: hold`` (daemon→server): the far end put the call on
+    hold. Distinct from the ``hold`` *command* the server sends."""
+
+    type = "hold"
+    call_id: str
+    seq: int
+    direction: str
+
+
+@dataclass(frozen=True)
+class FarEndResume:
+    """Wire ``type: resume`` (daemon→server)."""
+
+    type = "resume"
+    call_id: str
+    seq: int
+
+
+@dataclass(frozen=True)
+class SilenceDetected:
+    type = "silence_detected"
+    call_id: str
+    seq: int
+    duration_ms: int
+
+
+@dataclass(frozen=True)
+class DeadAirDetected:
+    type = "dead_air_detected"
+    call_id: str
+    seq: int
+    duration_ms: int
+
+
+@dataclass(frozen=True)
+class RtpStats:
+    type = "rtp_stats"
+    call_id: str
+    seq: int
+    jitter_ms: float | None = None
+    packet_loss_ratio: float | None = None
+    rtcp_rtt_ms: float | None = None
+
+
+@dataclass(frozen=True)
+class Dtmf:
+    type = "dtmf"
+    call_id: str
+    seq: int
+    digit: str
+    duration_ms: int
+    method: str
+
+
+@dataclass(frozen=True)
+class Mark:
+    """Playout-position echo of a ``mark`` the server sent."""
+
+    type = "mark"
+    call_id: str
+    seq: int
+    name: str
+
+
+@dataclass(frozen=True)
+class RecordingStarted:
+    type = "recording_started"
+    call_id: str
+    seq: int
+    recording_id: str
+
+
+@dataclass(frozen=True)
+class RecordingStopped:
+    type = "recording_stopped"
+    call_id: str
+    seq: int
+    recording_id: str
+
+
+@dataclass(frozen=True)
+class RecordingFailed:
+    type = "recording_failed"
+    call_id: str
+    seq: int
+    recording_id: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class ConferenceJoined:
+    type = "conference_joined"
+    call_id: str
+    seq: int
+    room_id: str
+    participants: int
+
+
+@dataclass(frozen=True)
+class ConferenceLeft:
+    type = "conference_left"
+    call_id: str
+    seq: int
+    room_id: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class ParticipantJoined:
+    type = "participant_joined"
+    call_id: str
+    seq: int
+    room_id: str
+    participant_call_id: str
+
+
+@dataclass(frozen=True)
+class ParticipantLeft:
+    type = "participant_left"
+    call_id: str
+    seq: int
+    room_id: str
+    participant_call_id: str
+
+
+@dataclass(frozen=True)
+class Held:
+    """Ack: the bot-requested hold is active."""
+
+    type = "held"
+    call_id: str
+    seq: int
+
+
+@dataclass(frozen=True)
+class Resumed:
+    """Ack: the bot-requested hold ended."""
+
+    type = "resumed"
+    call_id: str
+    seq: int
+
+
+@dataclass(frozen=True)
+class Stop:
+    """Last message of a session; the daemon closes after sending it."""
+
+    type = "stop"
+    call_id: str
+    seq: int
+    reason: str
+
+
+@dataclass(frozen=True)
+class Error:
+    type = "error"
+    call_id: str
+    seq: int
+    code: str
+    message: str
+
+
+@dataclass(frozen=True)
+class UnknownEvent:
+    """A ``type`` this SDK version doesn't know. The protocol is additive
+    within v1, so carry the raw payload rather than failing the call."""
+
+    type: str
+    raw: Mapping[str, Any]
+
+
+Event = Union[
+    Start,
+    SpeechStarted,
+    SpeechStopped,
+    FarEndHold,
+    FarEndResume,
+    SilenceDetected,
+    DeadAirDetected,
+    RtpStats,
+    Dtmf,
+    Mark,
+    RecordingStarted,
+    RecordingStopped,
+    RecordingFailed,
+    ConferenceJoined,
+    ConferenceLeft,
+    ParticipantJoined,
+    ParticipantLeft,
+    Held,
+    Resumed,
+    Stop,
+    Error,
+    UnknownEvent,
+]
+
+_EVENT_TYPES: dict[str, type] = {
+    "start": Start,
+    "speech_started": SpeechStarted,
+    "speech_stopped": SpeechStopped,
+    "hold": FarEndHold,
+    "resume": FarEndResume,
+    "silence_detected": SilenceDetected,
+    "dead_air_detected": DeadAirDetected,
+    "rtp_stats": RtpStats,
+    "dtmf": Dtmf,
+    "mark": Mark,
+    "recording_started": RecordingStarted,
+    "recording_stopped": RecordingStopped,
+    "recording_failed": RecordingFailed,
+    "conference_joined": ConferenceJoined,
+    "conference_left": ConferenceLeft,
+    "participant_joined": ParticipantJoined,
+    "participant_left": ParticipantLeft,
+    "held": Held,
+    "resumed": Resumed,
+    "stop": Stop,
+    "error": Error,
+}
+
+# JSON key → dataclass field renames (Python keywords).
+_RENAMES = {"from": "from_"}
+
+
+def parse_event(text: str | bytes | Mapping[str, Any]) -> Event:
+    """Parse one JSON text frame into a typed event.
+
+    Raises ``ValueError`` for malformed JSON or a payload missing required
+    fields; returns :class:`UnknownEvent` for a well-formed message whose
+    ``type`` this SDK doesn't know.
+    """
+    if isinstance(text, (str, bytes)):
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"malformed protocol JSON: {e}") from e
+    else:
+        payload = dict(text)
+    if not isinstance(payload, Mapping) or not isinstance(payload.get("type"), str):
+        raise ValueError("protocol message must be an object with a string `type`")
+
+    cls = _EVENT_TYPES.get(payload["type"])
+    if cls is None:
+        return UnknownEvent(type=payload["type"], raw=payload)
+
+    known = {f.name for f in fields(cls)}
+    kwargs: dict[str, Any] = {}
+    for key, value in payload.items():
+        name = _RENAMES.get(key, key)
+        if name == "type" or name not in known:
+            continue  # tolerant: additive fields are expected within v1
+        kwargs[name] = value
+
+    if cls is Start:
+        kwargs["audio"] = _load(AudioFormat, kwargs.get("audio"), "audio")
+        kwargs["sip"] = _load(SipMeta, kwargs.get("sip"), "sip")
+        if kwargs.get("trace_context") is not None:
+            kwargs["trace_context"] = _load(
+                TraceContext, kwargs["trace_context"], "trace_context"
+            )
+    try:
+        return cls(**kwargs)
+    except TypeError as e:
+        raise ValueError(f"invalid `{payload['type']}` message: {e}") from e
+
+
+def _load(cls: type, value: Any, where: str) -> Any:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"invalid `{where}` object")
+    known = {f.name for f in fields(cls)}
+    try:
+        return cls(**{k: v for k, v in value.items() if k in known})
+    except TypeError as e:
+        raise ValueError(f"invalid `{where}` object: {e}") from e

--- a/sdks/python/src/siphon_ai_server/server.py
+++ b/sdks/python/src/siphon_ai_server/server.py
@@ -1,0 +1,142 @@
+"""The accept loop: WebSocket server speaking `siphon-ai.v1`."""
+
+from __future__ import annotations
+
+import asyncio
+import http
+import logging
+from typing import Awaitable, Callable
+
+from websockets.asyncio.server import Request, Response, ServerConnection, serve
+from websockets.exceptions import ConnectionClosed
+
+from .call import Call
+from .events import Start, parse_event
+
+__all__ = ["SiphonServer", "SUBPROTOCOL"]
+
+SUBPROTOCOL = "siphon-ai.v1"
+
+# The daemon sends `start` immediately after the upgrade; a socket that
+# never does isn't a SiphonAI bridge.
+START_DEADLINE_SECS = 10.0
+
+logger = logging.getLogger("siphon_ai_server")
+
+CallHandler = Callable[[Call], Awaitable[None]]
+
+
+class SiphonServer:
+    """Accepts SiphonAI bridge connections and hands each to a handler.
+
+    ```python
+    server = SiphonServer(handler, host="0.0.0.0", port=8080)
+    await server.serve_forever()
+    ```
+
+    The handler receives a :class:`Call` whose `start` has already been
+    parsed. Handler exceptions are logged and close that call only.
+
+    `auth_token`: when set, upgrade requests must carry
+    `Authorization: Bearer <token>` (rejected with 401 otherwise) —
+    matching the daemon's `[bridge].auth_bearer`.
+    """
+
+    def __init__(
+        self,
+        handler: CallHandler,
+        *,
+        host: str = "0.0.0.0",
+        port: int = 8080,
+        auth_token: str | None = None,
+        ping_interval: float | None = 15.0,
+        ping_timeout: float | None = 10.0,
+    ) -> None:
+        self._handler = handler
+        self._host = host
+        self._port = port
+        self._auth_token = auth_token
+        self._ping_interval = ping_interval
+        self._ping_timeout = ping_timeout
+
+    async def serve_forever(self) -> None:
+        async with self.listen():
+            await asyncio.get_running_loop().create_future()  # run until cancelled
+
+    def listen(self):
+        """The underlying ``websockets.serve`` context manager, for callers
+        that manage their own lifetime."""
+        return serve(
+            self._connection,
+            self._host,
+            self._port,
+            subprotocols=[SUBPROTOCOL],
+            process_request=self._process_request,
+            max_size=256 * 1024,  # PROTOCOL.md §2 text-frame cap
+            ping_interval=self._ping_interval,
+            ping_timeout=self._ping_timeout,
+        )
+
+    def _process_request(
+        self, connection: ServerConnection, request: Request
+    ) -> Response | None:
+        # Container/k8s-probe-friendly healthcheck, short-circuited before
+        # WS handshake validation so probes don't log as upgrade errors.
+        if request.path == "/healthz":
+            return connection.respond(http.HTTPStatus.OK, "ok\n")
+        if self._auth_token is None:
+            return None
+        expected = f"Bearer {self._auth_token}"
+        if request.headers.get("Authorization") != expected:
+            return connection.respond(http.HTTPStatus.UNAUTHORIZED, "unauthorized\n")
+        return None
+
+    async def _connection(self, ws: ServerConnection) -> None:
+        call_id = ws.request.headers.get("X-Siphon-Call-Id", "?") if ws.request else "?"
+        try:
+            first = await asyncio.wait_for(ws.recv(), timeout=START_DEADLINE_SECS)
+        except (asyncio.TimeoutError, ConnectionClosed):
+            logger.warning("connection %s closed before `start`", call_id)
+            await ws.close()
+            return
+        if isinstance(first, bytes):
+            logger.warning("connection %s sent audio before `start`; closing", call_id)
+            await ws.close(code=1002, reason="expected start")
+            return
+        event = parse_event(first)
+        if isinstance(event, Start) and event.version != "1":
+            logger.error(
+                "connection %s: unsupported protocol version %r; closing",
+                call_id,
+                event.version,
+            )
+            await ws.close(code=1003, reason="unsupported version")
+            return
+        if not isinstance(event, Start):
+            logger.warning(
+                "connection %s first message was `%s`, not `start`; closing",
+                call_id,
+                event.type,
+            )
+            await ws.close(code=1002, reason="expected start")
+            return
+
+        call = Call(ws, event)
+        logger.info(
+            "call %s: %s -> %s (%d Hz%s)",
+            event.call_id,
+            event.from_,
+            event.to,
+            event.audio.sample_rate,
+            ", reconnected" if event.reconnected else "",
+        )
+        try:
+            await self._handler(call)
+        except ConnectionClosed:
+            pass
+        except Exception:
+            logger.exception("handler failed for call %s", event.call_id)
+        finally:
+            await call.audio_out.aclose()
+            await ws.close()
+            logger.info("call %s: session ended", event.call_id)

--- a/sdks/python/tests/test_audio.py
+++ b/sdks/python/tests/test_audio.py
@@ -1,0 +1,79 @@
+"""AudioSender re-framing + pacing unit tests."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from siphon_ai_server.audio import AudioSender, frame_bytes  # noqa: E402
+
+
+class FrameBytesTest(unittest.TestCase):
+    def test_spec_sizes(self) -> None:
+        self.assertEqual(frame_bytes(8000), 320)
+        self.assertEqual(frame_bytes(16000), 640)
+        with self.assertRaises(ValueError):
+            frame_bytes(44100)
+
+
+class AudioSenderTest(unittest.IsolatedAsyncioTestCase):
+    async def test_reframes_arbitrary_pushes_to_exact_frames(self) -> None:
+        sent: list[bytes] = []
+
+        async def send(frame: bytes) -> None:
+            sent.append(frame)
+
+        sender = AudioSender(send, 8000)
+        # 700 bytes in awkward chunks = 2 whole frames + 60-byte tail.
+        sender.push(b"\x01" * 100)
+        sender.push(b"\x02" * 500)
+        sender.push(b"\x03" * 100)
+        await sender.flush()
+        await sender.aclose()
+
+        self.assertEqual(len(sent), 3)
+        self.assertTrue(all(len(f) == 320 for f in sent), [len(f) for f in sent])
+        # Tail frame is zero-padded, not dropped.
+        self.assertTrue(sent[-1].endswith(b"\x00" * 260))
+
+    async def test_pacing_is_real_time(self) -> None:
+        stamps: list[float] = []
+        loop = asyncio.get_running_loop()
+
+        async def send(_: bytes) -> None:
+            stamps.append(loop.time())
+
+        sender = AudioSender(send, 8000)
+        sender.push(b"\x00" * 320 * 5)  # exactly 5 frames
+        await sender.flush()
+        await sender.aclose()
+
+        self.assertEqual(len(stamps), 5)
+        elapsed = stamps[-1] - stamps[0]
+        # 4 inter-frame gaps at 20 ms = 80 ms nominal; generous CI bounds.
+        self.assertGreaterEqual(elapsed, 0.06, f"sent too fast: {elapsed:.3f}s")
+        self.assertLess(elapsed, 0.5, f"sent too slow: {elapsed:.3f}s")
+
+    async def test_clear_drops_buffer(self) -> None:
+        sent: list[bytes] = []
+
+        async def send(frame: bytes) -> None:
+            sent.append(frame)
+
+        sender = AudioSender(send, 8000)
+        sender.push(b"\x00" * 320)  # one frame gets sent
+        await asyncio.sleep(0.03)
+        sender.push(b"\x00" * 3200)  # ten more…
+        dropped = sender.clear()  # …dropped before pacing reaches them
+        await sender.aclose()
+
+        self.assertGreater(dropped, 0)
+        self.assertLessEqual(len(sent), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdks/python/tests/test_events.py
+++ b/sdks/python/tests/test_events.py
@@ -1,0 +1,182 @@
+"""Corpus + schema conformance for the typed events (design D2).
+
+Three legs:
+1. every `docs/PROTOCOL.md` daemon→server example parses into the right
+   typed event (no UnknownEvent, no ValueError);
+2. every command the SDK can send validates against
+   `schemas/siphon-ai.v1.json` `$defs/BridgeIn`;
+3. tolerance invariants — unknown fields ignored, unknown types wrapped.
+
+Run from the repo root: `python -m unittest discover sdks/python/tests`.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO / "sdks" / "python" / "src"))
+
+from siphon_ai_server import events  # noqa: E402
+from siphon_ai_server.events import Start, UnknownEvent, parse_event  # noqa: E402
+
+SCHEMA = json.loads((REPO / "schemas" / "siphon-ai.v1.json").read_text())
+PROTOCOL_MD = (REPO / "docs" / "PROTOCOL.md").read_text()
+
+
+def _known_types(union: str) -> set[str]:
+    return {
+        v["properties"]["type"]["const"] for v in SCHEMA["$defs"][union]["oneOf"]
+    }
+
+
+BRIDGE_OUT_TYPES = _known_types("BridgeOut")
+BRIDGE_IN_TYPES = _known_types("BridgeIn")
+# Direction-ambiguous discriminators (hold/resume/mark): PROTOCOL.md
+# examples can't be classified by name alone; classify by shape instead —
+# BridgeOut messages always carry `seq`, BridgeIn commands never do.
+AMBIGUOUS = BRIDGE_OUT_TYPES & BRIDGE_IN_TYPES
+
+
+def corpus() -> list[dict]:
+    objects: list[dict] = []
+    for match in re.finditer(r"```json\n(.*?)```", PROTOCOL_MD, re.S):
+        text = match.group(1)
+        decoder = json.JSONDecoder()
+        idx = 0
+        while idx < len(text):
+            brace = text.find("{", idx)
+            if brace == -1:
+                break
+            try:
+                obj, end = decoder.raw_decode(text, brace)
+            except json.JSONDecodeError:
+                idx = brace + 1
+                continue
+            if isinstance(obj, dict):
+                objects.append(obj)
+            idx = end
+    return objects
+
+
+class CorpusTest(unittest.TestCase):
+    def test_every_documented_event_parses_typed(self) -> None:
+        seen: set[str] = set()
+        for obj in corpus():
+            t = obj.get("type")
+            if t not in BRIDGE_OUT_TYPES:
+                continue
+            if t in AMBIGUOUS and "seq" not in obj:
+                continue  # it's the BridgeIn command form
+            event = parse_event(json.dumps(obj))
+            self.assertNotIsInstance(
+                event, UnknownEvent, f"documented `{t}` must parse typed"
+            )
+            self.assertEqual(event.type, t)
+            seen.add(t)
+        # The corpus must exercise a healthy majority of the surface.
+        self.assertGreaterEqual(
+            len(seen), 15, f"corpus only covered {sorted(seen)}"
+        )
+
+    def test_sdk_knows_every_bridge_out_type(self) -> None:
+        self.assertEqual(set(events._EVENT_TYPES), BRIDGE_OUT_TYPES)
+
+
+class CommandSchemaTest(unittest.TestCase):
+    """Every command the SDK can emit validates against $defs/BridgeIn."""
+
+    def test_commands_validate(self) -> None:
+        try:
+            import jsonschema
+        except ImportError:
+            self.skipTest("jsonschema not installed")
+        validator = jsonschema.Draft202012Validator(
+            {"$ref": "#/$defs/BridgeIn", "$defs": SCHEMA["$defs"]}
+        )
+        commands = [
+            {"type": "clear"},
+            {"type": "mark", "name": "greeting_done"},
+            {"type": "hangup", "cause": "normal"},
+            {"type": "hangup", "cause": "busy"},
+            {"type": "transfer", "target": "sip:agent@pbx.example.com"},
+            {"type": "transfer", "replaces_call_id": "siphon-abc"},
+            {"type": "send_dtmf", "digit": "5", "duration_ms": 160},
+            {"type": "mute"},
+            {"type": "unmute"},
+            {"type": "start_recording"},
+            {"type": "stop_recording"},
+            {"type": "pause_recording"},
+            {"type": "resume_recording"},
+            {"type": "set_recording_consent", "note": "dtmf-1"},
+            {"type": "set_recording_consent"},
+            {"type": "park", "slot": "vip"},
+            {"type": "park"},
+            {"type": "conference_join", "room_id": "support-7"},
+            {"type": "conference_leave"},
+            {"type": "hold"},
+            {"type": "resume"},
+        ]
+        emitted_types = set()
+        for msg in commands:
+            msg = {**msg, "call_id": "siphon-test"}
+            problems = list(validator.iter_errors(msg))
+            self.assertFalse(
+                problems, f"{msg['type']} fails schema: {problems[:1]}"
+            )
+            emitted_types.add(msg["type"])
+        self.assertEqual(
+            emitted_types,
+            BRIDGE_IN_TYPES,
+            "the SDK must exercise every BridgeIn command",
+        )
+
+
+class ToleranceTest(unittest.TestCase):
+    def test_unknown_type_wraps_not_raises(self) -> None:
+        event = parse_event('{"type": "yodel", "call_id": "c", "seq": 1}')
+        self.assertIsInstance(event, UnknownEvent)
+        self.assertEqual(event.raw["seq"], 1)
+
+    def test_unknown_fields_ignored(self) -> None:
+        event = parse_event(
+            '{"type": "dtmf", "call_id": "c", "seq": 9, "digit": "1",'
+            ' "duration_ms": 160, "method": "rfc2833", "novel_field": true}'
+        )
+        self.assertEqual(event.digit, "1")
+
+    def test_start_from_keyword_rename(self) -> None:
+        raw = {
+            "type": "start",
+            "version": "1",
+            "call_id": "c",
+            "seq": 0,
+            "from": "+13125551212",
+            "to": "5000",
+            "direction": "inbound",
+            "audio": {
+                "encoding": "pcm16le",
+                "sample_rate": 8000,
+                "channels": 1,
+                "frame_ms": 20,
+            },
+            "sip": {"call_id": "x@y", "headers": {}},
+        }
+        event = parse_event(json.dumps(raw))
+        self.assertIsInstance(event, Start)
+        self.assertEqual(event.from_, "+13125551212")
+        self.assertFalse(event.reconnected)
+
+    def test_malformed_json_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            parse_event("{nope")
+        with self.assertRaises(ValueError):
+            parse_event('{"no_type": 1}')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdks/typescript/.gitignore
+++ b/sdks/typescript/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+package-lock.json
+yarn.lock

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -1,0 +1,79 @@
+# siphon-ai-server (TypeScript)
+
+Server SDK for the [SiphonAI](https://github.com/thevoiceguy/siphon-ai)
+WebSocket bridge protocol v1: typed events (discriminated unions), paced
+20 ms audio framing, and connection lifecycle — write handlers, not wire
+code.
+
+**This SDK contains no AI code.** SiphonAI streams call audio to your server
+and plays back whatever you send; STT/LLM/TTS are your handler's business.
+
+## Install
+
+Not yet on npm — install from the repo (vendorable):
+
+```bash
+npm install ./sdks/typescript
+# or from a checkout URL:
+npm install "github:thevoiceguy/siphon-ai#main" --workspace sdks/typescript
+```
+
+Requires Node ≥ 20. Sole runtime dependency: `ws`.
+
+## Quickstart
+
+```ts
+import { SiphonServer } from "siphon-ai-server";
+
+const server = new SiphonServer(async (call) => {
+  console.log("call from", call.start.from, "to", call.start.to);
+  for await (const item of call) {
+    if (item.type === "audio") call.sendAudioFrame(item.pcm); // echo
+    else if (item.type === "dtmf" && item.digit === "0") call.hangup();
+  }
+});
+await server.listen({ port: 8080 });
+```
+
+Point a SiphonAI route at `ws://your-host:8080/` and place a call.
+
+## What you get
+
+- **`SiphonServer(handler)`** — accepts WS connections, echoes the
+  `siphon-ai.v1` subprotocol, waits for `start`, and invokes your handler
+  with a `Call`. Handler exceptions tear down only that call.
+- **`Call`** — `for await` it to receive `{ type: "audio", pcm }` frames
+  and typed `BridgeEvent`s (`dtmf`, `speech_started`, `mark`, `rtp_stats`,
+  `stop`, …) as a discriminated union on `type`. Iteration ends when the
+  call does.
+- **Commands** — one method per protocol v1 command: `sendAudio` /
+  `sendAudioFrame`, `clear`, `mark`, `hangup`, `transfer`, `sendDtmf`,
+  `mute`/`unmute`, `startRecording`/`stopRecording`/`pauseRecording`/
+  `resumeRecording`, `setRecordingConsent`, `park`, `hold`/`resume`,
+  `conferenceJoin`/`conferenceLeave`, `abort`.
+- **`sendAudio(pcm)`** takes arbitrary byte lengths and re-frames to exact
+  20 ms frames (320 B @ 8 kHz, 640 B @ 16 kHz — per `call.start.audio`),
+  paced at 50 frames/s. `sendAudioFrame` sends one pre-framed frame.
+- **Close semantics** per PROTOCOL §5.7: end a call with `hangup()`; a bare
+  close is treated as a drop (and triggers daemon-side reconnect if
+  enabled). `call.start.reconnected` tells you a session is a resumption.
+- **Tolerant parsing** — unknown event types arrive as
+  `{ type: "unknown", raw }`, unknown fields are ignored, so older SDKs
+  keep working as the daemon grows.
+
+## Conformance
+
+The test suite parses every canonical example in `docs/PROTOCOL.md` into
+typed events and validates every command the SDK can emit against
+`schemas/siphon-ai.v1.json` (via `ajv`):
+
+```bash
+cd sdks/typescript && npm install && npm test
+```
+
+The canonical spec is [`docs/PROTOCOL.md`](../../docs/PROTOCOL.md); the
+machine-readable contract is
+[`schemas/siphon-ai.v1.json`](../../schemas/siphon-ai.v1.json).
+
+A complete working server built on this SDK:
+[`examples/echo-ws-server-node`](../../examples/echo-ws-server-node).

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "siphon-ai-server",
+  "version": "0.28.0",
+  "description": "Server SDK for the SiphonAI WebSocket bridge protocol v1: typed events, 20 ms audio framing, and connection lifecycle — write handlers, not wire code.",
+  "license": "(MIT OR Apache-2.0)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thevoiceguy/siphon-ai.git",
+    "directory": "sdks/typescript"
+  },
+  "keywords": ["siphon-ai", "sip", "voice", "websocket", "telephony"],
+  "type": "module",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "engines": { "node": ">=20" },
+  "files": ["dist/src", "src"],
+  "scripts": {
+    "build": "tsc",
+    "prepare": "tsc",
+    "test": "tsc && node --test dist/test/"
+  },
+  "dependencies": {
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/ws": "^8",
+    "ajv": "^8",
+    "typescript": "^5.5"
+  }
+}

--- a/sdks/typescript/src/audio.ts
+++ b/sdks/typescript/src/audio.ts
@@ -1,0 +1,100 @@
+/**
+ * Outbound audio framing: arbitrary PCM byte pushes → exact 20 ms frames,
+ * paced at real time (one frame per 20 ms) so a fast TTS engine can't
+ * flood the daemon's bounded playout queue and blunt barge-in `clear`.
+ */
+
+export const FRAME_MS = 20;
+export const SUPPORTED_RATES = [8000, 16000] as const;
+
+/** Bytes per 20 ms PCM16-LE mono frame at `sampleRate`. */
+export function frameBytes(sampleRate: number): number {
+  if (!SUPPORTED_RATES.includes(sampleRate as 8000 | 16000)) {
+    throw new Error(`unsupported sample rate ${sampleRate} (8000 or 16000)`);
+  }
+  return (sampleRate / 1000) * FRAME_MS * 2;
+}
+
+export type SendFrame = (frame: Buffer) => void;
+
+/**
+ * Paced 20 ms re-framer over a raw frame sender.
+ *
+ * `push()` never blocks; a timer drains the buffer one frame per 20 ms.
+ * `clear()` drops everything buffered (barge-in); `flush()` resolves when
+ * the buffer has fully played out, zero-padding the final partial frame.
+ */
+export class AudioSender {
+  private readonly frameSize: number;
+  private buffer: Buffer = Buffer.alloc(0);
+  private timer: NodeJS.Timeout | null = null;
+  private closed = false;
+
+  constructor(
+    private readonly send: SendFrame,
+    sampleRate: number,
+  ) {
+    this.frameSize = frameBytes(sampleRate);
+  }
+
+  /** Queue PCM16-LE mono bytes of any length for paced sending. */
+  push(pcm: Buffer): void {
+    if (this.closed) return;
+    this.buffer = Buffer.concat([this.buffer, pcm]);
+    this.arm();
+  }
+
+  /** Drop all buffered audio (the local half of barge-in). Returns the
+   * byte count dropped — pair with sending the daemon a `clear`. */
+  clear(): number {
+    const dropped = this.buffer.length;
+    this.buffer = Buffer.alloc(0);
+    return dropped;
+  }
+
+  /** Resolve once everything pushed so far has been sent; the final
+   * partial frame (if any) is zero-padded to spec size. */
+  async flush(): Promise<void> {
+    const tail = this.buffer.length % this.frameSize;
+    if (tail !== 0) {
+      this.buffer = Buffer.concat([
+        this.buffer,
+        Buffer.alloc(this.frameSize - tail),
+      ]);
+      this.arm();
+    }
+    while (this.buffer.length > 0 && !this.closed) {
+      await new Promise((resolve) => setTimeout(resolve, FRAME_MS));
+    }
+  }
+
+  close(): void {
+    this.closed = true;
+    this.buffer = Buffer.alloc(0);
+    if (this.timer !== null) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private arm(): void {
+    if (this.timer !== null || this.closed) return;
+    this.timer = setInterval(() => {
+      if (this.closed || this.buffer.length < this.frameSize) {
+        // Idle: disarm; the next push re-arms (no catch-up bursts).
+        if (this.timer !== null) {
+          clearInterval(this.timer);
+          this.timer = null;
+        }
+        return;
+      }
+      const frame = this.buffer.subarray(0, this.frameSize);
+      this.buffer = this.buffer.subarray(this.frameSize);
+      try {
+        this.send(Buffer.from(frame));
+      } catch {
+        this.close(); // dead socket just stops the pacer
+      }
+    }, FRAME_MS);
+  }
+}

--- a/sdks/typescript/src/call.ts
+++ b/sdks/typescript/src/call.ts
@@ -1,0 +1,199 @@
+/** One bridged call: typed event stream + command senders. */
+
+import type { WebSocket } from "ws";
+
+import { AudioSender } from "./audio.js";
+import { parseEvent, type BridgeEvent, type Start } from "./events.js";
+
+/** One 20 ms caller-audio frame (raw PCM16-LE mono). */
+export interface AudioFrame {
+  type: "audio";
+  pcm: Buffer;
+}
+
+export type CallItem = AudioFrame | BridgeEvent;
+
+/**
+ * A live SiphonAI bridge session.
+ *
+ * Iterate it (`for await (const item of call)`) to receive caller audio
+ * frames interleaved with typed protocol events; the iterator ends when
+ * the daemon closes the session (normally right after `stop`).
+ *
+ * Command methods mirror `docs/PROTOCOL.md` §4. End a call with
+ * `hangup()` — per §5.7 a bare WS close is an unexpected drop, not a
+ * hangup.
+ */
+export class Call implements AsyncIterable<CallItem> {
+  readonly callId: string;
+  readonly audioOut: AudioSender;
+
+  constructor(
+    private readonly ws: WebSocket,
+    readonly start: Start,
+  ) {
+    this.callId = start.call_id;
+    this.audioOut = new AudioSender(
+      (frame) => this.ws.send(frame),
+      start.audio.sample_rate,
+    );
+  }
+
+  // ─── receiving ─────────────────────────────────────────────────
+
+  [Symbol.asyncIterator](): AsyncIterator<CallItem> {
+    const queue: CallItem[] = [];
+    let notify: (() => void) | null = null;
+    let done = false;
+
+    const wake = () => {
+      if (notify !== null) {
+        const n = notify;
+        notify = null;
+        n();
+      }
+    };
+    this.ws.on("message", (data: Buffer, isBinary: boolean) => {
+      if (isBinary) {
+        queue.push({ type: "audio", pcm: data });
+      } else {
+        try {
+          queue.push(parseEvent(data));
+        } catch {
+          // The daemon never sends malformed JSON; a robust server
+          // drops the frame rather than the call.
+        }
+      }
+      wake();
+    });
+    const finish = () => {
+      done = true;
+      this.audioOut.close();
+      wake();
+    };
+    this.ws.on("close", finish);
+    this.ws.on("error", finish);
+
+    return {
+      next: async (): Promise<IteratorResult<CallItem>> => {
+        for (;;) {
+          const item = queue.shift();
+          if (item !== undefined) return { value: item, done: false };
+          if (done) return { value: undefined, done: true };
+          await new Promise<void>((resolve) => {
+            notify = resolve;
+          });
+        }
+      },
+    };
+  }
+
+  // ─── audio ─────────────────────────────────────────────────────
+
+  /** Queue PCM16-LE mono bytes (any length) — re-framed to exact 20 ms
+   * frames and paced at real time. */
+  sendAudio(pcm: Buffer): void {
+    this.audioOut.push(pcm);
+  }
+
+  /** Send one already-exact 20 ms frame immediately (no pacing) — for
+   * echo/replay servers mirroring the daemon's own cadence. */
+  sendAudioFrame(frame: Buffer): void {
+    this.ws.send(frame);
+  }
+
+  /** Barge-in: drop locally buffered audio AND tell the daemon to flush
+   * everything already queued on its side. */
+  clear(): void {
+    this.audioOut.clear();
+    this.command({ type: "clear" });
+  }
+
+  // ─── commands (PROTOCOL.md §4) ─────────────────────────────────
+
+  mark(name: string): void {
+    this.command({ type: "mark", name });
+  }
+
+  hangup(cause = "normal"): void {
+    this.command({ type: "hangup", cause });
+  }
+
+  transfer(target?: string, opts?: { replacesCallId?: string }): void {
+    const msg: Record<string, unknown> = { type: "transfer" };
+    if (target !== undefined) msg.target = target;
+    if (opts?.replacesCallId !== undefined)
+      msg.replaces_call_id = opts.replacesCallId;
+    this.command(msg);
+  }
+
+  sendDtmf(digit: string, durationMs = 160): void {
+    this.command({ type: "send_dtmf", digit, duration_ms: durationMs });
+  }
+
+  mute(): void {
+    this.command({ type: "mute" });
+  }
+
+  unmute(): void {
+    this.command({ type: "unmute" });
+  }
+
+  startRecording(): void {
+    this.command({ type: "start_recording" });
+  }
+
+  stopRecording(): void {
+    this.command({ type: "stop_recording" });
+  }
+
+  pauseRecording(): void {
+    this.command({ type: "pause_recording" });
+  }
+
+  resumeRecording(): void {
+    this.command({ type: "resume_recording" });
+  }
+
+  setRecordingConsent(note?: string): void {
+    const msg: Record<string, unknown> = { type: "set_recording_consent" };
+    if (note !== undefined) msg.note = note;
+    this.command(msg);
+  }
+
+  park(slot?: string): void {
+    const msg: Record<string, unknown> = { type: "park" };
+    if (slot !== undefined) msg.slot = slot;
+    this.command(msg);
+  }
+
+  conferenceJoin(roomId: string): void {
+    this.command({ type: "conference_join", room_id: roomId });
+  }
+
+  conferenceLeave(): void {
+    this.command({ type: "conference_leave" });
+  }
+
+  hold(): void {
+    this.command({ type: "hold" });
+  }
+
+  resume(): void {
+    this.command({ type: "resume" });
+  }
+
+  // ─── lifecycle ─────────────────────────────────────────────────
+
+  /** Hard-drop the socket without a hangup — the daemon treats it as an
+   * unexpected WS drop. Test harnesses use this; bots want `hangup()`. */
+  abort(): void {
+    this.audioOut.close();
+    this.ws.close(1011, "aborted");
+  }
+
+  private command(msg: Record<string, unknown>): void {
+    if (this.ws.readyState !== this.ws.OPEN) return; // best-effort near teardown
+    this.ws.send(JSON.stringify({ call_id: this.callId, ...msg }));
+  }
+}

--- a/sdks/typescript/src/events.ts
+++ b/sdks/typescript/src/events.ts
@@ -1,0 +1,247 @@
+/**
+ * Typed events for the SiphonAI WS protocol v1 (daemon → server).
+ *
+ * A discriminated union mirroring `schemas/siphon-ai.v1.json`
+ * `$defs/BridgeOut` exactly — the SDK test suite validates this module
+ * against the schema and every example in `docs/PROTOCOL.md`.
+ *
+ * Parsing is tolerant by contract: unknown JSON fields pass through and an
+ * unknown `type` becomes `{ type: "unknown" }` (the protocol is additive
+ * within v1).
+ */
+
+export interface AudioFormat {
+  encoding: string;
+  sample_rate: number;
+  channels: number;
+  frame_ms: number;
+}
+
+export interface SipMeta {
+  call_id: string;
+  headers: Record<string, string>;
+}
+
+export interface TraceContext {
+  traceparent: string;
+  tracestate?: string;
+}
+
+interface Base {
+  call_id: string;
+  seq: number;
+}
+
+export interface Start extends Base {
+  type: "start";
+  version: string;
+  from: string;
+  to: string;
+  direction: "inbound" | "outbound";
+  audio: AudioFormat;
+  sip: SipMeta;
+  srtp?: Record<string, unknown>;
+  verstat?: Record<string, unknown>;
+  trace_context?: TraceContext;
+  retrieved?: boolean;
+  reconnected?: boolean;
+}
+
+export interface SpeechStarted extends Base {
+  type: "speech_started";
+  ts_ms: number;
+}
+
+export interface SpeechStopped extends Base {
+  type: "speech_stopped";
+  ts_ms: number;
+  duration_ms: number;
+}
+
+/** Wire `type: hold` (daemon→server): the far end held the call. */
+export interface FarEndHold extends Base {
+  type: "hold";
+  direction: string;
+}
+
+/** Wire `type: resume` (daemon→server). */
+export interface FarEndResume extends Base {
+  type: "resume";
+}
+
+export interface SilenceDetected extends Base {
+  type: "silence_detected";
+  duration_ms: number;
+}
+
+export interface DeadAirDetected extends Base {
+  type: "dead_air_detected";
+  duration_ms: number;
+}
+
+export interface RtpStats extends Base {
+  type: "rtp_stats";
+  jitter_ms?: number | null;
+  packet_loss_ratio?: number | null;
+  rtcp_rtt_ms?: number | null;
+}
+
+export interface Dtmf extends Base {
+  type: "dtmf";
+  digit: string;
+  duration_ms: number;
+  method: "rfc2833" | "inband";
+}
+
+/** Playout-position echo of a `mark` the server sent. */
+export interface MarkEvent extends Base {
+  type: "mark";
+  name: string;
+}
+
+export interface RecordingStarted extends Base {
+  type: "recording_started";
+  recording_id: string;
+}
+
+export interface RecordingStopped extends Base {
+  type: "recording_stopped";
+  recording_id: string;
+}
+
+export interface RecordingFailed extends Base {
+  type: "recording_failed";
+  recording_id: string;
+  reason: string;
+}
+
+export interface ConferenceJoined extends Base {
+  type: "conference_joined";
+  room_id: string;
+  participants: number;
+}
+
+export interface ConferenceLeft extends Base {
+  type: "conference_left";
+  room_id: string;
+  reason: string;
+}
+
+export interface ParticipantJoined extends Base {
+  type: "participant_joined";
+  room_id: string;
+  participant_call_id: string;
+}
+
+export interface ParticipantLeft extends Base {
+  type: "participant_left";
+  room_id: string;
+  participant_call_id: string;
+}
+
+/** Ack: the bot-requested hold is active. */
+export interface Held extends Base {
+  type: "held";
+}
+
+/** Ack: the bot-requested hold ended. */
+export interface Resumed extends Base {
+  type: "resumed";
+}
+
+/** Last message of a session; the daemon closes after sending it. */
+export interface StopEvent extends Base {
+  type: "stop";
+  reason: string;
+}
+
+export interface ErrorEvent extends Base {
+  type: "error";
+  code: string;
+  message: string;
+}
+
+/** A `type` this SDK version doesn't know — additive within v1. */
+export interface UnknownEvent {
+  type: "unknown";
+  wireType: string;
+  raw: Record<string, unknown>;
+}
+
+export type BridgeEvent =
+  | Start
+  | SpeechStarted
+  | SpeechStopped
+  | FarEndHold
+  | FarEndResume
+  | SilenceDetected
+  | DeadAirDetected
+  | RtpStats
+  | Dtmf
+  | MarkEvent
+  | RecordingStarted
+  | RecordingStopped
+  | RecordingFailed
+  | ConferenceJoined
+  | ConferenceLeft
+  | ParticipantJoined
+  | ParticipantLeft
+  | Held
+  | Resumed
+  | StopEvent
+  | ErrorEvent
+  | UnknownEvent;
+
+export const KNOWN_EVENT_TYPES: ReadonlySet<string> = new Set([
+  "start",
+  "speech_started",
+  "speech_stopped",
+  "hold",
+  "resume",
+  "silence_detected",
+  "dead_air_detected",
+  "rtp_stats",
+  "dtmf",
+  "mark",
+  "recording_started",
+  "recording_stopped",
+  "recording_failed",
+  "conference_joined",
+  "conference_left",
+  "participant_joined",
+  "participant_left",
+  "held",
+  "resumed",
+  "stop",
+  "error",
+]);
+
+/**
+ * Parse one JSON text frame into a typed event.
+ *
+ * Throws for malformed JSON or a non-object payload; returns
+ * `UnknownEvent` for a well-formed message whose `type` this SDK doesn't
+ * know. Unknown *fields* on known types pass through untouched.
+ */
+export function parseEvent(text: string | Buffer): BridgeEvent {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(text.toString());
+  } catch (e) {
+    throw new Error(`malformed protocol JSON: ${(e as Error).message}`);
+  }
+  if (
+    typeof payload !== "object" ||
+    payload === null ||
+    typeof (payload as { type?: unknown }).type !== "string"
+  ) {
+    throw new Error("protocol message must be an object with a string `type`");
+  }
+  const message = payload as Record<string, unknown> & { type: string };
+  if (!KNOWN_EVENT_TYPES.has(message.type)) {
+    return { type: "unknown", wireType: message.type, raw: message };
+  }
+  // The wire shape IS the type shape (schema-validated in tests) — no
+  // per-field mapping layer to drift.
+  return message as unknown as BridgeEvent;
+}

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -1,0 +1,55 @@
+/**
+ * Server SDK for the SiphonAI WebSocket bridge protocol v1.
+ *
+ * ```ts
+ * import { SiphonServer } from "siphon-ai-server";
+ *
+ * const server = new SiphonServer(async (call) => {
+ *   console.log("call from", call.start.from);
+ *   for await (const item of call) {
+ *     if (item.type === "audio") call.sendAudioFrame(item.pcm); // echo
+ *     else if (item.type === "dtmf" && item.digit === "0") call.hangup();
+ *   }
+ * });
+ * await server.listen();
+ * ```
+ *
+ * The canonical protocol spec is `docs/PROTOCOL.md`; the machine-readable
+ * contract is `schemas/siphon-ai.v1.json` (this SDK's test suite validates
+ * against both). **This SDK contains no AI code** — STT/LLM/TTS are your
+ * handler's business.
+ */
+
+export { AudioSender, FRAME_MS, frameBytes } from "./audio.js";
+export { Call, type AudioFrame, type CallItem } from "./call.js";
+export {
+  KNOWN_EVENT_TYPES,
+  parseEvent,
+  type AudioFormat,
+  type BridgeEvent,
+  type ConferenceJoined,
+  type ConferenceLeft,
+  type DeadAirDetected,
+  type Dtmf,
+  type ErrorEvent,
+  type FarEndHold,
+  type FarEndResume,
+  type Held,
+  type MarkEvent,
+  type ParticipantJoined,
+  type ParticipantLeft,
+  type RecordingFailed,
+  type RecordingStarted,
+  type RecordingStopped,
+  type Resumed,
+  type RtpStats,
+  type SilenceDetected,
+  type SipMeta,
+  type SpeechStarted,
+  type SpeechStopped,
+  type Start,
+  type StopEvent,
+  type TraceContext,
+  type UnknownEvent,
+} from "./events.js";
+export { SiphonServer, SUBPROTOCOL, type CallHandler } from "./server.js";

--- a/sdks/typescript/src/server.ts
+++ b/sdks/typescript/src/server.ts
@@ -1,0 +1,145 @@
+/** The accept loop: WebSocket server speaking `siphon-ai.v1`. */
+
+import { createServer, type IncomingMessage, type Server } from "node:http";
+
+import { WebSocketServer, type WebSocket } from "ws";
+
+import { Call } from "./call.js";
+import { parseEvent, type Start } from "./events.js";
+
+export const SUBPROTOCOL = "siphon-ai.v1";
+
+/** The daemon sends `start` immediately after the upgrade. */
+const START_DEADLINE_MS = 10_000;
+
+export type CallHandler = (call: Call) => Promise<void> | void;
+
+export interface SiphonServerOptions {
+  host?: string;
+  port?: number;
+  /** When set, upgrade requests must carry `Authorization: Bearer <token>`
+   * (rejected with 401 otherwise) — matching `[bridge].auth_bearer`. */
+  authToken?: string;
+}
+
+/**
+ * Accepts SiphonAI bridge connections and hands each to a handler.
+ *
+ * ```ts
+ * const server = new SiphonServer(async (call) => {
+ *   for await (const item of call) {
+ *     if (item.type === "audio") call.sendAudioFrame(item.pcm); // echo
+ *   }
+ * });
+ * await server.listen();
+ * ```
+ *
+ * Serves `GET /healthz` → 200 for container probes. Handler exceptions
+ * are logged and close that call only.
+ */
+export class SiphonServer {
+  private readonly host: string;
+  private readonly port: number;
+  private readonly authToken?: string;
+  private http: Server | null = null;
+
+  constructor(
+    private readonly handler: CallHandler,
+    options: SiphonServerOptions = {},
+  ) {
+    this.host = options.host ?? "0.0.0.0";
+    this.port = options.port ?? 8080;
+    this.authToken = options.authToken;
+  }
+
+  /** Bind and start accepting; resolves once listening. */
+  async listen(): Promise<void> {
+    const http = createServer((req, res) => {
+      if (req.url === "/healthz") {
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.end("ok\n");
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    const wss = new WebSocketServer({
+      server: http,
+      handleProtocols: (protocols) =>
+        protocols.has(SUBPROTOCOL) ? SUBPROTOCOL : false,
+      maxPayload: 256 * 1024, // PROTOCOL.md §2 text-frame cap
+      verifyClient: ({ req }: { req: IncomingMessage }) =>
+        this.authToken === undefined ||
+        req.headers.authorization === `Bearer ${this.authToken}`,
+    });
+    wss.on("connection", (ws: WebSocket) => this.connection(ws));
+    this.http = http;
+    await new Promise<void>((resolve) =>
+      http.listen(this.port, this.host, resolve),
+    );
+  }
+
+  /** The port actually bound (useful with `port: 0`). */
+  address(): { port: number } {
+    const addr = this.http?.address();
+    if (addr === null || addr === undefined || typeof addr === "string") {
+      throw new Error("server is not listening");
+    }
+    return { port: addr.port };
+  }
+
+  async close(): Promise<void> {
+    const http = this.http;
+    this.http = null;
+    if (http !== null) {
+      await new Promise<void>((resolve) => http.close(() => resolve()));
+    }
+  }
+
+  private connection(ws: WebSocket): void {
+    const deadline = setTimeout(() => {
+      console.warn("siphon-ai-server: connection closed before `start`");
+      ws.close(1002, "expected start");
+    }, START_DEADLINE_MS);
+
+    ws.once("message", (data: Buffer, isBinary: boolean) => {
+      clearTimeout(deadline);
+      if (isBinary) {
+        ws.close(1002, "expected start");
+        return;
+      }
+      let start: Start;
+      try {
+        const event = parseEvent(data);
+        if (event.type !== "start") {
+          ws.close(1002, "expected start");
+          return;
+        }
+        start = event;
+      } catch {
+        ws.close(1002, "expected start");
+        return;
+      }
+      if (start.version !== "1") {
+        console.error(
+          `siphon-ai-server: unsupported protocol version ${start.version}`,
+        );
+        ws.close(1003, "unsupported version");
+        return;
+      }
+
+      const call = new Call(ws, start);
+      Promise.resolve(this.handler(call))
+        .catch((err) => {
+          console.error(
+            `siphon-ai-server: handler failed for call ${start.call_id}:`,
+            err,
+          );
+        })
+        .finally(() => {
+          call.audioOut.close();
+          if (ws.readyState === ws.OPEN) ws.close();
+        });
+    });
+  }
+}

--- a/sdks/typescript/test/audio.test.ts
+++ b/sdks/typescript/test/audio.test.ts
@@ -1,0 +1,52 @@
+/** AudioSender re-framing + pacing. */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { AudioSender, frameBytes } from "../src/audio.js";
+
+test("frameBytes matches the spec", () => {
+  assert.equal(frameBytes(8000), 320);
+  assert.equal(frameBytes(16000), 640);
+  assert.throws(() => frameBytes(44100));
+});
+
+test("re-frames arbitrary pushes into exact zero-padded frames", async () => {
+  const sent: Buffer[] = [];
+  const sender = new AudioSender((f) => sent.push(f), 8000);
+  sender.push(Buffer.alloc(100, 1));
+  sender.push(Buffer.alloc(500, 2));
+  sender.push(Buffer.alloc(100, 3));
+  await sender.flush();
+  sender.close();
+
+  assert.equal(sent.length, 3);
+  for (const f of sent) assert.equal(f.length, 320);
+  // Tail zero-padded, not dropped.
+  assert.ok(sent[2].subarray(60).every((b) => b === 0));
+});
+
+test("pacing is real time", async () => {
+  const stamps: number[] = [];
+  const sender = new AudioSender(() => stamps.push(Date.now()), 8000);
+  sender.push(Buffer.alloc(320 * 5)); // exactly 5 frames
+  await sender.flush();
+  sender.close();
+
+  assert.equal(stamps.length, 5);
+  const elapsed = stamps[4] - stamps[0];
+  assert.ok(elapsed >= 60, `sent too fast: ${elapsed}ms`);
+  assert.ok(elapsed < 500, `sent too slow: ${elapsed}ms`);
+});
+
+test("clear drops buffered audio", async () => {
+  const sent: Buffer[] = [];
+  const sender = new AudioSender((f) => sent.push(f), 8000);
+  sender.push(Buffer.alloc(3200)); // ten frames queued
+  await new Promise((r) => setTimeout(r, 30));
+  const dropped = sender.clear();
+  sender.close();
+
+  assert.ok(dropped > 0);
+  assert.ok(sent.length <= 2);
+});

--- a/sdks/typescript/test/events.test.ts
+++ b/sdks/typescript/test/events.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Corpus + schema conformance (design D2): every PROTOCOL.md
+ * daemon→server example parses typed; every command shape the SDK emits
+ * validates against `schemas/siphon-ai.v1.json` `$defs/BridgeIn`.
+ */
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { Ajv2020 } from "ajv/dist/2020.js";
+
+import { KNOWN_EVENT_TYPES, parseEvent } from "../src/events.js";
+
+const repo = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../..",
+);
+const schema = JSON.parse(
+  readFileSync(path.join(repo, "schemas/siphon-ai.v1.json"), "utf8"),
+);
+const protocolMd = readFileSync(path.join(repo, "docs/PROTOCOL.md"), "utf8");
+
+function knownTypes(union: "BridgeOut" | "BridgeIn"): Set<string> {
+  return new Set(
+    schema.$defs[union].oneOf.map(
+      (v: { properties: { type: { const: string } } }) =>
+        v.properties.type.const,
+    ),
+  );
+}
+
+const bridgeOutTypes = knownTypes("BridgeOut");
+const bridgeInTypes = knownTypes("BridgeIn");
+const ambiguous = new Set(
+  [...bridgeOutTypes].filter((t) => bridgeInTypes.has(t)),
+);
+
+function corpus(): Record<string, unknown>[] {
+  const objects: Record<string, unknown>[] = [];
+  for (const match of protocolMd.matchAll(/```json\n([\s\S]*?)```/g)) {
+    const text = match[1];
+    let idx = 0;
+    while (idx < text.length) {
+      const brace = text.indexOf("{", idx);
+      if (brace === -1) break;
+      // Greedy parse: find the shortest prefix that is valid JSON.
+      let end = brace;
+      let depth = 0;
+      let inString = false;
+      let escaped = false;
+      for (; end < text.length; end++) {
+        const ch = text[end];
+        if (inString) {
+          if (escaped) escaped = false;
+          else if (ch === "\\") escaped = true;
+          else if (ch === '"') inString = false;
+          continue;
+        }
+        if (ch === '"') inString = true;
+        else if (ch === "{") depth++;
+        else if (ch === "}" && --depth === 0) break;
+      }
+      if (depth !== 0) break;
+      try {
+        objects.push(JSON.parse(text.slice(brace, end + 1)));
+      } catch {
+        // not a standalone JSON object (fragment) — skip
+      }
+      idx = end + 1;
+    }
+  }
+  return objects;
+}
+
+test("SDK knows every BridgeOut discriminator", () => {
+  assert.deepEqual(new Set(KNOWN_EVENT_TYPES), bridgeOutTypes);
+});
+
+test("every documented daemon→server example parses typed", () => {
+  const seen = new Set<string>();
+  for (const obj of corpus()) {
+    const t = obj.type as string | undefined;
+    if (t === undefined || !bridgeOutTypes.has(t)) continue;
+    if (ambiguous.has(t) && !("seq" in obj)) continue; // BridgeIn form
+    const event = parseEvent(JSON.stringify(obj));
+    assert.notEqual(event.type, "unknown", `documented \`${t}\` must parse typed`);
+    seen.add(t);
+  }
+  assert.ok(seen.size >= 15, `corpus only covered ${[...seen].sort()}`);
+});
+
+test("every command the SDK can emit validates against $defs/BridgeIn", () => {
+  const ajv = new Ajv2020({ strict: false });
+  const validate = ajv.compile({
+    $ref: "#/$defs/BridgeIn",
+    $defs: schema.$defs,
+  });
+  const commands: Record<string, unknown>[] = [
+    { type: "clear" },
+    { type: "mark", name: "greeting_done" },
+    { type: "hangup", cause: "normal" },
+    { type: "transfer", target: "sip:agent@pbx.example.com" },
+    { type: "transfer", replaces_call_id: "siphon-abc" },
+    { type: "send_dtmf", digit: "5", duration_ms: 160 },
+    { type: "mute" },
+    { type: "unmute" },
+    { type: "start_recording" },
+    { type: "stop_recording" },
+    { type: "pause_recording" },
+    { type: "resume_recording" },
+    { type: "set_recording_consent", note: "dtmf-1" },
+    { type: "park", slot: "vip" },
+    { type: "conference_join", room_id: "support-7" },
+    { type: "conference_leave" },
+    { type: "hold" },
+    { type: "resume" },
+  ];
+  const emitted = new Set<string>();
+  for (const msg of commands) {
+    const wire = { call_id: "siphon-test", ...msg };
+    assert.ok(
+      validate(wire),
+      `${msg.type} fails schema: ${JSON.stringify(validate.errors?.[0])}`,
+    );
+    emitted.add(msg.type as string);
+  }
+  assert.deepEqual(emitted, bridgeInTypes, "must exercise every BridgeIn command");
+});
+
+test("unknown type wraps, unknown fields pass through, malformed throws", () => {
+  const unknown = parseEvent('{"type": "yodel", "call_id": "c"}');
+  assert.equal(unknown.type, "unknown");
+
+  const dtmf = parseEvent(
+    '{"type":"dtmf","call_id":"c","seq":9,"digit":"1","duration_ms":160,"method":"rfc2833","novel":true}',
+  );
+  assert.equal(dtmf.type, "dtmf");
+
+  assert.throws(() => parseEvent("{nope"));
+  assert.throws(() => parseEvent('{"no_type": 1}'));
+});

--- a/sdks/typescript/tsconfig.json
+++ b/sdks/typescript/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
Second release of the P1 **Protocol SDKs & machine-readable schemas** theme (`docs/design/DESIGN_PROTOCOL_SDKS.md` §3, locked D2/D3). Follows #271 (v0.27.0 JSON Schema).

## What

Two dependency-light **server SDKs** under `sdks/`, so a bot author writes handlers, not wire code:

```python
async def handle(call):
    async for item in call:
        if isinstance(item, AudioFrame):
            await call.send_audio_frame(item.pcm)   # echo
        elif isinstance(item, Dtmf) and item.digit == "0":
            await call.hangup()
```

- **`sdks/python`** (`siphon-ai-server`, dep: `websockets` only) and **`sdks/typescript`** (`siphon-ai-server`, dep: `ws` only): WS accept + `siphon-ai.v1` subprotocol echo, start-deadline + version gate, typed events for all **21 BridgeOut** variants, one `Call` method per **BridgeIn** command (all 17), **paced 20 ms audio re-framer** (arbitrary byte pushes → exact 320/640 B frames, real-time paced, no catch-up bursts — the code every example hand-rolled), PROTOCOL §5.7 close semantics (`hangup` vs `abort`), `start.reconnected` surfaced. **Zero AI deps.**
- **Hand-written types, schema-validated** (locked D2 — no codegen): each SDK's suite parses every `docs/PROTOCOL.md` example into typed events, validates every emittable command against `schemas/siphon-ai.v1.json`, and asserts **full coverage of both unions** — an SDK missing a variant fails its own tests. New **`sdk-tests` CI job** runs both suites per PR (no cargo).
- **Dogfood**: `examples/echo-ws-server-python` rewritten on the Python SDK (566 → 408 lines; every `--auto-*` SIPp harness knob kept) — so the SIPp job now exercises the SDK end-to-end on every daemon PR. New minimal `examples/echo-ws-server-node` on the TS SDK.
- **Packaging: vendorable, not published** (locked D5): `pip install ./sdks/python` and `npm install ./sdks/typescript` verified from clean envs (TS `prepare` script builds `dist/` on folder/git installs).
- Docs: PROTOCOL.md §1 SDK pointer, README scope + layout, CLAUDE.md layout / where-things-go / §7.1 lockstep step.

## Verification

- **SIPp suite 35/35 green against the SDK-based echo server** — transfer, attended transfer, park/retrieve, conference, bot-hold, WS-reconnect (in+out), opus, delayed-offer (+SRTP/DTLS), digest auth, admission, STIR/SHAKEN, graceful drain.
- echo-python `test_smoke.py` 5/5 (now drives the SDK's `SiphonServer`).
- SDK unit suites: Python 11/11, TS 8/8 (corpus + schema + tolerance legs).
- Fake-daemon smoke against the node echo: subprotocol echo + `mark` + binary echo + `stop` all observed.
- Protocol stays **v1**; daemon/Rust code untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)