### PR TITLE
chore(release): 0.28.0 — Python + TypeScript server SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.0] - 2026-07-10
+
+### Added
+
+- **Server SDKs — `sdks/python` + `sdks/typescript`** (P1 "Protocol SDKs
+  & machine-readable schemas", second release). Two dependency-light
+  packages (`siphon-ai-server`; `websockets` / `ws` respectively) that
+  implement the WS bridge protocol so a bot author writes handlers, not
+  wire code: WS accept with `siphon-ai.v1` subprotocol echo, typed events
+  for all 21 daemon→server messages, one `Call` method per server→daemon
+  command (all 17), a **paced 20 ms audio re-framer** (arbitrary byte
+  pushes → exact 320/640 B frames at real time — the code every example
+  hand-rolled), §5.7 close semantics (`hangup` vs bare-close drop), and
+  `start.reconnected` surfaced. Zero AI dependencies. Types are
+  hand-written and **validated against `schemas/siphon-ai.v1.json` plus
+  every `docs/PROTOCOL.md` example** in each SDK's test suite, with full
+  union coverage asserted — a new `sdk-tests` CI job runs both suites on
+  every PR. Vendorable (`pip install ./sdks/python`,
+  `npm install ./sdks/typescript`); registry publishing deferred.
+- **`examples/echo-ws-server-node`** — new minimal echo server on the
+  TypeScript SDK.
+
+### Changed
+
+- **`examples/echo-ws-server-python` is rewritten on the Python SDK**
+  (566 → 408 lines, same CLI and behavior, every `--auto-*` test-harness
+  knob kept). It remains the SIPp CI fixture, so every daemon PR now
+  exercises the Python SDK end-to-end against real calls.
+
+The WS protocol stays **v1**; the daemon binary is unchanged.
+
 ## [0.27.0] - 2026-07-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3106,7 +3106,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3152,7 +3152,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3168,7 +3168,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "base64",
  "bytes",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "regex",
  "serde",
@@ -3226,7 +3226,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3270,7 +3270,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "base64",
  "hmac",
@@ -3293,7 +3293,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "aes-gcm",
  "audiopus",
@@ -3331,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "regex",
  "serde",
@@ -3343,7 +3343,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "schemars",
  "serde",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3380,7 +3380,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3427,7 +3427,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.27.0.** Production-deployed against real carriers
+**Current release: v0.28.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -145,11 +145,12 @@ The WS protocol (`docs/PROTOCOL.md`) is the product contract, but every
 integrator hand-rolls JSON + 20 ms audio framing from prose. Lower the
 barrier and make the contract testable:
 
-- **JSON Schema** for every WS message (generated from / checked against the
-  Rust types in `crates/bridge`).
-- **Server SDKs** — TypeScript and Python, handling framing, audio
-  endianness/rate, and the message envelope, so a bot author writes handlers
-  not wire code.
+- **JSON Schema** for every WS message — ✅ **delivered in v0.27.0**
+  (`schemas/siphon-ai.v1.json`, generated from the Rust types in
+  `crates/bridge`, drift-checked + docs-corpus-validated in CI).
+- **Server SDKs** — ✅ **delivered in v0.28.0** (`sdks/python` +
+  `sdks/typescript`: typed events, paced 20 ms framing, close semantics;
+  schema/corpus-validated in CI; echo examples rewritten on them).
 - **Conformance suite + protocol testkit** — a harness that replays a
   scripted call against a candidate WS server and validates its responses,
   plus a local mock daemon for SDK CI.


### PR DESCRIPTION
Release housekeeping for **v0.28.0** (feature landed in #273):

- Workspace version 0.27.0 → 0.28.0 (+ `Cargo.lock` refresh)
- CHANGELOG 0.28.0 entry (server SDKs, node echo example, echo-python rewrite)
- README current-release marker
- ROADMAP: JSON Schema ✅ v0.27.0, Server SDKs ✅ v0.28.0 (theme's remaining item: conformance testkit → v0.29.0)

Tag `v0.28.0` follows the merge (auto-cut release pipeline per `RELEASING.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)