### PR TITLE
feat(testkit): protocol conformance testkit + CI vs both SDK echo servers (0.29.0)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,6 +132,78 @@ jobs:
           pip install --quiet jsonschema
           python3 scripts/check-protocol-schema.py
 
+  conformance:
+    name: protocol conformance (testkit vs SDK echo servers)
+    runs-on: ubuntu-latest
+    needs: lint-and-test
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - name: Cache cargo + target
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build the testkit
+        run: cargo build -p siphon-ai-protocol-testkit
+
+      # ── Python SDK echo server ──────────────────────────────
+      - name: Prep + start echo-ws-server-python
+        run: |
+          python3 -m venv examples/echo-ws-server-python/.venv
+          examples/echo-ws-server-python/.venv/bin/pip install --no-input \
+              -r examples/echo-ws-server-python/requirements.txt
+          examples/echo-ws-server-python/.venv/bin/python \
+              examples/echo-ws-server-python/server.py \
+              --bind 127.0.0.1:8861 > /tmp/echo-py.log 2>&1 &
+          for _ in 1 2 3 4 5; do
+            ss -ltn 'sport = :8861' | grep -q LISTEN && exit 0
+            sleep 1
+          done
+          echo "python echo server failed to bind"; cat /tmp/echo-py.log; exit 1
+
+      - name: Testkit vs Python SDK echo server
+        run: |
+          ./target/debug/siphon-ai-testkit run ws://127.0.0.1:8861/ \
+              --report /tmp/conformance-python.json
+
+      # ── TypeScript SDK echo server (Node's first CI outing) ─
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Prep + start echo-ws-server-node
+        run: |
+          cd examples/echo-ws-server-node
+          npm install --no-audit --no-fund
+          node server.mjs --bind 127.0.0.1:8862 > /tmp/echo-node.log 2>&1 &
+          for _ in 1 2 3 4 5; do
+            ss -ltn 'sport = :8862' | grep -q LISTEN && exit 0
+            sleep 1
+          done
+          echo "node echo server failed to bind"; cat /tmp/echo-node.log; exit 1
+
+      - name: Testkit vs TypeScript SDK echo server
+        run: |
+          ./target/debug/siphon-ai-testkit run ws://127.0.0.1:8862/ \
+              --report /tmp/conformance-node.json
+
+      - name: Dump server logs on failure
+        if: failure()
+        run: |
+          echo "── echo-py.log ──";   cat /tmp/echo-py.log   || true
+          echo "── echo-node.log ──"; cat /tmp/echo-node.log || true
+
+      - name: Upload conformance reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: conformance-reports
+          path: /tmp/conformance-*.json
+          if-no-files-found: ignore
+
   sipp:
     name: SIPp signaling regression
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -176,6 +176,10 @@ jobs:
 
       - name: Prep + start echo-ws-server-node
         run: |
+          # npm `file:` deps are symlinks — the SDK must be installed
+          # (and thereby tsc-built via its prepare script) in its own
+          # directory first, or the example's install finds no dist/.
+          (cd sdks/typescript && npm install --no-audit --no-fund)
           cd examples/echo-ws-server-node
           npm install --no-audit --no-fund
           node server.mjs --bind 127.0.0.1:8862 > /tmp/echo-node.log 2>&1 &

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ siphon-ai/
 │   ├── cdr/                      # CDR generation (JSON), file sink, webhook sink
 │   ├── webhooks/                 # Out-of-band lifecycle webhooks (HTTP POST)
 │   ├── config/                   # TOML config + validation + reload
+│   ├── protocol-testkit/         # siphon-ai-testkit: WS protocol conformance harness
 │   └── telemetry/                # tracing + metrics + HEP wiring + admin/health endpoints
 ├── bins/
 │   └── siphon-ai/                # The daemon binary
@@ -94,6 +95,7 @@ siphon-ai/
 | New CDR field | `crates/cdr/src/schema.rs` + bump CDR `version` + update `docs/` |
 | New webhook event type | `crates/webhooks/src/events.rs` + update `docs/` |
 | Server SDK change (typed events, `Call` commands, framing) | `sdks/python` + `sdks/typescript` — keep both in lockstep; their tests validate against `schemas/siphon-ai.v1.json` + `docs/PROTOCOL.md` |
+| Conformance scenario or testkit assertion | `crates/protocol-testkit/` (bundled scenarios in its `scenarios/`) + update `docs/CONFORMANCE.md` |
 | New HEP chunk emission | `crates/telemetry/src/hep.rs` (uses `hep-rs` crate) |
 | New metric | `crates/telemetry/src/metrics.rs` + document in `docs/DEPLOY.md` |
 | New admin endpoint | `crates/telemetry/src/admin.rs` + document in `docs/DEPLOY.md` |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -57,6 +59,12 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -210,6 +218,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,6 +252,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "borsh"
@@ -251,6 +280,12 @@ name = "byte-slice-cast"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -586,6 +621,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,6 +713,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,6 +736,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,6 +757,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -910,6 +982,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,7 +1180,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1106,6 +1188,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -1621,6 +1708,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "281c43ff06dcb331e9356d30e38853d559ce3d0a3f693e0b0e102667dec14fb1"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "jsonschema-regex",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee0b351864e7ffbc5db9273daf7fa1b4d5177b0946713d667ca571b83c0b4045"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1761,6 +1884,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1820,6 +1949,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1840,6 +1999,27 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2007,6 +2187,12 @@ dependencies = [
  "tokio",
  "tokio-stream",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking_lot"
@@ -2417,6 +2603,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "referencing"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348e860aeb0b7bd035778fd11dd9cd5290d32e4aed3b8f2274a00287a9fd362b"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.17.0",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
 ]
 
 [[package]]
@@ -3313,6 +3516,24 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "siphon-ai-protocol-testkit"
+version = "0.28.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "futures",
+ "jsonschema",
+ "serde",
+ "serde_json",
+ "siphon-ai-bridge",
+ "tokio",
+ "tokio-tungstenite",
+ "toml",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4229,6 +4450,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4305,6 +4532,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4321,6 +4558,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/core",
     "crates/http",
     "crates/media-glue",
+    "crates/protocol-testkit",
     "crates/recording",
     "crates/routes",
     "crates/security",

--- a/README.md
+++ b/README.md
@@ -98,9 +98,11 @@ DTMF, and the WebSocket protocol:
   **graceful shutdown** for zero-drop deploys (`SIGTERM` flips `/ready`,
   503s new INVITEs, drains active calls before exit).
 - **Developer surface** — the WS protocol as a machine-readable **JSON
-  Schema** (`schemas/siphon-ai.v1.json`, drift-checked in CI) and **server
+  Schema** (`schemas/siphon-ai.v1.json`, drift-checked in CI), **server
   SDKs** for Python + TypeScript (`sdks/`) — typed events, paced 20 ms audio
-  framing, connection lifecycle.
+  framing, connection lifecycle — and a **conformance testkit**
+  (`siphon-ai-testkit`) that plays the daemon side against any WS server
+  and validates its behavior (`docs/CONFORMANCE.md`).
 
 See [`docs/DEV_PLAN.md`](docs/DEV_PLAN.md) for design rationale. Still
 deliberately out of scope: multi-tenancy, video, and WebRTC client support.
@@ -238,6 +240,7 @@ journal — grep `turn_summary` for SLO numbers. See
 | `crates/http/`        | Shared retrying HTTP delivery (signing, idempotency, spool) |
 | `crates/config/`      | TOML config + validation + SIGHUP reload |
 | `crates/telemetry/`   | tracing + metrics + HEP wiring + admin API (auth + RBAC) |
+| `crates/protocol-testkit/` | `siphon-ai-testkit` — WS protocol conformance harness |
 | `bins/siphon-ai/`     | The daemon binary |
 | `sdks/`               | Server SDKs (Python + TypeScript) for the WS protocol |
 | `examples/`           | Reference WS servers and the local Homer stack |
@@ -294,7 +297,8 @@ secure default). See [`docs/DEPLOY.md`](docs/DEPLOY.md) → *Admin auth & RBAC*.
 7. Feature guides — `docs/OUTBOUND.md`, `docs/CONFERENCE.md`,
    `docs/PARK.md`, `docs/RECORDING.md`, `docs/SECURITY_STIR_SHAKEN.md`,
    `docs/AUDIT.md`, `docs/OPERATIONS.md` (dashboards, OTLP, fleet ops),
-   `docs/INTEGRATIONS_TWILIO.md`.
+   `docs/INTEGRATIONS_TWILIO.md`, `docs/CONFORMANCE.md` (testkit for WS
+   server authors).
 
 ## Upstream dependencies
 

--- a/crates/protocol-testkit/Cargo.toml
+++ b/crates/protocol-testkit/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name        = "siphon-ai-protocol-testkit"
+description = "Conformance testkit for the SiphonAI WS bridge protocol: plays the daemon side against a candidate server and validates its behavior."
+version.workspace      = true
+edition.workspace      = true
+rust-version.workspace = true
+license.workspace      = true
+authors.workspace      = true
+repository.workspace   = true
+
+[[bin]]
+name = "siphon-ai-testkit"
+path = "src/main.rs"
+
+[dependencies]
+tokio.workspace             = true
+tokio-tungstenite.workspace = true
+futures.workspace           = true
+serde.workspace             = true
+serde_json.workspace        = true
+toml.workspace              = true
+anyhow.workspace            = true
+clap.workspace              = true
+tracing.workspace           = true
+tracing-subscriber.workspace = true
+
+# The wire types ARE the contract — construct/parse with the real serde
+# impls so the testkit can't drift from the daemon.
+siphon-ai-bridge.workspace = true
+
+# Schema-validating assertions (DESIGN_PROTOCOL_SDKS §4, locked D5):
+# every server message is validated against schemas/siphon-ai.v1.json.
+# Test-tooling only — never a daemon dependency.
+jsonschema = { version = "0.47", default-features = false }

--- a/crates/protocol-testkit/scenarios/basic-echo.toml
+++ b/crates/protocol-testkit/scenarios/basic-echo.toml
@@ -1,0 +1,37 @@
+# The bread-and-butter path: audio in, audio out, plus unknown-message
+# tolerance. A conformant server keeps the session alive and keeps its
+# messages schema-valid throughout.
+
+name = "basic-echo"
+description = "Stream audio, expect it back correctly framed; survive an unknown event."
+
+[[steps]]                 # 1 s of caller audio at the daemon's 20 ms cadence
+action = "send_audio"
+frames = 50
+
+[[steps]]                 # expect the server to have sent audio back
+action = "expect_audio"
+min_frames = 40
+within_ms = 3000
+
+# Tolerance probe (PROTOCOL.md §5.1): the daemon may add NEW event types
+# within protocol v1 — servers must ignore what they don't know, not die.
+[[steps]]
+action = "send_raw"
+json = '{ "type": "testkit_future_event", "novel_field": true }'
+
+[[steps]]                 # prove the server survived: echo still flows
+action = "send_audio"
+frames = 25
+
+[[steps]]                 # cumulative session total: 75 sent, allow loss
+action = "expect_audio"
+min_frames = 65
+within_ms = 2000
+
+[[steps]]                 # the daemon's last message on a session…
+action = "send_stop"
+reason = "caller_hangup"
+
+[[steps]]                 # …followed by a clean close (PROTOCOL.md §5.7)
+action = "close"

--- a/crates/protocol-testkit/scenarios/dtmf.toml
+++ b/crates/protocol-testkit/scenarios/dtmf.toml
@@ -1,0 +1,39 @@
+# DTMF events mid-stream. The digits are delivered exactly as the daemon
+# sends them (typed round-trip through BridgeOut); a conformant server
+# processes or ignores them without disturbing the audio path, and any
+# commands it sends back stay schema-valid.
+
+name = "dtmf"
+description = "Inject DTMF events mid-audio; the session must sail on."
+
+[[steps]]
+action = "send_audio"
+frames = 25
+
+[[steps]]
+action = "send_event"
+json = '{ "type": "dtmf", "digit": "1", "duration_ms": 160, "method": "rfc2833" }'
+
+[[steps]]
+action = "send_event"
+json = '{ "type": "dtmf", "digit": "*", "duration_ms": 160, "method": "rfc2833" }'
+
+[[steps]]
+action = "send_event"
+json = '{ "type": "dtmf", "digit": "#", "duration_ms": 240, "method": "inband" }'
+
+[[steps]]                 # audio keeps flowing around the events
+action = "send_audio"
+frames = 25
+
+[[steps]]
+action = "expect_audio"
+min_frames = 35
+within_ms = 3000
+
+[[steps]]
+action = "send_stop"
+reason = "caller_hangup"
+
+[[steps]]
+action = "close"

--- a/crates/protocol-testkit/scenarios/hangup-semantics.toml
+++ b/crates/protocol-testkit/scenarios/hangup-semantics.toml
@@ -1,0 +1,43 @@
+# PROTOCOL.md §5.7 close semantics, both directions:
+#   * an unexpected WS drop is NOT a hangup — after an abrupt drop the
+#     daemon may redial with `start { reconnected: true }`, and the server
+#     must accept that fresh session;
+#   * a server that wants the call over sends `hangup` (the testkit honors
+#     it daemon-style: `stop { server_hangup }` + clean close — that path
+#     passing shows up as a note, not a failure).
+
+name = "hangup-semantics"
+description = "Abrupt drop + reconnected session must be accepted; hangup (if sent) is honored."
+
+[[steps]]
+action = "send_audio"
+frames = 25
+
+[[steps]]
+action = "expect_audio"
+min_frames = 15
+within_ms = 3000
+
+# Abrupt drop (no close handshake), fresh socket, `start` with
+# reconnected: true and seq restarting at 0 — a daemon-side WS reconnect.
+[[steps]]
+action = "reconnect"
+
+[[steps]]                 # the resumed session must carry audio again
+action = "send_audio"
+frames = 25
+
+# Some servers (e.g. the echo reference) choose to hang up a reconnected
+# call once they've seen it work; that's a legal reaction, not required.
+[[steps]]
+action = "expect_command"
+type = "hangup"
+within_ms = 1000
+optional = true
+
+[[steps]]
+action = "send_stop"
+reason = "caller_hangup"
+
+[[steps]]
+action = "close"

--- a/crates/protocol-testkit/scenarios/keepalive.toml
+++ b/crates/protocol-testkit/scenarios/keepalive.toml
@@ -1,0 +1,35 @@
+# PROTOCOL.md §5.6: the daemon pings every [bridge].ws_ping_interval_secs
+# and declares the connection half-open if the pong never comes. A server
+# (or a middlebox in front of it) that doesn't answer pings gets its calls
+# torn down in production — catch it here instead.
+
+name = "keepalive"
+description = "Pong our pings; survive idle gaps with the session intact."
+
+[[steps]]                 # ping on a fresh, quiet connection
+action = "ping"
+within_ms = 2000
+
+[[steps]]                 # idle: no audio for 2 s (daemon-side comfort noise
+action = "wait"           # gaps look like this); anything the server sends
+ms = 2000                 # meanwhile is still validated
+
+[[steps]]                 # ping again after the idle gap
+action = "ping"
+within_ms = 2000
+
+[[steps]]                 # the session must still carry audio
+action = "send_audio"
+frames = 25
+
+[[steps]]
+action = "expect_audio"
+min_frames = 15
+within_ms = 3000
+
+[[steps]]
+action = "send_stop"
+reason = "caller_hangup"
+
+[[steps]]
+action = "close"

--- a/crates/protocol-testkit/scenarios/recording-controls.toml
+++ b/crates/protocol-testkit/scenarios/recording-controls.toml
@@ -1,0 +1,42 @@
+# Recording lifecycle events (0.5.0+). Servers that never touch recording
+# must still tolerate the daemon announcing recordings (mode = "always",
+# operator-initiated, or failures) without wobbling the audio path.
+
+name = "recording-controls"
+description = "Announce recording lifecycle events; the audio path must be unaffected."
+
+[[steps]]
+action = "send_audio"
+frames = 25
+
+[[steps]]                 # a recording began (e.g. route has mode = "always")
+action = "send_event"
+json = '{ "type": "recording_started", "recording_id": "rec-testkit-1" }'
+
+[[steps]]
+action = "send_audio"
+frames = 15
+
+[[steps]]                 # recording is best-effort: failures are events, not call teardown
+action = "send_event"
+json = '{ "type": "recording_failed", "recording_id": "rec-testkit-1", "reason": "disk full (testkit probe)" }'
+
+[[steps]]
+action = "send_event"
+json = '{ "type": "recording_stopped", "recording_id": "rec-testkit-1" }'
+
+[[steps]]                 # audio must have kept flowing throughout
+action = "send_audio"
+frames = 15
+
+[[steps]]
+action = "expect_audio"
+min_frames = 40
+within_ms = 3000
+
+[[steps]]
+action = "send_stop"
+reason = "caller_hangup"
+
+[[steps]]
+action = "close"

--- a/crates/protocol-testkit/src/client.rs
+++ b/crates/protocol-testkit/src/client.rs
@@ -1,0 +1,134 @@
+//! Thin WS client playing the daemon's side of the bridge protocol.
+//!
+//! Deliberately NOT `siphon_ai_bridge::conn` — that module is entangled
+//! with the daemon's call machinery (reconnect state, media channels).
+//! The testkit needs a bare socket it can drive step-by-step.
+
+use anyhow::{bail, Context, Result};
+use futures::{SinkExt, StreamExt};
+use tokio::net::TcpStream;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::http::HeaderValue;
+use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
+use tokio_tungstenite::tungstenite::protocol::CloseFrame;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
+
+use siphon_ai_bridge::WS_SUBPROTOCOL;
+
+/// One inbound frame, as the step runner sees it.
+#[derive(Debug)]
+pub enum Incoming {
+    Text(String),
+    Binary(Vec<u8>),
+    Pong,
+    /// Server closed (code, reason) — `None` when the socket dropped
+    /// without a close handshake.
+    Closed(Option<(u16, String)>),
+}
+
+pub struct WsClient {
+    ws: WebSocketStream<MaybeTlsStream<TcpStream>>,
+}
+
+impl WsClient {
+    /// Connect and require the server to echo the `siphon-ai.v1`
+    /// subprotocol, exactly as the daemon does.
+    pub async fn connect(url: &str) -> Result<Self> {
+        let mut request = url
+            .into_client_request()
+            .with_context(|| format!("bad WebSocket URL `{url}`"))?;
+        request.headers_mut().insert(
+            "Sec-WebSocket-Protocol",
+            HeaderValue::from_static(WS_SUBPROTOCOL),
+        );
+        let (ws, response) = tokio_tungstenite::connect_async(request)
+            .await
+            .with_context(|| format!("WebSocket connect to `{url}` failed"))?;
+        let negotiated = response
+            .headers()
+            .get("Sec-WebSocket-Protocol")
+            .and_then(|v| v.to_str().ok());
+        if negotiated != Some(WS_SUBPROTOCOL) {
+            bail!(
+                "server did not negotiate subprotocol `{WS_SUBPROTOCOL}` \
+                 (got {negotiated:?}) — PROTOCOL.md §2.1 requires echoing it"
+            );
+        }
+        Ok(Self { ws })
+    }
+
+    pub async fn send_text(&mut self, text: String) -> Result<()> {
+        self.ws
+            .send(Message::Text(text))
+            .await
+            .context("WS text send failed")
+    }
+
+    pub async fn send_binary(&mut self, frame: Vec<u8>) -> Result<()> {
+        self.ws
+            .send(Message::Binary(frame))
+            .await
+            .context("WS binary send failed")
+    }
+
+    pub async fn send_ping(&mut self) -> Result<()> {
+        self.ws
+            .send(Message::Ping(Vec::new()))
+            .await
+            .context("WS ping send failed")
+    }
+
+    /// Next protocol-relevant frame. Never blocks past the caller's
+    /// surrounding timeout (use `tokio::time::timeout`).
+    pub async fn recv(&mut self) -> Result<Incoming> {
+        loop {
+            match self.ws.next().await {
+                None => return Ok(Incoming::Closed(None)),
+                Some(Err(e)) => {
+                    // A peer that vanishes mid-read is a drop, not an error
+                    // the runner needs to distinguish further.
+                    tracing::debug!("ws read error treated as drop: {e}");
+                    return Ok(Incoming::Closed(None));
+                }
+                Some(Ok(Message::Text(t))) => return Ok(Incoming::Text(t.to_string())),
+                Some(Ok(Message::Binary(b))) => return Ok(Incoming::Binary(b.to_vec())),
+                Some(Ok(Message::Pong(_))) => return Ok(Incoming::Pong),
+                Some(Ok(Message::Ping(_))) => continue, // auto-ponged by tungstenite
+                Some(Ok(Message::Close(frame))) => {
+                    return Ok(Incoming::Closed(
+                        frame.map(|f| (f.code.into(), f.reason.to_string())),
+                    ));
+                }
+                Some(Ok(Message::Frame(_))) => continue,
+            }
+        }
+    }
+
+    /// Clean close (1000), waiting briefly for the server's close reply.
+    pub async fn close(&mut self) -> Result<()> {
+        let _ = self
+            .ws
+            .close(Some(CloseFrame {
+                code: CloseCode::Normal,
+                reason: "".into(),
+            }))
+            .await;
+        // Drain until the close handshake completes or the peer drops.
+        let drain = async {
+            while let Some(msg) = self.ws.next().await {
+                if msg.is_err() || matches!(msg, Ok(Message::Close(_))) {
+                    break;
+                }
+            }
+        };
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), drain).await;
+        Ok(())
+    }
+
+    /// Abrupt drop — no close handshake. What an unexpected WS drop
+    /// looks like from the server's side (PROTOCOL.md §5.7).
+    pub fn abort(self) {
+        drop(self.ws);
+    }
+}

--- a/crates/protocol-testkit/src/main.rs
+++ b/crates/protocol-testkit/src/main.rs
@@ -1,0 +1,152 @@
+//! `siphon-ai-testkit` — conformance testkit for the SiphonAI WS bridge
+//! protocol v1. Plays the *daemon's* side of the protocol against a
+//! candidate WebSocket server and validates its behavior: every JSON
+//! message against `schemas/siphon-ai.v1.json`, binary frame sizing and
+//! pacing, close semantics, unknown-message tolerance.
+//!
+//! ```text
+//! siphon-ai-testkit run ws://localhost:8765/            # all scenarios
+//! siphon-ai-testkit run --scenario basic-echo ws://...  # one scenario
+//! siphon-ai-testkit run --report report.json ws://...   # machine-readable
+//! siphon-ai-testkit list
+//! ```
+//!
+//! Exit code 0 iff every scenario passed — gate your server's CI on it.
+//! See `docs/CONFORMANCE.md`.
+
+mod client;
+mod report;
+mod runner;
+mod scenario;
+mod validate;
+
+use std::path::PathBuf;
+
+use anyhow::{bail, Context, Result};
+use clap::{Parser, Subcommand};
+
+use report::Report;
+use scenario::Scenario;
+use validate::MessageValidator;
+
+#[derive(Parser)]
+#[command(
+    name = "siphon-ai-testkit",
+    version,
+    about = "Conformance testkit for the SiphonAI WS bridge protocol v1"
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Run scenarios against a candidate WS server.
+    Run {
+        /// The server under test, e.g. `ws://127.0.0.1:8765/`.
+        url: String,
+        /// Scenario name (repeatable), or `all` (the default).
+        #[arg(long, short, default_value = "all")]
+        scenario: Vec<String>,
+        /// Directory of additional `*.toml` scenario files.
+        #[arg(long)]
+        scenario_dir: Option<PathBuf>,
+        /// Write the JSON report here (stdout keeps the human summary).
+        #[arg(long)]
+        report: Option<PathBuf>,
+    },
+    /// List available scenarios.
+    List {
+        /// Directory of additional `*.toml` scenario files.
+        #[arg(long)]
+        scenario_dir: Option<PathBuf>,
+    },
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "warn".into()),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+
+    match Cli::parse().command {
+        Command::List { scenario_dir } => {
+            for s in &load_scenarios(scenario_dir.as_deref())? {
+                println!("{:<22} {}", s.name, s.description);
+            }
+            Ok(())
+        }
+        Command::Run {
+            url,
+            scenario,
+            scenario_dir,
+            report,
+        } => {
+            let available = load_scenarios(scenario_dir.as_deref())?;
+            let selected: Vec<&Scenario> = if scenario.iter().any(|s| s == "all") {
+                available.iter().collect()
+            } else {
+                scenario
+                    .iter()
+                    .map(|want| {
+                        available.iter().find(|s| &s.name == want).with_context(|| {
+                            format!(
+                                "unknown scenario `{want}` — `siphon-ai-testkit list` shows \
+                                 what's available"
+                            )
+                        })
+                    })
+                    .collect::<Result<_>>()?
+            };
+
+            let validator = MessageValidator::new()?;
+            let mut results = Vec::with_capacity(selected.len());
+            for s in selected {
+                eprintln!("running {} …", s.name);
+                results.push(runner::run_scenario(&url, s, &validator).await.finalize());
+            }
+
+            let full_report = Report::new(&url, results);
+            print!("{}", full_report.render_text());
+            if let Some(path) = report {
+                std::fs::write(&path, serde_json::to_string_pretty(&full_report)?)
+                    .with_context(|| format!("writing report to {}", path.display()))?;
+                eprintln!("report written to {}", path.display());
+            }
+            if !full_report.conformant {
+                std::process::exit(1);
+            }
+            Ok(())
+        }
+    }
+}
+
+/// Bundled scenarios plus any from `--scenario-dir` (which may shadow a
+/// bundled name to override it).
+fn load_scenarios(dir: Option<&std::path::Path>) -> Result<Vec<Scenario>> {
+    let mut scenarios = scenario::bundled()?;
+    if let Some(dir) = dir {
+        let entries = std::fs::read_dir(dir)
+            .with_context(|| format!("reading --scenario-dir {}", dir.display()))?;
+        let mut paths: Vec<PathBuf> = entries
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| p.extension().is_some_and(|ext| ext == "toml"))
+            .collect();
+        paths.sort();
+        if paths.is_empty() {
+            bail!("--scenario-dir {} contains no .toml files", dir.display());
+        }
+        for path in paths {
+            let text = std::fs::read_to_string(&path)
+                .with_context(|| format!("reading {}", path.display()))?;
+            let parsed = scenario::parse(&path.display().to_string(), &text)?;
+            scenarios.retain(|s| s.name != parsed.name);
+            scenarios.push(parsed);
+        }
+    }
+    Ok(scenarios)
+}

--- a/crates/protocol-testkit/src/report.rs
+++ b/crates/protocol-testkit/src/report.rs
@@ -1,0 +1,125 @@
+//! The conformance report: human summary on stdout, JSON on `--report`.
+
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct ScenarioResult {
+    pub name: String,
+    pub passed: bool,
+    pub duration_ms: u64,
+    /// Protocol violations + unmet expectations, in observation order.
+    pub failures: Vec<String>,
+    /// Non-failure observations (e.g. "server sent hangup — honored").
+    pub notes: Vec<String>,
+    pub audio_frames_received: u64,
+    pub commands_received: u64,
+}
+
+impl ScenarioResult {
+    pub fn new(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            passed: false,
+            duration_ms: 0,
+            failures: Vec::new(),
+            notes: Vec::new(),
+            audio_frames_received: 0,
+            commands_received: 0,
+        }
+    }
+
+    pub fn finalize(mut self) -> Self {
+        self.passed = self.failures.is_empty();
+        self
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct Report {
+    /// The candidate server under test.
+    pub target: String,
+    /// WS bridge protocol version the testkit speaks.
+    pub protocol_version: String,
+    pub testkit_version: String,
+    pub scenarios: Vec<ScenarioResult>,
+    pub passed: usize,
+    pub failed: usize,
+    /// True iff every scenario passed: "conformant with protocol v1"
+    /// as a machine-checkable claim.
+    pub conformant: bool,
+}
+
+impl Report {
+    pub fn new(target: &str, scenarios: Vec<ScenarioResult>) -> Self {
+        let passed = scenarios.iter().filter(|s| s.passed).count();
+        let failed = scenarios.len() - passed;
+        Self {
+            target: target.to_string(),
+            protocol_version: siphon_ai_bridge::PROTOCOL_VERSION.to_string(),
+            testkit_version: env!("CARGO_PKG_VERSION").to_string(),
+            scenarios,
+            passed,
+            failed,
+            conformant: failed == 0,
+        }
+    }
+
+    /// The human-readable summary printed to stdout.
+    pub fn render_text(&self) -> String {
+        let mut out = String::new();
+        for s in &self.scenarios {
+            out.push_str(&format!(
+                "─── {} ── {} ({} ms, {} audio frames, {} commands)\n",
+                s.name,
+                if s.passed { "OK" } else { "FAIL" },
+                s.duration_ms,
+                s.audio_frames_received,
+                s.commands_received,
+            ));
+            for note in &s.notes {
+                out.push_str(&format!("      note: {note}\n"));
+            }
+            for failure in &s.failures {
+                out.push_str(&format!("      FAIL: {failure}\n"));
+            }
+        }
+        out.push_str(&format!(
+            "\n{}: {} passed, {} failed — target {} is {}conformant with protocol v{}\n",
+            if self.conformant { "PASS" } else { "FAIL" },
+            self.passed,
+            self.failed,
+            self.target,
+            if self.conformant { "" } else { "NOT " },
+            self.protocol_version,
+        ));
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn conformant_only_when_all_pass() {
+        let ok = ScenarioResult::new("a").finalize();
+        let mut bad = ScenarioResult::new("b");
+        bad.failures.push("boom".into());
+        let bad = bad.finalize();
+        assert!(ok.passed);
+        assert!(!bad.passed);
+
+        let report = Report::new("ws://x", vec![ok, bad]);
+        assert_eq!(report.passed, 1);
+        assert_eq!(report.failed, 1);
+        assert!(!report.conformant);
+        assert!(report.render_text().contains("NOT conformant"));
+    }
+
+    #[test]
+    fn report_serializes_to_json() {
+        let report = Report::new("ws://x", vec![ScenarioResult::new("a").finalize()]);
+        let json = serde_json::to_string_pretty(&report).unwrap();
+        assert!(json.contains("\"conformant\": true"));
+    }
+}

--- a/crates/protocol-testkit/src/runner.rs
+++ b/crates/protocol-testkit/src/runner.rs
@@ -1,0 +1,615 @@
+//! Executes one scenario against a candidate server, playing the daemon.
+
+use std::time::{Duration, Instant};
+
+use anyhow::{bail, Context, Result};
+use serde_json::Value;
+use siphon_ai_bridge::{
+    AudioEncoding, AudioFormat, BridgeIn, BridgeOut, CallId, Direction, SipMeta, StartMsg,
+    PROTOCOL_VERSION,
+};
+use tokio::time::timeout;
+
+use crate::client::{Incoming, WsClient};
+use crate::report::ScenarioResult;
+use crate::scenario::{Scenario, Step};
+use crate::validate::MessageValidator;
+
+pub const FRAME_MS: u64 = 20;
+
+/// Hard cap per scenario so a wedged server can't hang a CI job.
+const SCENARIO_DEADLINE: Duration = Duration::from_secs(60);
+
+pub async fn run_scenario(
+    url: &str,
+    scenario: &Scenario,
+    validator: &MessageValidator,
+) -> ScenarioResult {
+    let started = Instant::now();
+    let mut result = ScenarioResult::new(&scenario.name);
+    let outcome = timeout(
+        SCENARIO_DEADLINE,
+        drive(url, scenario, validator, &mut result),
+    )
+    .await;
+    match outcome {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => result.failures.push(format!("{e:#}")),
+        Err(_) => result.failures.push(format!(
+            "scenario exceeded the {}s deadline (server wedged?)",
+            SCENARIO_DEADLINE.as_secs()
+        )),
+    }
+    result.duration_ms = started.elapsed().as_millis() as u64;
+    result
+}
+
+struct SessionState {
+    call_id: String,
+    seq: u64,
+    frame_bytes: usize,
+    /// Reference points for the pacing bound.
+    opened_at: Instant,
+    frames_sent: u64,
+    frames_received: u64,
+    /// Server asked to hang up — the daemon honors it; so do we.
+    hangup: bool,
+}
+
+impl SessionState {
+    fn next_seq(&mut self) -> u64 {
+        let s = self.seq;
+        self.seq += 1;
+        s
+    }
+}
+
+async fn drive(
+    url: &str,
+    scenario: &Scenario,
+    validator: &MessageValidator,
+    result: &mut ScenarioResult,
+) -> Result<()> {
+    let mut client = WsClient::connect(url).await?;
+    let mut state = open_session(&mut client, scenario, /*reconnected=*/ false).await?;
+
+    for (idx, step) in scenario.steps.iter().enumerate() {
+        if state.hangup {
+            // PROTOCOL §4.2: after the server's `hangup` the daemon sends
+            // `stop` and closes. We did; the rest of the script is moot.
+            result.notes.push(format!(
+                "server sent `hangup` — honored it; skipped remaining steps from #{}",
+                idx + 1
+            ));
+            return Ok(());
+        }
+        let label = format!("step #{} {:?}", idx + 1, step_name(step));
+        match step {
+            Step::SendAudio { frames } => {
+                send_audio(
+                    &mut client,
+                    &mut state,
+                    scenario,
+                    validator,
+                    result,
+                    *frames,
+                )
+                .await
+                .context(label)?;
+            }
+            Step::ExpectAudio {
+                min_frames,
+                within_ms,
+            } => {
+                let got = pump_until(
+                    &mut client,
+                    &mut state,
+                    scenario,
+                    validator,
+                    result,
+                    Duration::from_millis(*within_ms),
+                    PumpGoal::AudioFrames(*min_frames),
+                )
+                .await
+                .context(label.clone())?;
+                if let PumpOutcome::TimedOut { audio_seen } = got {
+                    result.failures.push(format!(
+                        "{label}: expected a session total of ≥{min_frames} audio frames \
+                         within {within_ms} ms, session has {audio_seen}"
+                    ));
+                }
+            }
+            Step::SendEvent { json } => {
+                let text = build_event(&mut state, json, /*typed=*/ true).context(label)?;
+                client.send_text(text).await?;
+            }
+            Step::SendRaw { json } => {
+                let text = build_event(&mut state, json, /*typed=*/ false).context(label)?;
+                client.send_text(text).await?;
+            }
+            Step::ExpectCommand {
+                command,
+                within_ms,
+                optional,
+            } => {
+                let got = pump_until(
+                    &mut client,
+                    &mut state,
+                    scenario,
+                    validator,
+                    result,
+                    Duration::from_millis(*within_ms),
+                    PumpGoal::Command(command.clone()),
+                )
+                .await
+                .context(label.clone())?;
+                if matches!(got, PumpOutcome::TimedOut { .. }) && !optional {
+                    result.failures.push(format!(
+                        "{label}: server did not send `{command}` within {within_ms} ms"
+                    ));
+                }
+            }
+            Step::ExpectSilence { ms } => {
+                let before = (state.frames_received, result.commands_received);
+                pump_until(
+                    &mut client,
+                    &mut state,
+                    scenario,
+                    validator,
+                    result,
+                    Duration::from_millis(*ms),
+                    PumpGoal::Nothing,
+                )
+                .await
+                .context(label.clone())?;
+                let after = (state.frames_received, result.commands_received);
+                if after != before {
+                    result.failures.push(format!(
+                        "{label}: expected no traffic for {ms} ms, saw {} audio frames \
+                         and {} commands",
+                        after.0 - before.0,
+                        after.1 - before.1
+                    ));
+                }
+            }
+            Step::Ping { within_ms } => {
+                client.send_ping().await?;
+                let got = pump_until(
+                    &mut client,
+                    &mut state,
+                    scenario,
+                    validator,
+                    result,
+                    Duration::from_millis(*within_ms),
+                    PumpGoal::Pong,
+                )
+                .await
+                .context(label.clone())?;
+                if matches!(got, PumpOutcome::TimedOut { .. }) {
+                    result.failures.push(format!(
+                        "{label}: no pong within {within_ms} ms — the daemon's §5.6 keepalive \
+                         would declare this connection half-open and abandon it"
+                    ));
+                }
+            }
+            Step::Wait { ms } => {
+                pump_until(
+                    &mut client,
+                    &mut state,
+                    scenario,
+                    validator,
+                    result,
+                    Duration::from_millis(*ms),
+                    PumpGoal::Nothing,
+                )
+                .await
+                .context(label)?;
+            }
+            Step::SendStop { reason } => {
+                let seq = state.next_seq();
+                let msg = serde_json::json!({
+                    "type": "stop",
+                    "call_id": state.call_id,
+                    "seq": seq,
+                    "reason": reason,
+                });
+                // Round-trip through the real type so scenario typos fail.
+                let typed: BridgeOut = serde_json::from_value(msg)
+                    .with_context(|| format!("{label}: invalid stop reason `{reason}`"))?;
+                client.send_text(serde_json::to_string(&typed)?).await?;
+            }
+            Step::Close => {
+                client.close().await?;
+            }
+            Step::Reconnect => {
+                // Abrupt drop, fresh socket, `start { reconnected: true }`,
+                // seq restarting at 0 (PROTOCOL §5.7).
+                let call_id = state.call_id.clone();
+                client.abort();
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                client = WsClient::connect(url).await.context("reconnect dial")?;
+                state = open_session(&mut client, scenario, true).await?;
+                state.call_id = call_id;
+                result.notes.push("reconnected with a fresh session".into());
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn open_session(
+    client: &mut WsClient,
+    scenario: &Scenario,
+    reconnected: bool,
+) -> Result<SessionState> {
+    let call_id = format!("testkit-{}", scenario.name);
+    let start = BridgeOut::Start(StartMsg {
+        version: PROTOCOL_VERSION.to_string(),
+        call_id: CallId::new(call_id.clone()),
+        seq: 0,
+        from: scenario.session.from.clone(),
+        to: scenario.session.to.clone(),
+        direction: Direction::Inbound,
+        audio: AudioFormat {
+            encoding: AudioEncoding::Pcm16le,
+            sample_rate: scenario.session.sample_rate,
+            channels: 1,
+            frame_ms: FRAME_MS as u32,
+        },
+        sip: SipMeta {
+            call_id: format!("{call_id}@testkit.invalid"),
+            headers: Default::default(),
+        },
+        srtp: None,
+        verstat: None,
+        retrieved: false,
+        reconnected,
+        trace_context: None,
+    });
+    client.send_text(serde_json::to_string(&start)?).await?;
+    Ok(SessionState {
+        call_id,
+        seq: 1,
+        frame_bytes: (scenario.session.sample_rate as usize / 1000) * FRAME_MS as usize * 2,
+        opened_at: Instant::now(),
+        frames_sent: 0,
+        frames_received: 0,
+        hangup: false,
+    })
+}
+
+/// Build an injected event: parse the scenario's JSON, add `call_id`/`seq`
+/// (not overriding an explicit one), and — for typed events — round-trip
+/// through the daemon's `BridgeOut` so scenarios can't emit garbage
+/// accidentally. Raw events skip the type check by design.
+fn build_event(state: &mut SessionState, json: &str, typed: bool) -> Result<String> {
+    let mut value: Value = serde_json::from_str(json).context("step `json` is not valid JSON")?;
+    let obj = value
+        .as_object_mut()
+        .context("step `json` must be a JSON object")?;
+    obj.entry("call_id")
+        .or_insert_with(|| Value::String(state.call_id.clone()));
+    if !obj.contains_key("seq") {
+        obj.insert("seq".into(), Value::from(state.next_seq()));
+    }
+    if typed {
+        let typed_msg: BridgeOut = serde_json::from_value(value)
+            .context("send_event json does not round-trip through BridgeOut — typo?")?;
+        Ok(serde_json::to_string(&typed_msg)?)
+    } else {
+        Ok(serde_json::to_string(&value)?)
+    }
+}
+
+/// Send `frames` × 20 ms tone frames, paced, validating anything that
+/// arrives while we stream.
+async fn send_audio(
+    client: &mut WsClient,
+    state: &mut SessionState,
+    scenario: &Scenario,
+    validator: &MessageValidator,
+    result: &mut ScenarioResult,
+    frames: u64,
+) -> Result<()> {
+    let frame = tone_frame(state.frame_bytes, scenario.session.sample_rate);
+    let mut ticker = tokio::time::interval(Duration::from_millis(FRAME_MS));
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let target = state.frames_sent + frames;
+    while state.frames_sent < target {
+        tokio::select! {
+            _ = ticker.tick() => {
+                client.send_binary(frame.clone()).await?;
+                state.frames_sent += 1;
+            }
+            incoming = client.recv() => {
+                handle_incoming(incoming?, state, scenario, validator, result)?;
+                if state.hangup {
+                    finish_after_hangup(client, state).await?;
+                    return Ok(());
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+enum PumpGoal {
+    AudioFrames(u64),
+    Command(String),
+    Pong,
+    Nothing,
+}
+
+enum PumpOutcome {
+    Reached,
+    TimedOut { audio_seen: u64 },
+}
+
+/// Receive + validate until the goal is met or the window elapses.
+/// Returning `Ok` never means "no violations" — those accumulate in
+/// `result.failures` as they're seen.
+async fn pump_until(
+    client: &mut WsClient,
+    state: &mut SessionState,
+    scenario: &Scenario,
+    validator: &MessageValidator,
+    result: &mut ScenarioResult,
+    window: Duration,
+    goal: PumpGoal,
+) -> Result<PumpOutcome> {
+    let deadline = Instant::now() + window;
+    // Audio totals are cumulative for the session — echo arrives
+    // concurrently while `send_audio` streams, so the goal may already
+    // be met before this step starts.
+    if let PumpGoal::AudioFrames(n) = &goal {
+        if state.frames_received >= *n {
+            return Ok(PumpOutcome::Reached);
+        }
+    }
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Ok(PumpOutcome::TimedOut {
+                audio_seen: state.frames_received,
+            });
+        }
+        let incoming = match timeout(remaining, client.recv()).await {
+            Err(_) => continue, // window elapsed; loop exits above
+            Ok(incoming) => incoming?,
+        };
+        let is_pong = matches!(incoming, Incoming::Pong);
+        let command = handle_incoming(incoming, state, scenario, validator, result)?;
+        if state.hangup {
+            finish_after_hangup(client, state).await?;
+            return Ok(PumpOutcome::Reached);
+        }
+        let reached = match &goal {
+            PumpGoal::AudioFrames(n) => state.frames_received >= *n,
+            PumpGoal::Command(want) => command.as_deref() == Some(want.as_str()),
+            PumpGoal::Pong => is_pong,
+            PumpGoal::Nothing => false,
+        };
+        if reached {
+            return Ok(PumpOutcome::Reached);
+        }
+    }
+}
+
+/// Validate one incoming frame; returns the command discriminator for
+/// text frames. Violations are recorded, not returned as `Err` — an `Err`
+/// here means the transport itself is unusable.
+fn handle_incoming(
+    incoming: Incoming,
+    state: &mut SessionState,
+    scenario: &Scenario,
+    validator: &MessageValidator,
+    result: &mut ScenarioResult,
+) -> Result<Option<String>> {
+    match incoming {
+        Incoming::Pong => Ok(None),
+        Incoming::Closed(frame) => {
+            bail!(
+                "server closed the connection mid-scenario ({}) — a server ends a call \
+                 with `hangup`, not a bare close (PROTOCOL.md §5.7)",
+                match frame {
+                    Some((code, reason)) if !reason.is_empty() =>
+                        format!("code {code}, reason `{reason}`"),
+                    Some((code, _)) => format!("code {code}"),
+                    None => "no close frame".to_string(),
+                }
+            );
+        }
+        Incoming::Binary(frame) => {
+            state.frames_received += 1;
+            result.audio_frames_received += 1;
+            if frame.len() != state.frame_bytes {
+                record_once(
+                    &mut result.failures,
+                    format!(
+                        "audio frame of {} bytes — every binary frame must be exactly one \
+                         20 ms chunk ({} bytes at {} Hz)",
+                        frame.len(),
+                        state.frame_bytes,
+                        scenario.session.sample_rate
+                    ),
+                );
+            }
+            // Pacing: a server may echo at our cadence or generate at real
+            // time, but must never flood. Bound = the larger of (frames we
+            // sent) and (real-time since open), plus configured slack.
+            let elapsed_frames = state.opened_at.elapsed().as_millis() as u64 / FRAME_MS;
+            let budget =
+                state.frames_sent.max(elapsed_frames) + scenario.session.pacing_slack_frames;
+            if state.frames_received > budget {
+                record_once(
+                    &mut result.failures,
+                    format!(
+                        "audio arriving faster than real time: {} frames received vs a budget \
+                         of {} (sent {}, elapsed ≈{} frames, slack {}) — outbound audio must \
+                         be paced (PROTOCOL.md §2.2)",
+                        state.frames_received,
+                        budget,
+                        state.frames_sent,
+                        elapsed_frames,
+                        scenario.session.pacing_slack_frames
+                    ),
+                );
+            }
+            Ok(None)
+        }
+        Incoming::Text(text) => {
+            result.commands_received += 1;
+            match validator.check(&text) {
+                Err(violation) => {
+                    result.failures.push(violation);
+                    Ok(None)
+                }
+                Ok(command) => {
+                    let name = command_name(&command);
+                    if let BridgeIn::Hangup { .. } = command {
+                        state.hangup = true;
+                    }
+                    Ok(Some(name.to_string()))
+                }
+            }
+        }
+    }
+}
+
+/// The daemon's reaction to a server `hangup`: `stop { server_hangup }`,
+/// then a clean close.
+async fn finish_after_hangup(client: &mut WsClient, state: &mut SessionState) -> Result<()> {
+    let seq = state.next_seq();
+    let stop = serde_json::json!({
+        "type": "stop",
+        "call_id": state.call_id,
+        "seq": seq,
+        "reason": "server_hangup",
+    });
+    client.send_text(stop.to_string()).await?;
+    client.close().await
+}
+
+/// Repeating a per-frame violation 200 times drowns the report; once per
+/// distinct message is enough.
+fn record_once(failures: &mut Vec<String>, message: String) {
+    if !failures.contains(&message) {
+        failures.push(message);
+    }
+}
+
+fn command_name(command: &BridgeIn) -> &'static str {
+    match command {
+        BridgeIn::Clear { .. } => "clear",
+        BridgeIn::Mark { .. } => "mark",
+        BridgeIn::Hangup { .. } => "hangup",
+        BridgeIn::Transfer { .. } => "transfer",
+        BridgeIn::SendDtmf { .. } => "send_dtmf",
+        BridgeIn::Mute { .. } => "mute",
+        BridgeIn::Unmute { .. } => "unmute",
+        BridgeIn::StartRecording { .. } => "start_recording",
+        BridgeIn::StopRecording { .. } => "stop_recording",
+        BridgeIn::PauseRecording { .. } => "pause_recording",
+        BridgeIn::ResumeRecording { .. } => "resume_recording",
+        BridgeIn::SetRecordingConsent { .. } => "set_recording_consent",
+        BridgeIn::Park { .. } => "park",
+        BridgeIn::ConferenceJoin { .. } => "conference_join",
+        BridgeIn::ConferenceLeave { .. } => "conference_leave",
+        BridgeIn::Hold { .. } => "hold",
+        BridgeIn::Resume { .. } => "resume",
+    }
+}
+
+fn step_name(step: &Step) -> &'static str {
+    match step {
+        Step::SendAudio { .. } => "send_audio",
+        Step::ExpectAudio { .. } => "expect_audio",
+        Step::SendEvent { .. } => "send_event",
+        Step::SendRaw { .. } => "send_raw",
+        Step::ExpectCommand { .. } => "expect_command",
+        Step::ExpectSilence { .. } => "expect_silence",
+        Step::Ping { .. } => "ping",
+        Step::Wait { .. } => "wait",
+        Step::SendStop { .. } => "send_stop",
+        Step::Close => "close",
+        Step::Reconnect => "reconnect",
+    }
+}
+
+/// One 20 ms PCM16-LE frame of a 1 kHz tone at modest volume — audibly
+/// non-silence if a human ever points a scenario at a real bot.
+fn tone_frame(frame_bytes: usize, sample_rate: u32) -> Vec<u8> {
+    let samples = frame_bytes / 2;
+    let mut out = Vec::with_capacity(frame_bytes);
+    for n in 0..samples {
+        let t = n as f32 / sample_rate as f32;
+        let s = (2.0 * std::f32::consts::PI * 1000.0 * t).sin();
+        let v = (s * 8000.0) as i16;
+        out.extend_from_slice(&v.to_le_bytes());
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scenario::Session;
+
+    fn state() -> SessionState {
+        SessionState {
+            call_id: "testkit-t".into(),
+            seq: 1,
+            frame_bytes: 320,
+            opened_at: Instant::now(),
+            frames_sent: 0,
+            frames_received: 0,
+            hangup: false,
+        }
+    }
+
+    #[test]
+    fn build_event_injects_envelope_and_type_checks() {
+        let mut s = state();
+        let text = build_event(
+            &mut s,
+            r#"{"type":"dtmf","digit":"5","duration_ms":160,"method":"rfc2833"}"#,
+            true,
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(v["call_id"], "testkit-t");
+        assert_eq!(v["seq"], 1);
+        assert_eq!(s.seq, 2);
+    }
+
+    #[test]
+    fn build_event_rejects_typos_for_typed_sends() {
+        let mut s = state();
+        let err = build_event(&mut s, r#"{"type":"dtmpf","digit":"5"}"#, true).unwrap_err();
+        assert!(format!("{err:#}").contains("BridgeOut"));
+        // ...but raw sends are allowed to be anything (that's their job).
+        build_event(&mut s, r#"{"type":"dtmpf","digit":"5"}"#, false).unwrap();
+    }
+
+    #[test]
+    fn tone_frame_is_exactly_one_frame() {
+        assert_eq!(tone_frame(320, 8000).len(), 320);
+        assert_eq!(tone_frame(640, 16000).len(), 640);
+    }
+
+    #[test]
+    fn violations_are_deduplicated() {
+        let mut failures = Vec::new();
+        record_once(&mut failures, "same".into());
+        record_once(&mut failures, "same".into());
+        record_once(&mut failures, "other".into());
+        assert_eq!(failures.len(), 2);
+    }
+
+    #[test]
+    fn session_defaults_are_sane() {
+        let s = Session::default();
+        assert_eq!(s.sample_rate, 8000);
+        assert_eq!(s.pacing_slack_frames, 25);
+    }
+}

--- a/crates/protocol-testkit/src/scenario.rs
+++ b/crates/protocol-testkit/src/scenario.rs
@@ -1,0 +1,198 @@
+//! Scenario files: a scripted call, declaratively.
+//!
+//! Bundled scenarios live in `crates/protocol-testkit/scenarios/*.toml`
+//! and are embedded in the binary; `--scenario-dir` loads additional
+//! ones from disk. See `docs/CONFORMANCE.md` for the file format.
+
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+
+/// The five bundled scenarios, embedded so the shipped binary is
+/// self-contained (DESIGN_PROTOCOL_SDKS §4).
+pub const BUNDLED: &[(&str, &str)] = &[
+    ("basic-echo", include_str!("../scenarios/basic-echo.toml")),
+    ("dtmf", include_str!("../scenarios/dtmf.toml")),
+    (
+        "recording-controls",
+        include_str!("../scenarios/recording-controls.toml"),
+    ),
+    (
+        "hangup-semantics",
+        include_str!("../scenarios/hangup-semantics.toml"),
+    ),
+    ("keepalive", include_str!("../scenarios/keepalive.toml")),
+];
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Scenario {
+    pub name: String,
+    pub description: String,
+    #[serde(default)]
+    pub session: Session,
+    pub steps: Vec<Step>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Session {
+    /// `8000` or `16000` — sets the exact binary frame size asserted on
+    /// every audio frame the server sends.
+    #[serde(default = "default_sample_rate")]
+    pub sample_rate: u32,
+    #[serde(default = "default_from")]
+    pub from: String,
+    #[serde(default = "default_to")]
+    pub to: String,
+    /// Extra frames of audio the server may send beyond real-time pacing
+    /// before it's a violation (500 ms of slack by default). Servers must
+    /// pace generated audio (PROTOCOL.md §2.2); echo servers mirror our
+    /// own cadence and never come near the bound.
+    #[serde(default = "default_pacing_slack")]
+    pub pacing_slack_frames: u64,
+}
+
+impl Default for Session {
+    fn default() -> Self {
+        Self {
+            sample_rate: default_sample_rate(),
+            from: default_from(),
+            to: default_to(),
+            pacing_slack_frames: default_pacing_slack(),
+        }
+    }
+}
+
+fn default_sample_rate() -> u32 {
+    8000
+}
+fn default_from() -> String {
+    "+13125551212".into()
+}
+fn default_to() -> String {
+    "5000".into()
+}
+fn default_pacing_slack() -> u64 {
+    25
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "action", rename_all = "snake_case", deny_unknown_fields)]
+pub enum Step {
+    /// Stream `frames` × 20 ms of paced audio (1 kHz tone), like the
+    /// daemon's RTP→WS path.
+    SendAudio { frames: u64 },
+    /// Expect the session's CUMULATIVE audio-frame total to reach
+    /// `min_frames` within `within_ms`. Cumulative because echo arrives
+    /// concurrently while `send_audio` streams; the total resets on
+    /// `reconnect` (new session).
+    ExpectAudio { min_frames: u64, within_ms: u64 },
+    /// Inject a daemon event. `json` is the message body WITHOUT
+    /// `call_id`/`seq` (the runner owns those) and must round-trip
+    /// through the daemon's real `BridgeOut` type — a typo'd scenario
+    /// fails loudly, not silently.
+    SendEvent { json: String },
+    /// Send a text frame verbatim — for unknown-message-tolerance probes.
+    /// `call_id`/`seq` are still injected if absent.
+    SendRaw { json: String },
+    /// Expect the server to send a specific command within `within_ms`.
+    /// With `optional = true`, absence is not a failure (presence is
+    /// still validated).
+    ExpectCommand {
+        #[serde(rename = "type")]
+        command: String,
+        within_ms: u64,
+        #[serde(default)]
+        optional: bool,
+    },
+    /// Expect NO text/binary traffic from the server for `ms`
+    /// (pongs excluded).
+    ExpectSilence { ms: u64 },
+    /// WS ping; expect a pong within `within_ms` (PROTOCOL.md §5.6:
+    /// "Servers MAY ping SiphonAI; SiphonAI always pongs" — and the
+    /// reverse must hold for the daemon's keepalive to work).
+    Ping { within_ms: u64 },
+    /// Idle for `ms`, still receiving + validating whatever arrives.
+    Wait { ms: u64 },
+    /// Send `stop { reason }` — the daemon's last message on a session.
+    SendStop { reason: String },
+    /// Clean close (1000) and wait for the server's close reply.
+    Close,
+    /// Drop the socket abruptly (no close handshake), then open a fresh
+    /// connection and send `start` with `reconnected: true` and `seq`
+    /// restarting at 0 — exactly what a daemon-side WS reconnect looks
+    /// like (PROTOCOL.md §5.7). The server must accept the session.
+    Reconnect,
+}
+
+pub fn parse(name_hint: &str, text: &str) -> Result<Scenario> {
+    let scenario: Scenario =
+        toml::from_str(text).with_context(|| format!("scenario `{name_hint}` failed to parse"))?;
+    if scenario.steps.is_empty() {
+        bail!("scenario `{}` has no steps", scenario.name);
+    }
+    if !matches!(scenario.session.sample_rate, 8000 | 16000) {
+        bail!(
+            "scenario `{}`: sample_rate must be 8000 or 16000",
+            scenario.name
+        );
+    }
+    Ok(scenario)
+}
+
+/// All bundled scenarios, parsed (a broken bundled file is a build bug —
+/// covered by the unit test below).
+pub fn bundled() -> Result<Vec<Scenario>> {
+    BUNDLED
+        .iter()
+        .map(|(name, text)| parse(name, text))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_bundled_scenarios_parse() {
+        let scenarios = bundled().expect("bundled scenarios parse");
+        assert_eq!(scenarios.len(), BUNDLED.len());
+        for ((file_name, _), scenario) in BUNDLED.iter().zip(&scenarios) {
+            assert_eq!(
+                &scenario.name, file_name,
+                "scenario `name` must match its file name"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_step_action_rejected() {
+        let err = parse(
+            "t",
+            r#"
+name = "t"
+description = "x"
+[[steps]]
+action = "explode"
+"#,
+        )
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("failed to parse"));
+    }
+
+    #[test]
+    fn bad_sample_rate_rejected() {
+        assert!(parse(
+            "t",
+            r#"
+name = "t"
+description = "x"
+[session]
+sample_rate = 44100
+[[steps]]
+action = "close"
+"#,
+        )
+        .is_err());
+    }
+}

--- a/crates/protocol-testkit/src/validate.rs
+++ b/crates/protocol-testkit/src/validate.rs
@@ -1,0 +1,117 @@
+//! Schema + typed validation of server→daemon messages.
+//!
+//! Two independent legs, both must pass (DESIGN_PROTOCOL_SDKS §4):
+//! 1. JSON Schema — the message validates against `$defs/BridgeIn` in the
+//!    committed `schemas/siphon-ai.v1.json` (embedded at compile time, so
+//!    the binary is self-contained for third parties).
+//! 2. Typed parse — the message deserializes into the daemon's real
+//!    [`BridgeIn`] type, exactly as the daemon itself would parse it.
+
+use anyhow::{Context, Result};
+use jsonschema::Validator;
+use serde_json::Value;
+use siphon_ai_bridge::BridgeIn;
+
+/// The protocol schema the daemon's CI regenerates and diffs on every PR.
+pub const SCHEMA_JSON: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../schemas/siphon-ai.v1.json"
+));
+
+pub struct MessageValidator {
+    bridge_in: Validator,
+}
+
+impl MessageValidator {
+    pub fn new() -> Result<Self> {
+        let schema: Value =
+            serde_json::from_str(SCHEMA_JSON).context("embedded protocol schema is not JSON")?;
+        let defs = schema
+            .get("$defs")
+            .context("embedded protocol schema has no $defs")?
+            .clone();
+        let wrapper = serde_json::json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "#/$defs/BridgeIn",
+            "$defs": defs,
+        });
+        let bridge_in = jsonschema::validator_for(&wrapper)
+            .context("embedded protocol schema failed to compile")?;
+        Ok(Self { bridge_in })
+    }
+
+    /// Validate one text frame from the candidate server. Returns the
+    /// parsed [`BridgeIn`] command on success; a human-readable violation
+    /// description on failure.
+    pub fn check(&self, text: &str) -> std::result::Result<BridgeIn, String> {
+        let value: Value = serde_json::from_str(text)
+            .map_err(|e| format!("not valid JSON: {e} — frame: {}", clip(text)))?;
+        let schema_errors: Vec<String> = self
+            .bridge_in
+            .iter_errors(&value)
+            .map(|e| format!("{} (at {})", e, e.instance_path()))
+            .collect();
+        if !schema_errors.is_empty() {
+            let ty = value.get("type").and_then(Value::as_str).unwrap_or("?");
+            return Err(format!(
+                "`{ty}` fails schema $defs/BridgeIn: {} — frame: {}",
+                schema_errors.join("; "),
+                clip(text),
+            ));
+        }
+        serde_json::from_value::<BridgeIn>(value).map_err(|e| {
+            format!(
+                "schema-valid but not parseable as BridgeIn: {e} — frame: {}",
+                clip(text)
+            )
+        })
+    }
+}
+
+fn clip(text: &str) -> String {
+    const MAX: usize = 200;
+    if text.len() <= MAX {
+        text.to_string()
+    } else {
+        let mut end = MAX;
+        while !text.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}…", &text[..end])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_commands_pass_both_legs() {
+        let v = MessageValidator::new().expect("schema compiles");
+        for cmd in [
+            r#"{"type":"hangup","call_id":"c1","cause":"normal"}"#,
+            r#"{"type":"mark","call_id":"c1","name":"greeting_done"}"#,
+            r#"{"type":"clear","call_id":"c1"}"#,
+            r#"{"type":"send_dtmf","call_id":"c1","digit":"5","duration_ms":160}"#,
+        ] {
+            v.check(cmd)
+                .unwrap_or_else(|e| panic!("{cmd} should pass: {e}"));
+        }
+    }
+
+    #[test]
+    fn unknown_type_fails() {
+        let v = MessageValidator::new().unwrap();
+        assert!(v.check(r#"{"type":"yodel","call_id":"c1"}"#).is_err());
+    }
+
+    #[test]
+    fn wrong_field_shape_fails() {
+        let v = MessageValidator::new().unwrap();
+        // digit must be a single char
+        assert!(v
+            .check(r#"{"type":"send_dtmf","call_id":"c1","digit":"55","duration_ms":160}"#)
+            .is_err());
+        assert!(v.check("{nope").is_err());
+    }
+}

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -1,0 +1,158 @@
+# Protocol conformance testkit
+
+`siphon-ai-testkit` plays the **daemon's side** of the WS bridge protocol
+(v1) against your WebSocket server — no SIP, no RTP, no SiphonAI daemon
+needed. It drives scripted calls from TOML scenarios and validates
+everything your server does:
+
+- every JSON message you send is validated against
+  [`schemas/siphon-ai.v1.json`](../schemas/siphon-ai.v1.json) **and**
+  parsed with the daemon's own wire types;
+- every binary frame must be exactly one 20 ms PCM16-LE chunk (320 B @
+  8 kHz, 640 B @ 16 kHz) and must not arrive faster than real time;
+- close semantics per [`PROTOCOL.md`](PROTOCOL.md) §5.7 — a bare close
+  mid-call is a violation; `hangup` is honored daemon-style
+  (`stop { server_hangup }` + clean close);
+- unknown-event tolerance — scenarios inject event types your server has
+  never seen; dying on them is a violation;
+- WS keepalive (§5.6) — your server (or whatever proxy fronts it) must
+  answer pings, or production calls get torn down as half-open.
+
+Exit code is `0` iff every scenario passed, so **"conformant with
+protocol v1" is a claim your CI can gate on**. SiphonAI's own CI runs the
+full set against both bundled SDK echo servers on every PR.
+
+## Quick start
+
+```sh
+cargo build -p siphon-ai-protocol-testkit   # or grab a release binary
+
+# your server listening on ws://localhost:8080/ …
+siphon-ai-testkit run ws://127.0.0.1:8080/
+
+siphon-ai-testkit run --scenario basic-echo ws://127.0.0.1:8080/
+siphon-ai-testkit run --report report.json ws://127.0.0.1:8080/
+siphon-ai-testkit list
+```
+
+Typical output:
+
+```text
+─── basic-echo ── OK (1465 ms, 74 audio frames, 0 commands)
+─── dtmf ── OK (965 ms, 49 audio frames, 0 commands)
+...
+PASS: 5 passed, 0 failed — target ws://127.0.0.1:8080/ is conformant with protocol v1
+```
+
+## Bundled scenarios
+
+| Scenario | What it proves |
+|---|---|
+| `basic-echo` | Audio in/out correctly framed; survives an unknown event type |
+| `dtmf` | DTMF events mid-stream don't disturb the session |
+| `recording-controls` | Recording lifecycle events tolerated; audio path unaffected |
+| `hangup-semantics` | Abrupt drop + `start { reconnected: true }` accepted; `hangup` honored if sent |
+| `keepalive` | Pings answered; session survives idle gaps |
+
+The bundled scenarios assume an **echo-shaped** server (it sends audio
+only in response to caller audio) — that's what makes pacing and silence
+assertions deterministic. A voicebot that speaks first will want its own
+scenario files (below).
+
+## Scenario files
+
+Bundled scenarios live in `crates/protocol-testkit/scenarios/` and are
+embedded in the binary. `--scenario-dir <dir>` loads additional `*.toml`
+files; a file whose `name` matches a bundled scenario replaces it.
+
+```toml
+name = "my-scenario"          # must match the file name (bundled) — free otherwise
+description = "One line for `list` output."
+
+[session]                     # all optional
+sample_rate = 8000            # 8000 | 16000 — sets the asserted frame size
+from = "+13125551212"         # start.from
+to = "5000"                   # start.to
+pacing_slack_frames = 25      # extra frames beyond real time before a pacing violation
+
+[[steps]]
+action = "send_audio"         # stream N × 20 ms tone frames, paced
+frames = 50
+```
+
+### Steps
+
+| `action` | Fields | Meaning |
+|---|---|---|
+| `send_audio` | `frames` | Stream N × 20 ms paced tone frames (the daemon's RTP→WS path) |
+| `expect_audio` | `min_frames`, `within_ms` | The session's **cumulative** received-frame total must reach `min_frames` (echo arrives concurrently with `send_audio`, so totals — not per-step counts — are race-free; the total resets on `reconnect`) |
+| `send_event` | `json` | Inject a daemon event. `call_id`/`seq` are added by the runner; the result must round-trip through the daemon's `BridgeOut` type, so a typo'd scenario fails loudly |
+| `send_raw` | `json` | Send a text frame verbatim (plus `call_id`/`seq` if absent) — the unknown-tolerance probe |
+| `expect_command` | `type`, `within_ms`, `optional` | Server must send this command in time (`optional = true`: absence is fine, presence is still validated) |
+| `expect_silence` | `ms` | No audio or commands for the window (pongs excluded) |
+| `ping` | `within_ms` | WS ping; a pong must come back in time |
+| `wait` | `ms` | Idle, still receiving + validating whatever arrives |
+| `send_stop` | `reason` | The daemon's last message on a session (`caller_hangup`, `server_hangup`, `transfer`, `ws_disconnect`, `park`, `error`) |
+| `close` | — | Clean close (1000), waiting for the server's close reply |
+| `reconnect` | — | Abrupt drop, fresh socket, `start { reconnected: true }` with `seq` restarting at 0 — a daemon-side WS reconnect (§5.7) |
+
+Two runner behaviors to know:
+
+- **Server `hangup` ends the scenario early, successfully.** The testkit
+  reacts like the daemon (`stop { server_hangup }` + clean close), skips
+  the remaining steps, and records a note. Reacting to a call by hanging
+  up is legal; scenarios therefore can't *require* a server not to.
+- **Every scenario has a 60 s hard deadline** so a wedged server fails
+  fast instead of hanging CI.
+
+## The JSON report
+
+`--report out.json` writes a machine-readable summary alongside the
+stdout text:
+
+```json
+{
+  "target": "ws://127.0.0.1:8080/",
+  "protocol_version": "1",
+  "testkit_version": "0.29.0",
+  "scenarios": [
+    {
+      "name": "basic-echo",
+      "passed": true,
+      "duration_ms": 1465,
+      "failures": [],
+      "notes": [],
+      "audio_frames_received": 74,
+      "commands_received": 0
+    }
+  ],
+  "passed": 5,
+  "failed": 0,
+  "conformant": true
+}
+```
+
+`conformant` mirrors the exit code. Failure strings are self-contained
+("audio frame of 160 bytes — every binary frame must be exactly one 20 ms
+chunk (320 bytes at 8000 Hz)"), so piping the report into a PR comment is
+enough for a developer to act on.
+
+## Gating your server's CI
+
+```yaml
+- run: cargo install --git https://github.com/thevoiceguy/siphon-ai siphon-ai-protocol-testkit
+# …start your server on :8080…
+- run: siphon-ai-testkit run ws://127.0.0.1:8080/ --report conformance.json
+```
+
+The testkit needs no daemon, no SIP stack, and no network beyond the
+one WebSocket — it's a single static-linkable binary.
+
+## Relationship to the SDKs
+
+The server SDKs ([`sdks/`](../sdks/)) and this testkit approach the same
+contract from opposite ends: the SDKs make it hard to *write* a
+non-conformant server, the testkit proves any server — SDK-based or
+hand-rolled in any language — actually *is* conformant. SiphonAI's CI
+runs the testkit against both SDK echo servers on every PR, which is also
+what keeps the testkit itself honest.

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -37,6 +37,12 @@ The SDKs in [`sdks/`](../sdks/) implement this protocol — typed events,
 paced 20 ms audio framing, close semantics — so you write handlers, not
 wire code. Their test suites validate against the schema and every
 example in this document, so they track the spec release-for-release.
+
+**Conformance testkit (0.29.0).** `siphon-ai-testkit` plays the daemon's
+side of this protocol against your server — scripted calls, every message
+schema-validated, framing/pacing/close semantics asserted — and exits
+non-zero on any violation, so "conformant with protocol v1" is a claim
+your CI can check. See [`CONFORMANCE.md`](CONFORMANCE.md).
 The binary audio framing is described by the schema's `x-binary-frames`
 annotation.
 

--- a/docs/design/DESIGN_PROTOCOL_SDKS.md
+++ b/docs/design/DESIGN_PROTOCOL_SDKS.md
@@ -195,3 +195,37 @@ the *daemon's* side of the protocol against a candidate WS server:
    running both SDK echo servers. Verify: testkit passes against both
    SDKs; deliberately-broken server fails with a readable report; theme
    retrospective back into this note.
+
+## 8. Retrospective (theme complete, 2026-07-10)
+
+Shipped as planned in three releases — v0.27.0 (#271/#272), v0.28.0
+(#273/#274), v0.29.0 (#276/release PR) — protocol stayed v1 throughout,
+zero daemon-binary changes across the whole theme. All six locked
+decisions held; nothing was reopened. What deviated or surprised:
+
+- **`oneOf` → `anyOf` at the schema top level** (v0.27): `hold`/`resume`/
+  `mark` exist in both directions, so exactly-one fails on
+  direction-ambiguous names. The corpus check caught it before release —
+  the §4.2 anti-drift loop paid for itself on day one. Direction-specific
+  validation (`$defs/BridgeOut` / `$defs/BridgeIn`) is the documented
+  answer.
+- **The SDKs found no protocol bugs** — expected, since 0.13/0.14 closed
+  the doc↔impl drift — but the corpus tests immediately constrain every
+  future protocol PR three ways (Rust types, schema, two SDKs), which was
+  the point.
+- **npm `file:` deps are symlinks, not packs** (v0.29 CI): the TS SDK
+  must be `npm install`ed in its own directory (building `dist/` via
+  `prepare`) before anything that depends on it — a fresh-checkout-only
+  failure that local verification with a warm tree can't see. Fixed in
+  the conformance job + vendoring docs.
+- **Testkit `expect_audio` had to be cumulative-per-session**: echo
+  arrives concurrently with `send_audio`, so per-step frame counts race.
+  Found live against the real echo server, not in unit tests — scenario
+  semantics need end-to-end verification like everything else.
+- **One new Rust dep per sub-item** held: `schemars` (v0.27, dev-path
+  feature) and `jsonschema` (v0.29, testkit-only). The daemon's dep tree
+  is unchanged.
+
+Deferred, still open: registry publishing (PyPI/npm — D4), SDK migration
+of the remaining examples (deepgram-node's hand-rolled re-framer would
+shrink ~100 lines), Go/Java SDKs (the schema is the extension point).

--- a/examples/echo-ws-server-node/README.md
+++ b/examples/echo-ws-server-node/README.md
@@ -12,7 +12,11 @@ This is the Node twin of
 ## Run
 
 ```bash
-npm install     # builds the in-repo SDK via its prepare script
+# One-time: build the in-repo SDK (npm links `file:` deps rather than
+# packing them, so the SDK needs its own install + tsc build first).
+(cd ../../sdks/typescript && npm install)
+
+npm install
 node server.mjs --bind 0.0.0.0:8080
 ```
 

--- a/examples/echo-ws-server-node/server.mjs
+++ b/examples/echo-ws-server-node/server.mjs
@@ -10,7 +10,8 @@
  * the SIPp test-harness knobs; this one stays minimal.
  *
  * Run:
- *   npm install          # builds the in-repo SDK via its prepare script
+ *   (cd ../../sdks/typescript && npm install)   # one-time: build the SDK
+ *   npm install
  *   node server.mjs --bind 0.0.0.0:8080
  */
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -13,9 +13,11 @@ and plays back whatever you send; STT/LLM/TTS are your handler's business.
 Not yet on npm — install from the repo (vendorable):
 
 ```bash
+# One-time in the checkout: install + build the SDK in place (npm links
+# local folder deps rather than packing them, so `dist/` must exist).
+(cd sdks/typescript && npm install)
+
 npm install ./sdks/typescript
-# or from a checkout URL:
-npm install "github:thevoiceguy/siphon-ai#main" --workspace sdks/typescript
 ```
 
 Requires Node ≥ 20. Sole runtime dependency: `ws`.


### PR DESCRIPTION
Final release of the P1 **Protocol SDKs & machine-readable schemas** theme (`docs/design/DESIGN_PROTOCOL_SDKS.md` §4, locked D5). Follows #271 (v0.27.0 schema) and #273 (v0.28.0 SDKs).

## What

New **`crates/protocol-testkit`** (bin `siphon-ai-testkit`) — plays the *daemon's* side of WS protocol v1 against any candidate server, no SIP/RTP/daemon needed:

```
$ siphon-ai-testkit run ws://127.0.0.1:8080/
─── basic-echo ── OK (1465 ms, 74 audio frames, 0 commands)
...
PASS: 5 passed, 0 failed — target ws://127.0.0.1:8080/ is conformant with protocol v1
```

- **Reuses the real wire types**: sends the daemon's own `BridgeOut::Start`, injects events by round-tripping scenario JSON through `BridgeOut` (typo'd scenarios fail loudly); its own thin tungstenite client (deliberately not the call-machinery-entangled `bridge::conn`).
- **Every server message validated twice**: against `$defs/BridgeIn` in the embedded `schemas/siphon-ai.v1.json` (**`jsonschema` crate = the release's one new dep** — test-tooling only, never linked into the daemon) *and* by parsing into the real `BridgeIn`. Binary frames must be exactly one 20 ms chunk, never faster than real time. Bare close mid-call flagged (§5.7); server `hangup` honored daemon-style.
- **5 bundled TOML scenarios** (embedded; `--scenario-dir` extends/overrides): `basic-echo` (+unknown-event tolerance), `dtmf`, `recording-controls`, `hangup-semantics` (abrupt drop → `start{reconnected:true}` acceptance), `keepalive`. `expect_audio` asserts a **cumulative** session total — echo arrives concurrently with `send_audio`, per-step counts race (caught during live verification).
- **Exit code + JSON report** (`--report`): *"conformant with protocol v1"* is now a claim third parties can gate their CI on.
- **New `conformance` CI job** runs the full set against **both SDK echo servers** — the first job to put the Node echo server in CI (the theme's last DoD item).
- Docs: `docs/CONFORMANCE.md` (usage, scenario format, report schema) + pointers in PROTOCOL.md §1, README, CLAUDE.md.

## Verification

- 13 unit tests (scenario parsing, validator legs, report, event builder).
- **5/5 scenarios green against `echo-ws-server-python` AND `echo-ws-server-node`** — both `hangup-semantics` branches exercised (python echo hangs up the reconnected call; node echo carries on).
- **Deliberately-broken server** (half-size frames, schema-invalid `send_dtmf`, unknown command type, bare close at 2 s) fails **all four ways** with readable, self-contained messages and exit 1.
- `cargo test --workspace` green (53 test binaries), clippy `-D warnings` + fmt clean.
- Protocol stays **v1**; the daemon binary is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)