### PR TITLE
chore(release): 0.29.0 — protocol conformance testkit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.0] - 2026-07-10
+
+### Added
+
+- **Protocol conformance testkit — `siphon-ai-testkit`** (P1 "Protocol
+  SDKs & machine-readable schemas", final release — the theme is
+  complete). A new `crates/protocol-testkit` binary that plays the
+  *daemon's* side of WS protocol v1 against any candidate server — no
+  SIP, no RTP, no daemon needed. Scripted calls from TOML scenarios
+  (five bundled: `basic-echo`, `dtmf`, `recording-controls`,
+  `hangup-semantics`, `keepalive`; `--scenario-dir` adds your own) with
+  every server message validated against `schemas/siphon-ai.v1.json`
+  **and** the daemon's real wire types, exact 20 ms frame sizing and
+  real-time pacing asserted, §5.7 close semantics enforced (bare close
+  mid-call is a violation; server `hangup` is honored daemon-style),
+  unknown-event tolerance probed, and WS keepalive checked. Exit code 0
+  iff conformant plus a JSON report (`--report`) — *"conformant with
+  protocol v1"* is now a claim any third-party server's CI can gate on.
+  See `docs/CONFORMANCE.md`.
+- **`conformance` CI job** — every PR now runs the full scenario set
+  against **both** SDK echo servers (`echo-ws-server-python`,
+  `echo-ws-server-node`) — the first CI coverage for the Node echo
+  server, closing the theme's last verification gap.
+
+The WS protocol stays **v1**; the daemon binary is unchanged (the
+testkit's one new dependency, the `jsonschema` validator, is
+test-tooling only).
+
 ## [0.28.0] - 2026-07-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3309,7 +3309,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3355,7 +3355,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "base64",
  "bytes",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3410,7 +3410,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "regex",
  "serde",
@@ -3429,7 +3429,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3473,7 +3473,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "base64",
  "hmac",
@@ -3496,7 +3496,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3538,7 +3538,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "aes-gcm",
  "audiopus",
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "regex",
  "serde",
@@ -3564,7 +3564,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "schemars",
  "serde",
@@ -3574,7 +3574,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3601,7 +3601,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -3619,7 +3619,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3648,7 +3648,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.28.0.** Production-deployed against real carriers
+**Current release: v0.29.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -151,9 +151,11 @@ barrier and make the contract testable:
 - **Server SDKs** — ✅ **delivered in v0.28.0** (`sdks/python` +
   `sdks/typescript`: typed events, paced 20 ms framing, close semantics;
   schema/corpus-validated in CI; echo examples rewritten on them).
-- **Conformance suite + protocol testkit** — a harness that replays a
-  scripted call against a candidate WS server and validates its responses,
-  plus a local mock daemon for SDK CI.
+- **Conformance suite + protocol testkit** — ✅ **delivered in v0.29.0**
+  (`siphon-ai-testkit`: TOML-scripted calls against a candidate WS server,
+  schema-validating assertions, JSON report; the `conformance` CI job runs
+  it against both SDK echo servers). **Theme complete** — see the
+  retrospective in `docs/design/DESIGN_PROTOCOL_SDKS.md` §8.
 
 ---
 


### PR DESCRIPTION
Release housekeeping for **v0.29.0** (feature landed in #276):

- Workspace version 0.28.0 → 0.29.0 (+ `Cargo.lock` refresh)
- CHANGELOG 0.29.0 entry (testkit + conformance CI job)
- README current-release marker
- ROADMAP: conformance testkit ✅ v0.29.0 — **the Protocol SDKs & machine-readable schemas theme is complete** (retrospective in `docs/design/DESIGN_PROTOCOL_SDKS.md` §8)

Tag `v0.29.0` follows the merge (auto-cut release pipeline per `RELEASING.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)