### PR TITLE
chore(release): 0.30.0 — per-call quality telemetry (rx rtp_stats + MOS + CDR v4 quality)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.0] - 2026-07-13
+
+### Added
+
+- **Local receive-side RTP stats on `rtp_stats`** (P1 "Per-call quality
+  telemetry", release 1 of 2). The `rtp_stats` WS event was
+  remote-reported only — RTCP Receiver Reports describing how the far
+  end hears the stream SiphonAI *sends*. It now also carries the side
+  SiphonAI *receives*, measured locally by forge-media
+  (`MediaStatsSnapshot`, forge-media#81; pin bumped to `5fa76fb38675`):
+  additive optional `rx_jitter_ms` (RFC 3550 §6.4.1 interarrival
+  jitter at the negotiated RTP clock), and cumulative
+  `rx_packets_received` / `rx_packets_lost` (sequence-gap transit
+  loss; late arrivals repair it) / `rx_packets_out_of_order` /
+  `rx_packets_duplicate`. A congested path is often asymmetric —
+  the two viewpoints on one event tell "they hear us badly" from
+  "we hear them badly". The WS protocol stays **v1**; schema
+  regenerated and both server SDKs updated in lockstep.
+- **`mos_estimate`** on `rtp_stats`: transport-only MOS-CQE in
+  `[1.0, 5.0]` via the simplified E-model over local RX jitter/loss
+  plus RTCP RTT — the same math heplify-server applies to SiphonAI's
+  HEP QoS chunks, so Homer-side and WS-side scores agree. `null`
+  until RX data exists.
+- **CDR `quality` block** — **CDR `version` 3 → 4** (additive-optional
+  block; bumped per the 0.9.5 new-block precedent). Per-call summary
+  in the record operators already ingest: `first_audio_out_ms` (WS
+  `start` on the wire → first server audio frame reaching playout —
+  the STT/LLM/TTS first-token latency; closes OPERATIONS.md Q5),
+  `barge_in_count` (`auto_clear` firings + server `clear` commands;
+  closes Q8), `avg/max_jitter_ms`, `avg/max_packet_loss_ratio`,
+  `avg_rtcp_rtt_ms` (RTCP-RR aggregates), end-of-call `rx_packets_*`
+  totals, and `mos_estimate_min/avg`. Unmeasured fields are omitted,
+  not zeroed; the block is omitted entirely for calls that never went
+  active.
+- **Metrics**: `siphon_ai_rtp_rx_jitter_ms` and
+  `siphon_ai_rtp_mos_estimate` histograms, recorded on every
+  `rtp_stats` emission once RX data exists.
+
+### Changed
+
+- The daemon now configures forge-media to publish local media-stats
+  snapshots at a fixed 5 s cadence (RTCP-conventional). They feed both
+  the `rtp_stats` `rx_*` fields and the CDR `quality` block, so the
+  CDR populates even on routes with WS `rtp_stats` emission disabled.
+  Cost: one broadcast event per receiving leg per 5 s.
+
 ## [0.29.0] - 2026-07-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3309,7 +3309,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3355,7 +3355,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "base64",
  "bytes",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3410,7 +3410,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "regex",
  "serde",
@@ -3429,7 +3429,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3473,7 +3473,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "base64",
  "hmac",
@@ -3496,7 +3496,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3538,7 +3538,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "aes-gcm",
  "audiopus",
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "regex",
  "serde",
@@ -3564,7 +3564,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "schemars",
  "serde",
@@ -3574,7 +3574,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3601,7 +3601,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -3619,7 +3619,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3648,7 +3648,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.29.0"
+version = "0.30.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.29.0.** Production-deployed against real carriers
+**Current release: v0.30.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a


### PR DESCRIPTION
Release-prep for **v0.30.0** per RELEASING.md: workspace version 0.29.0 → 0.30.0 (+ Cargo.lock), CHANGELOG `[Unreleased]` → `[0.30.0] - 2026-07-13`, README current-release marker.

Contents: #279 (rtp_stats rx_* fields + mos_estimate on protocol v1; CDR v4 `quality` block closing OPERATIONS Q5/Q8) on top of forge-media#81.

After merge: tag `v0.30.0` on main → release workflow builds/publishes.

Verified locally: `check-version-consistency.py` (plain + `--tag v0.30.0`), `extract-changelog.py 0.30.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)