### PR TITLE
feat: quality history records + live stats endpoint + Loki pipeline (v0.31.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3324,6 +3324,7 @@ dependencies = [
  "opentelemetry",
  "rustls",
  "rustls-pemfile",
+ "serde_json",
  "sip-core",
  "sip-dns",
  "sip-parse",
@@ -3338,6 +3339,7 @@ dependencies = [
  "siphon-ai-core",
  "siphon-ai-http",
  "siphon-ai-media-glue",
+ "siphon-ai-quality",
  "siphon-ai-recording",
  "siphon-ai-routes",
  "siphon-ai-sip-glue",
@@ -3444,6 +3446,7 @@ dependencies = [
  "metrics 0.23.1",
  "metrics-exporter-prometheus",
  "parking_lot",
+ "serde",
  "serde_json",
  "sip-core",
  "sip-dialog",
@@ -3457,6 +3460,7 @@ dependencies = [
  "siphon-ai-cdr",
  "siphon-ai-http",
  "siphon-ai-media-glue",
+ "siphon-ai-quality",
  "siphon-ai-recording",
  "siphon-ai-routes",
  "siphon-ai-security",
@@ -3534,6 +3538,24 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "siphon-ai-quality"
+version = "0.30.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "metrics 0.23.1",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "siphon-ai-cdr",
+ "siphon-ai-http",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/http",
     "crates/media-glue",
     "crates/protocol-testkit",
+    "crates/quality",
     "crates/recording",
     "crates/routes",
     "crates/security",
@@ -33,6 +34,7 @@ homepage = "https://github.com/thevoiceguy/siphon-ai"
 siphon-ai-audit       = { path = "crates/audit" }
 siphon-ai-bridge      = { path = "crates/bridge" }
 siphon-ai-cdr         = { path = "crates/cdr" }
+siphon-ai-quality     = { path = "crates/quality" }
 siphon-ai-config      = { path = "crates/config" }
 siphon-ai-core        = { path = "crates/core" }
 siphon-ai-http        = { path = "crates/http" }

--- a/bins/siphon-ai/Cargo.toml
+++ b/bins/siphon-ai/Cargo.toml
@@ -29,6 +29,8 @@ metrics.workspace          = true
 
 # Internal — the daemon composes every layer.
 siphon-ai-audit.workspace      = true
+siphon-ai-quality.workspace    = true
+serde_json.workspace           = true
 siphon-ai-bridge.workspace     = true
 siphon-ai-cdr.workspace        = true
 siphon-ai-config.workspace     = true

--- a/bins/siphon-ai/src/main.rs
+++ b/bins/siphon-ai/src/main.rs
@@ -471,6 +471,16 @@ fn print_check_summary(path: &Path, config: &Config) {
         }
         enabled.push(format!("audit({})", sinks.join("+")));
     }
+    if config.quality.enabled {
+        let mut sinks = Vec::new();
+        if config.quality.file.is_some() {
+            sinks.push("file");
+        }
+        if config.quality.webhook.is_some() {
+            sinks.push("webhook");
+        }
+        enabled.push(format!("quality({})", sinks.join("+")));
+    }
     if config.conference.enabled {
         enabled.push("conference".into());
     }

--- a/bins/siphon-ai/src/reload.rs
+++ b/bins/siphon-ai/src/reload.rs
@@ -192,6 +192,10 @@ pub fn restart_fingerprints(c: &Config) -> Vec<(&'static str, String)> {
         // address. The token hashes are what change; no cleartext.
         ("[admin]", fp_hash(&c.admin)),
         ("[hep]", fp_hash(&c.hep)),
+        // Quality-record sinks + the per-call record cadence live behind
+        // a process-global OnceLock facade (0.31.0) — set once at
+        // startup, not swappable.
+        ("[quality]", fp_hash(&c.quality)),
         // `[shutdown].drain_timeout_secs` is read once at `run()` entry,
         // so a reload can't change an in-flight drain window —
         // restart-required.

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -91,6 +91,10 @@ use siphon_ai_core::{
     ParkTimeoutAction as CoreParkTimeoutAction, StaticCredentials,
 };
 use siphon_ai_media_glue::MediaSetup;
+use siphon_ai_quality::{
+    FanoutSink as QualityFanoutSink, FileSink as QualityFileSink, HttpSink as QualityHttpSink,
+    HttpSinkConfig as QualityHttpSinkConfig, QualitySinkHandle,
+};
 use siphon_ai_sip_glue::{
     DialogTerminatorHandle, DrainFlag, RegisterSourceResolver, RegistrationEntry,
     RegistrationManager, RoutingHandler,
@@ -211,6 +215,7 @@ impl Runtime {
             observability,
             webhooks,
             audit,
+            quality,
             hep,
             park,
             admin,
@@ -317,6 +322,22 @@ impl Runtime {
         } else {
             None
         };
+
+        // ─── Quality history records (0.31.0) ──────────────────────
+        // Build the JSONL + signed-webhook sinks and install the
+        // process-wide facade; per-call record tasks in `core` sample
+        // the tap's quality feed at `[quality].interval_secs` and emit
+        // through it. When `[quality].enabled = false` nothing is
+        // installed and no record task is spawned. Restart-required —
+        // not swapped on SIGHUP in this release.
+        if quality.enabled {
+            let sink = build_quality_sink(&quality).await?;
+            siphon_ai_quality::install(sink, quality.interval);
+            info!(
+                interval_secs = quality.interval.as_secs(),
+                "quality history records active"
+            );
+        }
 
         // ─── Forge media stack ──────────────────────────────────────
         // One process-wide EventBus. Forge's session manager publishes
@@ -1021,6 +1042,12 @@ impl Runtime {
                 )) as AdminPark
             }),
             drain: Some(drain_status_fn),
+            // Live quality probe (0.31.0). Installed unconditionally —
+            // the tracker runs for every call regardless of [quality].
+            quality_stats: Some(Arc::new(|call_id: &str| {
+                siphon_ai_core::quality_live::snapshot(call_id)
+                    .and_then(|row| serde_json::to_value(row).ok())
+            })),
         };
         let observability_server =
             build_observability(observability, readiness.clone(), prometheus_handle).await?;
@@ -1999,6 +2026,46 @@ pub(crate) async fn build_audit_sink(cfg: &AuditConfig) -> Result<AuditSinkHandl
     } else {
         info!(allowlist = cfg.events.len(), "audit event allowlist active");
         Arc::new(AuditFilteredSink::new(fanned, cfg.events.clone())) as AuditSinkHandle
+    })
+}
+
+pub(crate) async fn build_quality_sink(
+    cfg: &siphon_ai_config::QualityConfig,
+) -> Result<QualitySinkHandle> {
+    let mut sinks: Vec<QualitySinkHandle> = Vec::new();
+
+    if let Some(file_cfg) = &cfg.file {
+        let sink = QualityFileSink::open(&file_cfg.path)
+            .await
+            .with_context(|| format!("open quality-record file {}", file_cfg.path.display()))?;
+        info!(path = %file_cfg.path.display(), "quality file sink active");
+        sinks.push(Arc::new(sink) as QualitySinkHandle);
+    }
+    if let Some(webhook_cfg) = &cfg.webhook {
+        let sink = QualityHttpSink::new(QualityHttpSinkConfig {
+            url: webhook_cfg.url.clone(),
+            auth_header: webhook_cfg.auth_header.clone(),
+            secret: webhook_cfg.secret.clone(),
+            spool_dir: webhook_cfg.spool_dir.clone(),
+            retry_max: webhook_cfg.retry_max,
+            timeout_ms: webhook_cfg.timeout.as_millis() as u64,
+        })
+        .map_err(|e| anyhow!("quality webhook client build failed: {e}"))?;
+        info!(
+            url = %webhook_cfg.url,
+            signed = webhook_cfg.secret.is_some(),
+            spooled = webhook_cfg.spool_dir.is_some(),
+            "quality webhook sink active"
+        );
+        sinks.push(Arc::new(sink) as QualitySinkHandle);
+    }
+
+    // Fan out to every enabled sub-sink; unwrap the single-sink case to
+    // skip the fan-out indirection.
+    Ok(if sinks.len() == 1 {
+        sinks.pop().unwrap()
+    } else {
+        Arc::new(QualityFanoutSink::new(sinks)) as QualitySinkHandle
     })
 }
 

--- a/crates/config/src/compile.rs
+++ b/crates/config/src/compile.rs
@@ -75,6 +75,8 @@ pub struct Config {
     pub webhooks: WebhooksConfig,
     /// `[audit]` — signed audit-event stream (0.20.0).
     pub audit: AuditConfig,
+    /// `[quality]` — per-call quality history records (0.31.0).
+    pub quality: QualityConfig,
     pub hep: HepConfig,
     /// `[admin]` — the authenticated admin API. `None` when no `[admin]`
     /// block is configured, in which case `/admin/*` is not served.
@@ -538,6 +540,37 @@ pub struct AuditWebhookConfig {
     pub timeout: Duration,
 }
 
+/// Resolved `[quality]` plan (0.31.0). The daemon translates this into
+/// real `siphon-ai-quality` sinks at runtime (config doesn't depend on
+/// the quality crate — same as CDR and audit).
+#[derive(Debug, Clone, Default)]
+pub struct QualityConfig {
+    /// `[quality].enabled`. Even when true, file and webhook are
+    /// individually off until their `enabled = true` is set.
+    pub enabled: bool,
+    /// Per-call record cadence.
+    pub interval: Duration,
+    pub file: Option<QualityFileConfig>,
+    pub webhook: Option<QualityWebhookConfig>,
+}
+
+#[derive(Debug, Clone)]
+pub struct QualityFileConfig {
+    pub path: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub struct QualityWebhookConfig {
+    pub url: String,
+    pub auth_header: Option<String>,
+    /// HMAC-SHA256 signing secret. `None` ⇒ unsigned deliveries.
+    pub secret: Option<String>,
+    /// Durable spool directory. `None` ⇒ best-effort delivery.
+    pub spool_dir: Option<String>,
+    pub retry_max: u32,
+    pub timeout: Duration,
+}
+
 #[derive(Debug, Clone)]
 pub struct NodeConfig {
     pub id: String,
@@ -936,6 +969,18 @@ pub enum CompileError {
     #[error("[audit].enabled = true but neither [audit.file] nor [audit.webhook] is enabled; enable at least one sink or set [audit].enabled = false")]
     AuditNoSink,
 
+    #[error("[quality.file].path is required when [quality.file].enabled = true")]
+    QualityFilePathRequired,
+
+    #[error("[quality.webhook].url is required when [quality.webhook].enabled = true")]
+    QualityWebhookUrlRequired,
+
+    #[error("[quality].enabled = true but neither [quality.file] nor [quality.webhook] is enabled; enable at least one sink or set [quality].enabled = false")]
+    QualityNoSink,
+
+    #[error("[quality].interval_secs must be at least 1 (got {0})")]
+    QualityIntervalZero(u64),
+
     #[error("[observability].http_listen {0:?} is not a valid socket address: {1}")]
     BadObservabilityListen(String, std::net::AddrParseError),
 
@@ -1111,6 +1156,7 @@ pub fn compile(raw: RawConfig) -> Result<Config, CompileError> {
     let observability = compile_observability(raw.observability)?;
     let webhooks = compile_webhooks(raw.webhooks)?;
     let audit = compile_audit(raw.audit)?;
+    let quality = compile_quality(raw.quality)?;
     let hep = compile_hep(raw.hep)?;
     let admin = compile_admin(raw.admin)?;
     let shutdown = compile_shutdown(raw.shutdown);
@@ -1207,6 +1253,7 @@ pub fn compile(raw: RawConfig) -> Result<Config, CompileError> {
         observability,
         webhooks,
         audit,
+        quality,
         hep,
         admin,
         shutdown,
@@ -2796,6 +2843,129 @@ fn compile_audit(raw: crate::raw::RawAudit) -> Result<AuditConfig, CompileError>
         file,
         webhook,
     })
+}
+
+fn compile_quality(raw: crate::raw::RawQuality) -> Result<QualityConfig, CompileError> {
+    if !raw.enabled {
+        // Master switch off; sub-block config parsed but ignored,
+        // matching the [cdr] / [audit] pattern.
+        return Ok(QualityConfig::default());
+    }
+    let interval_secs = raw.interval_secs.unwrap_or(30);
+    if interval_secs == 0 {
+        return Err(CompileError::QualityIntervalZero(0));
+    }
+    let file = if raw.file.enabled {
+        let path = raw.file.path.ok_or(CompileError::QualityFilePathRequired)?;
+        if path.is_empty() {
+            return Err(CompileError::QualityFilePathRequired);
+        }
+        Some(QualityFileConfig {
+            path: PathBuf::from(path),
+        })
+    } else {
+        None
+    };
+    let webhook = if raw.webhook.enabled {
+        let url = raw
+            .webhook
+            .url
+            .ok_or(CompileError::QualityWebhookUrlRequired)?;
+        if url.is_empty() {
+            return Err(CompileError::QualityWebhookUrlRequired);
+        }
+        Some(QualityWebhookConfig {
+            url,
+            auth_header: raw.webhook.auth_header.filter(|s| !s.is_empty()),
+            secret: raw.webhook.secret.filter(|s| !s.is_empty()),
+            spool_dir: raw.webhook.spool_dir.filter(|s| !s.is_empty()),
+            retry_max: raw.webhook.retry_max.unwrap_or(3),
+            timeout: Duration::from_millis(raw.webhook.timeout_ms.unwrap_or(5000)),
+        })
+    } else {
+        None
+    };
+    // `[quality].enabled = true` with no sink enabled is almost
+    // certainly a mistake. Fail loud rather than silently sample
+    // records into a null sink.
+    if file.is_none() && webhook.is_none() {
+        return Err(CompileError::QualityNoSink);
+    }
+    Ok(QualityConfig {
+        enabled: true,
+        interval: Duration::from_secs(interval_secs),
+        file,
+        webhook,
+    })
+}
+
+#[cfg(test)]
+mod quality_tests {
+    use super::{compile_quality, CompileError};
+    use crate::raw::{RawQuality, RawQualityFile, RawQualityWebhook};
+
+    fn base() -> RawQuality {
+        RawQuality {
+            enabled: true,
+            interval_secs: None,
+            file: RawQualityFile::default(),
+            webhook: RawQualityWebhook::default(),
+        }
+    }
+
+    #[test]
+    fn disabled_compiles_to_default() {
+        let cfg = compile_quality(RawQuality::default()).unwrap();
+        assert!(!cfg.enabled);
+    }
+
+    #[test]
+    fn enabled_without_sinks_fails_loud() {
+        let err = compile_quality(base()).unwrap_err();
+        assert!(matches!(err, CompileError::QualityNoSink));
+    }
+
+    #[test]
+    fn file_sink_requires_path() {
+        let mut raw = base();
+        raw.file.enabled = true;
+        let err = compile_quality(raw).unwrap_err();
+        assert!(matches!(err, CompileError::QualityFilePathRequired));
+    }
+
+    #[test]
+    fn webhook_requires_url() {
+        let mut raw = base();
+        raw.webhook.enabled = true;
+        let err = compile_quality(raw).unwrap_err();
+        assert!(matches!(err, CompileError::QualityWebhookUrlRequired));
+    }
+
+    #[test]
+    fn zero_interval_rejected() {
+        let mut raw = base();
+        raw.interval_secs = Some(0);
+        raw.file.enabled = true;
+        raw.file.path = Some("/tmp/q.jsonl".into());
+        let err = compile_quality(raw).unwrap_err();
+        assert!(matches!(err, CompileError::QualityIntervalZero(0)));
+    }
+
+    #[test]
+    fn full_config_compiles_with_defaults() {
+        let mut raw = base();
+        raw.file.enabled = true;
+        raw.file.path = Some("/tmp/q.jsonl".into());
+        raw.webhook.enabled = true;
+        raw.webhook.url = Some("https://example.com/q".into());
+        let cfg = compile_quality(raw).unwrap();
+        assert!(cfg.enabled);
+        assert_eq!(cfg.interval, std::time::Duration::from_secs(30));
+        assert!(cfg.file.is_some());
+        let wh = cfg.webhook.unwrap();
+        assert_eq!(wh.retry_max, 3);
+        assert_eq!(wh.timeout, std::time::Duration::from_millis(5000));
+    }
 }
 
 #[cfg(test)]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -37,9 +37,10 @@ pub use compile::{
     compile, AdminConfig, AdminTlsConfig, AuditConfig, AuditFileConfig, AuditWebhookConfig,
     CdrConfig, CdrFileConfig, CdrWebhookConfig, CompileError, ConferenceConfig, Config, Gateway,
     GatewayCredentials, HepConfig, MediaConfig, NodeConfig, ObservabilityConfig, OtlpConfig,
-    OutboundConfig, ParkConfig, ParkTimeoutAction, RegisterConfig, SecurityConfig, ShutdownConfig,
-    SipAdmissionConfig, SipAuthConfig, SipAuthUser, SipConfig, SipTlsConfig, SipTransport,
-    TrunkCidr, TrunkCidrParseError, TrunkConfig, WebhooksConfig,
+    OutboundConfig, ParkConfig, ParkTimeoutAction, QualityConfig, QualityFileConfig,
+    QualityWebhookConfig, RegisterConfig, SecurityConfig, ShutdownConfig, SipAdmissionConfig,
+    SipAuthConfig, SipAuthUser, SipConfig, SipTlsConfig, SipTransport, TrunkCidr,
+    TrunkCidrParseError, TrunkConfig, WebhooksConfig,
 };
 pub use env::{expand, expand_cow, EnvError, EnvSource, ProcessEnv};
 pub use raw::{

--- a/crates/config/src/raw.rs
+++ b/crates/config/src/raw.rs
@@ -85,6 +85,11 @@ pub struct RawConfig {
     #[serde(default)]
     pub audit: RawAudit,
 
+    /// `[quality]` — per-call quality history records (0.31.0). Off by
+    /// default.
+    #[serde(default)]
+    pub quality: RawQuality,
+
     #[serde(default)]
     pub hep: RawHep,
 
@@ -920,6 +925,69 @@ pub struct RawAuditWebhook {
     #[serde(default)]
     pub secret: Option<String>,
     /// Optional durable spool directory. When set, an event that
+    /// exhausts the in-memory retry budget is persisted here and
+    /// retried by a background worker that survives restarts.
+    #[serde(default)]
+    pub spool_dir: Option<String>,
+    #[serde(default)]
+    pub retry_max: Option<u32>,
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
+}
+
+/// `[quality]` — per-call quality history records (0.31.0). Periodic +
+/// end-of-call quality summaries (same shape as the CDR `quality`
+/// block) shipped to a JSONL file (`[quality.file]`) and/or an
+/// HMAC-signed webhook (`[quality.webhook]`); enable either or both.
+/// Off by default. Restart-required (not hot-reloaded on SIGHUP).
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawQuality {
+    /// Master switch. When `false` no record task runs and the
+    /// sub-blocks are parsed but ignored.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Per-call record cadence in seconds. Default 30. The final
+    /// end-of-call record is always emitted (when the call measured
+    /// anything), regardless of cadence.
+    #[serde(default)]
+    pub interval_secs: Option<u64>,
+
+    #[serde(default)]
+    pub file: RawQualityFile,
+
+    #[serde(default)]
+    pub webhook: RawQualityWebhook,
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawQualityFile {
+    #[serde(default)]
+    pub enabled: bool,
+    /// Required when `enabled = true`. Append-only JSONL; the parent
+    /// directory must exist at startup (the daemon does NOT mkdir).
+    #[serde(default)]
+    pub path: Option<String>,
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawQualityWebhook {
+    #[serde(default)]
+    pub enabled: bool,
+    /// Required when `enabled = true`.
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional `Authorization` header value, sent verbatim.
+    #[serde(default)]
+    pub auth_header: Option<String>,
+    /// HMAC-SHA256 signing secret. `${VAR}` / `${file:}` / `${cred:}`
+    /// resolved by the loader.
+    #[serde(default)]
+    pub secret: Option<String>,
+    /// Optional durable spool directory. When set, a record that
     /// exhausts the in-memory retry budget is persisted here and
     /// retried by a background worker that survives restarts.
     #[serde(default)]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -21,12 +21,14 @@ metrics.workspace     = true
 # Hot-swappable outbound gateway table for SIGHUP reload (0.12.1).
 arc-swap = "1"
 # Serialize the verstat verdict to JSON for the HEP3 Verstat chunk.
+serde.workspace       = true
 serde_json.workspace  = true
 
 # Internal crates
 siphon-ai-audit.workspace      = true
 siphon-ai-bridge.workspace     = true
 siphon-ai-cdr.workspace        = true
+siphon-ai-quality.workspace = true
 siphon-ai-media-glue.workspace = true
 siphon-ai-recording.workspace  = true
 siphon-ai-routes.workspace     = true

--- a/crates/core/src/call.rs
+++ b/crates/core/src/call.rs
@@ -270,6 +270,103 @@ pub struct QualityOutcome {
     pub stats: QualitySummary,
 }
 
+impl QualityOutcome {
+    /// Map the tap's live report + the bridge-connected epoch onto the
+    /// outcome shape. `None` when the call never measured anything —
+    /// the CDR omits the block and the record task emits nothing.
+    /// Shared by the CDR build and the quality record task (0.31.0) so
+    /// both feeds carry identical numbers.
+    pub(crate) fn from_report(
+        report: QualityReport,
+        connected_at: Option<Instant>,
+    ) -> Option<Self> {
+        let measured = !report.stats.is_empty()
+            || report.barge_in_count > 0
+            || report.first_audio_at.is_some();
+        measured.then(|| QualityOutcome {
+            first_audio_out_ms: match (report.first_audio_at, connected_at) {
+                (Some(first), Some(connected)) => {
+                    Some(first.saturating_duration_since(connected).as_millis() as u64)
+                }
+                _ => None,
+            },
+            barge_in_count: report.barge_in_count,
+            stats: report.stats,
+        })
+    }
+}
+
+/// Per-call quality history sampler (0.31.0). Emits one record per
+/// `interval` while the call measures anything, plus a final record
+/// when the tap winds down (its `quality_tx` drops → the watch
+/// closes). Runs entirely off the audio path: it only reads two watch
+/// channels at record cadence.
+async fn quality_record_task(
+    call_id: CallId,
+    mut quality_rx: tokio::sync::watch::Receiver<QualityReport>,
+    epoch_rx: tokio::sync::watch::Receiver<Option<Instant>>,
+    interval: Duration,
+) {
+    let mut seq: u64 = 0;
+    let mut tick = tokio::time::interval(interval);
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    tick.tick().await; // consume the immediate first tick
+
+    let emit = |kind: siphon_ai_quality::RecordKind,
+                seq: u64,
+                report: QualityReport,
+                connected_at: Option<Instant>|
+     -> bool {
+        // Skip records with nothing measured (e.g. early ticks before
+        // the first media-stats snapshot) — an empty record tells an
+        // operator nothing a CDR's absence doesn't.
+        let Some(outcome) = QualityOutcome::from_report(report, connected_at) else {
+            return false;
+        };
+        siphon_ai_quality::emit(siphon_ai_quality::QualityRecord {
+            version: siphon_ai_quality::QUALITY_RECORD_VERSION,
+            kind,
+            call_id: call_id.as_str().to_string(),
+            ts: Utc::now(),
+            seq,
+            quality: crate::acceptor::quality_info(outcome),
+        });
+        true
+    };
+
+    loop {
+        tokio::select! {
+            _ = tick.tick() => {
+                if emit(
+                    siphon_ai_quality::RecordKind::Interval,
+                    seq,
+                    *quality_rx.borrow(),
+                    *epoch_rx.borrow(),
+                ) {
+                    seq += 1;
+                }
+            }
+            res = quality_rx.changed() => {
+                match res {
+                    // A fresh report — just mark it seen; the tick arm
+                    // samples on cadence.
+                    Ok(()) => {}
+                    // Tap dropped its sender → call is winding down.
+                    Err(_) => {
+                        emit(
+                            siphon_ai_quality::RecordKind::Final,
+                            seq,
+                            *quality_rx.borrow(),
+                            *epoch_rx.borrow(),
+                        );
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Recording-consent audit trail surfaced on [`CallOutcome`] → CDR
 /// (0.26.0). `announced`/`announcement_ms` come from the daemon-played
 /// announcement; `server` is whatever the WS server reported via
@@ -846,9 +943,43 @@ impl CallController {
         // controller's `run` span so the WS-bridge, media-tap, and recording
         // spans nest under it — one trace per call in OTLP (0.22.0).
         // Readiness carries the "start on the wire" Instant — the epoch
-        // for the CDR `first_audio_out_ms` (0.30.0). Polled lazily at
-        // outcome build (`try_recv`), never awaited in the loop.
-        let (bridge_ready_tx, mut bridge_connected_rx) = oneshot::channel();
+        // for `first_audio_out_ms` (0.30.0). A tiny forwarder fans the
+        // oneshot into a watch so both the CDR build (below) and the
+        // quality record task (0.31.0) can read it without racing over
+        // a single consumer.
+        let (bridge_ready_tx, bridge_ready_rx) = oneshot::channel();
+        let (epoch_tx, epoch_rx) = tokio::sync::watch::channel(None::<Instant>);
+        tokio::spawn(async move {
+            if let Ok(connected_at) = bridge_ready_rx.await {
+                let _ = epoch_tx.send(Some(connected_at));
+            }
+            // Bridge died before ready → epoch stays None; forwarder ends.
+        });
+        // Live-stats registration (0.31.0): expose this call's quality
+        // feed to `GET /admin/v1/calls/{id}/stats` for the call's
+        // lifetime. RAII — dropping the guard on any exit path from
+        // `run` deregisters.
+        let _quality_live_guard = crate::quality_live::LiveQualityGuard::register(
+            call_id.as_str(),
+            quality_rx.clone(),
+            epoch_rx.clone(),
+        );
+        // Quality history records (0.31.0): when `[quality]` is
+        // configured, sample the tap's quality feed on the configured
+        // cadence + emit a final record at teardown. The task ends
+        // itself when the tap drops its `quality_tx` (watch closes), so
+        // its lifetime is bounded by the call — no JoinHandle needed.
+        if let Some(record_interval) = siphon_ai_quality::record_interval() {
+            tokio::spawn(
+                quality_record_task(
+                    call_id.clone(),
+                    quality_rx.clone(),
+                    epoch_rx.clone(),
+                    record_interval,
+                )
+                .instrument(tracing::Span::current()),
+            );
+        }
         let mut bridge_task: JoinHandle<Result<DisconnectReason, BridgeError>> = tokio::spawn(
             connect_and_run_with_ready(bridge, start, channels, Some(bridge_ready_tx))
                 .instrument(tracing::Span::current()),
@@ -2088,22 +2219,7 @@ impl CallController {
         // Latest quality state from the tap + the first session's
         // connect stamp. Omit the whole block when nothing measured —
         // a call that never went active has no quality story.
-        let quality_summary = {
-            let report = *quality_rx.borrow();
-            let measured = !report.stats.is_empty()
-                || report.barge_in_count > 0
-                || report.first_audio_at.is_some();
-            measured.then(|| QualityOutcome {
-                first_audio_out_ms: match (report.first_audio_at, bridge_connected_rx.try_recv()) {
-                    (Some(first), Ok(connected)) => {
-                        Some(first.saturating_duration_since(connected).as_millis() as u64)
-                    }
-                    _ => None,
-                },
-                barge_in_count: report.barge_in_count,
-                stats: report.stats,
-            })
-        };
+        let quality_summary = QualityOutcome::from_report(*quality_rx.borrow(), *epoch_rx.borrow());
 
         Ok(CallOutcome {
             call_id,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod outbound;
 pub mod outbound_service;
 pub mod park;
 pub mod park_admin;
+pub mod quality_live;
 pub mod registry;
 pub mod transfer;
 

--- a/crates/core/src/quality_live.rs
+++ b/crates/core/src/quality_live.rs
@@ -1,0 +1,136 @@
+//! Live per-call quality snapshots for `GET /admin/v1/calls/{id}/stats`
+//! (0.31.0) — the "what is this call doing *right now*" probe.
+//!
+//! Each `CallController` registers its quality + connect-epoch watch
+//! receivers here for the call's lifetime (RAII guard, so teardown can
+//! never leak an entry). An admin request resolves the bridge
+//! `call_id`, borrows the latest [`QualityReport`] from the watch, and
+//! serializes it in the same shape as the CDR `quality` block — one
+//! mapping (`acceptor::quality_info`) feeds the CDR, the history
+//! records, and this endpoint, so all three always agree.
+//!
+//! This is an admin-read registry in the spirit of
+//! [`crate::registry::CallRegistry`]: nothing on a call's audio or
+//! control path ever reads another call's entry (CLAUDE.md §4.4), and
+//! the lock is touched once per call setup/teardown plus per admin
+//! request — never per frame.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+use std::time::Instant;
+
+use chrono::{DateTime, Utc};
+use parking_lot::RwLock;
+use serde::Serialize;
+use siphon_ai_media_glue::QualityReport;
+use tokio::sync::watch;
+
+use crate::call::QualityOutcome;
+
+struct LiveEntry {
+    quality: watch::Receiver<QualityReport>,
+    epoch: watch::Receiver<Option<Instant>>,
+}
+
+fn live() -> &'static RwLock<HashMap<String, LiveEntry>> {
+    static LIVE: OnceLock<RwLock<HashMap<String, LiveEntry>>> = OnceLock::new();
+    LIVE.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+/// RAII registration: created by the `CallController` at setup,
+/// deregisters on drop (i.e. on any teardown path, including panics
+/// unwinding the controller task).
+pub struct LiveQualityGuard {
+    call_id: String,
+}
+
+impl LiveQualityGuard {
+    pub fn register(
+        call_id: &str,
+        quality: watch::Receiver<QualityReport>,
+        epoch: watch::Receiver<Option<Instant>>,
+    ) -> Self {
+        live()
+            .write()
+            .insert(call_id.to_string(), LiveEntry { quality, epoch });
+        Self {
+            call_id: call_id.to_string(),
+        }
+    }
+}
+
+impl Drop for LiveQualityGuard {
+    fn drop(&mut self) {
+        live().write().remove(&self.call_id);
+    }
+}
+
+/// What the admin endpoint serves: the CDR `quality` shape plus
+/// probe framing. `quality` fields are individually omitted when
+/// unmeasured — a young call legitimately answers `{}`-ish.
+#[derive(Debug, Clone, Serialize)]
+pub struct LiveQualityStats {
+    pub call_id: String,
+    /// When this snapshot was taken (i.e. now — it's a live probe).
+    pub sampled_at: DateTime<Utc>,
+    #[serde(flatten)]
+    pub quality: siphon_ai_cdr::QualityInfo,
+}
+
+/// Snapshot one active call's current quality state. `None` when no
+/// active call has that bridge `call_id` (ended calls answer through
+/// the CDR / history records instead).
+pub fn snapshot(call_id: &str) -> Option<LiveQualityStats> {
+    let (report, connected_at) = {
+        let map = live().read();
+        let entry = map.get(call_id)?;
+        let report = *entry.quality.borrow();
+        let connected_at = *entry.epoch.borrow();
+        (report, connected_at)
+    };
+    // Unlike the CDR (which omits an unmeasured block entirely), an
+    // existing call always answers — with whatever is known so far.
+    let outcome = QualityOutcome::from_report(report, connected_at).unwrap_or(QualityOutcome {
+        first_audio_out_ms: None,
+        barge_in_count: 0,
+        stats: Default::default(),
+    });
+    Some(LiveQualityStats {
+        call_id: call_id.to_string(),
+        sampled_at: Utc::now(),
+        quality: crate::acceptor::quality_info(outcome),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn unknown_call_returns_none() {
+        assert!(snapshot("siphon-nope").is_none());
+    }
+
+    #[tokio::test]
+    async fn registered_call_snapshots_and_guard_cleans_up() {
+        let (qtx, qrx) = watch::channel(QualityReport::default());
+        let (_etx, erx) = watch::channel(None);
+        let guard = LiveQualityGuard::register("siphon-live-1", qrx, erx);
+
+        // Young call: exists, empty quality fields.
+        let row = snapshot("siphon-live-1").expect("registered");
+        assert_eq!(row.call_id, "siphon-live-1");
+        assert_eq!(row.quality.barge_in_count, 0);
+
+        // A tap update shows up on the next probe.
+        qtx.send_replace(QualityReport {
+            barge_in_count: 2,
+            ..Default::default()
+        });
+        let row = snapshot("siphon-live-1").expect("registered");
+        assert_eq!(row.quality.barge_in_count, 2);
+
+        drop(guard);
+        assert!(snapshot("siphon-live-1").is_none(), "guard deregisters");
+    }
+}

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -85,6 +85,8 @@ pub enum SinkKind {
     Cdr,
     /// `siphon-ai-audit` admin/security audit events.
     Audit,
+    /// `siphon-ai-quality` per-call quality records (0.31.0).
+    Quality,
 }
 
 impl SinkKind {
@@ -94,6 +96,7 @@ impl SinkKind {
             SinkKind::Lifecycle => "lifecycle",
             SinkKind::Cdr => "cdr",
             SinkKind::Audit => "audit",
+            SinkKind::Quality => "quality",
         }
     }
 }

--- a/crates/quality/Cargo.toml
+++ b/crates/quality/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name        = "siphon-ai-quality"
+description = "Per-call quality history records: interval + end-of-call quality summaries shipped to a JSONL file and/or an HMAC-signed webhook."
+version.workspace      = true
+edition.workspace      = true
+rust-version.workspace = true
+license.workspace      = true
+authors.workspace      = true
+repository.workspace   = true
+
+[dependencies]
+tokio.workspace       = true
+async-trait.workspace = true
+serde.workspace       = true
+serde_json.workspace  = true
+chrono.workspace      = true
+thiserror.workspace   = true
+tracing.workspace     = true
+metrics.workspace     = true
+# Internal — the record's stats payload IS the CDR `quality` block, so
+# the two shapes can never drift.
+siphon-ai-cdr.workspace = true
+# Internal — shared retrying JSON-POST transport (HMAC signing, spool,
+# idempotency, delivery metrics) behind the webhook sink.
+siphon-ai-http.workspace = true
+
+[dev-dependencies]
+parking_lot.workspace = true
+tempfile              = "3"

--- a/crates/quality/src/facade.rs
+++ b/crates/quality/src/facade.rs
@@ -1,0 +1,78 @@
+//! Process-wide quality-record facade.
+//!
+//! Records are emitted by a per-call worker task deep inside the
+//! `CallController`; threading a sink handle plus the record cadence
+//! through the acceptor / outbound-service constructor chains would
+//! touch a lot of signatures for a best-effort, off-hot-path
+//! observability concern. Like the audit facade (0.20.0) — and the
+//! `metrics` / `tracing` facades before it — a single process-global
+//! handle is [`install`]ed once at startup.
+//!
+//! Contract:
+//! - Until [`install`] runs (`[quality]` disabled, or pre-startup),
+//!   [`emit`] is a cheap no-op and [`record_interval`] returns `None`
+//!   (the controller then spawns no record task at all).
+//! - [`emit`] is fire-and-forget: it spawns the sink's async `emit` so
+//!   the calling task never blocks on file or network I/O. It counts
+//!   `siphon_ai_quality_records_total{kind}` on the way through.
+//! - `[quality]` is restart-required (no SIGHUP swap in this release);
+//!   the global handle is set exactly once.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use tracing::debug;
+
+use crate::record::QualityRecord;
+use crate::sink::QualitySinkHandle;
+
+struct Installed {
+    sink: QualitySinkHandle,
+    interval: Duration,
+}
+
+static GLOBAL: OnceLock<Installed> = OnceLock::new();
+
+/// Install the process-wide quality sink and the per-call record
+/// cadence. First call wins; a second call is ignored and logged (the
+/// daemon installs once at startup). Returns `true` if this call
+/// installed the sink.
+pub fn install(sink: QualitySinkHandle, interval: Duration) -> bool {
+    let mut installed = false;
+    let _ = GLOBAL.get_or_init(|| {
+        installed = true;
+        Installed { sink, interval }
+    });
+    if !installed {
+        debug!("quality sink already installed; ignoring second install");
+    }
+    installed
+}
+
+/// Emit a quality record through the installed sink. No-op (no spawn)
+/// when `[quality]` is not configured. Never blocks the caller.
+pub fn emit(record: QualityRecord) {
+    if let Some(g) = GLOBAL.get() {
+        metrics::counter!(
+            "siphon_ai_quality_records_total",
+            "kind" => record.kind.as_str()
+        )
+        .increment(1);
+        let sink = g.sink.clone();
+        tokio::spawn(async move {
+            sink.emit(record).await;
+        });
+    }
+}
+
+/// The configured per-call record cadence, or `None` when `[quality]`
+/// is off — the controller uses this to decide whether to spawn a
+/// record task for the call at all.
+pub fn record_interval() -> Option<Duration> {
+    GLOBAL.get().map(|g| g.interval)
+}
+
+/// Whether a quality sink has been installed.
+pub fn is_enabled() -> bool {
+    GLOBAL.get().is_some()
+}

--- a/crates/quality/src/file.rs
+++ b/crates/quality/src/file.rs
@@ -1,0 +1,150 @@
+//! Append-only JSONL quality-record file sink.
+//!
+//! One record = one JSON object on one line, LF-terminated. The usual
+//! ingestion path is a log shipper (Vector / Filebeat / Fluent Bit)
+//! tailing this file into Loki / Elasticsearch / a TSDB — see the
+//! ingestion guide in `docs/OPERATIONS.md`.
+//!
+//! ## Concurrency & atomicity
+//!
+//! Identical to the CDR / audit file sinks: the handle lives behind a
+//! `tokio::sync::Mutex<BufWriter>`; each `emit` takes the lock, writes
+//! one line + LF, flushes, drops the lock. Record volume is low (one
+//! per call per `[quality].interval_secs`, not per-frame), so the lock
+//! is never meaningfully contended.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use thiserror::Error;
+use tokio::fs::{File, OpenOptions};
+use tokio::io::{AsyncWriteExt, BufWriter};
+use tokio::sync::Mutex;
+use tracing::{debug, warn};
+
+use crate::record::QualityRecord;
+use crate::sink::QualitySink;
+
+#[derive(Debug, Error)]
+pub enum FileSinkError {
+    /// Couldn't open / create the target file. Surfaced at
+    /// construction time so a misconfigured path fails loud at
+    /// startup, not on the first record.
+    #[error("failed to open quality-record file {path:?}: {source}")]
+    Open {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+pub struct FileSink {
+    path: PathBuf,
+    writer: Arc<Mutex<BufWriter<File>>>,
+}
+
+impl std::fmt::Debug for FileSink {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Tokio's BufWriter doesn't impl Debug; redact it.
+        f.debug_struct("FileSink")
+            .field("path", &self.path)
+            .finish_non_exhaustive()
+    }
+}
+
+impl FileSink {
+    /// Open / create the file in append mode. The parent directory must
+    /// exist — no `mkdir -p`, matching the CDR and audit file sinks:
+    /// the daemon typically runs under a service account and failing
+    /// loudly on a bad path is the right behaviour.
+    pub async fn open(path: impl AsRef<Path>) -> Result<Self, FileSinkError> {
+        let path = path.as_ref().to_path_buf();
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .await
+            .map_err(|source| FileSinkError::Open {
+                path: path.clone(),
+                source,
+            })?;
+        debug!(path = %path.display(), "opened quality-record file");
+        Ok(Self {
+            path,
+            writer: Arc::new(Mutex::new(BufWriter::new(file))),
+        })
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+#[async_trait]
+impl QualitySink for FileSink {
+    async fn emit(&self, record: QualityRecord) {
+        // Serialize outside the lock — the lock only guards the handle.
+        let line = match serde_json::to_string(&record) {
+            Ok(s) => s,
+            Err(e) => {
+                // Unreachable for our schema; record it and keep going.
+                warn!(call_id = %record.call_id, error = %e, "quality record JSON serialize failed");
+                return;
+            }
+        };
+
+        let mut guard = self.writer.lock().await;
+        if let Err(e) = guard.write_all(line.as_bytes()).await {
+            warn!(path = %self.path.display(), error = %e, "quality-record file write failed");
+            return;
+        }
+        if let Err(e) = guard.write_all(b"\n").await {
+            warn!(path = %self.path.display(), error = %e, "quality-record file write (newline) failed");
+            return;
+        }
+        if let Err(e) = guard.flush().await {
+            warn!(path = %self.path.display(), error = %e, "quality-record file flush failed");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::record::{RecordKind, QUALITY_RECORD_VERSION};
+
+    fn rec(kind: RecordKind, seq: u64) -> QualityRecord {
+        QualityRecord {
+            version: QUALITY_RECORD_VERSION,
+            kind,
+            call_id: "siphon-file-test".into(),
+            ts: chrono::Utc::now(),
+            seq,
+            quality: Default::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn appends_one_json_line_per_record() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let sink = FileSink::open(tmp.path()).await.unwrap();
+        sink.emit(rec(RecordKind::Interval, 0)).await;
+        sink.emit(rec(RecordKind::Final, 1)).await;
+
+        let body = tokio::fs::read_to_string(tmp.path()).await.unwrap();
+        let lines: Vec<&str> = body.lines().collect();
+        assert_eq!(lines.len(), 2);
+        let first: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(first["kind"], "interval");
+        assert_eq!(first["seq"], 0);
+        let second: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(second["kind"], "final");
+    }
+
+    #[tokio::test]
+    async fn open_fails_loud_on_bad_path() {
+        let err = FileSink::open("/nonexistent-dir-xyz/quality.jsonl").await;
+        assert!(err.is_err());
+    }
+}

--- a/crates/quality/src/http.rs
+++ b/crates/quality/src/http.rs
@@ -1,0 +1,111 @@
+//! Signed quality-record webhook sink — a thin [`QualitySink`] adapter
+//! over [`siphon_ai_http::RetryingPoster`], the same transport the
+//! lifecycle-webhook, CDR, and audit sinks use.
+//!
+//! Every delivery is HMAC-SHA256 signed (`X-SiphonAI-Signature`) when a
+//! secret is configured, carries an `X-SiphonAI-Event-Id` for
+//! idempotency, retries transient failures with exponential backoff,
+//! and — with a `spool_dir` — survives restarts. All of that lives in
+//! `siphon-ai-http`; this file only maps config and stamps the log
+//! label.
+
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use siphon_ai_http::{
+    BuildError, PostLog, PosterConfig, RetryingPoster, SinkKind, DEFAULT_RETRY_MAX,
+    DEFAULT_TIMEOUT_MS,
+};
+
+use crate::record::QualityRecord;
+use crate::sink::QualitySink;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HttpSinkConfig {
+    pub url: String,
+    /// Optional `Authorization` header value, sent verbatim.
+    #[serde(default)]
+    pub auth_header: Option<String>,
+    /// Optional HMAC-SHA256 signing secret. When set, every delivery
+    /// carries `X-SiphonAI-Signature: t=<unix>,v1=<hex>`. `None` ⇒
+    /// unsigned.
+    #[serde(default)]
+    pub secret: Option<String>,
+    /// Optional durable spool directory. When set, a delivery that
+    /// exhausts the in-memory retry budget is persisted here and
+    /// re-attempted by a background worker that survives restarts.
+    #[serde(default)]
+    pub spool_dir: Option<String>,
+    /// Maximum retries on transient failure. `0` = post once.
+    #[serde(default = "default_retry_max")]
+    pub retry_max: u32,
+    /// Per-attempt timeout, in milliseconds.
+    #[serde(default = "default_timeout_ms")]
+    pub timeout_ms: u64,
+}
+
+fn default_retry_max() -> u32 {
+    DEFAULT_RETRY_MAX
+}
+fn default_timeout_ms() -> u64 {
+    DEFAULT_TIMEOUT_MS
+}
+
+impl HttpSinkConfig {
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            auth_header: None,
+            secret: None,
+            spool_dir: None,
+            retry_max: DEFAULT_RETRY_MAX,
+            timeout_ms: DEFAULT_TIMEOUT_MS,
+        }
+    }
+}
+
+/// HTTP quality-record sink. Cheap to clone (the inner
+/// [`RetryingPoster`] holds a reference-counted client).
+#[derive(Debug, Clone)]
+pub struct HttpSink {
+    poster: RetryingPoster,
+}
+
+impl HttpSink {
+    pub fn new(config: HttpSinkConfig) -> Result<Self, BuildError> {
+        let poster = RetryingPoster::new(PosterConfig {
+            url: config.url,
+            auth_header: config.auth_header,
+            retry_max: config.retry_max,
+            timeout_ms: config.timeout_ms,
+            secret: config.secret,
+            spool_dir: config.spool_dir.map(PathBuf::from),
+            sink: SinkKind::Quality,
+        })?;
+        // Start the drain worker once, on the single poster we build
+        // (clones made per-emit don't re-spawn it).
+        poster.spawn_drainer();
+        Ok(Self { poster })
+    }
+}
+
+#[async_trait]
+impl QualitySink for HttpSink {
+    async fn emit(&self, record: QualityRecord) {
+        // Spawn so the emitting task never blocks on network I/O.
+        let poster = self.poster.clone();
+        tokio::spawn(async move {
+            poster
+                .post(
+                    &record,
+                    PostLog {
+                        kind: "quality record",
+                        call_id: record.call_id.as_str(),
+                        detail: Some(record.kind.as_str()),
+                    },
+                )
+                .await;
+        });
+    }
+}

--- a/crates/quality/src/lib.rs
+++ b/crates/quality/src/lib.rs
@@ -1,0 +1,36 @@
+//! Per-call quality history records (0.31.0): a clean, signed, durable
+//! feed of quality summaries operators ingest into their own store
+//! (Loki / Influx / a TSDB) — SiphonAI ships records, it does not run a
+//! database. Second half of the per-call quality telemetry theme; see
+//! `docs/design/DESIGN_QUALITY_TELEMETRY.md` (D3).
+//!
+//! ## Pipeline
+//!
+//! ```text
+//!   per-call record task (core) ─► quality::emit(QualityRecord)
+//!        │   (process-global facade, installed from [quality])
+//!        ▼
+//!   QualitySink ─┬─► FileSink   (append-only JSONL, on-box)
+//!                └─► HttpSink   (HMAC-signed POST, durable spool)
+//! ```
+//!
+//! One record per call per `[quality].interval_secs`, plus a final
+//! end-of-call summary. The stats payload is the CDR `quality` block
+//! (`siphon_ai_cdr::QualityInfo`) verbatim — flattened into the record
+//! so the CDR and the history feed can never drift.
+//!
+//! Per CLAUDE.md §4.7 sinks are best-effort and never block the call
+//! path: records are sampled from the tap's watch feed by a per-call
+//! worker task, and every sink write happens off the emitting task.
+
+pub mod facade;
+pub mod file;
+pub mod http;
+pub mod record;
+pub mod sink;
+
+pub use facade::{emit, install, is_enabled, record_interval};
+pub use file::{FileSink, FileSinkError};
+pub use http::{HttpSink, HttpSinkConfig};
+pub use record::{QualityRecord, RecordKind, QUALITY_RECORD_VERSION};
+pub use sink::{FanoutSink, NullSink, QualitySink, QualitySinkHandle};

--- a/crates/quality/src/record.rs
+++ b/crates/quality/src/record.rs
@@ -1,0 +1,122 @@
+//! The on-the-wire quality record.
+//!
+//! Shape = the CDR `quality` block plus record framing
+//! (`call_id` / `ts` / `seq` / `kind`), per the locked design (D3).
+//! Reusing [`siphon_ai_cdr::QualityInfo`] as the flattened payload
+//! guarantees the history feed and the CDR agree field-for-field.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use siphon_ai_cdr::QualityInfo;
+
+/// Schema version of the quality record. Follows the CDR rules
+/// (CLAUDE.md §7.7): additive optional fields don't bump; anything a
+/// strict parser could choke on does.
+pub const QUALITY_RECORD_VERSION: u32 = 1;
+
+/// Whether this record is a mid-call sample or the end-of-call summary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecordKind {
+    /// Periodic sample at `[quality].interval_secs` cadence. Counters
+    /// inside are cumulative-since-call-start, not per-interval deltas.
+    Interval,
+    /// Final summary, emitted once when the call's media tap winds
+    /// down. Field-for-field the same numbers the CDR `quality` block
+    /// carries for the call.
+    Final,
+}
+
+impl RecordKind {
+    /// Stable low-cardinality metric label.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Interval => "interval",
+            Self::Final => "final",
+        }
+    }
+}
+
+/// One quality record: framing + the flattened CDR quality payload.
+/// Serialised as a single JSON object on a single line for JSONL
+/// sinks.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct QualityRecord {
+    /// Schema version ([`QUALITY_RECORD_VERSION`]).
+    pub version: u32,
+    /// Sample or end-of-call summary.
+    pub kind: RecordKind,
+    /// SiphonAI bridge call id — the same one on the WS `start`
+    /// message and the CDR, so records join against both.
+    pub call_id: String,
+    /// When this record was sampled.
+    pub ts: DateTime<Utc>,
+    /// Per-call record counter, starting at 0. Monotonic within a
+    /// call; the final record carries the next value in sequence.
+    pub seq: u64,
+    /// The quality numbers, identical in shape to the CDR `quality`
+    /// block (unmeasured fields omitted, not zeroed).
+    #[serde(flatten)]
+    pub quality: QualityInfo,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_quality() -> QualityInfo {
+        QualityInfo {
+            first_audio_out_ms: Some(742),
+            barge_in_count: 3,
+            avg_jitter_ms: Some(11.5),
+            max_jitter_ms: Some(30.0),
+            avg_packet_loss_ratio: Some(0.004),
+            max_packet_loss_ratio: Some(0.02),
+            avg_rtcp_rtt_ms: None,
+            rx_packets_received: Some(14_820),
+            rx_packets_lost: Some(12),
+            rx_packets_out_of_order: Some(3),
+            rx_packets_duplicate: Some(0),
+            mos_estimate_min: Some(3.9),
+            mos_estimate_avg: Some(4.3),
+        }
+    }
+
+    #[test]
+    fn record_flattens_quality_fields_to_top_level() {
+        let rec = QualityRecord {
+            version: QUALITY_RECORD_VERSION,
+            kind: RecordKind::Interval,
+            call_id: "siphon-abc".into(),
+            ts: Utc::now(),
+            seq: 4,
+            quality: sample_quality(),
+        };
+        let v = serde_json::to_value(&rec).unwrap();
+        // Framing + payload live side by side — no nested "quality"
+        // object (that's the CDR's shape; the record IS the block).
+        assert_eq!(v["kind"], "interval");
+        assert_eq!(v["call_id"], "siphon-abc");
+        assert_eq!(v["seq"], 4);
+        assert_eq!(v["rx_packets_received"], 14_820);
+        assert_eq!(v["barge_in_count"], 3);
+        assert!(v.get("quality").is_none());
+        // Unmeasured fields omitted, not null.
+        assert!(v.get("avg_rtcp_rtt_ms").is_none());
+    }
+
+    #[test]
+    fn record_round_trips() {
+        let rec = QualityRecord {
+            version: QUALITY_RECORD_VERSION,
+            kind: RecordKind::Final,
+            call_id: "siphon-xyz".into(),
+            ts: Utc::now(),
+            seq: 9,
+            quality: sample_quality(),
+        };
+        let json = serde_json::to_string(&rec).unwrap();
+        let back: QualityRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, rec);
+    }
+}

--- a/crates/quality/src/sink.rs
+++ b/crates/quality/src/sink.rs
@@ -1,0 +1,103 @@
+//! `QualitySink` trait + composition helpers.
+//!
+//! Same shape as the audit / CDR / webhook sinks: `emit` is
+//! fire-and-forget, sinks never panic and never block the call path,
+//! failures get logged and dropped (CLAUDE.md §4.7). Quality history
+//! is observability, not call control.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::record::QualityRecord;
+
+/// Trait every quality-record sink implements.
+#[async_trait]
+pub trait QualitySink: Send + Sync {
+    async fn emit(&self, record: QualityRecord);
+}
+
+/// `Arc<dyn QualitySink>` is what the facade and consumers hold.
+pub type QualitySinkHandle = Arc<dyn QualitySink>;
+
+/// No-op sink. Default-when-not-configured; also useful in tests.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NullSink;
+
+#[async_trait]
+impl QualitySink for NullSink {
+    async fn emit(&self, _record: QualityRecord) {
+        // Intentionally nothing.
+    }
+}
+
+/// Fans one record out to several inner sinks (local JSONL file *and*
+/// the signed webhook). Each inner `emit` is awaited in turn; the file
+/// sink is a quick locked write and the webhook sink spawns
+/// internally, so the fan-out never blocks meaningfully.
+pub struct FanoutSink {
+    sinks: Vec<QualitySinkHandle>,
+}
+
+impl FanoutSink {
+    pub fn new(sinks: impl IntoIterator<Item = QualitySinkHandle>) -> Self {
+        Self {
+            sinks: sinks.into_iter().collect(),
+        }
+    }
+}
+
+#[async_trait]
+impl QualitySink for FanoutSink {
+    async fn emit(&self, record: QualityRecord) {
+        for sink in &self.sinks {
+            sink.emit(record.clone()).await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::record::{RecordKind, QUALITY_RECORD_VERSION};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn rec() -> QualityRecord {
+        QualityRecord {
+            version: QUALITY_RECORD_VERSION,
+            kind: RecordKind::Interval,
+            call_id: "siphon-test".into(),
+            ts: chrono::Utc::now(),
+            seq: 0,
+            quality: Default::default(),
+        }
+    }
+
+    #[derive(Default)]
+    struct Counter(AtomicUsize);
+
+    #[async_trait]
+    impl QualitySink for Counter {
+        async fn emit(&self, _record: QualityRecord) {
+            self.0.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    #[tokio::test]
+    async fn null_sink_is_a_noop() {
+        NullSink.emit(rec()).await;
+    }
+
+    #[tokio::test]
+    async fn fanout_reaches_every_inner_sink() {
+        let a = Arc::new(Counter::default());
+        let b = Arc::new(Counter::default());
+        let fan = FanoutSink::new([
+            Arc::clone(&a) as QualitySinkHandle,
+            Arc::clone(&b) as QualitySinkHandle,
+        ]);
+        fan.emit(rec()).await;
+        assert_eq!(a.0.load(Ordering::Relaxed), 1);
+        assert_eq!(b.0.load(Ordering::Relaxed), 1);
+    }
+}

--- a/crates/telemetry/src/admin.rs
+++ b/crates/telemetry/src/admin.rs
@@ -84,7 +84,19 @@ pub struct AdminState {
     /// only in partially-built test states, where `/admin/v1/drain`
     /// then returns 503.
     pub drain: Option<DrainStatusFn>,
+    /// Live per-call quality snapshot (0.31.0), serving
+    /// `GET /admin/v1/calls/:id/stats`. Always installed by the runtime
+    /// (the quality tracker runs regardless of `[quality]`); `None`
+    /// only in partially-built test states → 503.
+    pub quality_stats: Option<QualityStatsFn>,
 }
+
+/// Closure resolving a bridge `call_id` to its live quality snapshot,
+/// pre-serialized by the runtime adapter. `None` = no active call with
+/// that id (→ 404). Same indirection rationale as
+/// [`CallRegistryHandle`] — keeps `siphon-ai-core` out of the
+/// telemetry crate's deps.
+pub type QualityStatsFn = Arc<dyn Fn(&str) -> Option<serde_json::Value> + Send + Sync>;
 
 /// Snapshot of the daemon's graceful-shutdown drain state (0.17.0),
 /// served by `GET /admin/v1/drain`. Lets an operator / deploy script
@@ -359,6 +371,17 @@ pub async fn dispatch(
             retrieve_call(state, id, &body)
         }
         (m, p)
+            if *m == hyper::Method::GET
+                && p.starts_with("/admin/v1/calls/")
+                && p.ends_with("/stats") =>
+        {
+            let id = p
+                .strip_prefix("/admin/v1/calls/")
+                .and_then(|s| s.strip_suffix("/stats"))
+                .unwrap_or("");
+            call_stats(state, id)
+        }
+        (m, p)
             if m == hyper::Method::POST
                 && p.starts_with("/admin/calls/")
                 && p.ends_with("/hangup") =>
@@ -448,6 +471,29 @@ fn drain_status(state: &AdminState) -> Response<Full<Bytes>> {
         return service_unavailable("drain status not installed");
     };
     json_response(StatusCode::OK, &json!(f()))
+}
+
+/// `GET /admin/v1/calls/:id/stats` (0.31.0) — live quality snapshot
+/// for one active call, in the CDR `quality` block's shape. 404 when
+/// no active call has that bridge `call_id`; ended calls answer
+/// through the CDR / `[quality]` history records instead.
+fn call_stats(state: &AdminState, call_id: &str) -> Response<Full<Bytes>> {
+    if call_id.is_empty() {
+        return json_response(
+            StatusCode::BAD_REQUEST,
+            &json!({ "error": "empty call_id" }),
+        );
+    }
+    let Some(f) = state.quality_stats.as_ref() else {
+        return service_unavailable("quality stats not installed");
+    };
+    match f(call_id) {
+        Some(row) => json_response(StatusCode::OK, &row),
+        None => json_response(
+            StatusCode::NOT_FOUND,
+            &json!({ "error": "no active call with that call_id" }),
+        ),
+    }
 }
 
 fn hangup_call(state: &AdminState, sip_call_id: &str) -> Response<Full<Bytes>> {

--- a/crates/telemetry/src/auth.rs
+++ b/crates/telemetry/src/auth.rs
@@ -210,6 +210,13 @@ pub fn min_role(method: &hyper::Method, path: &str) -> Option<Role> {
 
         // ── Operator (live-call control) ──
         (&Method::POST, "/admin/v1/conferences") => Some(Role::Operator),
+        // ── ReadOnly (parameterised) ──
+        // /admin/v1/calls/:id/stats — live quality probe (0.31.0).
+        (m, p)
+            if *m == Method::GET && p.starts_with("/admin/v1/calls/") && p.ends_with("/stats") =>
+        {
+            Some(Role::ReadOnly)
+        }
         (m, p) => operator_pattern(m, p).then_some(Role::Operator),
     }
 }
@@ -254,6 +261,11 @@ pub fn route_label(method: &hyper::Method, path: &str) -> &'static str {
             if *m == Method::POST && p.starts_with("/admin/calls/") && p.ends_with("/hangup") =>
         {
             "POST /admin/calls/:id/hangup"
+        }
+        (m, p)
+            if *m == Method::GET && p.starts_with("/admin/v1/calls/") && p.ends_with("/stats") =>
+        {
+            "GET /admin/v1/calls/:id/stats"
         }
         (m, p)
             if *m == Method::POST && p.starts_with("/admin/v1/calls/") && p.ends_with("/park") =>

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -72,6 +72,7 @@ credentials. Resolved secret values are never logged.
 [admin]           # authenticated /admin/* listener (0.10.0); off → /admin not served
 [webhooks]        # lifecycle events (call_start, call_end, …)
 [audit]           # signed audit-event stream for SIEM (0.20.0); off by default
+[quality]         # per-call quality history records (0.31.0); off by default
 [hep]             # HEP3 shipping to Homer
 [shutdown]        # graceful drain on SIGTERM/SIGINT (0.17.0)
 ```
@@ -933,6 +934,63 @@ the DoS-shedding fast path — auditing it would amplify the attack).
 `sip_auth` records `failed` / `stale` credentials but **not** the normal
 first-leg `challenged` 401 or a successful `ok` (both track call volume,
 not security). See `docs/AUDIT.md` for the full event schema.
+
+## `[quality]` — per-call quality history records (0.31.0)
+
+The **history half** of per-call quality telemetry: one JSON record per
+call per `interval_secs`, plus a **final end-of-call summary**, in
+exactly the shape of the CDR `quality` block (see DEPLOY.md) plus
+framing (`kind`, `call_id`, `ts`, `seq`, `version`). Chart per-call
+quality over time in *your* store — SiphonAI ships a clean, signed,
+durable feed; it does not run a database. **Off by default.**
+
+Ships to an append-only JSONL **file** (for a log shipper) and/or an
+HMAC-signed **webhook** — enable either or both. The webhook reuses the
+same delivery transport as `[webhooks]`/`[cdr]`/`[audit]`, so `secret`,
+`spool_dir`, the `X-SiphonAI-Event-Id` idempotency header, and the
+`siphon_ai_webhook_*` delivery metrics (label `sink="quality"`) all
+behave identically. Restart-required — `[quality]` edits are flagged on
+SIGHUP but not applied live.
+
+```toml
+[quality]
+enabled       = true
+interval_secs = 30              # per-call record cadence
+
+[quality.file]                  # append-only JSONL, one record per line
+enabled = true
+path    = "/var/log/siphon-ai/quality.jsonl"
+
+[quality.webhook]               # HMAC-signed HTTP POST per record
+enabled     = true
+url         = "https://metrics.example.com/ingest"
+auth_header = "Bearer ${QUALITY_TOKEN}"
+secret      = "${QUALITY_HMAC_SECRET}"
+spool_dir   = "/var/lib/siphon-ai/spool/quality" # optional durable retry
+retry_max   = 3
+timeout_ms  = 5000
+```
+
+| Field                | Type    | Default        | Notes |
+|----------------------|---------|----------------|-------|
+| `enabled`            | bool    | `false`        | Master switch. `true` with **no** sub-sink enabled is a fatal config error. |
+| `interval_secs`      | integer | `30`           | Per-call record cadence; must be ≥ 1. The final record is emitted regardless, whenever the call measured anything. |
+| `file.enabled`       | bool    | `false`        | |
+| `file.path`          | path    | required if on | Append-only JSONL. Parent dir must exist (no `mkdir`); opened fail-loud at startup. |
+| `webhook.enabled`    | bool    | `false`        | |
+| `webhook.url`        | URL     | required if on | POST target. |
+| `webhook.auth_header`| string  | unset          | Sent verbatim. `${VAR}` / `${file:}` / `${cred:}` expansion works. |
+| `webhook.secret`     | string  | unset          | HMAC-SHA256 signing secret → `X-SiphonAI-Signature`. Unset ⇒ unsigned deliveries. |
+| `webhook.spool_dir`  | path    | unset          | Durable retry spool (survives restarts). Unset ⇒ best-effort. |
+| `webhook.retry_max`  | integer | `3`            | In-memory retries before spooling / dropping. |
+| `webhook.timeout_ms` | integer | `5000`         | Per-attempt timeout. |
+
+Records with nothing measured are skipped (early ticks before the first
+media-stats snapshot, calls that never went active), so consumers never
+see empty rows. Counters inside a record are **cumulative since call
+start** — diff successive `seq`s of the same `call_id` for rates. See
+`docs/OPERATIONS.md` for the end-to-end ingestion pipeline
+(webhook/file → Vector → Loki → Grafana).
 
 ## `[hep]`
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -513,6 +513,7 @@ no/invalid token → `401`.
 | GET    | `/admin/v1/parked`            | —               | readonly | **List parked calls** (0.7.0). `501` when `[park]` is disabled. |
 | POST   | `/admin/v1/calls/:id/park`    | JSON (opt.)     | operator | **Park an active call** (0.7.0). Body `{slot?}`; `202` (dispatched). `404` if no active call has that id. `501` when `[park]` is disabled. |
 | POST   | `/admin/v1/calls/:id/retrieve`| JSON (opt.)     | operator | **Retrieve a parked call** (0.7.0). Body `{ws_url?}`; `202` (dispatched). `404` unknown call, `409` if the call isn't parked. `501` when `[park]` is disabled. |
+| GET    | `/admin/v1/calls/:id/stats`   | —               | readonly | **Live per-call quality snapshot** (0.31.0). `:id` is the bridge `call_id` (the one on the WS `start` message / CDR). Returns `{call_id, sampled_at, …}` with the CDR `quality` block's fields flattened in — whatever is measured *right now*, unmeasured fields omitted. `404` when no active call has that id (ended calls answer through the CDR / `[quality]` records). |
 | GET    | `/admin/v1/drain`             | —               | readonly | **Graceful-shutdown drain status** (0.17.0). Returns `{draining, active_calls, drain_timeout_secs, remaining_secs}` — `remaining_secs` is the countdown to the deadline (non-null only while draining). Lets a deploy script confirm a pod entered drain and watch it empty. |
 
 ### Admin auth & RBAC
@@ -855,6 +856,51 @@ unless `[cdr.webhook].spool_dir` is set, which makes delivery durable
 across restarts. Set `[cdr.webhook].secret` to sign each POST. See
 [Webhook delivery: signing, idempotency, durability](#webhook-delivery-signing-idempotency-durability).
 
+## Quality record consumers
+
+With `[quality]` enabled (0.31.0), the daemon emits per-call quality
+history records: one per call per `interval_secs` **plus a final
+end-of-call summary**. A record is the CDR `quality` block flattened to
+the top level, with framing fields:
+
+```json
+{
+  "version": 1,
+  "kind": "interval",
+  "call_id": "siphon-6ce27797cc0a4997b90cbae2f46ce7a4",
+  "ts": "2026-07-13T21:14:07.812Z",
+  "seq": 3,
+  "barge_in_count": 1,
+  "first_audio_out_ms": 742,
+  "avg_jitter_ms": 11.5,
+  "max_jitter_ms": 30.0,
+  "avg_packet_loss_ratio": 0.004,
+  "max_packet_loss_ratio": 0.02,
+  "rx_packets_received": 4820,
+  "rx_packets_lost": 4,
+  "rx_packets_out_of_order": 1,
+  "rx_packets_duplicate": 0,
+  "mos_estimate_min": 4.1,
+  "mos_estimate_avg": 4.3
+}
+```
+
+- `kind` — `"interval"` (cadence sample) or `"final"` (end-of-call; the
+  same numbers the CDR carries).
+- `seq` — per-call record counter from 0; the final record continues
+  the sequence.
+- Counters are **cumulative since call start** — diff successive `seq`s
+  for rates. Unmeasured fields are omitted, not zeroed. Records with
+  nothing measured at all are skipped.
+- File sink: append-only JSONL, same rotation story as the CDR file.
+  Webhook sink: HMAC-signed + spooled exactly like `[cdr.webhook]`
+  (label `sink="quality"` on the delivery metrics).
+
+For a live *right-now* probe of one call, use
+`GET /admin/v1/calls/{id}/stats` (readonly role) instead of waiting for
+the next record. See `docs/OPERATIONS.md` for the end-to-end ingestion
+pipeline into Loki/Grafana.
+
 ## Lifecycle webhooks
 
 Off-band events (NOT the per-call WS bridge). Same delivery transport as the
@@ -1057,7 +1103,8 @@ on the metrics crate's defaults (CLAUDE.md §7.4).
 | `siphon_ai_holds_total`                 | counter   | `result=ok\|failed`                   | Bot-initiated hold/resume re-INVITEs (0.7.2 — the WS server sends `hold`/`resume`). Covers both directions. `failed` = the re-INVITE was rejected / timed out / glared, or hold was rejected (already held by the far end, tap unavailable, not configured); the call stays in its prior media state. Does **not** count far-end (peer-initiated) holds. |
 | `siphon_ai_ws_reconnects_total`         | counter   | `result=recovered\|exhausted`         | WS reconnect episodes mid-call (0.7.3 — `[bridge].ws_reconnect_enabled`). One increment per unexpected drop that entered the reconnect path. `recovered` = re-dialed the same `ws_url` within `ws_reconnect_max_secs`; `exhausted` = the window elapsed (or the call ended mid-gap) and the call tore down (`ws_disconnect`). |
 | `siphon_ai_admin_requests_total`        | counter   | `endpoint`, `role`, `result=ok\|unauthenticated\|forbidden\|not_found` | Admin API requests on the `[admin]` listener (0.10.0). `endpoint` is the bounded route template (e.g. `POST /admin/v1/calls`, ids collapsed to `:id`), `role` is the authenticated token's role (`none` for `unauthenticated`). `unauthenticated` = 401 (missing/bad token); `forbidden` = 403 (role below the endpoint minimum). Pair with the structured audit log (actor = token name) for per-request detail. |
-| `siphon_ai_webhook_deliveries_total`    | counter   | `sink=lifecycle\|cdr\|audit`, `result=delivered\|spooled\|rejected\|dropped` | Terminal webhook/CDR/audit delivery outcomes (0.11.0; `audit` added 0.20.0). One increment per logical delivery. `delivered` = 2xx; `spooled` = persisted to the durable spool after the in-memory budget; `rejected` = non-retryable 4xx; `dropped` = budget (or spool) exhausted, or payload not serializable. |
+| `siphon_ai_webhook_deliveries_total`    | counter   | `sink=lifecycle\|cdr\|audit\|quality`, `result=delivered\|spooled\|rejected\|dropped` | Terminal webhook/CDR/audit/quality delivery outcomes (0.11.0; `audit` added 0.20.0, `quality` 0.31.0). One increment per logical delivery. `delivered` = 2xx; `spooled` = persisted to the durable spool after the in-memory budget; `rejected` = non-retryable 4xx; `dropped` = budget (or spool) exhausted, or payload not serializable. |
+| `siphon_ai_quality_records_total`       | counter   | `kind=interval\|final`               | Quality history records emitted through the `[quality]` sinks (0.31.0). Skipped-empty records don't count. |
 | `siphon_ai_webhook_delivery_attempts_total` | counter | `sink`, `outcome=ok\|transient\|error\|rejected` | Individual HTTP delivery attempts (0.11.0) — a retried delivery ticks several times. `transient` = retryable 5xx/408/429; `error` = connect/timeout; `rejected` = non-retryable 4xx. Divide by `siphon_ai_webhook_deliveries_total` for attempts-per-delivery. |
 | `siphon_ai_webhook_spool_depth`         | gauge     | `sink`                                | Deliveries waiting in the durable spool (0.11.0, set when `spool_dir` is configured). Sampled by the drain worker each pass (self-correcting across restarts). Healthy = 0; a rising value means deliveries are failing and backing up on disk. |
 | `siphon_ai_recording_uploads_total`     | counter   | `result`                              | Recording uploads to object storage (0.25.0): `ok` (durable), `failed` (will retry), `dropped` (retry budget exhausted / recording gone — stays local-only). |

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -191,6 +191,40 @@ siphon_ai:rtp_packet_loss_ratio:p95   # SiphonAIHighPacketLoss    (> 5%/10m)
 These tell you *a fleet-wide quality problem is happening*; drop to Homer's
 per-leg RTP-QoS panel to see *which stream*.
 
+**Per-call quality over time — the middle layer (0.30.0/0.31.0):**
+between fleet aggregates and single-call Homer forensics sits the
+question "chart *this call's* (or *every call's*) quality over its
+lifetime, in my own dashboards." Three feeds, one shape (the CDR
+`quality` block — MOS estimate, RX loss/reorder counters, RR jitter/loss
+aggregates, `first_audio_out_ms`, `barge_in_count`):
+
+1. **Live** — `GET /admin/v1/calls/{id}/stats` (readonly role): what one
+   active call measures *right now*.
+2. **History** — `[quality]` records (0.31.0): one JSON record per call
+   per `interval_secs` + a final summary, to a JSONL file and/or an
+   HMAC-signed webhook. Ingestion pipeline (reference stack in
+   `examples/observability/`, runs with one `docker compose up`):
+
+   ```text
+   siphon-ai [quality.webhook] ──HTTP POST (signed, spooled)──► Vector :9411
+                                                                   │
+        [quality.file] quality.jsonl ──(alt: Vector file source)───┤
+                                                                   ▼
+                                             Loki (label job="siphon-quality",
+                                                   kind=interval|final)
+                                                                   ▼
+                                  Grafana "Per-Call Quality History" dashboard
+   ```
+
+   Only `kind` becomes a Loki label — `call_id` stays a JSON field
+   (per-call label values would explode the index; LogQL filters it via
+   `| json | call_id=~"..."`). Counters are cumulative per call; use
+   `max_over_time`-style unwraps rather than `rate` for staircase reads.
+   The daemon's spool (`[quality.webhook].spool_dir`) rides out Vector /
+   Loki restarts with no record loss.
+3. **Post-mortem** — the CDR `quality` block (v4): the final record's
+   numbers in the record you already ingest for billing.
+
 ### 7. What did the SIP exchange actually look like?
 
 **Source:** Homer UI's Call Flow view.

--- a/docs/design/DESIGN_QUALITY_TELEMETRY.md
+++ b/docs/design/DESIGN_QUALITY_TELEMETRY.md
@@ -1,6 +1,6 @@
 # Design: Per-call quality telemetry (live + history)
 
-**Status: LOCKED (2026-07-13) — decisions in §6 confirmed; implementing per §7.**
+**Status: SHIPPED — v0.30.0 + v0.31.0 (2026-07-13/14). Retrospective in §8.**
 Theme: ROADMAP P1 "Per-call quality telemetry (live + history)", bundled
 with the P2 "CDR call-quality fields" item (the ROADMAP itself notes they
 complement each other).
@@ -140,3 +140,40 @@ quality summary at all. Two documented gaps (`docs/OPERATIONS.md` Q5/Q8:
    OPERATIONS.md ingestion guide. Verify: records flow + signature
    validates; spool survives restart; dashboard renders; theme
    retrospective here.
+
+## 8. Retrospective (2026-07-14, theme complete)
+
+**Shipped as planned, two releases:**
+
+- **v0.30.0** (#279 + #280): forge-media#81 (`MediaStatsSnapshot` +
+  `RxStreamStats`), `rtp_stats` `rx_*` + `mos_estimate` (protocol stayed
+  v1), CDR v4 `quality` block, OPERATIONS Q5/Q8 closed.
+- **v0.31.0** (single feature PR + release): `crates/quality`
+  (records = the CDR block flattened, JSONL + HMAC/spool webhook over
+  `siphon-ai-http`), `[quality]` config, per-call record task,
+  `GET /admin/v1/calls/{id}/stats` via a `core::quality_live` RAII
+  registry, Vector→Loki reference pipeline + Grafana history dashboard.
+
+**Deviations from the locked design, all small:**
+
+- D2 naming: `rx_packets_dropped` → `rx_packets_lost` (the forwarding
+  path measures sequence-gap transit loss, not jitter-buffer drops);
+  `rx_packets_duplicate` added for forge/WS/CDR symmetry.
+- The forge counters weren't actually on the media path yet — the
+  jitter buffer that §2 pointed at is unused there. forge-media#81
+  added RFC 3550-style tracking to the forwarding engine itself.
+- The bridge-ready oneshot became an `Instant`-carrying watch: three
+  consumers (CDR build, record task, live endpoint) need the
+  first-audio epoch, not one.
+
+**What worked well:** one shape (`siphon_ai_cdr::QualityInfo`) feeding
+three surfaces (CDR / records / live endpoint) killed every drift
+question at review time; the audit crate was a near-verbatim template
+for the sink stack (a day saved); the tap's watch channel meant zero
+new state on the audio path.
+
+**Worth remembering:** the local SIPp suite silently fails 8/34 without
+the echo server on :8765 (cost an hour of triage before a main-branch
+baseline proved it environmental); forge's `--features ha` restore path
+doesn't compile in default local checks — CI caught the missing
+`rx_stream` initializer.

--- a/examples/observability/README.md
+++ b/examples/observability/README.md
@@ -26,7 +26,15 @@ grafana/
                                registrations, delivery health, drain
     siphon-ai-call-quality.json  Call Quality — WS/SDP/duration latency, RTP RTT
                                & loss, conference mixer health
-compose.yaml                   Prometheus + auto-provisioned Grafana
+  dashboards/
+    siphon-ai-quality-history.json  Per-Call Quality History — [quality]
+                               records via Vector → Loki: MOS, RX loss,
+                               RR loss, first-audio latency, final-record
+                               table (0.31.0)
+vector.toml                    Vector pipeline: quality webhook (or JSONL
+                               file) → Loki, kind as the only extra label
+compose.yaml                   Prometheus + Loki + Vector + auto-provisioned
+                               Grafana
 ```
 
 ## Run it
@@ -38,6 +46,23 @@ docker compose -f examples/observability/compose.yaml up
 - **Grafana** → http://127.0.0.1:3000 (`admin` / `admin`) — both dashboards
   are pre-loaded under the `siphon-ai` tag.
 - **Prometheus** → http://127.0.0.1:9090 — check *Status → Rules* and *Alerts*.
+- **Quality history** (0.31.0): enable `[quality]` in the daemon pointing at
+  Vector —
+
+  ```toml
+  [quality]
+  enabled = true
+
+  [quality.webhook]
+  enabled = true
+  url = "http://127.0.0.1:9411/"
+  ```
+
+  Records land in Loki (label `job="siphon-quality"`), and the *Per-Call
+  Quality History* dashboard charts MOS / loss / first-audio latency per
+  `call_id`. The daemon's spool + retry semantics apply — a Vector restart
+  loses nothing when `[quality.webhook].spool_dir` is set. See the
+  ingestion guide in `docs/OPERATIONS.md`.
 
 By default Prometheus scrapes a daemon at `siphon-ai:9091` (mapped to the
 host gateway, so a daemon running on the host is reachable). Point it at your

--- a/examples/observability/compose.yaml
+++ b/examples/observability/compose.yaml
@@ -33,6 +33,25 @@ services:
     extra_hosts:
       - "siphon-ai:host-gateway"
 
+  # ── Quality-history pipeline (0.31.0): [quality] records → Loki ──
+  # Point the daemon at Vector:  [quality.webhook].url = "http://127.0.0.1:9411/"
+  # (or use [quality.file] + Vector's file source — see vector.toml).
+  loki:
+    image: grafana/loki:3.0.0
+    command: ["-config.file=/etc/loki/local-config.yaml"]
+    ports:
+      - "127.0.0.1:3100:3100"
+
+  vector:
+    image: timberio/vector:0.39.0-alpine
+    command: ["--config", "/etc/vector/vector.toml"]
+    volumes:
+      - ./vector.toml:/etc/vector/vector.toml:ro
+    ports:
+      - "127.0.0.1:9411:9411"
+    depends_on:
+      - loki
+
   grafana:
     image: grafana/grafana:latest
     environment:
@@ -48,3 +67,4 @@ services:
       - "127.0.0.1:3000:3000"
     depends_on:
       - prometheus
+      - loki

--- a/examples/observability/grafana/dashboards/siphon-ai-quality-history.json
+++ b/examples/observability/grafana/dashboards/siphon-ai-quality-history.json
@@ -1,0 +1,134 @@
+{
+  "uid": "siphonai-quality-history",
+  "title": "SiphonAI — Per-Call Quality History",
+  "tags": ["siphon-ai"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "editable": true,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "loki",
+        "type": "datasource",
+        "query": "loki",
+        "current": { "text": "Loki", "value": "siphonai-loki" },
+        "hide": 0
+      },
+      {
+        "name": "call_id",
+        "type": "textbox",
+        "label": "call_id (regex, empty = all)",
+        "query": ".*",
+        "current": { "text": ".*", "value": ".*" },
+        "hide": 0
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "MOS estimate (avg per record, by call)",
+      "description": "Transport-only MOS-CQE from the [quality] records. One series per call_id matching the filter. 4.4 ≈ clean G.711; < 3.5 = users notice.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "loki", "uid": "${loki}" },
+      "fieldConfig": {
+        "defaults": {
+          "min": 1,
+          "max": 5,
+          "custom": { "drawStyle": "line", "fillOpacity": 10 }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "${loki}" },
+          "expr": "avg_over_time({job=\"siphon-quality\"} | json | call_id=~\"$call_id\" | unwrap mos_estimate_avg [$__auto]) by (call_id)",
+          "legendFormat": "{{call_id}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "RX packets lost (cumulative, by call)",
+      "description": "Sequence-gap loss on the caller→SiphonAI stream, cumulative since call start (late arrivals can shrink it). A rising staircase = ongoing loss.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "loki", "uid": "${loki}" },
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "drawStyle": "line", "fillOpacity": 10 }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "${loki}" },
+          "expr": "max_over_time({job=\"siphon-quality\"} | json | call_id=~\"$call_id\" | unwrap rx_packets_lost [$__auto]) by (call_id)",
+          "legendFormat": "{{call_id}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "RR loss ratio (max per record, by call)",
+      "description": "Worst remote-reported cumulative-loss ratio (how the far end receives SiphonAI's stream). Compare with RX loss on the left to see which direction hurts.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "loki", "uid": "${loki}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "custom": { "drawStyle": "line", "fillOpacity": 10 }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "${loki}" },
+          "expr": "max_over_time({job=\"siphon-quality\"} | json | call_id=~\"$call_id\" | unwrap max_packet_loss_ratio [$__auto]) by (call_id)",
+          "legendFormat": "{{call_id}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "First-audio latency (final records)",
+      "description": "first_audio_out_ms from each call's final record: WS start-on-the-wire → first server audio at playout. The STT/LLM/TTS first-token budget.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": { "type": "loki", "uid": "${loki}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "custom": { "drawStyle": "points", "pointSize": 6 }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "${loki}" },
+          "expr": "max_over_time({job=\"siphon-quality\", kind=\"final\"} | json | call_id=~\"$call_id\" | unwrap first_audio_out_ms [$__auto]) by (call_id)",
+          "legendFormat": "{{call_id}}"
+        }
+      ]
+    },
+    {
+      "type": "table",
+      "title": "Recent end-of-call summaries",
+      "description": "The final record per call — the same numbers the CDR quality block carries.",
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 16 },
+      "datasource": { "type": "loki", "uid": "${loki}" },
+      "options": { "showHeader": true },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "${loki}" },
+          "expr": "{job=\"siphon-quality\", kind=\"final\"} | json | call_id=~\"$call_id\" | line_format \"{{.call_id}}  mos_min={{.mos_estimate_min}} first_audio={{.first_audio_out_ms}}ms barge_ins={{.barge_in_count}} rx_lost={{.rx_packets_lost}}/{{.rx_packets_received}}\""
+        }
+      ]
+    }
+  ]
+}

--- a/examples/observability/grafana/provisioning/datasources/loki.yml
+++ b/examples/observability/grafana/provisioning/datasources/loki.yml
@@ -1,0 +1,12 @@
+# Provisions the Loki datasource the quality-history dashboard references
+# by a fixed uid (`siphonai-loki`), so it loads without manual wiring.
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    uid: siphonai-loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: false
+    editable: true

--- a/examples/observability/vector.toml
+++ b/examples/observability/vector.toml
@@ -1,0 +1,55 @@
+# Vector pipeline: SiphonAI [quality] records → Loki (0.31.0).
+#
+# Two interchangeable intake modes — enable ONE:
+#
+#   1. Webhook intake (default here): point the daemon's
+#      [quality.webhook].url at this Vector instance and records arrive
+#      pushed, spooled, and retried by the daemon:
+#
+#        [quality.webhook]
+#        enabled = true
+#        url     = "http://127.0.0.1:9411/"
+#
+#      (Signature note: this reference pipeline does not verify
+#      X-SiphonAI-Signature — Vector forwards the body as-is. Verify at
+#      a terminating receiver if your ingest path crosses trust
+#      boundaries, or keep the webhook loopback-only like this lab.)
+#
+#   2. File tailing: enable [quality.file] in the daemon and swap the
+#      source below for the commented `quality_file` variant — the
+#      classic log-shipper pattern, useful when Vector runs as a
+#      sidecar with access to the JSONL path.
+#
+# Labels: only `job` and the low-cardinality `kind` (interval|final)
+# become Loki labels. `call_id` stays a JSON field — per-call ids as
+# labels would explode Loki's index (same rule as CLAUDE.md's "no
+# call_id metric labels"); LogQL filters on it just fine via `| json`.
+
+[sources.quality_webhook]
+type = "http_server"
+address = "0.0.0.0:9411"
+decoding.codec = "json"
+
+# [sources.quality_file]
+# type = "file"
+# include = ["/var/log/siphon-ai/quality.jsonl"]
+# decoding.codec = "json"
+
+[transforms.quality_labels]
+type = "remap"
+inputs = ["quality_webhook"]
+source = '''
+# Lift the record kind to a Loki label; keep everything else as fields.
+.kind_label = to_string(.kind) ?? "unknown"
+'''
+
+[sinks.loki]
+type = "loki"
+inputs = ["quality_labels"]
+endpoint = "http://loki:3100"
+encoding.codec = "json"
+labels.job = "siphon-quality"
+labels.kind = "{{ kind_label }}"
+# One JSON record per Loki line; timestamps come from ingest time (the
+# record's own `ts` field remains inside the JSON for queries).
+remove_label_fields = true


### PR DESCRIPTION
## What

Sub-item 2 of the per-call quality telemetry theme (design D3/D6 — **completes the theme**; retrospective added in §8). Three commits:

### 1. `[quality]` history records + sinks
- New `crates/quality` (`siphon-ai-quality`): one JSON record per call per `interval_secs` + a **final end-of-call summary**. A record is the CDR `quality` block (`siphon_ai_cdr::QualityInfo`) flattened, plus framing (`version`/`kind`/`call_id`/`ts`/`seq`) — one shape for CDR, records, and the live endpoint, so they can never drift.
- JSONL `FileSink` + HMAC-signed `HttpSink` over the shared `siphon-ai-http` transport (new `SinkKind::Quality`; signing, `X-SiphonAI-Event-Id` idempotency, durable spool inherited from 0.11.0). Audit-style process-global facade; `siphon_ai_quality_records_total{kind}`.
- `[quality]` config (off by default; fail-loud with no sink; restart-required, fingerprinted for the SIGHUP warn list; shows in `siphon-ai check`).
- Per-call record task samples the tap's `QualityReport` watch; watch-close = final record + task end (lifetime bounded by the call; nothing on the audio path). Empty records skipped.

### 2. `GET /admin/v1/calls/{id}/stats` (readonly)
Live quality snapshot for one active call via a new `core::quality_live` RAII registry (register at controller start, deregister on any teardown). 404 for unknown ids. The bridge-ready oneshot became an `Instant`-carrying watch so the CDR build, record task, and live endpoint share the first-audio epoch.

### 3. Reference ingestion pipeline + dashboard
`examples/observability` grows Loki + Vector (webhook intake on :9411 or file tailing; only `kind` becomes a Loki label — `call_id` stays a JSON field per the cardinality rule) and a **Per-Call Quality History** Grafana dashboard (MOS, RX loss, RR loss, first-audio latency, final-record table). OPERATIONS.md Q6 documents the live/history/CDR three-layer model end-to-end.

## Verification (all live, not just unit tests)

- Records flow: SIPp pcap call → 3 interval + 1 final in `quality.jsonl` and 4 webhook deliveries; **all HMAC signatures verified** against the shared secret.
- Spool survives restart: receiver down → 4 records spooled → daemon restarted → all 4 drained with valid signatures.
- Admin probe mid-call returned live counters (rx=170, between the seq-1/seq-2 samples); 404 on unknown id.
- Full stack: daemon webhook → Vector → Loki (both `kind` streams); Grafana provisions the dashboard + Loki datasource, and a dashboard query through Grafana's proxy returned the call's `first_audio_out_ms`.
- `cargo fmt` + `clippy -D warnings` + 55 test binaries green; SIPp **34/34**; doc/metric/link checkers green. Protocol stays v1; CDR stays v4.

Release PR (0.31.0 bump + tag) follows after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)