### PR TITLE
chore(release): 0.31.0 — quality history records + live stats endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.0] - 2026-07-14
+
+### Added
+
+- **`[quality]` per-call quality history records** (P1 "Per-call
+  quality telemetry", release 2 of 2 — the theme is complete). One JSON
+  record per call per `interval_secs` (default 30) plus a **final
+  end-of-call summary**, in exactly the CDR `quality` block's shape
+  flattened with framing (`version`/`kind`/`call_id`/`ts`/`seq`) — one
+  shape feeds the CDR, the records, and the live endpoint, so they can
+  never drift. Ships to an append-only JSONL file and/or an HMAC-signed
+  webhook over the shared delivery transport (signing,
+  `X-SiphonAI-Event-Id` idempotency, and durable spool exactly as
+  `[cdr.webhook]`; delivery metrics under `sink="quality"`). Off by
+  default; restart-required; fail-loud when enabled with no sink.
+  Records with nothing measured are skipped.
+- **`GET /admin/v1/calls/{id}/stats`** (readonly role): live quality
+  snapshot for one active call — the "what is this call doing *right
+  now*" probe, same field shape as the CDR block. `404` when no active
+  call has that bridge `call_id`.
+- **Quality-history ingestion pipeline** in `examples/observability`:
+  Loki + Vector services (webhook intake or JSONL file tailing; only
+  `kind` becomes a Loki label — `call_id` stays a JSON field per the
+  cardinality rule) and a **Per-Call Quality History** Grafana
+  dashboard (MOS, RX loss, RR loss ratio, first-audio latency,
+  end-of-call summary table). End-to-end ingestion guide in
+  `docs/OPERATIONS.md` (live / history / CDR — three layers, one
+  shape).
+- **Metric**: `siphon_ai_quality_records_total{kind=interval|final}`.
+
+The WS protocol stays **v1** and the CDR stays **v4** — this release
+adds delivery surfaces, not wire changes.
+
 ## [0.30.0] - 2026-07-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3309,7 +3309,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3357,7 +3357,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3373,7 +3373,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "base64",
  "bytes",
@@ -3395,7 +3395,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3412,7 +3412,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "regex",
  "serde",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3477,7 +3477,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "base64",
  "hmac",
@@ -3500,7 +3500,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3524,7 +3524,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3542,7 +3542,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3560,7 +3560,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "aes-gcm",
  "audiopus",
@@ -3574,7 +3574,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "regex",
  "serde",
@@ -3586,7 +3586,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "schemars",
  "serde",
@@ -3596,7 +3596,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3623,7 +3623,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -3641,7 +3641,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3670,7 +3670,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.30.0"
+version = "0.31.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.30.0.** Production-deployed against real carriers
+**Current release: v0.31.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a


### PR DESCRIPTION
Release-prep for **v0.31.0** per RELEASING.md: workspace version 0.30.0 → 0.31.0 (+ Cargo.lock), CHANGELOG `[Unreleased]` → `[0.31.0] - 2026-07-14`, README marker.

Contents: #281 (`[quality]` records + sinks, `GET /admin/v1/calls/{id}/stats`, Vector→Loki pipeline + dashboard) — **completes the per-call quality telemetry theme** (retrospective in the design note §8).

After merge: tag `v0.31.0` on main → release workflow.

Verified locally: `check-version-consistency.py` (plain + `--tag v0.31.0`), `extract-changelog.py 0.31.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)