### PR TITLE
chore(deps): bump siphon-rs (security fixes) + forge-media; metrics facade → 0.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,8 +8,18 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
+]
+
+[[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -19,8 +29,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -29,11 +50,25 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
+ "aead 0.5.2",
+ "aes 0.8.4",
+ "cipher 0.4.4",
+ "ctr 0.9.2",
+ "ghash 0.5.1",
+ "subtle",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
+dependencies = [
+ "aead 0.6.1",
+ "aes 0.9.1",
+ "cipher 0.5.2",
+ "ctr 0.10.1",
+ "ghash 0.6.0",
  "subtle",
 ]
 
@@ -254,6 +289,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,8 +413,19 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
- "inout",
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -423,6 +478,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,6 +524,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -524,12 +591,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "getrandom 0.4.2",
+ "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher 0.5.2",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -580,8 +676,8 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -652,6 +748,17 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "evmap"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8874945f036109c72242964c1174cf99434e30cfa45bf45fedc983f50046f8"
+dependencies = [
+ "hashbag",
+ "left-right",
+ "smallvec",
 ]
 
 [[package]]
@@ -782,7 +889,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "forge-codecs"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=5fa76fb38675#5fa76fb38675174444b9794e0169a9c8824b829a"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=3c59b5f6e464#3c59b5f6e464ed7c6346a9ad88e4aa70ae9945ba"
 dependencies = [
  "audiopus",
  "ezk-g722",
@@ -794,7 +901,7 @@ dependencies = [
 [[package]]
 name = "forge-core"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=5fa76fb38675#5fa76fb38675174444b9794e0169a9c8824b829a"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=3c59b5f6e464#3c59b5f6e464ed7c6346a9ad88e4aa70ae9945ba"
 dependencies = [
  "chrono",
  "serde",
@@ -809,7 +916,7 @@ dependencies = [
 [[package]]
 name = "forge-dtmf"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=5fa76fb38675#5fa76fb38675174444b9794e0169a9c8824b829a"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=3c59b5f6e464#3c59b5f6e464ed7c6346a9ad88e4aa70ae9945ba"
 dependencies = [
  "chrono",
  "forge-core",
@@ -821,7 +928,7 @@ dependencies = [
 [[package]]
 name = "forge-engine"
 version = "0.4.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=5fa76fb38675#5fa76fb38675174444b9794e0169a9c8824b829a"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=3c59b5f6e464#3c59b5f6e464ed7c6346a9ad88e4aa70ae9945ba"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -837,9 +944,9 @@ dependencies = [
  "forge-rtp",
  "forge-transcoder",
  "forge-vad",
- "metrics 0.21.1",
+ "metrics",
  "parking_lot",
- "rand 0.9.4",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -851,7 +958,7 @@ dependencies = [
 [[package]]
 name = "forge-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=5fa76fb38675#5fa76fb38675174444b9794e0169a9c8824b829a"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=3c59b5f6e464#3c59b5f6e464ed7c6346a9ad88e4aa70ae9945ba"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -864,7 +971,7 @@ dependencies = [
 [[package]]
 name = "forge-injection"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=5fa76fb38675#5fa76fb38675174444b9794e0169a9c8824b829a"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=3c59b5f6e464#3c59b5f6e464ed7c6346a9ad88e4aa70ae9945ba"
 dependencies = [
  "forge-core",
  "rubato",
@@ -877,7 +984,7 @@ dependencies = [
 [[package]]
 name = "forge-mixer"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=5fa76fb38675#5fa76fb38675174444b9794e0169a9c8824b829a"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=3c59b5f6e464#3c59b5f6e464ed7c6346a9ad88e4aa70ae9945ba"
 dependencies = [
  "bytes",
  "dashmap 6.2.1",
@@ -891,7 +998,7 @@ dependencies = [
 [[package]]
 name = "forge-recorder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=5fa76fb38675#5fa76fb38675174444b9794e0169a9c8824b829a"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=3c59b5f6e464#3c59b5f6e464ed7c6346a9ad88e4aa70ae9945ba"
 dependencies = [
  "bytes",
  "forge-core",
@@ -905,7 +1012,7 @@ dependencies = [
 [[package]]
 name = "forge-resampler"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=5fa76fb38675#5fa76fb38675174444b9794e0169a9c8824b829a"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=3c59b5f6e464#3c59b5f6e464ed7c6346a9ad88e4aa70ae9945ba"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -914,19 +1021,19 @@ dependencies = [
 [[package]]
 name = "forge-rtp"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=5fa76fb38675#5fa76fb38675174444b9794e0169a9c8824b829a"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=3c59b5f6e464#3c59b5f6e464ed7c6346a9ad88e4aa70ae9945ba"
 dependencies = [
- "aes",
- "aes-gcm",
+ "aes 0.9.1",
+ "aes-gcm 0.11.0",
  "bytes",
  "foreign-types",
  "forge-core",
  "hmac",
  "libc",
- "metrics 0.21.1",
+ "metrics",
  "openssl",
  "openssl-sys",
- "rand 0.9.4",
+ "rand 0.10.1",
  "sha1",
  "sha2",
  "socket2 0.6.3",
@@ -939,14 +1046,14 @@ dependencies = [
 [[package]]
 name = "forge-sdp"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=5fa76fb38675#5fa76fb38675174444b9794e0169a9c8824b829a"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=3c59b5f6e464#3c59b5f6e464ed7c6346a9ad88e4aa70ae9945ba"
 dependencies = [
  "base64",
  "chrono",
  "forge-core",
  "forge-rtp",
- "rand 0.9.4",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=5fa76fb38675)",
+ "rand 0.10.1",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=3c59b5f6e464)",
  "smol_str",
  "thiserror 2.0.18",
 ]
@@ -954,7 +1061,7 @@ dependencies = [
 [[package]]
 name = "forge-transcoder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=5fa76fb38675#5fa76fb38675174444b9794e0169a9c8824b829a"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=3c59b5f6e464#3c59b5f6e464ed7c6346a9ad88e4aa70ae9945ba"
 dependencies = [
  "bytes",
  "forge-codecs",
@@ -967,7 +1074,7 @@ dependencies = [
 [[package]]
 name = "forge-vad"
 version = "0.1.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=5fa76fb38675#5fa76fb38675174444b9794e0169a9c8824b829a"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=3c59b5f6e464#3c59b5f6e464ed7c6346a9ad88e4aa70ae9945ba"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -1086,6 +1193,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1143,7 +1265,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
- "polyval",
+ "polyval 0.6.2",
+]
+
+[[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval 0.7.2",
 ]
 
 [[package]]
@@ -1166,13 +1297,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbag"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7040a10f52cba493ddb09926e15d10a9d8a28043708a405931fe4c6f19fac064"
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1181,6 +1315,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1210,12 +1353,6 @@ dependencies = [
  "tokio",
  "tracing",
 ]
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1354,6 +1491,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1384,7 +1530,6 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "log",
  "rustls",
  "rustls-native-certs",
  "tokio",
@@ -1584,6 +1729,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ipconfig"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1756,6 +1910,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "left-right"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0c21e4c8ff95f487fb34e6f9182875f42c84cef966d29216bf115d9bba835a"
+dependencies = [
+ "crossbeam-utils",
+ "loom",
+ "slab",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1789,6 +1954,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1817,69 +1995,51 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metrics"
-version = "0.21.1"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde3af1a009ed76a778cb84fdef9e7dbbdf5775ae3e4cc1f434a6a307f6f76c5"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
 dependencies = [
- "ahash",
- "metrics-macros",
  "portable-atomic",
-]
-
-[[package]]
-name = "metrics"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3045b4193fbdc5b5681f32f11070da9be3609f189a79f3390706d42587f46bb5"
-dependencies = [
- "ahash",
- "portable-atomic",
+ "rapidhash",
 ]
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.15.3"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f0c8427b39666bf970460908b213ec09b3b350f20c0c2eabcbba51704a08e6"
+checksum = "1db0d8f1fc9e62caebd0319e11eaec5822b0186c171568f0480b46a0137f9108"
 dependencies = [
  "base64",
+ "evmap",
  "http-body-util",
  "hyper",
  "hyper-rustls",
  "hyper-util",
  "indexmap",
  "ipnet",
- "metrics 0.23.1",
+ "metrics",
  "metrics-util",
  "quanta",
- "thiserror 1.0.69",
+ "rustls",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
 
 [[package]]
-name = "metrics-macros"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b4faf00617defe497754acde3024865bc143d44a86799b24e191ecff91354f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "metrics-util"
-version = "0.17.0"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4259040465c955f9f2f1a4a8a16dc46726169bca0f88e8fb2dbeced487c3e828"
+checksum = "96f8722f8562635f92f8ed992f26df0532266eb03d5202607c20c0d7e9745e13"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
- "hashbrown 0.14.5",
- "metrics 0.23.1",
- "num_cpus",
+ "hashbrown 0.16.1",
+ "metrics",
  "quanta",
+ "rand 0.9.4",
+ "rand_xoshiro",
+ "rapidhash",
  "sketches-ddsketch",
 ]
 
@@ -2030,16 +2190,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -2274,7 +2424,18 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "polyval"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b20f20e954175de5f463f67781b35583397d916b1d148738923711b2ad16bee8"
+dependencies = [
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -2544,6 +2705,24 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da7e78a036ce858e8d55b7e7dc8ba3a88b78350fd2155d3591bbd966b58589e"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "raw-cpuid"
@@ -2906,6 +3085,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3081,7 +3266,7 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 [[package]]
 name = "sip-auth"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d#83523662848da594d4bee8271c06ee6c65a7df0a"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9#f3454c77c3d9d398c8c40c2d1e0b9da3525e17e3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3089,7 +3274,7 @@ dependencies = [
  "dashmap 5.5.3",
  "hex",
  "md5",
- "rand 0.9.4",
+ "rand 0.10.1",
  "sha2",
  "sip-core",
  "sip-parse",
@@ -3104,7 +3289,7 @@ dependencies = [
 [[package]]
 name = "sip-core"
 version = "0.7.6"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d#83523662848da594d4bee8271c06ee6c65a7df0a"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9#f3454c77c3d9d398c8c40c2d1e0b9da3525e17e3"
 dependencies = [
  "bytes",
  "httpdate",
@@ -3117,14 +3302,14 @@ dependencies = [
 [[package]]
 name = "sip-dialog"
 version = "0.3.3"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d#83523662848da594d4bee8271c06ee6c65a7df0a"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9#f3454c77c3d9d398c8c40c2d1e0b9da3525e17e3"
 dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
  "dashmap 5.5.3",
  "parking_lot",
- "rand 0.9.4",
+ "rand 0.10.1",
  "sip-core",
  "sip-parse",
  "smol_str",
@@ -3135,12 +3320,12 @@ dependencies = [
 [[package]]
 name = "sip-dns"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d#83523662848da594d4bee8271c06ee6c65a7df0a"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9#f3454c77c3d9d398c8c40c2d1e0b9da3525e17e3"
 dependencies = [
  "anyhow",
  "async-trait",
  "hickory-resolver",
- "rand 0.9.4",
+ "rand 0.10.1",
  "sip-core",
  "smol_str",
  "tokio",
@@ -3149,7 +3334,7 @@ dependencies = [
 [[package]]
 name = "sip-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d#83523662848da594d4bee8271c06ee6c65a7df0a"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9#f3454c77c3d9d398c8c40c2d1e0b9da3525e17e3"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -3160,7 +3345,7 @@ dependencies = [
 [[package]]
 name = "sip-identity"
 version = "0.1.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d#83523662848da594d4bee8271c06ee6c65a7df0a"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9#f3454c77c3d9d398c8c40c2d1e0b9da3525e17e3"
 dependencies = [
  "base64",
  "ring",
@@ -3173,7 +3358,7 @@ dependencies = [
 [[package]]
 name = "sip-observe"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d#83523662848da594d4bee8271c06ee6c65a7df0a"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9#f3454c77c3d9d398c8c40c2d1e0b9da3525e17e3"
 dependencies = [
  "once_cell",
  "tracing",
@@ -3182,7 +3367,7 @@ dependencies = [
 [[package]]
 name = "sip-parse"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d#83523662848da594d4bee8271c06ee6c65a7df0a"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9#f3454c77c3d9d398c8c40c2d1e0b9da3525e17e3"
 dependencies = [
  "bytes",
  "httpdate",
@@ -3196,7 +3381,7 @@ dependencies = [
 [[package]]
 name = "sip-ratelimit"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d#83523662848da594d4bee8271c06ee6c65a7df0a"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9#f3454c77c3d9d398c8c40c2d1e0b9da3525e17e3"
 dependencies = [
  "dashmap 5.5.3",
  "parking_lot",
@@ -3207,7 +3392,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=5fa76fb38675#5fa76fb38675174444b9794e0169a9c8824b829a"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=3c59b5f6e464#3c59b5f6e464ed7c6346a9ad88e4aa70ae9945ba"
 dependencies = [
  "nom",
  "smol_str",
@@ -3216,7 +3401,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d#83523662848da594d4bee8271c06ee6c65a7df0a"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9#f3454c77c3d9d398c8c40c2d1e0b9da3525e17e3"
 dependencies = [
  "nom",
  "smol_str",
@@ -3225,14 +3410,14 @@ dependencies = [
 [[package]]
 name = "sip-transaction"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d#83523662848da594d4bee8271c06ee6c65a7df0a"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9#f3454c77c3d9d398c8c40c2d1e0b9da3525e17e3"
 dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
  "dashmap 5.5.3",
  "parking_lot",
- "rand 0.9.4",
+ "rand 0.10.1",
  "sip-core",
  "sip-parse",
  "sip-transport",
@@ -3244,7 +3429,7 @@ dependencies = [
 [[package]]
 name = "sip-transport"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d#83523662848da594d4bee8271c06ee6c65a7df0a"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9#f3454c77c3d9d398c8c40c2d1e0b9da3525e17e3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3264,20 +3449,20 @@ dependencies = [
 [[package]]
 name = "sip-uac"
 version = "0.4.2"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d#83523662848da594d4bee8271c06ee6c65a7df0a"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9#f3454c77c3d9d398c8c40c2d1e0b9da3525e17e3"
 dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
  "hex",
- "rand 0.9.4",
+ "rand 0.10.1",
  "sha1",
  "sip-auth",
  "sip-core",
  "sip-dialog",
  "sip-dns",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -3289,17 +3474,17 @@ dependencies = [
 [[package]]
 name = "sip-uas"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d#83523662848da594d4bee8271c06ee6c65a7df0a"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9#f3454c77c3d9d398c8c40c2d1e0b9da3525e17e3"
 dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
- "rand 0.9.4",
+ "rand 0.10.1",
  "sip-auth",
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -3320,7 +3505,7 @@ dependencies = [
  "forge-core",
  "forge-engine",
  "forge-rtp",
- "metrics 0.23.1",
+ "metrics",
  "opentelemetry",
  "rustls",
  "rustls-pemfile",
@@ -3443,7 +3628,7 @@ dependencies = [
  "forge-rtp",
  "forge-sdp",
  "futures",
- "metrics 0.23.1",
+ "metrics",
  "metrics-exporter-prometheus",
  "parking_lot",
  "serde",
@@ -3451,7 +3636,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=83523662848d)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9)",
  "sip-transaction",
  "sip-uac",
  "sip-uas",
@@ -3484,7 +3669,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "metrics 0.23.1",
+ "metrics",
  "reqwest",
  "serde",
  "serde_json",
@@ -3513,7 +3698,7 @@ dependencies = [
  "forge-mixer",
  "forge-rtp",
  "forge-sdp",
- "metrics 0.23.1",
+ "metrics",
  "siphon-ai-bridge",
  "siphon-ai-recording",
  "thiserror 1.0.69",
@@ -3546,7 +3731,7 @@ version = "0.31.0"
 dependencies = [
  "async-trait",
  "chrono",
- "metrics 0.23.1",
+ "metrics",
  "parking_lot",
  "serde",
  "serde_json",
@@ -3562,7 +3747,7 @@ dependencies = [
 name = "siphon-ai-recording"
 version = "0.31.0"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.10.3",
  "audiopus",
  "ogg",
  "siphon-ai-http",
@@ -3603,7 +3788,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
- "metrics 0.23.1",
+ "metrics",
  "parking_lot",
  "sha2",
  "sip-auth",
@@ -3649,7 +3834,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "metrics 0.23.1",
+ "metrics",
  "metrics-exporter-prometheus",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -3685,9 +3870,9 @@ dependencies = [
 
 [[package]]
 name = "sketches-ddsketch"
-version = "0.2.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"
@@ -4495,8 +4680,18 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,8 +107,8 @@ http-body-util = "0.1"
 # Tracing / metrics
 tracing                     = "0.1"
 tracing-subscriber          = { version = "0.3", features = ["env-filter", "json"] }
-metrics                     = "0.23"
-metrics-exporter-prometheus = "0.15"
+metrics                     = "0.24"
+metrics-exporter-prometheus = "0.18"
 
 # Match / parse
 regex = "1"
@@ -130,24 +130,24 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 # main branch and replace the rev hashes here (see CLAUDE.md §7.5).
 
 # siphon-rs — RFC 3261 SIP stack
-sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "83523662848d" }
-sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "83523662848d" }
-sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "83523662848d", features = ["tls"] }
-sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "83523662848d" }
-sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "83523662848d" }
-sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "83523662848d" }
-sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "83523662848d" }
-sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "83523662848d" }
-sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "83523662848d" }
+sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "f3454c77c3d9" }
+sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "f3454c77c3d9" }
+sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "f3454c77c3d9", features = ["tls"] }
+sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "f3454c77c3d9" }
+sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "f3454c77c3d9" }
+sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "f3454c77c3d9" }
+sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "f3454c77c3d9" }
+sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "f3454c77c3d9" }
+sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "f3454c77c3d9" }
 # sip-sdp — the SAME sip-sdp sip-uac's SdpAnswerGenerator trait speaks
 # (distinct from forge-media's pinned sip-sdp). Used by the outbound
 # delayed-offer answer generator to hand the UAC a SessionDescription it
 # accepts. Must stay on the same siphon-rs rev as the rest below.
-sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "83523662848d" }
-sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "83523662848d" }
+sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "f3454c77c3d9" }
+sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "f3454c77c3d9" }
 # sip-identity — STIR/SHAKEN Identity-header parsing + PASSporT verification
 # (ES256 + X.509 chain validation). Consumed by the stir-shaken verifier crate.
-sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "83523662848d" }
+sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "f3454c77c3d9" }
 
 # forge-media — RTP / codecs / SDP / DTMF / engine.
 #
@@ -157,30 +157,29 @@ sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "835
 # AI logic belongs in the WS server, never here. See CLAUDE.md §4.1 and the
 # upstream gate at https://github.com/thevoiceguy/forge-media/pull/39.
 #
-# forge-media is pinned to a `main` rev. Bumped 2026-07-13 to 5fa76fb38675
-# = forge-media PR #81 (feat(forge-engine): periodic MediaStatsSnapshot
-# with local receive-side stream stats) — adds ForgeEvent::MediaStatsSnapshot
-# + MediaSessionConfig::media_stats_interval, consumed by the per-call
-# quality telemetry theme (rx_* rtp_stats fields + CDR quality block).
-# (Prior pin 049a19983a95 = PR #76 logging fix.) Some unrelated crates on
-# forge main are still broken from dependabot regressions (rand 0.9 in
-# forge-ice, Cow/lifetime in forge-recorder), but the subset SiphonAI
-# pulls — forge-core, forge-rtp, forge-engine (g722 only), forge-codecs,
-# forge-sdp, forge-dtmf, forge-vad, forge-hep — all build cleanly.
-forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "5fa76fb38675" }
-forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "5fa76fb38675" }
-forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "5fa76fb38675", default-features = false, features = ["g722", "dtls", "opus"] }
-forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "5fa76fb38675" }
-forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "5fa76fb38675" }
-forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "5fa76fb38675" }
-forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "5fa76fb38675" }
-forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "5fa76fb38675" }
+# forge-media is pinned to a `main` rev. Bumped 2026-07-14 to 3c59b5f6e464
+# = forge-media #82-#85: siphon-rs lockstep bumps + dependency
+# migrations (rand 0.10, aes 0.9/aes-gcm 0.11/cipher 0.5 for SRTP,
+# openssl 0.10.81, metrics 0.24 — our own `metrics`/exporter versions
+# move in the same commit so forge and siphon-ai share one facade).
+# siphon-rs bumped in lockstep to f3454c77c3d9 = #61 (SECURITY:
+# registration-hijack auth bypass + remote parser panics) + #62
+# (rand 0.10). (Prior pins: forge 5fa76fb38675 = #81, siphon-rs
+# 83523662848d.)
+forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "3c59b5f6e464" }
+forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "3c59b5f6e464" }
+forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "3c59b5f6e464", default-features = false, features = ["g722", "dtls", "opus"] }
+forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "3c59b5f6e464" }
+forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "3c59b5f6e464" }
+forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "3c59b5f6e464" }
+forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "3c59b5f6e464" }
+forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "3c59b5f6e464" }
 # Conference rooms (0.7.0): forge-mixer is the per-room AudioMixer;
 # forge-injection provides ToneGenerator (join/leave tones now, MOH
 # for park later). Deliberately NOT forge-conference — its DTMF
 # IVR/PIN/host-control layer is unused per DEV_PLAN_0.7.0.md §9.4.
-forge-mixer     = { git = "https://github.com/thevoiceguy/forge-media", rev = "5fa76fb38675" }
-forge-injection = { git = "https://github.com/thevoiceguy/forge-media", rev = "5fa76fb38675" }
+forge-mixer     = { git = "https://github.com/thevoiceguy/forge-media", rev = "3c59b5f6e464" }
+forge-injection = { git = "https://github.com/thevoiceguy/forge-media", rev = "3c59b5f6e464" }
 
 # hep-rs — HEP3 codec, transport, HepSink trait. Owned by the same
 # author as siphon-rs and forge-media; lives in its own repo.


### PR DESCRIPTION
Pin bump for both upstreams, per CLAUDE.md §7.5.

## siphon-rs `8352366 → f3454c7` (12 crates)
- **#61 SECURITY**: registration-hijack auth bypass, remote parser panics, `--all-features` build repair
- #62: rand 0.10

## forge-media `5fa76fb → 3c59b5f` (10 crates)
- #82/#84: siphon-rs lockstep bumps
- #83: openssl 0.10.81, **metrics 0.24**
- #85: aes 0.9 / aes-gcm 0.11 — SRTP on cipher 0.5

## siphon-ai side
Only one change needed: `metrics` 0.23 → 0.24 + `metrics-exporter-prometheus` 0.15 → 0.18, keeping forge and the daemon on **one** metrics facade (a version split would silently blackhole every `forge_*` series). Zero glue-layer changes.

## Verification
- build + clippy `-D warnings` + fmt clean; **55/55** test binaries
- conformance testkit **5/5**
- SIPp **34/34** — incl. SRTP-SDES + DTLS scenarios exercising the cipher-0.5 migration
- live pcap smoke: `rtp_stats` rx/MOS intact; 4 quality records + 4 HMAC-verified webhook deliveries; `/metrics` serves both facades on one recorder (22 `forge_*` + 65 `siphon_ai_*` series, `forge_rtp_packets_received_total=236` from the smoke call)
- `Cargo.lock`: single `metrics` version (0.24.6)

Given the siphon-rs security content, a 0.31.1 patch release right after this merges is probably warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)