### PR TITLE
chore(release): 0.31.1 — upstream security fixes + dependency migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.1] - 2026-07-14
+
+### Security
+
+- **siphon-rs bumped to `f3454c7`**, picking up upstream **#61**: a
+  registration-hijack authentication-bypass fix plus remote parser
+  panic fixes. Deployments using `[[register]]` / digest auth should
+  update.
+
+### Changed
+
+- **forge-media bumped to `3c59b5f`** (lockstep with siphon-rs):
+  dependency migrations — rand 0.10, openssl 0.10.81, and SRTP moving
+  to aes 0.9 / aes-gcm 0.11 (cipher 0.5). Wire behavior is unchanged;
+  the SIPp SRTP-SDES and DTLS scenarios pass against the new cipher
+  stack.
+- **`metrics` facade 0.23 → 0.24** (+ `metrics-exporter-prometheus`
+  0.15 → 0.18) so forge and the daemon share one metrics recorder —
+  forge moved to metrics 0.24, and a version-split facade would have
+  silently dropped every `forge_*` series from `/metrics`. No metric
+  names or labels changed.
+
+No protocol, CDR, config, or API changes — a dependency-only patch.
+
 ## [0.31.0] - 2026-07-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3542,7 +3542,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3558,7 +3558,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "base64",
  "bytes",
@@ -3580,7 +3580,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3597,7 +3597,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "regex",
  "serde",
@@ -3616,7 +3616,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3662,7 +3662,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "base64",
  "hmac",
@@ -3685,7 +3685,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3709,7 +3709,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3727,7 +3727,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -3759,7 +3759,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "regex",
  "serde",
@@ -3771,7 +3771,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "schemars",
  "serde",
@@ -3781,7 +3781,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "base64",
  "rcgen",
@@ -3826,7 +3826,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3855,7 +3855,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.31.0"
+version = "0.31.1"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.31.0.** Production-deployed against real carriers
+**Current release: v0.31.1.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a


### PR DESCRIPTION
Release-prep for **v0.31.1** per RELEASING.md: version 0.31.0 → 0.31.1 (+ Cargo.lock), CHANGELOG, README marker.

Contents: #283 — siphon-rs `f3454c7` (**security**: registration-hijack auth-bypass + parser panic fixes) + forge-media `3c59b5f` (rand 0.10, openssl 0.10.81, SRTP on cipher 0.5) + metrics facade 0.24. Dependency-only patch: no protocol/CDR/config changes.

After merge: tag `v0.31.1` → release workflow.

Verified locally: `check-version-consistency.py` (plain + `--tag v0.31.1`), `extract-changelog.py 0.31.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)