### PR TITLE
feat(media-glue): pause-mode barge-in mechanics — flush, retain, arbitrate (chunk 1/3)

### DIFF
--- a/crates/media-glue/src/lib.rs
+++ b/crates/media-glue/src/lib.rs
@@ -30,4 +30,4 @@ pub use setup::{
     InboundAccepted, InboundCall, MediaSetup, OutboundAccepted, OutboundOffer,
     OutboundOfferRequest, OutboundSrtp, SetupError, TapOptions,
 };
-pub use tap::{BargeInAction, MediaTap, MediaTapError, TapCommand, TapDisconnect};
+pub use tap::{BargeInAction, MediaTap, MediaTapError, TapCommand, TapDisconnect, TimeoutVerdict};

--- a/crates/media-glue/src/tap.rs
+++ b/crates/media-glue/src/tap.rs
@@ -55,6 +55,7 @@
 //!   from forge-vad. Each transition publishes once — hysteresis
 //!   inside the detector filters per-frame jitter.
 
+use std::collections::VecDeque;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -182,6 +183,21 @@ pub enum TapCommand {
     /// if the tap is not currently muted.
     Unmute,
 
+    /// Server verdict on a pause-mode barge-in arbitration
+    /// ([`BargeInAction::Pause`]): the speech was a real interruption
+    /// — drop the retained playout tail and stay quiet. Audio the
+    /// server streamed since the pause plays immediately (it barged
+    /// over itself — its choice). A no-op when no arbitration is
+    /// pending: verdicts race with the deadline and with preempting
+    /// commands by nature, so a late one must be harmless.
+    BargeInConfirm,
+
+    /// Server verdict: false positive (cough / backchannel / noise) —
+    /// re-queue the retained tail and resume playout where it
+    /// stopped, followed by any audio streamed since the pause. Same
+    /// no-op semantics as [`BargeInConfirm`](Self::BargeInConfirm).
+    BargeInReject,
+
     /// Re-plumb this call into a conference room (0.7.0 §2.1). The
     /// membership comes from `RoomHandle::join` (driven by core's
     /// `ConferenceRegistry`). While joined:
@@ -261,6 +277,39 @@ pub enum BargeInAction {
     /// Drop pending outbound playout (drain the tap-side audio
     /// channel + ask forge to flush leg A) AND forward the event.
     AutoClear,
+    /// Reversible barge-in (`docs/design/DESIGN_REVERSIBLE_BARGE_IN.md`):
+    /// flush playout immediately — the same one-frame reaction as
+    /// `AutoClear` — but retain the unplayed tail so the WS server
+    /// (the only layer with STT) can rule on intent.
+    /// [`TapCommand::BargeInConfirm`] drops the tail;
+    /// [`TapCommand::BargeInReject`] re-queues it and playout resumes
+    /// where it stopped. No verdict within `decision` applies
+    /// `on_timeout`. Arbitration only arms while the bot is playing,
+    /// and degrades to `Notify` inside a conference room (design
+    /// note §7.2).
+    Pause {
+        /// Server verdict deadline (`[bridge.barge_in].decision_ms`).
+        decision: Duration,
+        /// Fallback verdict at the deadline.
+        on_timeout: TimeoutVerdict,
+        /// Cap on retained audio (`[bridge.barge_in].resume_max_secs`).
+        /// A single utterance longer than this loses its oldest
+        /// unplayed frames — warned once per call.
+        resume_max: Duration,
+    },
+}
+
+/// What a [`BargeInAction::Pause`] arbitration falls back to when the
+/// server doesn't rule within the decision window.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TimeoutVerdict {
+    /// Treat the speech as a real barge-in: drop the retained tail and
+    /// stay quiet. The safe default — never talk over the caller. A
+    /// server that ignores arbitration entirely therefore degrades to
+    /// "auto_clear delayed by the decision window".
+    Confirm,
+    /// Treat it as a false positive: resume the retained playout.
+    Reject,
 }
 
 /// Why the tap pump exited cleanly.
@@ -505,6 +554,92 @@ impl MediaTap {
         }
     }
 
+    /// Record the resolution of a pause-mode barge-in arbitration:
+    /// the decision metrics always; the CDR barge-in count only when
+    /// the resolution treats the speech as a real interruption
+    /// (confirm-shaped outcomes — a rejected arbitration was, by the
+    /// server's own ruling, not a barge-in).
+    fn note_barge_in_decision(
+        &mut self,
+        armed_at: Instant,
+        outcome: &'static str,
+        is_barge_in: bool,
+    ) {
+        metrics::counter!("siphon_ai_barge_in_decisions_total", "outcome" => outcome).increment(1);
+        metrics::histogram!("siphon_ai_barge_in_decision_seconds")
+            .record(armed_at.elapsed().as_secs_f64());
+        if is_barge_in {
+            self.barge_in_count += 1;
+            self.publish_quality();
+        }
+    }
+
+    /// Resolve a pending pause arbitration as confirm without
+    /// re-queuing anything — used when another feature takes over the
+    /// caller's ear (mute / clear / hold / park / announce / room) or
+    /// the WS drops. The retained tail is moot in every such case, and
+    /// the interruption stands for CDR purposes. A `None` pending is a
+    /// no-op, so call sites don't need their own guard.
+    fn abandon_arbitration(&mut self, pending: &mut Option<PendingVerdict>, site: &'static str) {
+        if let Some(p) = pending.take() {
+            self.note_barge_in_decision(p.armed_at, "confirmed", true);
+            debug!(
+                call_id = %self.call_id,
+                site,
+                "pending barge-in arbitration resolved as confirm",
+            );
+        }
+    }
+
+    /// Re-queue retained playout chunks into forge at arbitration
+    /// resolution (design note §5.3). `fork_recording` is set for the
+    /// post-pause `fresh` audio (first time it plays) and unset for
+    /// the `resume` tail (already forked at its original push — the
+    /// recording must not carry it twice). Re-pushed chunks re-enter
+    /// the shadow ring so an immediate second barge-in stays
+    /// reversible; the caller re-anchors the playout clock afterwards
+    /// via [`restore_playout_clock`].
+    async fn repush_chunks(
+        &self,
+        chunks: Vec<Vec<u8>>,
+        fork_recording: bool,
+        shadow: &mut VecDeque<Vec<u8>>,
+        shadow_cap: usize,
+    ) -> Result<u64, MediaTapError> {
+        let mut pushed = 0u64;
+        for bytes in chunks {
+            let samples = unpack_pcm16_le(&bytes)?;
+            if fork_recording {
+                if let Some((rec, drops)) = &self.recording {
+                    if let Err(mpsc::error::TrySendError::Full(_)) =
+                        rec.try_send(RecFrame::Bot(bytes.clone()))
+                    {
+                        drops.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+            }
+            let frame = OutboundMediaFrame {
+                target: MediaTarget::A,
+                sample_rate: self.sample_rate,
+                samples,
+                playback_id: None,
+                mode: PlayoutMode::Append,
+            };
+            self.handle
+                .send_audio(frame)
+                .await
+                .map_err(|e| MediaTapError::PlayoutFailed(e.to_string()))?;
+            if shadow_cap > 0 {
+                if shadow.len() == shadow_cap {
+                    shadow.pop_front();
+                }
+                shadow.push_back(bytes);
+            }
+            pushed += 1;
+        }
+        Ok(pushed)
+    }
+
     /// Install the playout-gated barge-in debounce from
     /// `[bridge.barge_in].debounce_ms` (and any per-route override).
     /// `None`/`Some(0)` disables it (immediate flush, pre-0.7.1 behaviour).
@@ -679,6 +814,26 @@ impl MediaTap {
         tokio::pin!(barge_debounce);
         let mut pending_barge_in: Option<OutgoingEvent> = None;
 
+        // Pause-mode barge-in arbitration (§5 of the design note).
+        // `shadow` holds the *unplayed* playout tail — each pushed frame
+        // is retained until the playout clock says it has played (plus
+        // one frame of early-bias slop) — so a reject can re-queue what
+        // the pause's flush dropped. Capacity 0 in the other modes
+        // makes every push a no-op. `pending_verdict` gates the
+        // deadline arm; same pinned-placeholder pattern as the
+        // debounce timer above.
+        let shadow_cap = match self.barge_in_action {
+            BargeInAction::Pause { resume_max, .. } => {
+                (resume_max.as_millis() as u64 / PLAYOUT_FRAME_MS).max(1) as usize
+            }
+            _ => 0,
+        };
+        let mut shadow: VecDeque<Vec<u8>> = VecDeque::with_capacity(shadow_cap.min(2048));
+        let mut shadow_truncation_warned = false;
+        let mut pending_verdict: Option<PendingVerdict> = None;
+        let arb_deadline = tokio::time::sleep(Duration::from_secs(86_400));
+        tokio::pin!(arb_deadline);
+
         loop {
             tokio::select! {
                 biased;
@@ -696,6 +851,11 @@ impl MediaTap {
                         // `commands_rx` closing.
                         debug!(call_id = %self.call_id,
                             "caller_audio_tx receiver dropped; holding for reconnect");
+                        // The arbiter is gone — a pending pause verdict
+                        // resolves as confirm (§7.2 of the design note);
+                        // flushed-and-quiet is the right state alongside
+                        // the reconnect hold music.
+                        self.abandon_arbitration(&mut pending_verdict, "ws_drop");
                         ws_dropped = true;
                     } else {
                         debug!("caller_audio_tx receiver dropped; ending tap");
@@ -727,6 +887,9 @@ impl MediaTap {
                             // down (mirrors the caller_audio_tx arm).
                             debug!(call_id = %self.call_id,
                                 "playout_audio_rx closed; holding for reconnect");
+                            // Same as the caller_audio_tx arm: no arbiter,
+                            // pending verdict resolves as confirm.
+                            self.abandon_arbitration(&mut pending_verdict, "ws_drop");
                             ws_dropped = true;
                             continue;
                         }
@@ -757,6 +920,26 @@ impl MediaTap {
                     // play, so they don't move the "audio queued so
                     // far" clock.
                     if self.muted {
+                        continue;
+                    }
+                    // Pause-mode arbitration in flight: post-pause server
+                    // audio queues behind the retained tail (§5.3 of the
+                    // design note) instead of reaching forge mid-pause —
+                    // it's re-queued (and recording-forked) at
+                    // resolution. Bounded by the shadow cap; a server
+                    // that floods faster than real time during the
+                    // sub-second window loses the excess.
+                    if let Some(p) = pending_verdict.as_mut() {
+                        if p.fresh.len() < shadow_cap {
+                            p.fresh.push(bytes);
+                        } else if !shadow_truncation_warned {
+                            shadow_truncation_warned = true;
+                            warn!(
+                                call_id = %self.call_id,
+                                cap_frames = shadow_cap,
+                                "barge-in pause buffer full; dropping incoming playout",
+                            );
+                        }
                         continue;
                     }
                     // In a room, bot playout becomes the `ws`
@@ -813,6 +996,31 @@ impl MediaTap {
                         playout_until.map_or(push_now, |c| c.max(push_now))
                             + Duration::from_millis(PLAYOUT_FRAME_MS),
                     );
+                    // Pause mode: shadow the pushed frame so a barge-in
+                    // reject can re-queue it, then drop frames the
+                    // playout clock says have already played — the ring
+                    // only ever holds the unplayed tail plus one frame
+                    // of early-bias slop (repeating ≤20 ms on resume
+                    // beats skipping a syllable). Steady-state cost is
+                    // moving the already-owned `bytes` Vec, no copy.
+                    if shadow_cap > 0 {
+                        if shadow.len() == shadow_cap {
+                            shadow.pop_front();
+                            if !shadow_truncation_warned {
+                                shadow_truncation_warned = true;
+                                warn!(
+                                    call_id = %self.call_id,
+                                    cap_frames = shadow_cap,
+                                    "utterance exceeds barge-in resume_max; oldest unplayed audio won't survive a reject",
+                                );
+                            }
+                        }
+                        shadow.push_back(bytes);
+                        let keep = unplayed_frames(playout_until, push_now).saturating_add(1);
+                        while shadow.len() > keep {
+                            shadow.pop_front();
+                        }
+                    }
                 }
 
                 // Caller → server: PCM16 samples from forge, reframed and packed.
@@ -1072,31 +1280,51 @@ impl MediaTap {
                                 if matches!(out, OutgoingEvent::SpeechStarted { .. }) {
                                     self.idle_detector.note_speech_started(Instant::now());
                                 }
-                                // Barge-in `auto_clear`: when forge-vad
-                                // reports speech-started AND this call's
-                                // policy is AutoClear, drop pending
-                                // outbound playout before forwarding the
-                                // WS event. The drain catches bytes in
-                                // the controller→tap audio channel that
-                                // haven't yet reached forge; the flush
-                                // dumps forge's encoder queue. Reset the
-                                // Mark bookkeeping so the next `Mark`
-                                // doesn't wait on now-dropped audio.
-                                //
-                                // Playout-gated debounce (echo/noise): if
-                                // the bot is currently talking and a
-                                // debounce is configured, the speech is
-                                // *provisional* — hold the event (no flush,
-                                // no forward) and let the `barge_debounce`
-                                // timer confirm it or a `SpeechStopped`
-                                // cancel it. While the bot is silent,
-                                // barge-in stays immediate.
-                                if matches!(out, OutgoingEvent::SpeechStarted { .. })
-                                    && self.barge_in_action == BargeInAction::AutoClear
+                                // Barge-in reaction beyond forwarding the
+                                // event. `auto_clear` drops pending
+                                // outbound playout; `pause` does the same
+                                // flush but retains the unplayed tail and
+                                // arms the server arbitration (design note
+                                // §5.2). Pause degrades to notify-only in
+                                // a room (§7.2), while an arbitration is
+                                // already pending (forge-vad won't re-fire
+                                // without a SpeechStopped between, but the
+                                // bus is best-effort), and while the bot
+                                // is silent — nothing to pause.
+                                let speech_now = Instant::now();
+                                let reaction = if matches!(out, OutgoingEvent::SpeechStarted { .. })
                                 {
+                                    match self.barge_in_action {
+                                        BargeInAction::Notify => None,
+                                        BargeInAction::AutoClear => Some(self.barge_in_action),
+                                        BargeInAction::Pause { .. }
+                                            if room_send.is_some()
+                                                || pending_verdict.is_some()
+                                                || !bot_is_playing(playout_until, speech_now) =>
+                                        {
+                                            None
+                                        }
+                                        pause @ BargeInAction::Pause { .. } => Some(pause),
+                                    }
+                                } else {
+                                    None
+                                };
+                                if let Some(action) = reaction {
+                                    // Playout-gated debounce (echo/noise):
+                                    // if the bot is currently talking and a
+                                    // debounce is configured, the speech is
+                                    // *provisional* — hold the event (no
+                                    // flush, no forward) and let the
+                                    // `barge_debounce` timer confirm it or
+                                    // a `SpeechStopped` cancel it. While
+                                    // the bot is silent, barge-in stays
+                                    // immediate. Applies to both flushing
+                                    // modes: the gate is the acoustic
+                                    // filter, arbitration the semantic one
+                                    // — they compose (§7.1).
                                     let gate = self
                                         .barge_in_debounce
-                                        .filter(|_| bot_is_playing(playout_until, Instant::now()));
+                                        .filter(|_| bot_is_playing(playout_until, speech_now));
                                     if let Some(debounce) = gate {
                                         if pending_barge_in.is_none() {
                                             barge_debounce
@@ -1111,37 +1339,72 @@ impl MediaTap {
                                         }
                                         continue; // timer or speech-stopped decides
                                     }
-                                    self.barge_in_count += 1;
-                                    self.publish_quality();
-                                    let mut drained = 0usize;
-                                    while let Ok(_bytes) = playout_audio_rx.try_recv() {
-                                        drained += 1;
+                                    match action {
+                                        BargeInAction::AutoClear => {
+                                            // Drop pending outbound playout
+                                            // before forwarding the WS
+                                            // event. The drain catches bytes
+                                            // in the controller→tap audio
+                                            // channel that haven't yet
+                                            // reached forge; the flush dumps
+                                            // forge's encoder queue. Reset
+                                            // the Mark bookkeeping so the
+                                            // next `Mark` doesn't wait on
+                                            // now-dropped audio.
+                                            self.barge_in_count += 1;
+                                            self.publish_quality();
+                                            let mut drained = 0usize;
+                                            while let Ok(_bytes) = playout_audio_rx.try_recv() {
+                                                drained += 1;
+                                            }
+                                            // In a room, the queued tail also
+                                            // lives in the room's ws buffer.
+                                            if let Some(send) = &room_send {
+                                                send.clear_ws_input();
+                                            }
+                                            if let Err(e) = self
+                                                .handle
+                                                .flush(Some(MediaTarget::A), None)
+                                                .await
+                                            {
+                                                warn!(
+                                                    call_id = %self.call_id,
+                                                    error = %e,
+                                                    "forge flush failed during auto_clear",
+                                                );
+                                            } else {
+                                                debug!(
+                                                    call_id = %self.call_id,
+                                                    drained,
+                                                    "auto_clear: dropped pending playout on speech",
+                                                );
+                                            }
+                                            frames_sent_to_forge = 0;
+                                            first_audio_pushed_at = None;
+                                            playout_until = None;
+                                        }
+                                        BargeInAction::Pause { decision, .. } => {
+                                            let resume = begin_pause_arbitration(
+                                                &self.call_id,
+                                                &self.handle,
+                                                &mut playout_audio_rx,
+                                                &mut shadow,
+                                            )
+                                            .await;
+                                            frames_sent_to_forge = 0;
+                                            first_audio_pushed_at = None;
+                                            playout_until = None;
+                                            arb_deadline
+                                                .as_mut()
+                                                .reset(tokio::time::Instant::now() + decision);
+                                            pending_verdict = Some(PendingVerdict {
+                                                resume,
+                                                fresh: Vec::new(),
+                                                armed_at: speech_now,
+                                            });
+                                        }
+                                        BargeInAction::Notify => {}
                                     }
-                                    // In a room, the queued tail also
-                                    // lives in the room's ws buffer.
-                                    if let Some(send) = &room_send {
-                                        send.clear_ws_input();
-                                    }
-                                    if let Err(e) = self
-                                        .handle
-                                        .flush(Some(MediaTarget::A), None)
-                                        .await
-                                    {
-                                        warn!(
-                                            call_id = %self.call_id,
-                                            error = %e,
-                                            "forge flush failed during auto_clear",
-                                        );
-                                    } else {
-                                        debug!(
-                                            call_id = %self.call_id,
-                                            drained,
-                                            "auto_clear: dropped pending playout on speech",
-                                        );
-                                    }
-                                    frames_sent_to_forge = 0;
-                                    first_audio_pushed_at = None;
-                                    playout_until = None;
                                 }
                                 // A speech-stopped within the debounce
                                 // window cancels the held barge-in — it was
@@ -1226,6 +1489,11 @@ impl MediaTap {
                     };
                     match cmd {
                         TapCommand::Mute => {
+                            // Mute takes over the caller's ear — a
+                            // pending pause arbitration resolves as
+                            // confirm (§7.2); the retained tail would be
+                            // flushed below anyway.
+                            self.abandon_arbitration(&mut pending_verdict, "mute");
                             // Sustained AI-side gate. Same drain +
                             // forge-flush combo as Clear so the
                             // caller hears silence immediately; the
@@ -1273,12 +1541,80 @@ impl MediaTap {
                                 "unmuted; AI playout resumes",
                             );
                         }
+                        TapCommand::BargeInConfirm => {
+                            if let Some(p) = pending_verdict.take() {
+                                self.note_barge_in_decision(p.armed_at, "confirmed", true);
+                                // The pause already flushed; only the
+                                // post-pause server audio plays (§5.3).
+                                let n = self
+                                    .repush_chunks(p.fresh, true, &mut shadow, shadow_cap)
+                                    .await?;
+                                restore_playout_clock(
+                                    n,
+                                    &mut frames_sent_to_forge,
+                                    &mut first_audio_pushed_at,
+                                    &mut playout_until,
+                                );
+                                debug!(
+                                    call_id = %self.call_id,
+                                    fresh = n,
+                                    "barge-in confirmed by server; retained tail dropped",
+                                );
+                            } else {
+                                debug!(
+                                    call_id = %self.call_id,
+                                    "barge_in_confirm with no pending arbitration; ignoring",
+                                );
+                            }
+                        }
+                        TapCommand::BargeInReject => {
+                            if let Some(p) = pending_verdict.take() {
+                                self.note_barge_in_decision(p.armed_at, "rejected", false);
+                                // Resume where playout stopped: the
+                                // retained tail first (already recording-
+                                // forked at its original push — §5.3 "no
+                                // double-record"), then the post-pause
+                                // server audio.
+                                let resumed = self
+                                    .repush_chunks(p.resume, false, &mut shadow, shadow_cap)
+                                    .await?;
+                                let fresh = self
+                                    .repush_chunks(p.fresh, true, &mut shadow, shadow_cap)
+                                    .await?;
+                                restore_playout_clock(
+                                    resumed + fresh,
+                                    &mut frames_sent_to_forge,
+                                    &mut first_audio_pushed_at,
+                                    &mut playout_until,
+                                );
+                                debug!(
+                                    call_id = %self.call_id,
+                                    resumed,
+                                    fresh,
+                                    "barge-in rejected by server; playout resumed",
+                                );
+                            } else {
+                                debug!(
+                                    call_id = %self.call_id,
+                                    "barge_in_reject with no pending arbitration; ignoring",
+                                );
+                            }
+                        }
                         TapCommand::Clear => {
-                            // CDR barge_in_count: a server-driven clear is
-                            // the Notify-mode barge-in (the server heard
-                            // speech_started and interrupted its playout).
-                            self.barge_in_count += 1;
-                            self.publish_quality();
+                            // `clear` during a pending pause arbitration
+                            // acts as confirm (design note §2) — the
+                            // count is bumped once, via the arbitration
+                            // path.
+                            if pending_verdict.is_some() {
+                                self.abandon_arbitration(&mut pending_verdict, "clear");
+                            } else {
+                                // CDR barge_in_count: a server-driven clear
+                                // is the Notify-mode barge-in (the server
+                                // heard speech_started and interrupted its
+                                // playout).
+                                self.barge_in_count += 1;
+                                self.publish_quality();
+                            }
                             // Drain any bytes queued in the
                             // controller→tap audio channel before
                             // they can reach forge. The mpsc bound
@@ -1327,6 +1663,10 @@ impl MediaTap {
                             );
                         }
                         TapCommand::JoinRoom { membership } => {
+                            // Arbitration is suspended in rooms (§7.2) —
+                            // a pending one resolves as confirm before
+                            // the re-plumb.
+                            self.abandon_arbitration(&mut pending_verdict, "join_room");
                             if room_send.is_some() {
                                 // Switching rooms: dropping the old
                                 // RoomSender signals the old room to
@@ -1390,6 +1730,10 @@ impl MediaTap {
                             }
                         }
                         TapCommand::Park { moh } => {
+                            // Park takes over the caller's ear — a
+                            // pending pause arbitration resolves as
+                            // confirm (§7.2).
+                            self.abandon_arbitration(&mut pending_verdict, "park");
                             // Parking while in a room first leaves it
                             // (drops the RoomSender → the room reaps us).
                             if let Some(send) = room_send.take() {
@@ -1437,6 +1781,9 @@ impl MediaTap {
                             }
                         }
                         TapCommand::Hold { moh } => {
+                            // Same as Park: MOH takes over the caller's
+                            // ear, pending arbitration resolves as confirm.
+                            self.abandon_arbitration(&mut pending_verdict, "hold");
                             // Holding while in a room first leaves it
                             // (drops the RoomSender → the room reaps us),
                             // same as Park.
@@ -1460,6 +1807,9 @@ impl MediaTap {
                             moh_tick.reset();
                         }
                         TapCommand::Announce { source, done } => {
+                            // The prompt preempts playout — pending
+                            // arbitration resolves as confirm (§7.2).
+                            self.abandon_arbitration(&mut pending_verdict, "announce");
                             if parked.is_some() || held.is_some() {
                                 // Park/hold owns the caller's ear; skip
                                 // the prompt rather than queue it.
@@ -1629,36 +1979,74 @@ impl MediaTap {
                 }
 
                 // Barge-in debounce elapsed with a candidate still held →
-                // the speech sustained past the window, so it's a real
-                // barge-in: flush the bot's playout and forward the held
-                // `speech_started`. (A `SpeechStopped` would have cleared
-                // `pending_barge_in` first, disabling this arm.)
+                // the speech sustained past the acoustic gate, so it's a
+                // real barge-in for this layer. `auto_clear` flushes the
+                // bot's playout; `pause` runs the same flush but retains
+                // the tail and arms the semantic arbitration (§7.1: the
+                // two filters compose). Either way the held
+                // `speech_started` is forwarded. (A `SpeechStopped`
+                // would have cleared `pending_barge_in` first, disabling
+                // this arm.)
                 _ = &mut barge_debounce, if pending_barge_in.is_some() => {
-                    self.barge_in_count += 1;
-                    self.publish_quality();
-                    let mut drained = 0usize;
-                    while let Ok(_bytes) = playout_audio_rx.try_recv() {
-                        drained += 1;
+                    match self.barge_in_action {
+                        BargeInAction::Pause { decision, .. } if pending_verdict.is_none() => {
+                            let resume = begin_pause_arbitration(
+                                &self.call_id,
+                                &self.handle,
+                                &mut playout_audio_rx,
+                                &mut shadow,
+                            )
+                            .await;
+                            frames_sent_to_forge = 0;
+                            first_audio_pushed_at = None;
+                            playout_until = None;
+                            arb_deadline
+                                .as_mut()
+                                .reset(tokio::time::Instant::now() + decision);
+                            pending_verdict = Some(PendingVerdict {
+                                resume,
+                                fresh: Vec::new(),
+                                armed_at: Instant::now(),
+                            });
+                            debug!(
+                                call_id = %self.call_id,
+                                "barge-in sustained past debounce; pause arbitration armed",
+                            );
+                        }
+                        BargeInAction::Pause { .. } => {
+                            // An arbitration is somehow already pending
+                            // (shouldn't happen — the gate only arms
+                            // while playing, and the pause cleared the
+                            // clock). Just forward the held event below.
+                        }
+                        _ => {
+                            self.barge_in_count += 1;
+                            self.publish_quality();
+                            let mut drained = 0usize;
+                            while let Ok(_bytes) = playout_audio_rx.try_recv() {
+                                drained += 1;
+                            }
+                            if let Some(send) = &room_send {
+                                send.clear_ws_input();
+                            }
+                            if let Err(e) = self.handle.flush(Some(MediaTarget::A), None).await {
+                                warn!(
+                                    call_id = %self.call_id,
+                                    error = %e,
+                                    "forge flush failed during confirmed barge-in",
+                                );
+                            } else {
+                                debug!(
+                                    call_id = %self.call_id,
+                                    drained,
+                                    "barge-in confirmed after debounce; dropped pending playout",
+                                );
+                            }
+                            frames_sent_to_forge = 0;
+                            first_audio_pushed_at = None;
+                            playout_until = None;
+                        }
                     }
-                    if let Some(send) = &room_send {
-                        send.clear_ws_input();
-                    }
-                    if let Err(e) = self.handle.flush(Some(MediaTarget::A), None).await {
-                        warn!(
-                            call_id = %self.call_id,
-                            error = %e,
-                            "forge flush failed during confirmed barge-in",
-                        );
-                    } else {
-                        debug!(
-                            call_id = %self.call_id,
-                            drained,
-                            "barge-in confirmed after debounce; dropped pending playout",
-                        );
-                    }
-                    frames_sent_to_forge = 0;
-                    first_audio_pushed_at = None;
-                    playout_until = None;
                     if let Some(out) = pending_barge_in.take() {
                         if let Err(e) = events_tx.try_send(out) {
                             warn!(
@@ -1666,6 +2054,58 @@ impl MediaTap {
                                 error = %e,
                                 "events_tx full or closed; dropping confirmed barge-in event"
                             );
+                        }
+                    }
+                }
+
+                // Pause-mode decision window elapsed without a server
+                // verdict → apply the configured fallback (§1: the
+                // default `confirm` fails toward not talking over the
+                // caller, so a server that never arbitrates degrades to
+                // "auto_clear delayed by the decision window").
+                _ = &mut arb_deadline, if pending_verdict.is_some() => {
+                    if let (Some(p), BargeInAction::Pause { on_timeout, .. }) =
+                        (pending_verdict.take(), self.barge_in_action)
+                    {
+                        match on_timeout {
+                            TimeoutVerdict::Confirm => {
+                                self.note_barge_in_decision(p.armed_at, "timeout", true);
+                                let fresh = self
+                                    .repush_chunks(p.fresh, true, &mut shadow, shadow_cap)
+                                    .await?;
+                                restore_playout_clock(
+                                    fresh,
+                                    &mut frames_sent_to_forge,
+                                    &mut first_audio_pushed_at,
+                                    &mut playout_until,
+                                );
+                                debug!(
+                                    call_id = %self.call_id,
+                                    fresh,
+                                    "barge-in arbitration timed out; confirmed (tail dropped)",
+                                );
+                            }
+                            TimeoutVerdict::Reject => {
+                                self.note_barge_in_decision(p.armed_at, "timeout", false);
+                                let resumed = self
+                                    .repush_chunks(p.resume, false, &mut shadow, shadow_cap)
+                                    .await?;
+                                let fresh = self
+                                    .repush_chunks(p.fresh, true, &mut shadow, shadow_cap)
+                                    .await?;
+                                restore_playout_clock(
+                                    resumed + fresh,
+                                    &mut frames_sent_to_forge,
+                                    &mut first_audio_pushed_at,
+                                    &mut playout_until,
+                                );
+                                debug!(
+                                    call_id = %self.call_id,
+                                    resumed,
+                                    fresh,
+                                    "barge-in arbitration timed out; rejected (playout resumed)",
+                                );
+                            }
                         }
                     }
                 }
@@ -1829,6 +2269,83 @@ fn bot_is_playing(playout_until: Option<Instant>, now: Instant) -> bool {
     }
 }
 
+/// How many queued 20 ms frames the playout clock says have NOT yet
+/// played. The shadow ring is trimmed to this (plus one frame of
+/// early-bias slop) on every push, so at pause time the ring IS the
+/// resume tail. Rounds up — estimation slop must lean toward
+/// repeating audio, never skipping it.
+fn unplayed_frames(playout_until: Option<Instant>, now: Instant) -> usize {
+    match playout_until {
+        Some(end) if end > now => {
+            ((end - now).as_millis() as u64).div_ceil(PLAYOUT_FRAME_MS) as usize
+        }
+        _ => 0,
+    }
+}
+
+/// In-flight pause-mode barge-in arbitration (design note §5).
+struct PendingVerdict {
+    /// The unplayed tail retained at pause time (shadow ring +
+    /// drained controller→tap channel bytes, in playout order).
+    /// Re-queued on reject, dropped on confirm.
+    resume: Vec<Vec<u8>>,
+    /// Audio the WS server streamed *after* the pause (§5.3) — queued
+    /// behind the tail on reject, plays immediately on confirm.
+    fresh: Vec<Vec<u8>>,
+    /// When the arbitration armed, for the decision-latency histogram.
+    armed_at: Instant,
+}
+
+/// Arm a pause arbitration (design note §5.2): capture the resume
+/// tail — the shadow ring (everything estimated unplayed) plus
+/// whatever is still queued in the controller→tap channel — then
+/// flush forge so the caller hears the bot stop within one frame,
+/// exactly like `auto_clear`. The caller resets the Mark/playout
+/// bookkeeping and arms the decision deadline.
+async fn begin_pause_arbitration(
+    call_id: &CallId,
+    handle: &MediaBridgeHandle,
+    playout_audio_rx: &mut mpsc::Receiver<Vec<u8>>,
+    shadow: &mut VecDeque<Vec<u8>>,
+) -> Vec<Vec<u8>> {
+    let mut resume: Vec<Vec<u8>> = shadow.drain(..).collect();
+    while let Ok(bytes) = playout_audio_rx.try_recv() {
+        resume.push(bytes);
+    }
+    if let Err(e) = handle.flush(Some(MediaTarget::A), None).await {
+        warn!(
+            call_id = %call_id,
+            error = %e,
+            "forge flush failed while arming pause arbitration",
+        );
+    } else {
+        debug!(
+            call_id = %call_id,
+            retained = resume.len(),
+            "barge-in pause armed; playout flushed, tail retained",
+        );
+    }
+    resume
+}
+
+/// Re-anchor the Mark / barge-in playout bookkeeping after re-queuing
+/// `frames` chunks at arbitration resolution. Zero frames leaves
+/// everything cleared — the pause's flush already reset it.
+fn restore_playout_clock(
+    frames: u64,
+    frames_sent_to_forge: &mut u64,
+    first_audio_pushed_at: &mut Option<Instant>,
+    playout_until: &mut Option<Instant>,
+) {
+    if frames == 0 {
+        return;
+    }
+    let now = Instant::now();
+    *frames_sent_to_forge = frames;
+    *first_audio_pushed_at = Some(now);
+    *playout_until = Some(now + Duration::from_millis(frames * PLAYOUT_FRAME_MS));
+}
+
 /// Returns `None` for events that aren't this call's, that aren't part
 /// of the v1 WS protocol surface, or that don't carry the final
 /// duration we need (DTMF `Start`/`Continue`).
@@ -1914,6 +2431,21 @@ mod tests {
             until,
             t0 + Duration::from_millis(200) + BARGE_IN_PLAYOUT_GRACE + Duration::from_millis(1)
         ));
+    }
+
+    #[test]
+    fn unplayed_frames_rounds_up_and_clamps_at_zero() {
+        let t0 = Instant::now();
+        // Nothing queued / clock in the past → 0.
+        assert_eq!(unplayed_frames(None, t0), 0);
+        assert_eq!(unplayed_frames(Some(t0), t0 + Duration::from_millis(1)), 0);
+        // Exact multiples and mid-frame remainders round UP — slop
+        // must lean toward repeating audio, never skipping it.
+        let until = Some(t0 + Duration::from_millis(100));
+        assert_eq!(unplayed_frames(until, t0), 5);
+        assert_eq!(unplayed_frames(until, t0 + Duration::from_millis(39)), 4);
+        assert_eq!(unplayed_frames(until, t0 + Duration::from_millis(40)), 3);
+        assert_eq!(unplayed_frames(until, t0 + Duration::from_millis(99)), 1);
     }
 
     #[test]

--- a/crates/media-glue/tests/tap.rs
+++ b/crates/media-glue/tests/tap.rs
@@ -1204,3 +1204,669 @@ async fn notify_only_does_not_flush_on_speech_started() {
     drop(_playout_tx);
     let _ = tokio::time::timeout(Duration::from_secs(1), pump).await;
 }
+
+// ─── Barge-in pause (reversible, server-arbitrated) ────────────────
+//
+// `BargeInAction::Pause` (docs/design/DESIGN_REVERSIBLE_BARGE_IN.md):
+// a SpeechStarted while the bot is playing flushes forge exactly like
+// auto_clear but retains the unplayed tail; the server then rules via
+// `TapCommand::BargeInConfirm` / `BargeInReject`, or the decision
+// deadline applies the configured fallback.
+
+/// Shared fixture: a Pause policy with a generous resume cap.
+fn pause_action(
+    decision: Duration,
+    on_timeout: siphon_ai_media_glue::TimeoutVerdict,
+) -> siphon_ai_media_glue::BargeInAction {
+    siphon_ai_media_glue::BargeInAction::Pause {
+        decision,
+        on_timeout,
+        resume_max: Duration::from_secs(30),
+    }
+}
+
+/// Drain forge's outbound queue until an Audio frame arrives, return
+/// its first sample (the tests use constant-pattern frames). Panics
+/// on timeout.
+async fn next_audio_pattern(manager: &Arc<MediaBridgeManager>, call: &CallId) -> i16 {
+    tokio::time::timeout(Duration::from_millis(700), async {
+        loop {
+            if let Some(OutboundMediaRequest::Audio(f)) =
+                manager.try_recv_outbound_request(call).await
+            {
+                return f.samples[0];
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("audio frame reaches forge")
+}
+
+/// Wait until forge sees a Flush for leg A (draining Audio requests on
+/// the way — pre-pause pushes may still be queued).
+async fn await_flush(manager: &Arc<MediaBridgeManager>, call: &CallId) {
+    tokio::time::timeout(Duration::from_millis(700), async {
+        loop {
+            if let Some(req) = manager.try_recv_outbound_request(call).await {
+                if matches!(req, OutboundMediaRequest::Flush { .. }) {
+                    return;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("forge sees Flush")
+}
+
+/// Assert that no Audio request reaches forge within `window` (Flush
+/// requests are tolerated — several commands legitimately emit one).
+async fn assert_no_audio_for(manager: &Arc<MediaBridgeManager>, call: &CallId, window: Duration) {
+    let deadline = tokio::time::Instant::now() + window;
+    loop {
+        if tokio::time::Instant::now() >= deadline {
+            return;
+        }
+        if let Some(OutboundMediaRequest::Audio(f)) = manager.try_recv_outbound_request(call).await
+        {
+            panic!(
+                "unexpected audio reached forge during pause: {:?}",
+                f.samples[0]
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+}
+
+/// Full pause→reject round trip: the retained tail must be re-queued
+/// in order (ending with the newest frame), and the tap must keep
+/// pumping normally afterwards.
+#[tokio::test]
+async fn pause_reject_resumes_retained_tail() {
+    use chrono::Utc;
+    use forge_core::{EventBus as ForgeEventBus, ForgeEvent};
+    use siphon_ai_bridge::OutgoingEvent;
+    use siphon_ai_media_glue::{TapCommand, TimeoutVerdict};
+
+    let manager = Arc::new(MediaBridgeManager::with_capacities(64, 64));
+    let bus = Arc::new(ForgeEventBus::new());
+    let call = CallId::new("pause-reject");
+    let tap = MediaTap::attach_with_barge_in(
+        &manager,
+        &bus,
+        call.clone(),
+        8000,
+        pause_action(Duration::from_secs(5), TimeoutVerdict::Confirm),
+    )
+    .expect("attach");
+
+    let (caller_tx, _caller_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (events_tx, mut events_rx) = mpsc::channel::<OutgoingEvent>(8);
+    let (cmd_tx, cmd_rx) = mpsc::channel::<TapCommand>(8);
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, events_tx, cmd_rx));
+
+    // Queue a 100 ms utterance (5 frames, patterns 1..=5) and let the
+    // tap push it into forge.
+    for k in 1..=5i16 {
+        playout_tx
+            .send(pack_pcm16_le(&vec![k; 160]))
+            .await
+            .expect("send frame");
+    }
+    for _ in 0..5 {
+        let _ = next_audio_pattern(&manager, &call).await;
+    }
+
+    // Caller speaks → pause fires: flush lands on forge, the
+    // speech_started is forwarded, and nothing else plays.
+    bus.publish(ForgeEvent::SpeechStarted {
+        call_id: call.clone(),
+        timestamp: Utc::now(),
+    })
+    .expect("publish");
+    await_flush(&manager, &call).await;
+    let event = tokio::time::timeout(Duration::from_millis(500), events_rx.recv())
+        .await
+        .expect("speech_started arrives")
+        .expect("events_tx open");
+    assert!(matches!(event, OutgoingEvent::SpeechStarted { .. }));
+
+    // Server rules: false positive. The retained tail replays in
+    // order, ending with the newest frame (pattern 5). The playout
+    // clock only trims *played* frames, so at minimum the un-elapsed
+    // majority of the 100 ms utterance must come back.
+    cmd_tx
+        .send(TapCommand::BargeInReject)
+        .await
+        .expect("send reject");
+    let mut replayed = Vec::new();
+    loop {
+        let p = next_audio_pattern(&manager, &call).await;
+        replayed.push(p);
+        if p == 5 {
+            break;
+        }
+    }
+    assert!(
+        replayed.len() >= 3,
+        "expected most of the 5-frame tail to replay, got {replayed:?}",
+    );
+    assert!(
+        replayed.windows(2).all(|w| w[0] < w[1]),
+        "tail must replay in playout order, got {replayed:?}",
+    );
+
+    // Tap is back to normal pumping.
+    playout_tx
+        .send(pack_pcm16_le(&vec![7i16; 160]))
+        .await
+        .expect("send post-reject frame");
+    assert_eq!(next_audio_pattern(&manager, &call).await, 7);
+
+    drop(cmd_tx);
+    drop(_caller_rx);
+    drop(playout_tx);
+    let _ = tokio::time::timeout(Duration::from_secs(1), pump).await;
+}
+
+/// Pause→confirm ends in the auto_clear end-state: tail dropped,
+/// nothing replays, and the barge-in is counted for the CDR (visible
+/// on the quality watch).
+#[tokio::test]
+async fn pause_confirm_drops_tail_and_counts_barge_in() {
+    use chrono::Utc;
+    use forge_core::{EventBus as ForgeEventBus, ForgeEvent};
+    use siphon_ai_bridge::OutgoingEvent;
+    use siphon_ai_media_glue::{QualityReport, TapCommand, TimeoutVerdict};
+
+    let manager = Arc::new(MediaBridgeManager::with_capacities(64, 64));
+    let bus = Arc::new(ForgeEventBus::new());
+    let call = CallId::new("pause-confirm");
+    let (quality_tx, quality_rx) = tokio::sync::watch::channel(QualityReport::default());
+    let tap = MediaTap::attach_with_barge_in(
+        &manager,
+        &bus,
+        call.clone(),
+        8000,
+        pause_action(Duration::from_secs(5), TimeoutVerdict::Confirm),
+    )
+    .expect("attach")
+    .with_quality_watch(quality_tx);
+
+    let (caller_tx, _caller_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (events_tx, _events_rx) = mpsc::channel::<OutgoingEvent>(8);
+    let (cmd_tx, cmd_rx) = mpsc::channel::<TapCommand>(8);
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, events_tx, cmd_rx));
+
+    for k in 1..=5i16 {
+        playout_tx
+            .send(pack_pcm16_le(&vec![k; 160]))
+            .await
+            .expect("send frame");
+    }
+    for _ in 0..5 {
+        let _ = next_audio_pattern(&manager, &call).await;
+    }
+
+    bus.publish(ForgeEvent::SpeechStarted {
+        call_id: call.clone(),
+        timestamp: Utc::now(),
+    })
+    .expect("publish");
+    await_flush(&manager, &call).await;
+
+    cmd_tx
+        .send(TapCommand::BargeInConfirm)
+        .await
+        .expect("send confirm");
+    assert_no_audio_for(&manager, &call, Duration::from_millis(120)).await;
+    assert_eq!(
+        quality_rx.borrow().barge_in_count,
+        1,
+        "confirmed arbitration must count as a barge-in",
+    );
+
+    // Tap still alive.
+    playout_tx
+        .send(pack_pcm16_le(&vec![7i16; 160]))
+        .await
+        .expect("send post-confirm frame");
+    assert_eq!(next_audio_pattern(&manager, &call).await, 7);
+
+    drop(cmd_tx);
+    drop(_caller_rx);
+    drop(playout_tx);
+    let _ = tokio::time::timeout(Duration::from_secs(1), pump).await;
+}
+
+/// No verdict within the window → `on_timeout = Confirm` drops the
+/// tail without any command; a late reject is a harmless no-op.
+#[tokio::test]
+async fn pause_timeout_confirm_applies_fallback() {
+    use chrono::Utc;
+    use forge_core::{EventBus as ForgeEventBus, ForgeEvent};
+    use siphon_ai_bridge::OutgoingEvent;
+    use siphon_ai_media_glue::{TapCommand, TimeoutVerdict};
+
+    let manager = Arc::new(MediaBridgeManager::with_capacities(64, 64));
+    let bus = Arc::new(ForgeEventBus::new());
+    let call = CallId::new("pause-timeout-confirm");
+    let tap = MediaTap::attach_with_barge_in(
+        &manager,
+        &bus,
+        call.clone(),
+        8000,
+        pause_action(Duration::from_millis(150), TimeoutVerdict::Confirm),
+    )
+    .expect("attach");
+
+    let (caller_tx, _caller_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (events_tx, _events_rx) = mpsc::channel::<OutgoingEvent>(8);
+    let (cmd_tx, cmd_rx) = mpsc::channel::<TapCommand>(8);
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, events_tx, cmd_rx));
+
+    for k in 1..=3i16 {
+        playout_tx
+            .send(pack_pcm16_le(&vec![k; 160]))
+            .await
+            .expect("send frame");
+    }
+    for _ in 0..3 {
+        let _ = next_audio_pattern(&manager, &call).await;
+    }
+
+    bus.publish(ForgeEvent::SpeechStarted {
+        call_id: call.clone(),
+        timestamp: Utc::now(),
+    })
+    .expect("publish");
+    await_flush(&manager, &call).await;
+
+    // Past the 150 ms deadline the fallback confirms: nothing replays.
+    assert_no_audio_for(&manager, &call, Duration::from_millis(400)).await;
+
+    // A verdict arriving after the deadline must be ignored.
+    cmd_tx
+        .send(TapCommand::BargeInReject)
+        .await
+        .expect("send late reject");
+    assert_no_audio_for(&manager, &call, Duration::from_millis(120)).await;
+
+    playout_tx
+        .send(pack_pcm16_le(&vec![7i16; 160]))
+        .await
+        .expect("send post-timeout frame");
+    assert_eq!(next_audio_pattern(&manager, &call).await, 7);
+
+    drop(cmd_tx);
+    drop(_caller_rx);
+    drop(playout_tx);
+    let _ = tokio::time::timeout(Duration::from_secs(1), pump).await;
+}
+
+/// `on_timeout = Reject` resumes the tail at the deadline with no
+/// server involvement at all.
+#[tokio::test]
+async fn pause_timeout_reject_resumes_tail() {
+    use chrono::Utc;
+    use forge_core::{EventBus as ForgeEventBus, ForgeEvent};
+    use siphon_ai_bridge::OutgoingEvent;
+    use siphon_ai_media_glue::{TapCommand, TimeoutVerdict};
+
+    let manager = Arc::new(MediaBridgeManager::with_capacities(64, 64));
+    let bus = Arc::new(ForgeEventBus::new());
+    let call = CallId::new("pause-timeout-reject");
+    let tap = MediaTap::attach_with_barge_in(
+        &manager,
+        &bus,
+        call.clone(),
+        8000,
+        pause_action(Duration::from_millis(150), TimeoutVerdict::Reject),
+    )
+    .expect("attach");
+
+    let (caller_tx, _caller_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (events_tx, _events_rx) = mpsc::channel::<OutgoingEvent>(8);
+    let (_cmd_tx, cmd_rx) = mpsc::channel::<TapCommand>(8);
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, events_tx, cmd_rx));
+
+    for k in 1..=3i16 {
+        playout_tx
+            .send(pack_pcm16_le(&vec![k; 160]))
+            .await
+            .expect("send frame");
+    }
+    for _ in 0..3 {
+        let _ = next_audio_pattern(&manager, &call).await;
+    }
+
+    bus.publish(ForgeEvent::SpeechStarted {
+        call_id: call.clone(),
+        timestamp: Utc::now(),
+    })
+    .expect("publish");
+    await_flush(&manager, &call).await;
+
+    // No verdict — the deadline itself resumes playout.
+    let mut replayed = Vec::new();
+    loop {
+        let p = next_audio_pattern(&manager, &call).await;
+        replayed.push(p);
+        if p == 3 {
+            break;
+        }
+    }
+    assert!(
+        replayed.windows(2).all(|w| w[0] < w[1]),
+        "tail must replay in order, got {replayed:?}",
+    );
+
+    drop(_cmd_tx);
+    drop(_caller_rx);
+    drop(playout_tx);
+    let _ = tokio::time::timeout(Duration::from_secs(1), pump).await;
+}
+
+/// While the bot is silent there is nothing to pause: pause mode just
+/// forwards the event (no flush, no arbitration), and a stray verdict
+/// is a no-op.
+#[tokio::test]
+async fn pause_with_bot_silent_only_forwards() {
+    use chrono::Utc;
+    use forge_core::{EventBus as ForgeEventBus, ForgeEvent};
+    use siphon_ai_bridge::OutgoingEvent;
+    use siphon_ai_media_glue::{TapCommand, TimeoutVerdict};
+
+    let manager = Arc::new(MediaBridgeManager::with_capacities(64, 64));
+    let bus = Arc::new(ForgeEventBus::new());
+    let call = CallId::new("pause-silent");
+    let tap = MediaTap::attach_with_barge_in(
+        &manager,
+        &bus,
+        call.clone(),
+        8000,
+        pause_action(Duration::from_secs(5), TimeoutVerdict::Confirm),
+    )
+    .expect("attach");
+
+    let (caller_tx, _caller_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (events_tx, mut events_rx) = mpsc::channel::<OutgoingEvent>(8);
+    let (cmd_tx, cmd_rx) = mpsc::channel::<TapCommand>(8);
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, events_tx, cmd_rx));
+
+    bus.publish(ForgeEvent::SpeechStarted {
+        call_id: call.clone(),
+        timestamp: Utc::now(),
+    })
+    .expect("publish");
+
+    let event = tokio::time::timeout(Duration::from_millis(500), events_rx.recv())
+        .await
+        .expect("speech_started arrives")
+        .expect("events_tx open");
+    assert!(matches!(event, OutgoingEvent::SpeechStarted { .. }));
+
+    // No flush, no audio — nothing was playing.
+    let nothing = tokio::time::timeout(Duration::from_millis(80), async {
+        manager.try_recv_outbound_request(&call).await
+    })
+    .await;
+    assert!(
+        matches!(nothing, Ok(None)) || nothing.is_err(),
+        "silent-bot pause must NOT emit forge requests; got {nothing:?}",
+    );
+
+    // Stray verdict with nothing pending: ignored, tap stays alive.
+    cmd_tx
+        .send(TapCommand::BargeInReject)
+        .await
+        .expect("send stray reject");
+    playout_tx
+        .send(pack_pcm16_le(&vec![7i16; 160]))
+        .await
+        .expect("send frame");
+    assert_eq!(next_audio_pattern(&manager, &call).await, 7);
+
+    drop(cmd_tx);
+    drop(_caller_rx);
+    drop(playout_tx);
+    let _ = tokio::time::timeout(Duration::from_secs(1), pump).await;
+}
+
+/// Server audio arriving mid-arbitration must NOT reach forge during
+/// the pause; on reject it plays after the retained tail (§5.3).
+#[tokio::test]
+async fn fresh_audio_during_pause_queues_behind_tail() {
+    use chrono::Utc;
+    use forge_core::{EventBus as ForgeEventBus, ForgeEvent};
+    use siphon_ai_bridge::OutgoingEvent;
+    use siphon_ai_media_glue::{TapCommand, TimeoutVerdict};
+
+    let manager = Arc::new(MediaBridgeManager::with_capacities(64, 64));
+    let bus = Arc::new(ForgeEventBus::new());
+    let call = CallId::new("pause-fresh");
+    let tap = MediaTap::attach_with_barge_in(
+        &manager,
+        &bus,
+        call.clone(),
+        8000,
+        pause_action(Duration::from_secs(5), TimeoutVerdict::Confirm),
+    )
+    .expect("attach");
+
+    let (caller_tx, _caller_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (events_tx, _events_rx) = mpsc::channel::<OutgoingEvent>(8);
+    let (cmd_tx, cmd_rx) = mpsc::channel::<TapCommand>(8);
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, events_tx, cmd_rx));
+
+    for k in 1..=3i16 {
+        playout_tx
+            .send(pack_pcm16_le(&vec![k; 160]))
+            .await
+            .expect("send frame");
+    }
+    for _ in 0..3 {
+        let _ = next_audio_pattern(&manager, &call).await;
+    }
+
+    bus.publish(ForgeEvent::SpeechStarted {
+        call_id: call.clone(),
+        timestamp: Utc::now(),
+    })
+    .expect("publish");
+    await_flush(&manager, &call).await;
+
+    // Post-pause server audio: held back, not played.
+    playout_tx
+        .send(pack_pcm16_le(&vec![9i16; 160]))
+        .await
+        .expect("send fresh frame");
+    assert_no_audio_for(&manager, &call, Duration::from_millis(120)).await;
+
+    // Reject → tail first, fresh frame last.
+    cmd_tx
+        .send(TapCommand::BargeInReject)
+        .await
+        .expect("send reject");
+    let mut replayed = Vec::new();
+    loop {
+        let p = next_audio_pattern(&manager, &call).await;
+        replayed.push(p);
+        if p == 9 {
+            break;
+        }
+    }
+    assert!(
+        replayed.len() >= 2,
+        "expected tail + fresh frame, got {replayed:?}",
+    );
+    assert_eq!(*replayed.last().unwrap(), 9, "fresh audio plays last");
+    assert!(
+        replayed[..replayed.len() - 1].iter().all(|&p| p < 9),
+        "tail precedes fresh audio, got {replayed:?}",
+    );
+
+    drop(cmd_tx);
+    drop(_caller_rx);
+    drop(playout_tx);
+    let _ = tokio::time::timeout(Duration::from_secs(1), pump).await;
+}
+
+/// A preempting command (Mute here, standing in for hold/park/announce
+/// /room — same code path) resolves the pending arbitration as
+/// confirm: the tail is gone, the barge-in is counted, and a late
+/// verdict is a no-op.
+#[tokio::test]
+async fn mute_resolves_pending_arbitration_as_confirm() {
+    use chrono::Utc;
+    use forge_core::{EventBus as ForgeEventBus, ForgeEvent};
+    use siphon_ai_bridge::OutgoingEvent;
+    use siphon_ai_media_glue::{QualityReport, TapCommand, TimeoutVerdict};
+
+    let manager = Arc::new(MediaBridgeManager::with_capacities(64, 64));
+    let bus = Arc::new(ForgeEventBus::new());
+    let call = CallId::new("pause-mute-preempt");
+    let (quality_tx, quality_rx) = tokio::sync::watch::channel(QualityReport::default());
+    let tap = MediaTap::attach_with_barge_in(
+        &manager,
+        &bus,
+        call.clone(),
+        8000,
+        pause_action(Duration::from_secs(5), TimeoutVerdict::Confirm),
+    )
+    .expect("attach")
+    .with_quality_watch(quality_tx);
+
+    let (caller_tx, _caller_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (events_tx, _events_rx) = mpsc::channel::<OutgoingEvent>(8);
+    let (cmd_tx, cmd_rx) = mpsc::channel::<TapCommand>(8);
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, events_tx, cmd_rx));
+
+    for k in 1..=3i16 {
+        playout_tx
+            .send(pack_pcm16_le(&vec![k; 160]))
+            .await
+            .expect("send frame");
+    }
+    for _ in 0..3 {
+        let _ = next_audio_pattern(&manager, &call).await;
+    }
+
+    bus.publish(ForgeEvent::SpeechStarted {
+        call_id: call.clone(),
+        timestamp: Utc::now(),
+    })
+    .expect("publish");
+    await_flush(&manager, &call).await;
+
+    // Mute preempts: arbitration resolves as confirm (counted), and
+    // the later reject has nothing to act on.
+    cmd_tx.send(TapCommand::Mute).await.expect("send mute");
+    await_flush(&manager, &call).await; // Mute's own flush
+    assert_eq!(quality_rx.borrow().barge_in_count, 1);
+    cmd_tx
+        .send(TapCommand::BargeInReject)
+        .await
+        .expect("send late reject");
+    assert_no_audio_for(&manager, &call, Duration::from_millis(120)).await;
+
+    // Unmute → normal pumping resumes. Give the (lower-priority)
+    // command arm a beat to process the Unmute before pushing audio —
+    // the biased select polls the playout arm first, and a frame
+    // arriving while still muted is dropped by design.
+    cmd_tx.send(TapCommand::Unmute).await.expect("send unmute");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    playout_tx
+        .send(pack_pcm16_le(&vec![7i16; 160]))
+        .await
+        .expect("send frame");
+    assert_eq!(next_audio_pattern(&manager, &call).await, 7);
+
+    drop(cmd_tx);
+    drop(_caller_rx);
+    drop(playout_tx);
+    let _ = tokio::time::timeout(Duration::from_secs(1), pump).await;
+}
+
+/// The debounce gate composes with pause mode: a start→stop blip
+/// inside the window (the bot's own echo shape) neither flushes nor
+/// arms arbitration, and the provisional event pair is suppressed —
+/// identical to the auto_clear debounce contract.
+#[tokio::test]
+async fn pause_respects_debounce_cancel() {
+    use chrono::Utc;
+    use forge_core::{EventBus as ForgeEventBus, ForgeEvent};
+    use siphon_ai_bridge::OutgoingEvent;
+    use siphon_ai_media_glue::{TapCommand, TimeoutVerdict};
+
+    let manager = Arc::new(MediaBridgeManager::with_capacities(64, 64));
+    let bus = Arc::new(ForgeEventBus::new());
+    let call = CallId::new("pause-debounce");
+    let tap = MediaTap::attach_with_barge_in(
+        &manager,
+        &bus,
+        call.clone(),
+        8000,
+        pause_action(Duration::from_secs(5), TimeoutVerdict::Confirm),
+    )
+    .expect("attach")
+    .with_barge_in_debounce(Some(Duration::from_millis(200)));
+
+    let (caller_tx, _caller_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (playout_tx, playout_rx) = mpsc::channel::<Vec<u8>>(10);
+    let (events_tx, mut events_rx) = mpsc::channel::<OutgoingEvent>(8);
+    let (_cmd_tx, cmd_rx) = mpsc::channel::<TapCommand>(8);
+    let pump = tokio::spawn(tap.run(caller_tx, playout_rx, events_tx, cmd_rx));
+
+    // Long utterance so the bot is still "playing" when speech blips.
+    for k in 1..=10i16 {
+        playout_tx
+            .send(pack_pcm16_le(&vec![k; 160]))
+            .await
+            .expect("send frame");
+    }
+    for _ in 0..10 {
+        let _ = next_audio_pattern(&manager, &call).await;
+    }
+
+    let ts = Utc::now();
+    bus.publish(ForgeEvent::SpeechStarted {
+        call_id: call.clone(),
+        timestamp: ts,
+    })
+    .expect("publish start");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    bus.publish(ForgeEvent::SpeechStopped {
+        call_id: call.clone(),
+        timestamp: ts,
+        duration_ms: 50,
+    })
+    .expect("publish stop");
+
+    // Past the debounce window: no flush, no re-queued audio, no
+    // arbitration — and the provisional event pair was swallowed.
+    let deadline = tokio::time::Instant::now() + Duration::from_millis(300);
+    while tokio::time::Instant::now() < deadline {
+        if let Some(req) = manager.try_recv_outbound_request(&call).await {
+            panic!("cancelled debounce must not touch forge, got {req:?}");
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    assert!(
+        events_rx.try_recv().is_err(),
+        "echo-shaped blip must not surface speech events",
+    );
+
+    drop(_cmd_tx);
+    drop(_caller_rx);
+    drop(playout_tx);
+    let _ = tokio::time::timeout(Duration::from_secs(1), pump).await;
+}

--- a/docs/design/DESIGN_REVERSIBLE_BARGE_IN.md
+++ b/docs/design/DESIGN_REVERSIBLE_BARGE_IN.md
@@ -1,0 +1,350 @@
+# Design note — reversible (server-arbitrated) barge-in
+
+> **Status: APPROVED — decisions LOCKED (§11, all per recommendation,
+> 2026-07-14).** Pins the WS surface, the
+> media mechanics, and the interaction matrix before implementation — the
+> same design-first pass as hold (`DESIGN_HOLD.md`) and park
+> (`DESIGN_0.7.0_PARK.md`). The build follows this; deviations get noted
+> back here. Target: **0.32.0**, protocol stays `"1"` (additive).
+
+Makes barge-in a **provisional, reversible** action that the WS server
+arbitrates, instead of an instant irreversible flush. Today a cough, a
+backchannel ("uh-huh"), or background noise that gets past VAD kills the
+bot's playout (`auto_clear`) or forces the server into a
+latency-vs-talking-over-the-caller dilemma (`notify_only`). The fix:
+SiphonAI reacts **instantly but reversibly** (pause playout, retain the
+audio), and the server — the only layer with STT and conversational
+context — confirms or rejects the barge-in within a bounded window. A
+false positive costs a sub-second pause instead of a killed utterance.
+
+**What this is *not*** (scope fence):
+
+- **Not intent detection in the daemon.** Distinguishing "uh-huh" from
+  "yeah, but—" needs a transcript; that is the WS server's job
+  (CLAUDE.md §4.1). SiphonAI supplies the reversible mechanism and the
+  signals; the server supplies the verdict.
+- **Not a VAD upgrade.** A neural VAD (Silero-class) in `forge-vad` is a
+  separate, upstream-gated track that attacks the *acoustic* false-positive
+  class (coughs, noise). Complementary, not a dependency.
+- **Not AEC.** Echo-driven false positives are already mitigated by the
+  playout-gated `debounce_ms` (0.7.x, #173), which composes with this
+  design (§7.1); libwebrtc APM in forge-media remains the heavier fallback.
+
+---
+
+## 1. The new mode vs. the things it is not
+
+`[bridge.barge_in].mode` grows a third value, `"pause"`:
+
+| | On `speech_started` while bot is playing | Reversible | Who decides | False-positive cost |
+|---|---|---|---|---|
+| **`auto_clear`** (default, exists) | flush playout immediately | no | SiphonAI (VAD *is* the decision) | utterance killed |
+| **`notify_only`** (exists) | nothing — server may send `clear` | n/a | server, but reaction waits a full round-trip | bot talks over the caller |
+| **`pause`** (this) | **pause playout instantly, retain unplayed audio, await verdict** | **yes** | server (bounded by `decision_ms`, then `on_timeout`) | sub-second dip in the bot's speech |
+
+While the bot is **silent**, `pause` behaves exactly like the other modes:
+`speech_started` is forwarded and nothing else happens — there is nothing
+to pause, so no arbitration is armed. Arbitration exists only to protect
+in-flight playout.
+
+The verdict outcomes:
+
+- **confirm** → the retained audio is dropped; identical end-state to
+  today's `auto_clear` flush. Counted as a real barge-in.
+- **reject** → the retained audio is re-queued and playout resumes where
+  it stopped (biased to repeat ~1 frame rather than skip — §5.3).
+- **timeout** (`decision_ms` elapses with no verdict) → apply
+  `on_timeout` (default `"confirm"` — fail toward not talking over the
+  caller). A server that never arbitrates therefore degrades to
+  "auto_clear delayed by `decision_ms`", which is safe and predictable.
+
+Caller→server audio is **never** touched by arbitration — the server
+needs it for the STT that produces the verdict.
+
+---
+
+## 2. WS protocol additions (version stays `"1"` — additive)
+
+Per the CLAUDE.md §7.1 checklist: `BridgeIn`/`BridgeOut` variants +
+PROTOCOL.md + schema regen + both SDKs + example servers + testkit
+scenario, all in the same PR chain.
+
+- **`BridgeIn::BargeInConfirm { call_id }`** — verdict: real barge-in.
+  Drop the retained audio, stay quiet. No-op (debug log, no error) when no
+  arbitration is pending — verdicts race with `speech_stopped` and with
+  the deadline by nature, so a late verdict must be harmless.
+- **`BridgeIn::BargeInReject { call_id }`** — verdict: not a barge-in
+  (cough / backchannel / noise). Resume the retained playout. Same no-op
+  semantics when nothing is pending.
+- **`clear` while an arbitration is pending acts as confirm** (documented
+  in §4.1 of PROTOCOL.md) — it already means "drop pending playout", and
+  this keeps mode-oblivious servers coherent.
+- **`speech_started` gains an optional field** — in `pause` mode, when
+  arbitration was armed:
+
+  ```json
+  { "type": "speech_started", "call_id": "...", "seq": 42, "ts_ms": 1234,
+    "decision_pending": true, "decision_deadline_ms": 500 }
+  ```
+
+  Absent (not `false`) in every other case, so existing consumers and the
+  schema's `additionalProperties` posture are untouched. The event *is*
+  the arbitration request — no separate request message.
+- **`BridgeOut::BargeInResolved { call_id, seq, outcome }`** with
+  `outcome ∈ "confirmed" | "rejected" | "timeout"` — emitted when an
+  armed arbitration resolves, whatever resolved it. The server mostly
+  knows the outcome (it sent the verdict), but `timeout` is exactly the
+  case it *doesn't* know about, and a single uniform event keeps SDK
+  state machines and the conformance testkit honest. *(Decision §11.5.)*
+- **`start` gains an optional `barge_in_mode` field**
+  (`"auto_clear" | "notify_only" | "pause"`, the per-route resolved
+  value) so SDKs can discover whether verdicts are expected instead of
+  requiring out-of-band config agreement. *(Decision §11.8.)*
+
+Naming mirrors the hold precedent (`DESIGN_HOLD.md` §2): imperative
+request verbs, past-tense resolution event, explicit rather than
+overloaded (`barge_in_confirm`, not a repurposed `clear` — though `clear`
+aliases to confirm for compatibility).
+
+SDK surface: `call.barge_in_confirm()` / `call.barge_in_reject()` in
+both `sdks/python` and `sdks/typescript` (their tests assert full
+coverage of the schema unions, so CI enforces lockstep), plus typed
+`BargeInResolved` / extended `SpeechStarted` events.
+
+---
+
+## 3. Why "pause", not "duck" — the forge queue reality
+
+The obvious alternative — attenuate ("duck") the bot instead of pausing —
+**cannot be done tap-side today**. The tap pushes playout frames into
+forge eagerly (`send_audio`, `tap.rs` playout arm); the queued tail —
+potentially an entire TTS utterance — lives in **forge's encoder queue**,
+which the tap can flush (`handle.flush(MediaTarget::A)`) but cannot
+rewrite. Gain applied to *newly pushed* frames would leave seconds of
+full-volume audio already in flight. A true duck needs an upstream
+`forge-media` per-leg playout-gain API — a fine future variant
+(*upstream-gated*, same shape as the AMD dependency), but not v1.
+
+Pause has no such dependency, because **flush is instant and we can keep
+our own copy** (§5). It is also arguably the better conversational UX for
+a voice bot: going quiet the moment the caller speaks (as a human does),
+then resuming if it was nothing, reads more naturally than continuing to
+talk underneath them at low volume.
+
+---
+
+## 4. Config surface
+
+```toml
+[bridge.barge_in]                # global; [route.bridge.barge_in] mirrors it
+enabled     = true               # existing
+mode        = "pause"            # NEW value; "auto_clear" stays the default
+debounce_ms = 120                # existing echo/noise gate — composes, §7.1
+decision_ms = 500                # NEW — server verdict deadline (pause mode only)
+on_timeout  = "confirm"          # NEW — "confirm" | "reject"
+resume_max_secs = 30             # NEW — retained-audio cap per call (§5.4)
+```
+
+Validation at load (CLAUDE.md §4.6): `decision_ms` required > 0 when
+`mode = "pause"` (`0` is rejected — an unbounded pause would hang playout
+on a lost verdict); `on_timeout`/`resume_max_secs` rejected unless mode
+is `pause`; unknown mode strings fail loud. Per-route override inherits
+field-wise from the global block, same merge as today (`raw.rs`
+`RawBargeIn`). All new fields documented in `docs/CONFIG.md` +
+`docs/PROTOCOL.md` in the same PR.
+
+Default posture: **`auto_clear` remains the default mode** — `pause` is
+opt-in, consistent with every recent feature.
+
+---
+
+## 5. Media mechanics — the tap
+
+All inside `crates/media-glue/src/tap.rs`, which already owns the flush,
+the debounce, and the playout-clock estimation. Hot-path rules
+(CLAUDE.md §4.3) hold throughout: no steady-state allocation, no locks,
+no blocking, verdicts arrive via the existing `TapCommand` channel.
+
+### 5.1 Shadow ring (the resume buffer)
+
+In `pause` mode the playout arm copies each frame it pushes to forge into
+a **preallocated ring buffer** (allocated once at `attach` when the
+resolved mode is `pause`; other modes pay nothing). Frames are evicted
+as the existing playout clock (`playout_until` / `frames_sent_to_forge`
+cursor math, the same estimation that drives `Mark` and
+`bot_is_playing`) says they have played out. Steady-state cost: one
+~640-byte memcpy per 20 ms frame plus cursor arithmetic.
+
+### 5.2 Pause (arming arbitration)
+
+On a `speech_started` that passes the debounce gate while
+`bot_is_playing` and mode is `pause`, run **exactly today's `auto_clear`
+flush** — drain the controller→tap channel, `clear_ws_input()` if in a
+room, `flush(MediaTarget::A)`, reset Mark bookkeeping — with two
+differences:
+
+1. The drained-channel bytes and the shadow ring's unplayed tail are
+   spliced (shadow first, then drained bytes) into the **resume buffer**
+   instead of being dropped.
+2. A `decision_deadline` sleep is armed (same pinned-placeholder pattern
+   as the debounce timer) and the forwarded `speech_started` carries
+   `decision_pending: true`.
+
+The caller hears the bot stop within one frame — the same reaction time
+as `auto_clear`.
+
+### 5.3 Resolve
+
+- **Confirm** (verdict, `clear`, or timeout with `on_timeout="confirm"`):
+  drop the resume buffer, bump `barge_in_count`, `publish_quality()`,
+  emit `barge_in_resolved`. End-state identical to today's `auto_clear`.
+- **Reject** (verdict, or timeout with `on_timeout="reject"`): re-push
+  the resume buffer into forge (a burst push, which forge already
+  absorbs — it's how normal TTS arrives), restore the Mark/playout-clock
+  bookkeeping from the re-pushed frame count, emit `barge_in_resolved`.
+  The playout-clock estimate carries ±1–2 frames of slop, so the splice
+  point is biased **early** — repeating ≤40 ms is inaudible; skipping a
+  syllable is not.
+- New WS audio arriving from the server **while paused** queues behind
+  the resume buffer in the normal controller→tap channel; on reject it
+  plays after the resumed tail, on confirm it plays immediately (the
+  server barged over itself — its choice).
+
+### 5.4 Bounds
+
+The shadow ring is capped at `resume_max_secs` (default 30 s ≈ 960 KB at
+16 kHz — per-call, only in `pause` mode). On overflow the oldest frames
+are evicted and a once-per-call `warn!` is logged; a reject then resumes
+from the earliest retained frame (bounded content loss at the seam,
+which only occurs on pathological >30 s single utterances).
+
+---
+
+## 6. Core / controller wiring
+
+- `BargeInAction` (`tap.rs`) gains a third variant, `Pause { decision:
+  Duration, on_timeout: TimeoutVerdict, resume_max: Duration }`; the
+  acceptor resolves it from config exactly as it does the current two
+  (`acceptor.rs` call-setup translation, per-route override included).
+  *(Chunk-1 deviation noted: `resume_max` rides on the variant — it's
+  the natural carrier down to the tap. Also, the shadow ring is a
+  `VecDeque` of the already-owned frame `Vec`s — the frame buffers are
+  moved in, not copied, so §5.1's "one memcpy per frame" became zero
+  copies.)*
+- Two new `TapCommand`s — `BargeInConfirm` / `BargeInReject` — routed
+  from the `BridgeIn` match arm in `core/src/call.rs`, same shape as
+  `Clear`/`Mute`. Verdicts for a call with no pending arbitration are
+  dropped with a `debug!` (§2 no-op semantics).
+- Outbound calls need nothing special — same tap, same policy resolution
+  (barge-in is already direction-agnostic).
+
+---
+
+## 7. Interaction matrix
+
+### 7.1 `debounce_ms` (composes — two different filters)
+
+The debounce gate answers "was that even speech, or the bot's own echo?"
+(acoustic, ~100–200 ms); arbitration answers "was that speech an
+interruption?" (semantic, ~500 ms). In `pause` mode the debounce runs
+**first**, unchanged: a provisional `speech_started` held by the gate
+neither pauses nor forwards; only a debounce-confirmed barge-in triggers
+the pause + arbitration. Echo blips therefore never reach the server at
+all, exactly as with `auto_clear` today.
+
+### 7.2 Everything else
+
+| Feature | Interaction |
+|---|---|
+| `mute` / bot-`hold` / park / announce | Playout is already suppressed or preempted → `bot_is_playing` is false or the WS pair is detached → arbitration never arms. A `Park`/`Hold` command **during** a pending arbitration resolves it as confirm (drop the buffer) before the mode switch, mirroring how announce/park already preempt playout. |
+| WS reconnect (0.7.3) | WS drop during a pending arbitration → resolve as **confirm** immediately (the arbiter is gone; flushed-and-quiet is the safe state alongside the reconnect MOH). Fresh session starts with no arbitration state. |
+| Conference rooms (0.7.0) | Arbitration is **suspended while in a room** (`JoinRoom` resolves any pending arbitration as confirm; in-room `speech_started` behaves as `notify_only`). Multi-party barge-in semantics are genuinely different — out of scope for v1. *(Decision §11.7.)* |
+| `Mark` | Marks pending at pause time fire per existing `Clear` semantics (the flush is real). Marks queued after a reject re-anchor on the restored clock. Documented in PROTOCOL.md §4.2. |
+| Quality/CDR `barge_in_count` | Counts **confirmed + timeout-confirmed** resolutions (a rejected arbitration was, by the server's own ruling, not a barge-in). |
+
+---
+
+## 8. Observability (same PR as the feature — CLAUDE.md §4.5)
+
+- **Metrics** (`telemetry/src/metrics.rs`, documented in `DEPLOY.md`):
+  - `siphon_ai_barge_in_decisions_total{outcome="confirmed"|"rejected"|"timeout"}`
+  - `siphon_ai_barge_in_decision_seconds` histogram (arm → resolve;
+    explicit buckets around the expected 50 ms–1 s range).
+- **CDR** (`cdr/src/schema.rs` `quality` block): additive **optional**
+  fields `barge_in_rejected_count`, `barge_in_timeout_count` alongside
+  the existing `barge_in_count`. Additive-optional → **no CDR version
+  bump** (stays v4), per the §7.7 policy.
+- **Logs**: `debug!` on arm/verdict/timeout with `call_id` span field;
+  the existing once-per-call `warn!` pattern for ring overflow.
+- **Live quality feed**: `publish_quality()` on every resolution (the
+  watch already publishes on playout clears).
+- **Traces**: span events `barge_in.pause` / `barge_in.resolved` on the
+  call span (joins the OTLP per-call trace from 0.22.0).
+
+---
+
+## 9. Testing
+
+- **Unit (tap)**: pause→confirm ≡ auto_clear end-state; pause→reject
+  resumes with early-biased splice; timeout applies `on_timeout`;
+  ring eviction under overflow; debounce-then-arbitrate ordering;
+  verdict-with-nothing-pending is a no-op; room/park/hold/WS-drop
+  resolutions per §7.2. Existing `tests/tap.rs` fixtures extend.
+- **Protocol**: serde round-trips for the two `BridgeIn` verbs, the
+  extended `speech_started`, `barge_in_resolved`, `start.barge_in_mode`;
+  schema regen + docs-corpus validation (CI enforces).
+- **SDKs**: both suites' union-coverage assertions force the new types;
+  add verdict-method tests.
+- **Conformance testkit**: new bundled scenario — server receives
+  `decision_pending`, sends reject, asserts `barge_in_resolved
+  {outcome:"rejected"}` and that audio resumes; a timeout variant
+  asserts `outcome:"timeout"`. Runs against both echo servers in the
+  `conformance` CI job (echo servers gain a trivial arbitration hook).
+- **SIPp / harness**: one scenario with injected caller audio mid-playout
+  verifying the pause-resume path end-to-end against the Python echo
+  server (extends the existing barge-in phase).
+
+---
+
+## 10. Delivery plan (usual cadence)
+
+1. **Chunk 1 — media mechanics**: shadow ring, `BargeInAction::Pause`,
+   `TapCommand` verdicts, timeout, interaction resolutions (§7.2), tap
+   unit tests. No protocol surface yet — inert without config.
+2. **Chunk 2 — protocol + config + wiring**: config fields + validation,
+   acceptor resolution, `BridgeIn`/`BridgeOut` variants, core match arms,
+   schema regen, PROTOCOL.md + CONFIG.md, both SDKs, echo-server
+   arbitration hooks, testkit scenarios, metrics/CDR fields.
+3. **Chunk 3 — release 0.32.0**: changelog, version-consistency gate,
+   SIPp scenario, tag per `RELEASING.md`.
+
+---
+
+## 11. Decisions to lock
+
+1. **Mode name `"pause"`** (vs `"arbitrated"`, `"duck"`). *Recommend
+   `pause`* — it names what the caller hears; the config grammar stays
+   "what SiphonAI does alongside the event".
+2. **Reaction = flush-with-shadow pause**, not gain-duck. *Recommend
+   pause* (§3 — duck is upstream-gated on a forge playout-gain API; keep
+   it as a possible future mode value, not v1).
+3. **Defaults: `decision_ms = 500`, `on_timeout = "confirm"`.**
+   *Recommend as stated* — 500 ms covers STT-partial latency for the
+   major engines with margin; timeout-confirm fails toward silence.
+4. **Explicit verdict verbs + `clear`-as-confirm alias** (vs overloading
+   `clear`/`mark`). *Recommend explicit pair* — symmetric, self-listing
+   in the schema, and `reject` has no plausible overload anyway.
+5. **Emit `barge_in_resolved` for every resolution** (vs only timeout,
+   vs nothing). *Recommend yes* — one uniform event; timeout is
+   unknowable server-side without it.
+6. **No local auto-verdict on `speech_stopped`** within the window —
+   a short burst may be "stop!", which STT will catch; the server (or
+   the deadline) always rules. *Recommend yes (no local verdict) for v1*;
+   revisit if verdict latency proves annoying on real calls.
+7. **Rooms suspend arbitration** (§7.2). *Recommend yes* — define
+   multi-party semantics when conference demand exists.
+8. **`start.barge_in_mode` announce field.** *Recommend yes* — additive,
+   and SDKs otherwise can't know whether verdicts are expected.
+9. **`resume_max_secs = 30` default, evict-oldest + warn on overflow**
+   (vs degrade-to-confirm). *Recommend as stated* — graceful degradation
+   preserves the recent tail, which is what a resume needs.


### PR DESCRIPTION
Chunk 1 of 3 for **reversible (server-arbitrated) barge-in** — design note `docs/design/DESIGN_REVERSIBLE_BARGE_IN.md` (included in this PR, status APPROVED, all §11 decisions locked per recommendation).

## What this is

Today a false VAD hit (cough, backchannel, noise) irreversibly kills the bot's playout (`auto_clear`) or forces a full server round-trip before anything happens (`notify_only`). The new `pause` mode reacts instantly **but reversibly**: flush playout exactly like `auto_clear`, retain the unplayed tail, and let the WS server — the only layer with STT — confirm or reject within a bounded window.

## This chunk (tap mechanics only — inert)

Nothing constructs the new variant yet; config + protocol surface land in chunk 2, so this PR changes no runtime behavior for existing modes.

- `BargeInAction::Pause { decision, on_timeout, resume_max }` + `TimeoutVerdict` (`media-glue`).
- **Shadow ring**: each pushed playout frame's (already-owned) buffer is moved into a `VecDeque` and trimmed to the unplayed tail (+1 frame of early-bias slop) by the existing playout clock — zero copies, no steady-state allocation, capped by `resume_max` (§5.1/§5.4).
- **Arming** (§5.2): debounce-confirmed `speech_started` while the bot is playing → drain channel + flush forge (caller hears the bot stop within one frame), retain tail, arm the decision deadline, forward the event.
- **Verdicts**: `TapCommand::BargeInConfirm` drops the tail and counts the barge-in; `BargeInReject` re-queues it in playout order and the bot resumes mid-utterance. Late/stray verdicts are no-ops. Timeout applies `on_timeout` (recommended default `confirm`: a server that never arbitrates degrades to "auto_clear delayed by the window").
- **Fresh audio** (§5.3): server audio arriving mid-pause queues behind the tail — after it on reject, immediately on confirm; recording-forked exactly once.
- **Interactions** (§7.2): mute / clear / hold / park / announce / join-room / WS-drop resolve a pending arbitration as confirm; arbitration never arms in rooms or while the bot is silent; debounce composes as the acoustic gate in front of the semantic one.
- **Metrics**: `siphon_ai_barge_in_decisions_total{outcome=confirmed|rejected|timeout}` + `siphon_ai_barge_in_decision_seconds` (DEPLOY.md docs + explicit buckets ride with chunk 2, which makes them reachable).

## Tests

8 new integration tests in `crates/media-glue/tests/tap.rs` (reject-resume ordering, confirm end-state + CDR count via the quality watch, both timeout fallbacks, silent-bot forward-only, fresh-audio queueing, mute preemption, debounce-cancel) + unit tests for the unplayed-frames clock math. `cargo test --workspace`, `clippy -D warnings`, `fmt` all clean.

## Design deviations (noted back in the design note §6)

- `resume_max` rides on the `Pause` variant (natural carrier to the tap).
- Shadow ring moves the owned frame buffers instead of memcpy'ing into a preallocated byte ring — strictly cheaper.

**Next:** chunk 2 — `[bridge.barge_in]` config fields + acceptor resolution + `BridgeIn`/`BridgeOut` surface + schema regen + both SDKs + testkit scenario + docs. Chunk 3 — release 0.32.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
