### PR TITLE
chore(release): 0.32.0 — reversible barge-in (chunk 3/3: SIPp phase + release prep)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -219,7 +219,11 @@ jobs:
       - name: Install sip-tester + python venv
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends sip-tester python3-venv
+          sudo apt-get install -y --no-install-recommends sip-tester python3-venv libcap2-bin
+          # sipp's pcap playback (the barge_in_pause phase's caller media)
+          # opens a raw IPv4 socket on this distro's build; grant the
+          # capability rather than running the whole suite as root.
+          sudo setcap cap_net_raw+ep "$(command -v sipp)"
 
       - name: Install Rust toolchain
         run: rustup show

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.32.0] - 2026-07-14
+
+### Added
+
+- **Reversible (server-arbitrated) barge-in** —
+  `[bridge.barge_in].mode = "pause"`
+  (`docs/design/DESIGN_REVERSIBLE_BARGE_IN.md`; #285/#286). Today a
+  cough, laugh, or backchannel ("uh-huh") that trips VAD irreversibly
+  kills the bot's playout. Pause mode reacts instantly but
+  *reversibly*: playout is flushed within one frame — exactly like
+  `auto_clear` — but the unplayed tail is retained, and the WS server
+  (the only layer with STT) rules on intent:
+  - `speech_started` carries `decision_pending: true` +
+    `decision_deadline_ms` when an arbitration arms;
+  - the server answers **`barge_in_confirm`** (real interruption —
+    tail dropped) or **`barge_in_reject`** (false positive — playout
+    resumes mid-utterance); a `clear` during the window acts as
+    confirm, and late verdicts are harmless no-ops;
+  - every resolution is acknowledged with
+    **`barge_in_resolved { outcome: confirmed | rejected | timeout }`**;
+  - no verdict within `decision_ms` (default 500) applies
+    `on_timeout` (default `confirm` — a server that never rules
+    degrades safely to "auto_clear delayed by the window");
+  - `resume_max_secs` (default 30) caps the retained audio;
+  - `start.barge_in_mode` announces the call's resolved policy;
+  - per-route overrides via `[route.bridge.barge_in]`, field-wise;
+  - the existing `debounce_ms` echo gate composes in front (acoustic
+    filter first, semantic arbitration second).
+  Arbitration only arms while the bot is playing, is suspended in
+  conference rooms, and resolves as confirm when preempted by
+  mute/hold/park/announce/room-join or a WS drop. Off by default;
+  protocol stays **v1** (all additions additive), CDR stays **v4**
+  (additive optional `quality` counters).
+- **Server SDKs**: typed `BargeInResolved` / extended `SpeechStarted`
+  and `Start`, plus `barge_in_confirm()` / `barge_in_reject()` (Python)
+  and `bargeInConfirm()` / `bargeInReject()` (TypeScript). The echo
+  reference servers answer arbitration requests with a reject by
+  default (`SIPHON_ECHO_BARGE_IN_VERDICT=confirm` flips it).
+- **Conformance**: new bundled `barge-in-pause` testkit scenario
+  (verdict within the deadline + timeout-outcome tolerance) and a
+  `session.barge_in_mode` scenario option.
+- **Metrics**: `siphon_ai_barge_in_decisions_total{outcome}` and
+  `siphon_ai_barge_in_decision_seconds` (explicit 50 ms–5 s buckets).
+- **SIPp harness**: `barge_in_pause` phase with *real caller media* —
+  a run-time-generated G.711 tone pcap (`gen_tone_pcap.py`, stdlib
+  only) replayed via `play_pcap_audio`, driving VAD → pause →
+  reject → resume end-to-end. The suite is now 36 scenarios.
+
+### Fixed
+
+- Route-level `[route.bridge.barge_in]` strings are now **validated at
+  config load** — previously a typo'd route `mode` was silently inert
+  (the runtime merge skipped unparseable values).
+
 ## [0.31.1] - 2026-07-14
 
 ### Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3542,7 +3542,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3558,7 +3558,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "base64",
  "bytes",
@@ -3580,7 +3580,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3597,7 +3597,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "regex",
  "serde",
@@ -3616,7 +3616,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3662,7 +3662,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "base64",
  "hmac",
@@ -3685,7 +3685,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3709,7 +3709,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3727,7 +3727,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -3759,7 +3759,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "regex",
  "serde",
@@ -3771,7 +3771,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "schemars",
  "serde",
@@ -3781,7 +3781,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -3826,7 +3826,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3855,7 +3855,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.31.1"
+version = "0.32.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.31.1.** Production-deployed against real carriers
+**Current release: v0.32.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a

--- a/test-harness/sipp-scenarios/barge_in_pause_caller.xml
+++ b/test-harness/sipp-scenarios/barge_in_pause_caller.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  barge_in_pause_caller — SIPp is the caller (UAC) with REAL media:
+  after answer it replays a generated G.711 tone pcap (__PCAP__ is
+  substituted by run-all.sh) as ~3 s of "caller speech". With the
+  daemon in [bridge.barge_in] mode = "pause" and the echo WS server
+  bridged, the tone (a) gets echoed back, so the bot is mid-playout,
+  and (b) trips forge-vad, arming a pause arbitration. The echo server
+  replies barge_in_reject (its default verdict), the daemon resumes
+  the retained playout, and the phase asserts
+  siphon_ai_barge_in_decisions_total{outcome="rejected"} ticked.
+-->
+<scenario name="barge_in_pause_caller">
+  <send>
+<![CDATA[
+INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+Max-Forwards: 70
+From: <sip:sipp@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:sipp@[local_ip]:[local_port]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=user1 53655765 2353687637 IN IP4 [local_ip]
+s=-
+c=IN IP4 [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+]]>
+  </send>
+
+  <recv response="100" optional="true"/>
+  <recv response="180" optional="true"/>
+  <recv response="183" optional="true"/>
+
+  <recv response="200" rtd="true"/>
+
+  <send>
+<![CDATA[
+ACK sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]-ack
+Max-Forwards: 70
+From: <sip:sipp@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- Caller "speech": replay the generated tone capture. pcapplay
+       paces packets by the capture's own 20 ms timestamps. -->
+  <nop>
+    <action>
+      <exec play_pcap_audio="__PCAP__"/>
+    </action>
+  </nop>
+
+  <!-- Let the tone (3 s), the VAD trip, the arbitration round-trip,
+       and the post-reject resume all complete before hanging up. -->
+  <pause milliseconds="4500"/>
+
+  <send>
+<![CDATA[
+BYE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]-bye
+Max-Forwards: 70
+From: <sip:sipp@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 BYE
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="200" rtd="true"/>
+</scenario>

--- a/test-harness/sipp-scenarios/gen_tone_pcap.py
+++ b/test-harness/sipp-scenarios/gen_tone_pcap.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Generate a libpcap capture of a G.711 mu-law RTP tone stream.
+
+Used by run-all.sh's barge_in_pause phase: SIPp's `play_pcap_audio`
+replays the capture as the caller's media, giving forge-vad real
+speech-shaped energy to fire on — the one thing a signaling-only
+scenario can't provide. Generated at run time (stdlib only) so no
+binary audio file lives in the repo (CLAUDE.md §6.4).
+
+Usage: gen_tone_pcap.py OUT.pcap [SECONDS] [FREQ_HZ]
+"""
+
+import math
+import struct
+import sys
+
+SAMPLE_RATE = 8000
+SAMPLES_PER_FRAME = 160  # 20 ms
+AMPLITUDE = 12000  # loud enough to trip an energy VAD, no clipping
+
+
+def ulaw_encode(sample: int) -> int:
+    """ITU-T G.711 mu-law encode one 16-bit PCM sample."""
+    BIAS, CLIP = 0x84, 32635
+    sign = 0x80 if sample < 0 else 0x00
+    magnitude = min(abs(sample), CLIP) + BIAS
+    exponent = 7
+    mask = 0x4000
+    while exponent > 0 and not magnitude & mask:
+        exponent -= 1
+        mask >>= 1
+    mantissa = (magnitude >> (exponent + 3)) & 0x0F
+    return ~(sign | (exponent << 4) | mantissa) & 0xFF
+
+
+def main() -> None:
+    path = sys.argv[1]
+    seconds = float(sys.argv[2]) if len(sys.argv) > 2 else 3.0
+    freq = float(sys.argv[3]) if len(sys.argv) > 3 else 440.0
+
+    frames = int(seconds * SAMPLE_RATE / SAMPLES_PER_FRAME)
+    out = bytearray()
+    # libpcap global header, little-endian, linktype 1 (Ethernet) —
+    # the framing sipp's pcapplay parser expects.
+    out += struct.pack("<IHHiIII", 0xA1B2C3D4, 2, 4, 0, 0, 65535, 1)
+
+    ssrc = 0x51500BAD
+    for i in range(frames):
+        first = i * SAMPLES_PER_FRAME
+        payload = bytes(
+            ulaw_encode(int(AMPLITUDE * math.sin(2 * math.pi * freq * ((first + n) / SAMPLE_RATE))))
+            for n in range(SAMPLES_PER_FRAME)
+        )
+        # RTP: V=2, PT=0 (PCMU), 20 ms timestamp cadence.
+        rtp = struct.pack("!BBHII", 0x80, 0x00, i & 0xFFFF, first, ssrc) + payload
+        # sipp rewrites the destination; ports/addrs here are placeholders.
+        udp = struct.pack("!HHHH", 6000, 6001, 8 + len(rtp), 0) + rtp
+        ip = struct.pack(
+            "!BBHHHBBH4s4s",
+            0x45, 0, 20 + len(udp), i & 0xFFFF, 0, 64, 17, 0,
+            bytes([127, 0, 0, 1]), bytes([127, 0, 0, 1]),
+        )
+        eth = b"\x00" * 12 + struct.pack("!H", 0x0800)
+        pkt = eth + ip + udp
+        ts_us = i * 20_000
+        out += struct.pack("<IIII", ts_us // 1_000_000, ts_us % 1_000_000, len(pkt), len(pkt))
+        out += pkt
+
+    with open(path, "wb") as f:
+        f.write(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/test-harness/sipp-scenarios/run-all.sh
+++ b/test-harness/sipp-scenarios/run-all.sh
@@ -1960,6 +1960,93 @@ EOF
     trap - EXIT
 fi
 
+# ─── Always-on auxiliary phase: pause-mode barge-in ───────────────
+# Exercises reversible barge-in (0.32.0, DESIGN_REVERSIBLE_BARGE_IN.md)
+# end-to-end with REAL caller media — the one thing the signaling-only
+# scenarios can't do, because forge-vad needs actual speech energy:
+#   * gen_tone_pcap.py synthesizes ~3 s of G.711 tone RTP at run time
+#     (stdlib only; no binary audio in the repo),
+#   * SIPp replays it as the caller — the echo WS bridges it back, so
+#     the bot is mid-playout when the VAD fires,
+#   * the pause arbitration arms; the echo server's default verdict
+#     (barge_in_reject) resumes the retained playout.
+# Pass = the SIPp scenario completed AND
+# siphon_ai_barge_in_decisions_total{outcome="rejected"} ticked.
+echo
+echo "─── auxiliary phase: barge_in_pause ───────────────────"
+BI_WS_PORT=8793
+BI_OBS_PORT=9091
+BI_WS_LOG=$(mktemp -t echo-ws-bi.XXXXXX.log)
+BI_DAEMON_LOG=$(mktemp -t siphon-ai-bi.XXXXXX.log)
+BI_CONFIG=$(mktemp -t siphon-ai-bi.XXXXXX.toml)
+BI_PCAP=$(mktemp -t siphon-ai-bi.XXXXXX.pcap)
+BI_XML=$(mktemp -t siphon-ai-bi.XXXXXX.xml)
+
+python3 "$SCRIPT_DIR/gen_tone_pcap.py" "$BI_PCAP" 3.0
+sed "s|__PCAP__|$BI_PCAP|" \
+    "$SCRIPT_DIR/barge_in_pause_caller.xml" >"$BI_XML"
+
+cat >"$BI_CONFIG" <<EOF
+[node]
+id = "siphon-ai-sipp-bi"
+[sip]
+listen = "127.0.0.1:$DAEMON_PORT"
+[media]
+codecs = ["pcmu"]
+[bridge]
+ws_url = "ws://127.0.0.1:$BI_WS_PORT/"
+[bridge.barge_in]
+mode = "pause"
+# Generous window so a slow CI box can't race the echo's verdict into
+# a timeout; the reject normally lands within a few ms.
+decision_ms = 2000
+[observability]
+enabled = true
+http_listen = "127.0.0.1:$BI_OBS_PORT"
+[[route]]
+name = "default"
+[route.match]
+any = true
+EOF
+
+BI_PYTHON="$REPO_ROOT/examples/echo-ws-server-python/.venv/bin/python"
+[[ -x "$BI_PYTHON" ]] || BI_PYTHON=python3
+"$BI_PYTHON" "$REPO_ROOT/examples/echo-ws-server-python/server.py" \
+    --bind "127.0.0.1:$BI_WS_PORT" \
+    >"$BI_WS_LOG" 2>&1 &
+BI_WS_PID=$!
+
+RUST_LOG=siphon_ai=info "$DAEMON_BIN" --config "$BI_CONFIG" \
+    >"$BI_DAEMON_LOG" 2>&1 &
+BI_DAEMON_PID=$!
+bi_cleanup() {
+    kill "$BI_WS_PID" "$BI_DAEMON_PID" 2>/dev/null || true
+    wait "$BI_WS_PID" "$BI_DAEMON_PID" 2>/dev/null || true
+}
+trap bi_cleanup EXIT
+sleep 1.2
+
+total=$((total + 1))
+echo "─── barge_in_pause ───────────────────────────────────"
+bi_ok=0
+if sipp -i 127.0.0.1 -sf "$BI_XML" -m 1 -timeout 15s -trace_err \
+        -p "$SIPP_PORT" -s 1000 "127.0.0.1:$DAEMON_PORT" >/dev/null 2>&1; then
+    # The echo's reject must have resolved the arbitration.
+    if curl -s "http://127.0.0.1:$BI_OBS_PORT/metrics" \
+        | grep -q 'siphon_ai_barge_in_decisions_total{outcome="rejected"}'; then
+        bi_ok=1
+    fi
+fi
+if (( bi_ok )); then
+    echo "  OK"
+else
+    echo "  FAIL (daemon: $BI_DAEMON_LOG; ws: $BI_WS_LOG)"
+    failures=$((failures + 1))
+fi
+
+bi_cleanup
+trap - EXIT
+
 # ─── Always-on auxiliary phase: graceful drain ────────────────────
 # Exercises the 0.17.0 SIGTERM drain end-to-end (DESIGN_GRACEFUL_SHUTDOWN
 # §5):


### PR DESCRIPTION
Chunk 3 of 3 for **reversible barge-in** — the SIPp end-to-end phase plus the 0.32.0 release prep. Two commits:

## 1. SIPp `barge_in_pause` phase — real caller media

The signaling-only suite can't exercise this feature: forge-vad needs actual speech energy. So:

- **`gen_tone_pcap.py`** synthesizes ~3 s of G.711 µ-law tone RTP as a libpcap capture *at run time* (stdlib only — no binary audio committed, per the house rule; same generate-at-runtime pattern as the STIR/SHAKEN rig).
- **`barge_in_pause_caller.xml`** replays it via SIPp's `play_pcap_audio` as the caller's speech on a real call.
- The phase runs a fresh daemon with `mode = "pause"` + the echo WS server: the tone gets echoed back (bot mid-playout), the VAD fires, the arbitration arms, and the echo's default `barge_in_reject` resumes the retained playout. Pass = scenario completes **and** `siphon_ai_barge_in_decisions_total{outcome="rejected"}` ticked.

Verified locally — the daemon log shows the full cycle (`pause armed … retained=4` → `rejected by server … resumed=4 fresh=0`, decision latency 842 µs), and the **full suite is green: all 36 scenarios** including `--with-transfer`.

## 2. Release prep: 0.32.0

- `Cargo.toml` 0.31.1 → 0.32.0 (+ lockfile), CHANGELOG dated section, README marker.
- `check-version-consistency.py` (plain and `--tag v0.32.0`) and `extract-changelog.py 0.32.0` all pass locally; `cargo test --workspace` 55 suites green.

Protocol stays **v1**, CDR stays **v4**, pause mode is **off by default**.

After merge I'll tag `v0.32.0` on the release commit per RELEASING.md and the release workflow takes it from there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
