### PR TITLE
chore(release): 0.33.0 — registration management (admin API)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.0] - 2026-07-15
+
+### Added
+
+- **Registration management (admin API)** — operators can force a
+  `[[register]]` binding back **without bouncing the daemon** (which
+  tears down every active call). Two write actions on the
+  authenticated `[admin]` listener, operator role, audit-logged, no
+  new config (`docs/design/DESIGN_REGISTRATION_ADMIN.md`; #289):
+  - **`POST /admin/v1/registrations/{name}/refresh`** — immediate
+    off-cycle REGISTER; during a failure backoff the kick also resets
+    the backoff to its initial value.
+  - **`POST /admin/v1/registrations/{name}/restart`** — full cycle:
+    REGISTER `Expires: 0` to clear the registrar-side binding, then a
+    fresh REGISTER (stale server state, contact rebinding). A failed
+    unregister warns and proceeds — only the final attempt drives
+    status/metrics/webhook.
+  Both return `202` with the accept-time row; the outcome is
+  asynchronous and observable via `GET /admin/registrations`,
+  `siphon_ai_register_attempts_total`, and the
+  `registration_state_changed` webhook. `404` unknown name, `409`
+  while draining. Per-binding only (no "refresh all" in v1).
+- **Parked bindings**: `register_on_startup = false` now runs the
+  ordinary drive task **parked under operator control** — no REGISTER
+  until the first `refresh`/`restart` arrives (the "tell to register"
+  RPC the `disabled` status had reserved). Ship the config dark, kick
+  the binding when the maintenance window opens. No "re-disable"
+  action in v1.
+- **Metric**: `siphon_ai_register_admin_triggers_total{name,action}` —
+  accepted operator triggers; the resulting REGISTER lands on
+  `register_attempts_total` as usual.
+- **SIPp harness**: `registration_admin` phase — the suite's first
+  registrar-side scenario (SIPp answers REGISTER and asserts the
+  restart's `Expires: 0` on the wire). Suite is now 37 scenarios.
+
+No WS-protocol, CDR, config-schema, or webhook changes.
+
 ## [0.32.0] - 2026-07-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3542,7 +3542,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3558,7 +3558,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "base64",
  "bytes",
@@ -3580,7 +3580,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3597,7 +3597,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "regex",
  "serde",
@@ -3616,7 +3616,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3662,7 +3662,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "base64",
  "hmac",
@@ -3685,7 +3685,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3709,7 +3709,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3727,7 +3727,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -3759,7 +3759,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "regex",
  "serde",
@@ -3771,7 +3771,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "schemars",
  "serde",
@@ -3781,7 +3781,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -3826,7 +3826,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3855,7 +3855,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.32.0"
+version = "0.33.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.32.0.** Production-deployed against real carriers
+**Current release: v0.33.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -191,40 +191,25 @@ barrier and make the contract testable:
 
 ---
 
-## P2 — Registration management (admin)
+## P2 — Registration management (admin) — ✅ delivered in v0.33.0
 
-Today a `[[register]]` row only re-REGISTERs on its own refresh timer (or a
-daemon restart). When an upstream (e.g. CUCM) drops or stales a binding,
-operators have no way to force it back without bouncing the daemon — which
-interrupts active calls. Extends the existing read-only `GET
-/admin/registrations` (0.10.0) on the authenticated `[admin]` listener with
-two write actions (operator role), neither of which touches media:
+Extends the read-only `GET /admin/registrations` (0.10.0) with two
+per-binding write actions (operator role, audit-logged, no new config —
+design note `DESIGN_REGISTRATION_ADMIN.md`):
 
-- **`POST /admin/registrations/{name}/refresh`** — fire an immediate
-  authenticated REGISTER for one binding, off-cycle, without a restart.
-  Implementation: give each registration task a `Notify` (or a small command
-  channel) and have its loop select over all three wake sources —
+- **`POST /admin/v1/registrations/{name}/refresh`** — immediate
+  off-cycle REGISTER (also resets a failure backoff). Implemented as
+  the sketched select-arm nudge: each drive task's waits select over
+  timer / command / shutdown.
+- **`POST /admin/v1/registrations/{name}/restart`** — REGISTER
+  `Expires: 0` then a fresh REGISTER, for server-side stale state or
+  contact rebinding.
 
-  ```rust
-  tokio::select! {
-      _ = tokio::time::sleep(refresh_delay)   => {}  // normal cadence
-      _ = refresh_signal.notified()           => {}  // operator-triggered
-      _ = shutdown_signal.cancelled()         => return,
-  }
-  ```
-
-  so a refresh just nudges the existing loop rather than spawning anything.
-
-- **`POST /admin/registrations/{name}/restart`** — full unregister/register
-  cycle: REGISTER with `Expires: 0` to clear the binding, then a fresh
-  authenticated REGISTER. For when a refresh isn't enough (server-side stale
-  state, contact rebinding after an IP change).
-
-Both return the resulting registration state (reuse the `GET` snapshot
-shape). `404` for an unknown `{name}`; bounded-cardinality metric on
-trigger; audit-logged (actor = token name) like every other admin write.
-Per-binding only — no global "refresh all" in the first cut (operators can
-script the list).
+Bonus over the original sketch: `register_on_startup = false` bindings
+are now **parked under operator control** — the first `refresh` starts
+them (the "tell to register" RPC). Still deliberately per-binding only
+(no "refresh all"), and no "re-disable" action — natural follow-ups if
+demand shows up.
 
 ---
 


### PR DESCRIPTION
Release prep for **v0.33.0** (theme: registration management admin API, feature landed in #289):

- `Cargo.toml` 0.32.0 → 0.33.0 (+ lockfile)
- CHANGELOG: dated `[0.33.0]` section (refresh/restart endpoints, parked bindings, trigger metric, registrar-side SIPp phase)
- README release marker
- ROADMAP: P2 registration-management item marked ✅ delivered (with the parked-binding bonus and the deliberately-deferred follow-ups noted)

Verified locally: `check-version-consistency.py` (plain + `--tag v0.33.0`), `extract-changelog.py 0.33.0`, doc-links, `cargo test --workspace` 55 suites green.

After merge I'll tag `v0.33.0` per RELEASING.md and verify the release pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)