### PR TITLE
docs: marker-bit fix is in the shipped forge-media pin

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -252,7 +252,7 @@ demand shows up.
 
 - `print-config --format json` (config CLI nicety).
 - CSV CDR output (alongside JSON/JSONL).
-- Marker-bit fix — pending forge-media PR, then bump the pins.
+- ~~Marker-bit fix~~ — ✅ done: forge-media #68 (marker bit only on talkspurt start) merged 2026-06-04 and is included in the `3c59b5f` pin shipped with v0.31.1 (verified: the pin is 13 commits ahead of the merge commit).
 
 ---
 


### PR DESCRIPTION
forge-media #68 merged 2026-06-04; verified (gh compare: pin 3c59b5f
is 13 ahead / 0 behind the merge commit) that it's included in the
pin bump that shipped with v0.31.1. The ROADMAP follow-up line was
stale.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
