### PR TITLE
chore(release): 0.34.0 — WS-failure prompt playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.0] - 2026-07-15
+
+### Added
+
+- **WS-failure prompt playback** — `[bridge].on_ws_failure =
+  "play_prompt"` + `ws_failure_prompt_file`, both per-route
+  overridable (`docs/design/DESIGN_WS_FAILURE_PROMPT.md`; #292).
+  Finishes the switch reserved since v1: when the WS becomes
+  **unusable** — unexpected drop, connect failure at answer, keepalive
+  timeout, `protocol_error`, `server_too_slow`, or an exhausted
+  0.7.3 reconnect window — the caller hears a configurable WAV
+  (*"we're experiencing difficulties…"*) before the normal BYE,
+  instead of an unexplained disconnect. Details:
+  - Never fires when the ending was intended (server `hangup` / clean
+    `stop`), on caller actions, on `rtp_timeout`, or during drain.
+  - **Fail-open**: an unusable prompt (rate mismatch, file vanished)
+    degrades to today's immediate teardown; playback is capped at a
+    fixed 30 s. CDR termination causes are unchanged (`duration_ms`
+    grows by the prompt).
+  - **Announce-over-park**: a prompt started while the call is parked
+    on MOH now plays (MOH → prompt → BYE after a failed reconnect);
+    a park arriving mid-announcement still cuts it short, so the
+    0.26.0 consent semantics are unchanged.
+  - Prompt file is required + existence-checked at load when any
+    effective policy is `play_prompt`; WAVs longer than the 30 s cap
+    warn at load.
+- **Metric**: `siphon_ai_ws_failure_prompts_total{result}` with
+  `played | cut_short | unusable | timeout`.
+- **SIPp harness**: `ws_failure_prompt` phase (echo server drops the
+  WS mid-call; asserts the prompt played on a real call). Suite is
+  now 38 scenarios.
+
+### Changed
+
+- `MediaTap::with_ws_reconnect` renamed to `with_survive_ws_drop`
+  (internal API) — the tap's survive-WS-drop mode now serves both
+  reconnect and prompt calls.
+
+No WS-protocol, CDR, or webhook-schema changes.
+
 ## [0.33.0] - 2026-07-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3542,7 +3542,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3558,7 +3558,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "base64",
  "bytes",
@@ -3580,7 +3580,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3597,7 +3597,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "regex",
  "serde",
@@ -3616,7 +3616,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3662,7 +3662,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "base64",
  "hmac",
@@ -3685,7 +3685,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3709,7 +3709,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3727,7 +3727,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -3759,7 +3759,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "regex",
  "serde",
@@ -3771,7 +3771,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "schemars",
  "serde",
@@ -3781,7 +3781,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -3826,7 +3826,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3855,7 +3855,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.33.0"
+version = "0.34.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.33.0.** Production-deployed against real carriers
+**Current release: v0.34.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -186,8 +186,13 @@ barrier and make the contract testable:
 - **AMD (answering-machine / voicemail detection)** — human-vs-machine on
   answered outbound calls, surfaced as a WS event. Needs a `forge-amd`
   sibling to `forge-vad` (*upstream-gated*).
-- **WS-failure prompt playback** — on a WS failure, play a configurable prompt
-  before teardown instead of only `hangup`.
+- **WS-failure prompt playback** — ✅ **delivered in v0.34.0**:
+  `[bridge].on_ws_failure = "play_prompt"` + `ws_failure_prompt_file`
+  (per-route overridable) play a configurable WAV on every
+  siphon-initiated WS-unusable teardown — including after an exhausted
+  reconnect window (announce-over-park) — before the normal BYE.
+  Fail-open, 30 s cap, CDR causes unchanged. See
+  `DESIGN_WS_FAILURE_PROMPT.md`.
 
 ---
 


### PR DESCRIPTION
Release prep for **v0.34.0** (theme: WS-failure prompt playback, feature landed in #292):

- `Cargo.toml` 0.33.0 → 0.34.0 (+ lockfile)
- CHANGELOG: dated `[0.34.0]` section (play_prompt mode, failure taxonomy, announce-over-park, fail-open + 30 s cap, metric, SIPp phase; `with_survive_ws_drop` rename noted under Changed)
- README release marker
- ROADMAP: P2 WS-failure-prompt item marked ✅ delivered

Verified locally: `check-version-consistency.py` (plain + `--tag v0.34.0`), `extract-changelog.py 0.34.0`, doc-links, `cargo test --workspace` 55 suites green.

After merge I'll tag `v0.34.0` per RELEASING.md and verify the release pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)