### PR TITLE
chore(release): 0.35.0 — optional /metrics bearer auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.0] - 2026-07-15
+
+### Added
+
+- **Optional `/metrics` bearer auth** —
+  `[observability].metrics_token`
+  (`docs/design/DESIGN_METRICS_AUTH.md`; #294). Recon-hardening for
+  deployments that expose the observability port beyond loopback:
+  when set, `GET /metrics` requires `Authorization: Bearer <token>`
+  (SHA-256 + constant-time compare, the admin listener's scheme; only
+  the hash is retained in memory). Failures answer `401` +
+  `WWW-Authenticate: Bearer`. **Unset = open**, the default —
+  existing deployments are unchanged. `/health` and `/ready` are
+  never gated (probes must not need secrets). Empty-after-expansion
+  tokens fail at load; use `${file:…}` / `${cred:…}`.
+  Prometheus-side `authorization.credentials_file` snippet documented
+  in `docs/DEPLOY.md` and `examples/observability/prometheus.yml`.
+- **Metric**: `siphon_ai_metrics_requests_total{result=ok|unauthenticated}`
+  — emitted only when the gate is configured (an open endpoint counts
+  nothing); rejected scrapes also log a rate-limited warning.
+
+This closes the last locally-buildable P2 roadmap item. No WS-protocol,
+CDR, or webhook changes.
+
 ## [0.34.0] - 2026-07-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3542,7 +3542,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3558,7 +3558,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "base64",
  "bytes",
@@ -3580,7 +3580,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3597,7 +3597,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "regex",
  "serde",
@@ -3616,7 +3616,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3662,7 +3662,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "base64",
  "hmac",
@@ -3685,7 +3685,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3709,7 +3709,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3727,7 +3727,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -3759,7 +3759,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "regex",
  "serde",
@@ -3771,7 +3771,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "schemars",
  "serde",
@@ -3781,7 +3781,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -3826,7 +3826,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3855,7 +3855,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.34.0"
+version = "0.35.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.34.0.** Production-deployed against real carriers
+**Current release: v0.35.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -220,11 +220,10 @@ demand shows up.
 
 ## P2 — Security & CDR (small, high-signal)
 
-- **Optional `/metrics` bearer auth** — token on `/metrics` only, off by
-  default; `/health`+`/ready` stay open. Defense-in-depth for deployments
-  that expose the observability port widely. (Confirmed `/metrics` carries no
-  PII — only aggregate counters + operator-chosen route/register names — so
-  this is recon-hardening, not a PII fix.)
+- **Optional `/metrics` bearer auth** — ✅ **delivered in v0.35.0**:
+  `[observability].metrics_token` gates `GET /metrics` (constant-time
+  bearer compare, `401` + `WWW-Authenticate`), off by default;
+  `/health`+`/ready` stay open. See `DESIGN_METRICS_AUTH.md`.
 - **CDR call-quality fields** — ✅ **delivered in v0.30.0**:
   `first_audio_out_ms` and `barge_in_count` shipped in the CDR `quality`
   block (CDR v4), closing the `docs/OPERATIONS.md` Q5/Q8 gaps; v0.32.0


### PR DESCRIPTION
Release prep for **v0.35.0** (theme: optional `/metrics` bearer auth, feature landed in #294):

- `Cargo.toml` 0.34.0 → 0.35.0 (+ lockfile)
- CHANGELOG: dated `[0.35.0]` section
- README release marker
- ROADMAP: P2 `/metrics`-auth item marked ✅ delivered — **the last locally-buildable P2 item**; the remaining backlog is upstream-gated (AMD, neural VAD/duck), demand-gated (STIR/SHAKEN signing), and P3

Verified locally: `check-version-consistency.py` (plain + `--tag v0.35.0`), `extract-changelog.py 0.35.0`, doc-links, `cargo test --workspace` 55 suites green.

After merge I'll tag `v0.35.0` per RELEASING.md and verify the release pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)