### PR TITLE
feat(cli): print-config --format json (v0.36.0)

### DIFF
--- a/bins/siphon-ai/src/inspect.rs
+++ b/bins/siphon-ai/src/inspect.rs
@@ -14,6 +14,7 @@
 
 use std::fmt::Write as _;
 
+use serde_json::{json, Value};
 use siphon_ai_config::{Config, RecordingMode, SipTransport};
 use siphon_ai_routes::{CallInfo, Headers};
 
@@ -42,6 +43,26 @@ fn secret(opt: &Option<String>, show: bool) -> String {
 /// Present a plain optional string (no redaction).
 fn opt(o: &Option<String>) -> String {
     o.clone().unwrap_or_else(|| "<unset>".into())
+}
+
+/// JSON flavour of [`secret`]: `null` when unset, `"<redacted>"` when
+/// set but hidden, the value when `show`.
+fn secret_json(opt: &Option<String>, show: bool) -> Value {
+    match opt {
+        None => Value::Null,
+        Some(_) if !show => json!("<redacted>"),
+        Some(v) => json!(v),
+    }
+}
+
+/// A required (non-optional) secret string, e.g. a register/gateway
+/// password.
+fn secret_value(v: &str, show: bool) -> Value {
+    if show {
+        json!(v)
+    } else {
+        json!("<redacted>")
+    }
 }
 
 fn transport_str(t: &SipTransport) -> &'static str {
@@ -400,6 +421,221 @@ pub fn render_config(config: &Config, show_secrets: bool) -> String {
     }
 
     o
+}
+
+/// Render the effective compiled config as pretty-printed JSON — the
+/// same sections and redaction semantics as [`render_config`], shaped
+/// for tooling (`jq`, deploy diffing) instead of eyeballs.
+///
+/// This is an *inspection* view, not a config round-trip: enum-ish
+/// fields are rendered as strings, unset optionals are `null`, and
+/// redacted secrets are the literal string `"<redacted>"`. Feeding the
+/// output back into the daemon is not supported.
+pub fn render_config_json(config: &Config, show_secrets: bool) -> String {
+    let routes: Vec<Value> = config
+        .routes
+        .iter()
+        .map(|r| {
+            // Same rule as the text renderer: only overrides that are
+            // actually set appear (absent key = inherits the global).
+            let mut route = serde_json::Map::new();
+            route.insert("name".into(), json!(r.name));
+            if let Some(u) = &r.bridge.ws_url {
+                route.insert("ws_url".into(), json!(u));
+            }
+            if r.bridge.ws_auth_header.is_some() {
+                route.insert(
+                    "ws_auth_header".into(),
+                    secret_json(&r.bridge.ws_auth_header, show_secrets),
+                );
+            }
+            if let Some(c) = &r.media.codecs {
+                route.insert(
+                    "codecs".into(),
+                    json!(c.iter().map(|c| format!("{c:?}")).collect::<Vec<_>>()),
+                );
+            }
+            if let Some(m) = &r.media.srtp {
+                route.insert("srtp".into(), json!(m.to_string()));
+            }
+            if let Some(m) = &r.recording.mode {
+                route.insert("recording".into(), json!(m.to_string()));
+            }
+            if let Some(a) = &r.security.min_attestation {
+                route.insert("min_attestation".into(), json!(a.to_string()));
+            }
+            if r.bridge_tls.is_some() {
+                route.insert("bridge_tls".into(), json!("set (overrides global)"));
+            }
+            Value::Object(route)
+        })
+        .collect();
+
+    let registrations: Vec<Value> = config
+        .registrations
+        .iter()
+        .map(|reg| {
+            json!({
+                "name": reg.name,
+                "server": reg.server_host,
+                "transport": transport_str(&reg.transport),
+                "username": reg.username,
+                "password": secret_value(&reg.password, show_secrets),
+                "expires_secs": reg.expires.as_secs(),
+                "register_on_startup": reg.register_on_startup,
+            })
+        })
+        .collect();
+
+    let trunks: Vec<Value> = config
+        .trunks
+        .iter()
+        .map(|t| {
+            json!({
+                "name": t.name,
+                "peer_addrs": t.peer_addrs.len(),
+                "from_hosts": t.from_hosts,
+            })
+        })
+        .collect();
+
+    let gateways: Vec<Value> = config
+        .outbound
+        .gateways
+        .iter()
+        .map(|g| {
+            json!({
+                "name": g.name,
+                "proxy": format!("{}:{}", g.proxy_host, g.proxy_port),
+                "transport": transport_str(&g.transport),
+                "from": g.from,
+                "srtp": format!("{:?}", g.srtp),
+                "credentials": g.credentials.as_ref().map(|c| {
+                    json!({
+                        "username": c.username,
+                        "password": secret_value(&c.password, show_secrets),
+                    })
+                }),
+            })
+        })
+        .collect();
+
+    let b = &config.bridge_defaults;
+    let root = json!({
+        "node": {
+            "id": config.node.id,
+            "public_address": config.node.public_address.to_string(),
+        },
+        "sip": {
+            "listen": config.sip.listen_addr.to_string(),
+            "transports": config.sip.transports.iter().map(transport_str).collect::<Vec<_>>(),
+            "tls": config.sip.tls.is_some(),
+            "allow_delayed_offer": config.sip.allow_delayed_offer,
+        },
+        "media": {
+            "srtp": format!("{:?}", config.media.srtp),
+            "rtp_port_range": config.media.rtp_port_range.map(|(lo, hi)| format!("{lo}-{hi}")),
+            "moh_file": config.media.moh_file.as_ref().map(|p| p.display().to_string()),
+        },
+        "bridge": {
+            "ws_url": b.ws_url,
+            "auth_header": secret_json(&b.auth_header, show_secrets),
+            "codecs": b.codecs.iter().map(|c| format!("{c:?}")).collect::<Vec<_>>(),
+            "barge_in": format!("{:?}", b.barge_in.mode),
+            "forward_headers": b.forward_headers,
+        },
+        "routes": {
+            "count": config.routes.len(),
+            "has_default": config.routes.has_default(),
+            "list": routes,
+        },
+        "registrations": registrations,
+        "trunks": trunks,
+        "security": {
+            "stir_shaken": config.security.stir_shaken.enabled,
+            "min_attestation": format!("{:?}", config.security.min_attestation),
+        },
+        "recording": {
+            "mode": format!("{:?}", config.recording.mode),
+            "dir": if matches!(config.recording.mode, RecordingMode::Off) {
+                Value::Null
+            } else {
+                json!(config.recording.dir.display().to_string())
+            },
+        },
+        "outbound": {
+            "max_concurrent": config.outbound.max_concurrent,
+            "rate_limit_per_sec": config.outbound.rate_limit_per_sec,
+            "gateways": gateways,
+        },
+        "conference": {
+            "enabled": config.conference.enabled,
+            "max_rooms": config.conference.max_rooms,
+            "max_participants_per_room": config.conference.max_participants_per_room,
+        },
+        "park": {
+            "enabled": config.park.enabled,
+            "max_parked": config.park.max_parked,
+            "timeout_secs": config.park.timeout.map(|d| d.as_secs()),
+            "timeout_action": format!("{:?}", config.park.timeout_action),
+        },
+        "cdr": {
+            "enabled": config.cdr.enabled,
+            "file": config.cdr.file.as_ref().map(|f| json!({
+                "path": f.path.display().to_string(),
+            })),
+            "webhook": config.cdr.webhook.as_ref().map(|w| json!({
+                "url": w.url,
+                "auth_header": secret_json(&w.auth_header, show_secrets),
+                "secret": secret_json(&w.secret, show_secrets),
+                "spool_dir": w.spool_dir,
+            })),
+        },
+        "webhooks": {
+            "enabled": config.webhooks.enabled,
+            "url": config.webhooks.url,
+            "auth_header": secret_json(&config.webhooks.auth_header, show_secrets),
+            "secret": secret_json(&config.webhooks.secret, show_secrets),
+            "spool_dir": config.webhooks.spool_dir,
+            "events": config.webhooks.events,
+        },
+        "audit": {
+            "enabled": config.audit.enabled,
+            "events": config.audit.events,
+            "file": config.audit.file.as_ref().map(|f| json!({
+                "path": f.path.display().to_string(),
+            })),
+            "webhook": config.audit.webhook.as_ref().map(|w| json!({
+                "url": w.url,
+                "auth_header": secret_json(&w.auth_header, show_secrets),
+                "secret": secret_json(&w.secret, show_secrets),
+                "spool_dir": w.spool_dir,
+            })),
+        },
+        "observability": {
+            "enabled": config.observability.enabled,
+            "http_listen": config.observability.http_listen.map(|a| a.to_string()),
+        },
+        "admin": config.admin.as_ref().map(|a| json!({
+            "listen": a.listen_addr.to_string(),
+            "tokens": a.auth.iter().map(|t| json!({
+                "name": t.name,
+                "role": t.role.as_str(),
+            })).collect::<Vec<_>>(),
+        })),
+        "hep": {
+            "enabled": config.hep.enabled,
+            "collector": config.hep.collector.map(|a| a.to_string()),
+            "capture_id": config.hep.capture_id,
+            "capture_password": secret_json(&config.hep.capture_password, show_secrets),
+        },
+    });
+
+    // `to_string_pretty` can only fail on non-string map keys / broken
+    // `Serialize` impls — `Value` has neither.
+    let mut s = serde_json::to_string_pretty(&root).expect("Value serializes");
+    s.push('\n');
+    s
 }
 
 /// Run the dialplan against synthetic call attributes and report the

--- a/bins/siphon-ai/src/main.rs
+++ b/bins/siphon-ai/src/main.rs
@@ -57,6 +57,10 @@ enum Command {
         /// passwords) instead of `<redacted>`.
         #[arg(long)]
         show_secrets: bool,
+        /// Output format: `text` (human-readable, the default) or
+        /// `json` (pretty-printed, for `jq` / deploy diffing).
+        #[arg(long, value_enum, default_value_t = PrintFormat::Text)]
+        format: PrintFormat,
     },
 
     /// Report which route a synthetic call matches (first-match-wins)
@@ -128,6 +132,14 @@ enum Command {
     },
 }
 
+/// `print-config` output format. JSON is an inspection view (nulls
+/// for unset, `"<redacted>"` strings), not a loadable config.
+#[derive(clap::ValueEnum, Clone, Copy, Debug)]
+enum PrintFormat {
+    Text,
+    Json,
+}
+
 /// The config path, from `--config` or `$SIPHON_AI_CONFIG`. A clap
 /// `global` arg can't be `required`, so enforce presence here.
 fn config_path(cli: &Cli) -> Result<PathBuf> {
@@ -188,7 +200,10 @@ async fn main() -> Result<()> {
         let path = config_path(&cli)?;
         match command {
             Command::Check => run_check(&path),
-            Command::PrintConfig { show_secrets } => run_print_config(&path, *show_secrets),
+            Command::PrintConfig {
+                show_secrets,
+                format,
+            } => run_print_config(&path, *show_secrets, *format),
             Command::RouteTest {
                 ruri_user,
                 ruri_host,
@@ -272,9 +287,13 @@ fn run_check(path: &Path) -> ! {
 
 /// `siphon-ai print-config` — render the effective compiled config
 /// (secrets redacted unless `show_secrets`) and exit.
-fn run_print_config(path: &Path, show_secrets: bool) -> ! {
+fn run_print_config(path: &Path, show_secrets: bool, format: PrintFormat) -> ! {
     let config = load_or_exit(path);
-    print!("{}", inspect::render_config(&config, show_secrets));
+    let rendered = match format {
+        PrintFormat::Text => inspect::render_config(&config, show_secrets),
+        PrintFormat::Json => inspect::render_config_json(&config, show_secrets),
+    };
+    print!("{rendered}");
     std::process::exit(0);
 }
 

--- a/bins/siphon-ai/tests/cli.rs
+++ b/bins/siphon-ai/tests/cli.rs
@@ -200,6 +200,78 @@ fn print_config_show_secrets_reveals_them() {
 }
 
 #[test]
+fn print_config_json_parses_and_redacts() {
+    let cfg = write_cfg(WITH_SECRET_AND_ROUTES);
+    let out = Command::new(BIN)
+        .args(["print-config", "--format", "json", "--config"])
+        .arg(cfg.path())
+        .output()
+        .expect("run print-config --format json");
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("output is valid JSON");
+
+    assert_eq!(v["node"]["id"], "cli-test");
+    assert_eq!(v["bridge"]["ws_url"], "wss://default/ws");
+    assert_eq!(v["bridge"]["auth_header"], "<redacted>");
+    assert!(
+        !stdout.contains("SUPERSECRET"),
+        "secret leaked into JSON print-config output"
+    );
+
+    // Route list: only overrides that are set appear on a route.
+    assert_eq!(v["routes"]["has_default"], true);
+    assert_eq!(v["routes"]["list"][0]["name"], "sales");
+    assert_eq!(v["routes"]["list"][0]["ws_url"], "wss://sales/ws");
+    assert_eq!(v["routes"]["list"][1]["name"], "default");
+    assert!(
+        v["routes"]["list"][1].get("ws_url").is_none(),
+        "inheriting route must not carry an override key"
+    );
+
+    // Unset optionals are null, not omitted (top-level sections are a
+    // stable shape for jq).
+    assert!(v["admin"].is_null());
+    assert!(v["media"]["moh_file"].is_null());
+}
+
+#[test]
+fn print_config_json_show_secrets_reveals_them() {
+    let cfg = write_cfg(WITH_SECRET_AND_ROUTES);
+    let out = Command::new(BIN)
+        .args([
+            "print-config",
+            "--format",
+            "json",
+            "--show-secrets",
+            "--config",
+        ])
+        .arg(cfg.path())
+        .output()
+        .expect("run print-config --format json --show-secrets");
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("output is valid JSON");
+    assert_eq!(v["bridge"]["auth_header"], "Bearer SUPERSECRET");
+}
+
+#[test]
+fn print_config_default_format_is_text() {
+    let cfg = write_cfg(WITH_SECRET_AND_ROUTES);
+    let out = Command::new(BIN)
+        .args(["print-config", "--config"])
+        .arg(cfg.path())
+        .output()
+        .expect("run print-config");
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.starts_with("# Effective configuration"),
+        "default output must stay the text renderer; got: {}",
+        &stdout[..stdout.len().min(80)]
+    );
+}
+
+#[test]
 fn route_test_resolves_first_match_wins() {
     let cfg = write_cfg(WITH_SECRET_AND_ROUTES);
     // to=1000 matches the `sales` route and its ws_url override.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1079,7 +1079,7 @@ siphon-ai check --config /etc/siphon-ai/config.toml || echo "bad config, not dep
 A missing default route (`any = true`) warns but still exits `0` (matches
 the daemon's startup behavior).
 
-### `siphon-ai print-config --config X [--show-secrets]`
+### `siphon-ai print-config --config X [--show-secrets] [--format text|json]`
 
 Print the **effective** compiled config (post-`${VAR}`, post per-route
 merge) so you can see what your file actually resolved to — which `${VAR}`
@@ -1087,6 +1087,17 @@ won, what each route inherits vs overrides. **Secrets are redacted** (auth
 headers, signing secrets, register/gateway passwords, admin token hashes,
 HEP password → `<redacted>`); `--show-secrets` reveals them for local
 debugging.
+
+`--format json` renders the same sections as pretty-printed JSON for
+tooling (`jq`, deploy diffing). It's an inspection view, not a config
+round-trip: unset optionals are `null`, redacted secrets are the literal
+string `"<redacted>"`, and the output is not loadable as a config file.
+Per-route keys appear only when the route actually overrides them —
+an absent key means "inherits the global".
+
+```sh
+siphon-ai print-config --config x.toml --format json | jq '.routes.list[].name'
+```
 
 ### `siphon-ai route-test --config X --to N [...]`
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -254,7 +254,9 @@ demand shows up.
 
 ## Small follow-ups (low effort, do opportunistically)
 
-- `print-config --format json` (config CLI nicety).
+- ~~`print-config --format json`~~ — ✅ done in v0.36.0: `--format text|json`
+  on `print-config`, same sections/redaction as the text renderer, shaped
+  for `jq` / deploy diffing.
 - CSV CDR output (alongside JSON/JSONL).
 - ~~Marker-bit fix~~ — ✅ done: forge-media #68 (marker bit only on talkspurt start) merged 2026-06-04 and is included in the `3c59b5f` pin shipped with v0.31.1 (verified: the pin is 13 commits ahead of the merge commit).
 


### PR DESCRIPTION
## What

Adds `--format text|json` to `siphon-ai print-config` — the ROADMAP "small follow-ups" config-CLI nicety.

- `bins/siphon-ai/src/inspect.rs`: new `render_config_json` walking the same sections as the text renderer, with identical redaction semantics — unset optionals render as `null`, hidden secrets as the literal `"<redacted>"`, `--show-secrets` reveals. Per-route keys appear only when the route actually overrides them (absent = inherits), mirroring the text output's rule.
- `bins/siphon-ai/src/main.rs`: clap `ValueEnum` flag, default `text` (existing output byte-identical).
- Documented in `docs/CONFIG.md` (explicitly an inspection view, not a config round-trip); ROADMAP line struck.

## Tests

- 3 new CLI integration tests: JSON parses + redacts + route-override key rules, `--show-secrets` reveals in JSON, default format stays text.
- `cargo test -p siphon-ai --test cli`: 12 passed. Clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)