### PR TITLE
feat(cdr): CSV file output — [cdr.file].format = "csv" (v0.36.0)

### DIFF
--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -2109,10 +2109,14 @@ pub(crate) async fn build_quality_sink(
 }
 
 async fn build_file_sink(cfg: &CdrFileConfig) -> Result<CdrSinkHandle> {
-    let sink = FileSink::open(&cfg.path)
+    let format = match cfg.format {
+        siphon_ai_config::CdrFileFormat::Jsonl => siphon_ai_cdr::FileFormat::Jsonl,
+        siphon_ai_config::CdrFileFormat::Csv => siphon_ai_cdr::FileFormat::Csv,
+    };
+    let sink = FileSink::open_with_format(&cfg.path, format)
         .await
         .with_context(|| format!("open CDR file {}", cfg.path.display()))?;
-    info!(path = %cfg.path.display(), "CDR file sink active");
+    info!(path = %cfg.path.display(), ?format, "CDR file sink active");
     Ok(Arc::new(sink) as CdrSinkHandle)
 }
 

--- a/crates/cdr/src/csv.rs
+++ b/crates/cdr/src/csv.rs
@@ -1,0 +1,366 @@
+//! CSV rendering of [`CdrRecord`] for the file sink (0.36.0).
+//!
+//! CSV is a *flat* view of the record: nested optional blocks
+//! (`audio`, `termination`, `consent`, `park`, `hold`, `reconnect`,
+//! `quality`) become prefixed columns, and an absent block / unmeasured
+//! value is an **empty cell** — same "absent ≠ zero" semantics as the
+//! JSON shape. The column set is fixed per CDR schema version; adding a
+//! CDR field means appending a column here (and the header) in the same
+//! PR, per CLAUDE.md §7.7.
+//!
+//! Quoting follows RFC 4180: a field containing a comma, double quote,
+//! CR, or LF is wrapped in double quotes with embedded quotes doubled.
+//! We deliberately hand-roll this instead of pulling a csv crate — the
+//! writer is ~30 lines and the dep tree stays small.
+
+use std::fmt::Write as _;
+
+use crate::schema::CdrRecord;
+
+/// Header row (no trailing newline). Column order is append-only: new
+/// columns go at the end so downstream ingestors keyed by position
+/// survive additive schema changes.
+pub const HEADER: &str = "version,call_id,sip_call_id,started_at,ended_at,duration_ms,\
+from,to,direction,route,ws_url,\
+audio_codec,audio_payload_type,audio_sample_rate,\
+termination_cause,termination_bridge_disconnect,termination_tap_disconnect,\
+verstat_attest,verstat_passed,\
+recording_id,recording_path,recording_encrypted,recording_url,\
+consent_announced,consent_announcement_ms,consent_server,\
+park_count,park_total_ms,hold_count,hold_total_ms,\
+reconnect_count,reconnect_total_gap_ms,\
+quality_first_audio_out_ms,quality_barge_in_count,\
+quality_avg_jitter_ms,quality_max_jitter_ms,\
+quality_avg_packet_loss_ratio,quality_max_packet_loss_ratio,\
+quality_avg_rtcp_rtt_ms,\
+quality_rx_packets_received,quality_rx_packets_lost,\
+quality_rx_packets_out_of_order,quality_rx_packets_duplicate,\
+quality_mos_estimate_min,quality_mos_estimate_avg";
+
+/// Number of columns in [`HEADER`] (and every row). Only asserted in
+/// tests — production code appends by name, not position.
+#[cfg(test)]
+pub(crate) const COLUMNS: usize = 45;
+
+/// RFC 4180 field escaping: quote when the value contains a comma,
+/// quote, or line break; double embedded quotes.
+fn push_field(out: &mut String, value: &str) {
+    if value.contains([',', '"', '\n', '\r']) {
+        out.push('"');
+        for c in value.chars() {
+            if c == '"' {
+                out.push('"');
+            }
+            out.push(c);
+        }
+        out.push('"');
+    } else {
+        out.push_str(value);
+    }
+}
+
+/// Serialize an enum-on-the-wire value (Direction, TerminationCause)
+/// to its snake_case wire string, exactly as the JSON shape emits it.
+fn wire_str<T: serde::Serialize>(v: &T) -> String {
+    // Only enum-unit → string serialization reaches this; a non-string
+    // would be a schema bug caught by the round-trip tests below.
+    match serde_json::to_value(v) {
+        Ok(serde_json::Value::String(s)) => s,
+        _ => String::new(),
+    }
+}
+
+macro_rules! cell {
+    // Optional value: absent → empty cell.
+    (opt $out:ident, $v:expr) => {
+        if let Some(x) = $v {
+            let _ = write!($out, "{x}");
+        }
+        $out.push(',');
+    };
+    // Required Display value.
+    ($out:ident, $v:expr) => {
+        let _ = write!($out, "{}", $v);
+        $out.push(',');
+    };
+}
+
+/// Render one record as a CSV row (no trailing newline), column-for-
+/// column matching [`HEADER`].
+pub fn record_to_row(r: &CdrRecord) -> String {
+    let mut o = String::with_capacity(256);
+
+    cell!(o, r.version);
+    push_field(&mut o, &r.call_id);
+    o.push(',');
+    push_field(&mut o, &r.sip_call_id);
+    o.push(',');
+    cell!(
+        o,
+        r.started_at
+            .to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+    );
+    cell!(
+        o,
+        r.ended_at
+            .to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+    );
+    cell!(o, r.duration_ms);
+    push_field(&mut o, &r.from);
+    o.push(',');
+    push_field(&mut o, &r.to);
+    o.push(',');
+    cell!(o, wire_str(&r.direction));
+    push_field(&mut o, &r.route);
+    o.push(',');
+    push_field(&mut o, &r.ws_url);
+    o.push(',');
+
+    push_field(&mut o, &r.audio.codec);
+    o.push(',');
+    cell!(o, r.audio.payload_type);
+    cell!(o, r.audio.sample_rate);
+
+    cell!(o, wire_str(&r.termination.cause));
+    push_field(&mut o, &r.termination.bridge_disconnect);
+    o.push(',');
+    push_field(&mut o, &r.termination.tap_disconnect);
+    o.push(',');
+
+    cell!(opt o, &r.verstat_attest);
+    cell!(opt o, r.verstat_passed);
+
+    cell!(opt o, &r.recording_id);
+    if let Some(p) = &r.recording_path {
+        push_field(&mut o, p);
+    }
+    o.push(',');
+    cell!(opt o, r.recording_encrypted);
+    cell!(opt o, &r.recording_url);
+
+    let c = r.consent.as_ref();
+    cell!(opt o, c.map(|c| c.announced));
+    cell!(opt o, c.map(|c| c.announcement_ms));
+    cell!(opt o, c.and_then(|c| c.server.as_ref()));
+
+    cell!(opt o, r.park.map(|p| p.count));
+    cell!(opt o, r.park.map(|p| p.total_ms));
+    cell!(opt o, r.hold.map(|h| h.count));
+    cell!(opt o, r.hold.map(|h| h.total_ms));
+    cell!(opt o, r.reconnect.map(|c| c.count));
+    cell!(opt o, r.reconnect.map(|c| c.total_gap_ms));
+
+    let q = r.quality.as_ref();
+    cell!(opt o, q.and_then(|q| q.first_audio_out_ms));
+    cell!(opt o, q.map(|q| q.barge_in_count));
+    cell!(opt o, q.and_then(|q| q.avg_jitter_ms));
+    cell!(opt o, q.and_then(|q| q.max_jitter_ms));
+    cell!(opt o, q.and_then(|q| q.avg_packet_loss_ratio));
+    cell!(opt o, q.and_then(|q| q.max_packet_loss_ratio));
+    cell!(opt o, q.and_then(|q| q.avg_rtcp_rtt_ms));
+    cell!(opt o, q.and_then(|q| q.rx_packets_received));
+    cell!(opt o, q.and_then(|q| q.rx_packets_lost));
+    cell!(opt o, q.and_then(|q| q.rx_packets_out_of_order));
+    cell!(opt o, q.and_then(|q| q.rx_packets_duplicate));
+    cell!(opt o, q.and_then(|q| q.mos_estimate_min));
+    // Last column: no trailing comma.
+    if let Some(v) = q.and_then(|q| q.mos_estimate_avg) {
+        let _ = write!(o, "{v}");
+    }
+
+    o
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::{
+        AudioInfo, ConsentInfo, Direction, HoldInfo, ParkInfo, QualityInfo, ReconnectInfo,
+        TerminationCause, TerminationInfo, CDR_VERSION,
+    };
+    use chrono::TimeZone;
+
+    fn sample() -> CdrRecord {
+        CdrRecord {
+            version: CDR_VERSION,
+            call_id: "siphon-7f3a".into(),
+            sip_call_id: "abc-123@pbx.example.com".into(),
+            started_at: chrono::Utc.with_ymd_and_hms(2026, 5, 5, 14, 30, 0).unwrap(),
+            ended_at: chrono::Utc
+                .with_ymd_and_hms(2026, 5, 5, 14, 30, 42)
+                .unwrap(),
+            duration_ms: 42_000,
+            from: "+13125551234".into(),
+            to: "5000".into(),
+            direction: Direction::Inbound,
+            route: "main_reception".into(),
+            ws_url: "wss://reception.example.com/sip-bridge".into(),
+            audio: AudioInfo {
+                codec: "PCMU".into(),
+                payload_type: 0,
+                sample_rate: 8000,
+            },
+            termination: TerminationInfo {
+                cause: TerminationCause::ServerHangup,
+                bridge_disconnect: "stop_sent".into(),
+                tap_disconnect: "controller_hung_up".into(),
+            },
+            verstat_attest: None,
+            verstat_passed: None,
+            recording_id: None,
+            recording_path: None,
+            recording_encrypted: None,
+            recording_url: None,
+            consent: None,
+            park: None,
+            hold: None,
+            reconnect: None,
+            quality: None,
+        }
+    }
+
+    /// Split a CSV row into fields, honouring RFC 4180 quoting.
+    fn split(row: &str) -> Vec<String> {
+        let mut fields = Vec::new();
+        let mut cur = String::new();
+        let mut in_quotes = false;
+        let mut chars = row.chars().peekable();
+        while let Some(c) = chars.next() {
+            match c {
+                '"' if in_quotes && chars.peek() == Some(&'"') => {
+                    cur.push('"');
+                    chars.next();
+                }
+                '"' => in_quotes = !in_quotes,
+                ',' if !in_quotes => fields.push(std::mem::take(&mut cur)),
+                c => cur.push(c),
+            }
+        }
+        fields.push(cur);
+        fields
+    }
+
+    #[test]
+    fn header_has_declared_column_count() {
+        assert_eq!(HEADER.split(',').count(), COLUMNS);
+        assert!(!HEADER.contains(' '), "header must be bare column names");
+    }
+
+    #[test]
+    fn minimal_record_renders_all_columns() {
+        let row = record_to_row(&sample());
+        let fields = split(&row);
+        assert_eq!(fields.len(), COLUMNS, "row: {row}");
+
+        let header: Vec<&str> = HEADER.split(',').collect();
+        let get = |name: &str| {
+            let i = header.iter().position(|h| *h == name).expect(name);
+            fields[i].clone()
+        };
+        assert_eq!(get("version"), CDR_VERSION.to_string());
+        assert_eq!(get("call_id"), "siphon-7f3a");
+        assert_eq!(get("started_at"), "2026-05-05T14:30:00.000Z");
+        assert_eq!(get("direction"), "inbound");
+        assert_eq!(get("termination_cause"), "server_hangup");
+        assert_eq!(get("audio_codec"), "PCMU");
+        // Absent blocks are empty cells, not zeros.
+        assert_eq!(get("park_count"), "");
+        assert_eq!(get("quality_barge_in_count"), "");
+        assert_eq!(get("quality_mos_estimate_avg"), "");
+    }
+
+    #[test]
+    fn fully_populated_record_renders_all_columns() {
+        let mut r = sample();
+        r.verstat_attest = Some("A".into());
+        r.verstat_passed = Some(true);
+        r.recording_id = Some("siphon-7f3a".into());
+        r.recording_path = Some("/var/rec/siphon-7f3a.wava".into());
+        r.recording_encrypted = Some(true);
+        r.recording_url = Some("s3://bucket/siphon-7f3a.wava".into());
+        r.consent = Some(ConsentInfo {
+            announced: true,
+            announcement_ms: 3200,
+            server: Some("dtmf-1".into()),
+        });
+        r.park = Some(ParkInfo {
+            count: 1,
+            total_ms: 15_000,
+        });
+        r.hold = Some(HoldInfo {
+            count: 2,
+            total_ms: 4500,
+        });
+        r.reconnect = Some(ReconnectInfo {
+            count: 1,
+            total_gap_ms: 1200,
+        });
+        r.quality = Some(QualityInfo {
+            first_audio_out_ms: Some(742),
+            barge_in_count: 3,
+            avg_jitter_ms: Some(11.5),
+            max_jitter_ms: Some(30.0),
+            avg_packet_loss_ratio: Some(0.004),
+            max_packet_loss_ratio: Some(0.02),
+            avg_rtcp_rtt_ms: None,
+            rx_packets_received: Some(14_820),
+            rx_packets_lost: Some(12),
+            rx_packets_out_of_order: Some(3),
+            rx_packets_duplicate: Some(0),
+            mos_estimate_min: Some(3.9),
+            mos_estimate_avg: Some(4.3),
+        });
+
+        let fields = split(&record_to_row(&r));
+        assert_eq!(fields.len(), COLUMNS);
+        let header: Vec<&str> = HEADER.split(',').collect();
+        let get = |name: &str| {
+            let i = header.iter().position(|h| *h == name).expect(name);
+            fields[i].clone()
+        };
+        assert_eq!(get("verstat_attest"), "A");
+        assert_eq!(get("verstat_passed"), "true");
+        assert_eq!(get("consent_server"), "dtmf-1");
+        assert_eq!(get("park_total_ms"), "15000");
+        assert_eq!(get("hold_count"), "2");
+        assert_eq!(get("reconnect_total_gap_ms"), "1200");
+        assert_eq!(get("quality_first_audio_out_ms"), "742");
+        assert_eq!(get("quality_barge_in_count"), "3");
+        assert_eq!(get("quality_avg_rtcp_rtt_ms"), "", "unmeasured → empty");
+        assert_eq!(get("quality_mos_estimate_avg"), "4.3");
+    }
+
+    #[test]
+    fn fields_with_commas_and_quotes_are_escaped() {
+        let mut r = sample();
+        r.from = "\"Alice, ext. 5\" <sip:alice@pbx>".into();
+        r.termination.bridge_disconnect = "closed: reason=\"bye\", code=1000".into();
+        let row = record_to_row(&r);
+        let fields = split(&row);
+        assert_eq!(fields.len(), COLUMNS, "escaping must not add columns");
+        assert_eq!(fields[6], "\"Alice, ext. 5\" <sip:alice@pbx>");
+        assert!(
+            row.contains(r#""""Alice, ext. 5"" <sip:alice@pbx>""#),
+            "raw row must carry RFC 4180 doubling: {row}"
+        );
+    }
+
+    #[test]
+    fn all_termination_causes_and_directions_have_wire_strings() {
+        for cause in [
+            TerminationCause::ServerHangup,
+            TerminationCause::LocalShutdown,
+            TerminationCause::DrainForced,
+            TerminationCause::BridgeEnded,
+            TerminationCause::TapEnded,
+            TerminationCause::AckTimeout,
+            TerminationCause::MissingSdpAnswer,
+            TerminationCause::InvalidSdpAnswer,
+            TerminationCause::NoCompatibleCodec,
+            TerminationCause::InvalidRemoteMedia,
+        ] {
+            assert!(!wire_str(&cause).is_empty(), "{cause:?}");
+        }
+        assert_eq!(wire_str(&Direction::Outbound), "outbound");
+    }
+}

--- a/crates/cdr/src/file.rs
+++ b/crates/cdr/src/file.rs
@@ -1,7 +1,9 @@
-//! Append-only JSONL file sink.
+//! Append-only CDR file sink — JSONL (default) or CSV (0.36.0).
 //!
-//! One record = one JSON object on one line. Lines are terminated
-//! with a single `\n` (LF) regardless of platform — JSONL consumers
+//! One record = one line. JSONL writes one JSON object per line; CSV
+//! writes one fixed-column row per line (see [`crate::csv`]) and a
+//! header row when the file starts empty. Lines are terminated with a
+//! single `\n` (LF) regardless of platform — line-oriented consumers
 //! split on `\n`, and Windows operators reading the file in
 //! Notepad-modern handle LF fine.
 //!
@@ -51,8 +53,22 @@ pub enum FileSinkError {
     },
 }
 
+/// On-disk record layout for [`FileSink`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum FileFormat {
+    /// One JSON object per line (the default since 0.1.0).
+    #[default]
+    Jsonl,
+    /// Fixed-column CSV with a header row written when the file
+    /// starts empty. Switching an existing JSONL file to CSV (or
+    /// vice versa) mixes formats in one file — point a format change
+    /// at a new path.
+    Csv,
+}
+
 pub struct FileSink {
     path: PathBuf,
+    format: FileFormat,
     writer: Arc<Mutex<BufWriter<File>>>,
 }
 
@@ -66,11 +82,22 @@ impl std::fmt::Debug for FileSink {
 }
 
 impl FileSink {
-    /// Open / create the file in append mode. Parent directory must
-    /// exist; we don't `mkdir -p` because deployments typically run
-    /// the daemon under a service account that lacks `~root` write
-    /// — failing loudly is the right behaviour.
+    /// Open / create the file in append mode (JSONL layout). Parent
+    /// directory must exist; we don't `mkdir -p` because deployments
+    /// typically run the daemon under a service account that lacks
+    /// `~root` write — failing loudly is the right behaviour.
     pub async fn open(path: impl AsRef<Path>) -> Result<Self, FileSinkError> {
+        Self::open_with_format(path, FileFormat::Jsonl).await
+    }
+
+    /// [`Self::open`] with an explicit record layout. For
+    /// [`FileFormat::Csv`], a header row is written immediately when
+    /// the file starts empty (a restart appending to an existing CSV
+    /// does not repeat it).
+    pub async fn open_with_format(
+        path: impl AsRef<Path>,
+        format: FileFormat,
+    ) -> Result<Self, FileSinkError> {
         let path = path.as_ref().to_path_buf();
         let file = OpenOptions::new()
             .create(true)
@@ -81,10 +108,34 @@ impl FileSink {
                 path: path.clone(),
                 source,
             })?;
-        debug!(path = %path.display(), "opened CDR file");
+        let mut writer = BufWriter::new(file);
+        if format == FileFormat::Csv {
+            let is_empty = writer
+                .get_ref()
+                .metadata()
+                .await
+                .map(|m| m.len() == 0)
+                .map_err(|source| FileSinkError::Open {
+                    path: path.clone(),
+                    source,
+                })?;
+            if is_empty {
+                let header_write = async {
+                    writer.write_all(crate::csv::HEADER.as_bytes()).await?;
+                    writer.write_all(b"\n").await?;
+                    writer.flush().await
+                };
+                header_write.await.map_err(|source| FileSinkError::Open {
+                    path: path.clone(),
+                    source,
+                })?;
+            }
+        }
+        debug!(path = %path.display(), ?format, "opened CDR file");
         Ok(Self {
             path,
-            writer: Arc::new(Mutex::new(BufWriter::new(file))),
+            format,
+            writer: Arc::new(Mutex::new(writer)),
         })
     }
 
@@ -97,15 +148,18 @@ impl FileSink {
 impl CdrSink for FileSink {
     async fn emit(&self, record: CdrRecord) {
         // Serialize outside the lock — the lock only protects the
-        // file handle, not the JSON encoder.
-        let line = match serde_json::to_string(&record) {
-            Ok(s) => s,
-            Err(e) => {
-                // Should be unreachable for our schema; record it
-                // and keep going.
-                warn!(call_id = %record.call_id, error = %e, "CDR JSON serialize failed");
-                return;
-            }
+        // file handle, not the encoder.
+        let line = match self.format {
+            FileFormat::Jsonl => match serde_json::to_string(&record) {
+                Ok(s) => s,
+                Err(e) => {
+                    // Should be unreachable for our schema; record it
+                    // and keep going.
+                    warn!(call_id = %record.call_id, error = %e, "CDR JSON serialize failed");
+                    return;
+                }
+            },
+            FileFormat::Csv => crate::csv::record_to_row(&record),
         };
 
         let mut guard = self.writer.lock().await;
@@ -237,6 +291,54 @@ mod tests {
         assert_eq!(lines[0], "{\"prior\":true}");
         let v: Value = serde_json::from_str(lines[1]).unwrap();
         assert_eq!(v["call_id"], serde_json::json!("c-after"));
+    }
+
+    #[tokio::test]
+    async fn csv_writes_header_once_and_one_row_per_emit() {
+        let tmp = NamedTempFile::new().expect("tempfile");
+        let path = tmp.path().to_path_buf();
+
+        let sink = FileSink::open_with_format(&path, FileFormat::Csv)
+            .await
+            .expect("open");
+        sink.emit(sample("c-1")).await;
+        drop(sink);
+
+        // Reopen (daemon restart) — the header must not repeat.
+        let sink = FileSink::open_with_format(&path, FileFormat::Csv)
+            .await
+            .expect("reopen");
+        sink.emit(sample("c-2")).await;
+        drop(sink);
+
+        let body = read_all(&path).await;
+        let lines: Vec<&str> = body.lines().collect();
+        assert_eq!(lines.len(), 3, "header + 2 rows, got: {body:?}");
+        assert_eq!(lines[0], crate::csv::HEADER);
+        assert!(lines[1].starts_with(&format!("{CDR_VERSION},c-1,")));
+        assert!(lines[2].starts_with(&format!("{CDR_VERSION},c-2,")));
+        // Every row has the full column count.
+        for line in &lines[1..] {
+            assert_eq!(
+                line.split(',').count(),
+                crate::csv::HEADER.split(',').count(),
+                "row: {line}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn open_defaults_to_jsonl() {
+        let tmp = NamedTempFile::new().expect("tempfile");
+        let path = tmp.path().to_path_buf();
+        let sink = FileSink::open(&path).await.expect("open");
+        sink.emit(sample("c-1")).await;
+        drop(sink);
+        let body = read_all(&path).await;
+        assert!(
+            body.starts_with('{'),
+            "plain open() must stay JSONL: {body:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/cdr/src/lib.rs
+++ b/crates/cdr/src/lib.rs
@@ -23,13 +23,14 @@
 //! drop the record rather than blocking the per-call task or
 //! propagating panics.
 
+pub mod csv;
 pub mod file;
 pub mod hep;
 pub mod schema;
 pub mod sink;
 pub mod webhook;
 
-pub use file::{FileSink, FileSinkError};
+pub use file::{FileFormat, FileSink, FileSinkError};
 pub use hep::HepCdrSink;
 pub use schema::{
     AudioInfo, CdrRecord, ConsentInfo, Direction, HoldInfo, ParkInfo, QualityInfo, ReconnectInfo,

--- a/crates/config/src/compile.rs
+++ b/crates/config/src/compile.rs
@@ -35,9 +35,9 @@ use thiserror::Error;
 use tracing::warn;
 
 use crate::raw::{
-    RawBridge, RawCdr, RawConference, RawConfig, RawGateway, RawHep, RawMedia, RawNode,
-    RawObservability, RawOutbound, RawPark, RawRecording, RawRegister, RawSecurity, RawSip,
-    RawSipTls, RawWebhooks,
+    RawBridge, RawCdr, RawCdrFileFormat, RawConference, RawConfig, RawGateway, RawHep, RawMedia,
+    RawNode, RawObservability, RawOutbound, RawPark, RawRecording, RawRegister, RawSecurity,
+    RawSip, RawSipTls, RawWebhooks,
 };
 
 /// Compiled, ready-to-pass daemon config.
@@ -497,6 +497,19 @@ pub struct CdrConfig {
 #[derive(Debug, Clone)]
 pub struct CdrFileConfig {
     pub path: PathBuf,
+    pub format: CdrFileFormat,
+}
+
+/// `[cdr.file].format` — how records are laid out in the file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CdrFileFormat {
+    /// One JSON object per line (the default since 0.1.0).
+    #[default]
+    Jsonl,
+    /// Fixed-column CSV with a header row (0.36.0). Nested optional
+    /// blocks are flattened to prefixed columns; unmeasured values
+    /// are empty cells.
+    Csv,
 }
 
 #[derive(Debug, Clone)]
@@ -3034,6 +3047,10 @@ fn compile_cdr(raw: RawCdr) -> Result<CdrConfig, CompileError> {
         }
         Some(CdrFileConfig {
             path: PathBuf::from(path),
+            format: match raw.file.format {
+                None | Some(RawCdrFileFormat::Jsonl) => CdrFileFormat::Jsonl,
+                Some(RawCdrFileFormat::Csv) => CdrFileFormat::Csv,
+            },
         })
     } else {
         None

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -35,9 +35,9 @@ use thiserror::Error;
 
 pub use compile::{
     compile, AdminConfig, AdminTlsConfig, AuditConfig, AuditFileConfig, AuditWebhookConfig,
-    CdrConfig, CdrFileConfig, CdrWebhookConfig, CompileError, ConferenceConfig, Config, Gateway,
-    GatewayCredentials, HepConfig, MediaConfig, NodeConfig, ObservabilityConfig, OtlpConfig,
-    OutboundConfig, ParkConfig, ParkTimeoutAction, QualityConfig, QualityFileConfig,
+    CdrConfig, CdrFileConfig, CdrFileFormat, CdrWebhookConfig, CompileError, ConferenceConfig,
+    Config, Gateway, GatewayCredentials, HepConfig, MediaConfig, NodeConfig, ObservabilityConfig,
+    OtlpConfig, OutboundConfig, ParkConfig, ParkTimeoutAction, QualityConfig, QualityFileConfig,
     QualityWebhookConfig, RegisterConfig, SecurityConfig, ShutdownConfig, SipAdmissionConfig,
     SipAuthConfig, SipAuthUser, SipConfig, SipTlsConfig, SipTransport, TrunkCidr,
     TrunkCidrParseError, TrunkConfig, WebhooksConfig,

--- a/crates/config/src/raw.rs
+++ b/crates/config/src/raw.rs
@@ -732,6 +732,20 @@ pub struct RawCdrFile {
     /// at startup; the daemon does NOT mkdir.
     #[serde(default)]
     pub path: Option<String>,
+    /// Record format: `"jsonl"` (default) or `"csv"`. CSV flattens
+    /// the record into a fixed column set with a header row written
+    /// when the file starts empty — point a format change at a new
+    /// `path`.
+    #[serde(default)]
+    pub format: Option<RawCdrFileFormat>,
+}
+
+/// `[cdr.file].format` values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RawCdrFileFormat {
+    Jsonl,
+    Csv,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]

--- a/crates/config/tests/load.rs
+++ b/crates/config/tests/load.rs
@@ -1564,7 +1564,45 @@ any = true
     assert!(cfg.cdr.enabled);
     let file = cfg.cdr.file.expect("file sink configured");
     assert_eq!(file.path.to_str(), Some("/var/log/siphon-ai/cdr.jsonl"));
+    // No `format` key → JSONL, the pre-0.36.0 behaviour.
+    assert_eq!(file.format, siphon_ai_config::CdrFileFormat::Jsonl);
     assert!(cfg.cdr.webhook.is_none());
+}
+
+#[test]
+fn cdr_file_format_csv_compiles_and_bad_value_errors() {
+    let env = MapEnv::new([]);
+    let toml = r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[bridge]
+ws_url = "wss://x/y"
+
+[cdr]
+enabled = true
+[cdr.file]
+enabled = true
+path = "/var/log/siphon-ai/cdr.csv"
+format = "csv"
+
+[[route]]
+name = "d"
+[route.match]
+any = true
+"#;
+    let cfg = load_from_str_with_env(toml, &env).unwrap();
+    let file = cfg.cdr.file.expect("file sink configured");
+    assert_eq!(file.format, siphon_ai_config::CdrFileFormat::Csv);
+
+    // Unknown format value fails at load time, naming the variants.
+    let bad = toml.replace("format = \"csv\"", "format = \"xml\"");
+    let err = load_from_str_with_env(&bad, &env).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("unknown variant") && msg.contains("csv"),
+        "unhelpful error: {msg}"
+    );
 }
 
 #[test]

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -739,9 +739,10 @@ recorded" announcement are the operator's responsibility (see
 [cdr]
 enabled = true
 
-[cdr.file]                    # JSONL, one record per ended call
+[cdr.file]                    # one record per ended call
 enabled = true
 path    = "/var/log/siphon-ai/cdr.jsonl"
+format  = "jsonl"             # "jsonl" (default) | "csv" (0.36.0)
 
 [cdr.webhook]                 # HTTP POST per record
 enabled    = true
@@ -756,6 +757,15 @@ timeout_ms = 5000
 Both sinks can run simultaneously. Master `enabled = false` silences both
 regardless of sub-block state. Adding fields to the CDR schema bumps the
 `version` field; consumers should treat new keys as additive.
+
+`[cdr.file].format = "csv"` (0.36.0) writes a fixed-column CSV instead of
+JSONL: nested optional blocks flatten to prefixed columns (`park_count`,
+`quality_avg_jitter_ms`, …), absent/unmeasured values are **empty cells**
+(not zeros), and a header row is written when the file starts empty. New
+columns are only ever appended. When switching an existing file's format,
+point at a new `path` — the daemon appends and won't rewrite history. The
+webhook sink is always JSON; `format` affects the file sink only. See
+`docs/DEPLOY.md` → *CDR consumers* for the column list.
 
 The CDR webhook shares the delivery transport with `[webhooks]`, so
 `secret` (HMAC `X-SiphonAI-Signature`), `spool_dir` (durable retry), the

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -708,9 +708,11 @@ unparked. `retrieve` is `409` when the named call exists but isn't parked.
 
 ## CDR consumers
 
-When `[cdr.file]` is enabled, the daemon appends one JSON record per ended
-call to the configured path. Rotate the file with `logrotate`; the daemon
-re-opens on `SIGHUP` (in practice — restart is simpler).
+When `[cdr.file]` is enabled, the daemon appends one record per ended
+call to the configured path — a JSON object per line by default, or a
+fixed-column CSV row with `[cdr.file].format = "csv"` (0.36.0; see below).
+Rotate the file with `logrotate`; the daemon re-opens on `SIGHUP` (in
+practice — restart is simpler).
 
 ```json
 {
@@ -765,6 +767,25 @@ The `version` integer is **4** as of 0.30.0 (the optional `quality`
 block; 3 in 0.17.0 for `drain_forced`, 2 in 0.9.5 for the delayed-offer
 causes). It bumps on changes that could break a strict consumer. Adding
 a new optional *field* stays additive and does not bump.
+
+### CSV format (`[cdr.file].format = "csv"`, 0.36.0)
+
+The CSV layout is a flat view of the same record — 45 columns, one row
+per call, RFC 4180 quoting. A header row is written when the file starts
+empty (never repeated on restart). Semantics:
+
+- Nested blocks flatten to prefixed columns: `audio_codec`,
+  `termination_cause`, `consent_announced`, `park_count`, `hold_total_ms`,
+  `reconnect_count`, `quality_avg_jitter_ms`, `quality_mos_estimate_avg`, …
+- An absent block or unmeasured value is an **empty cell**, not a zero —
+  the same "clean vs unmeasured" distinction the JSON shape makes.
+- Enum values (`direction`, `termination_cause`) use the same snake_case
+  wire strings as JSON; timestamps are RFC 3339 UTC with milliseconds.
+- New columns are only ever **appended**, so position-keyed ingestors
+  survive additive schema changes. Prefer keying by header name anyway.
+- Switching an existing file's format mixes layouts in one file — point a
+  format change at a new `path`. The webhook sink is unaffected (always
+  JSON).
 
 Two optional STIR/SHAKEN fields appear when `[security.stir_shaken]` is
 enabled (added in 0.4.0; schema stays at version 1 — both are omitted

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -257,7 +257,9 @@ demand shows up.
 - ~~`print-config --format json`~~ — ✅ done in v0.36.0: `--format text|json`
   on `print-config`, same sections/redaction as the text renderer, shaped
   for `jq` / deploy diffing.
-- CSV CDR output (alongside JSON/JSONL).
+- ~~CSV CDR output~~ — ✅ done in v0.36.0: `[cdr.file].format = "csv"` —
+  fixed-column flat view (header row, empty-cell = unmeasured, append-only
+  columns); webhook sink stays JSON.
 - ~~Marker-bit fix~~ — ✅ done: forge-media #68 (marker bit only on talkspurt start) merged 2026-06-04 and is included in the `3c59b5f` pin shipped with v0.31.1 (verified: the pin is 13 commits ahead of the merge commit).
 
 ---


### PR DESCRIPTION
## What

`[cdr.file].format = "jsonl" | "csv"` (default `jsonl` — existing files byte-identical). The ROADMAP "small follow-ups" CSV CDR item.

- `crates/cdr/src/csv.rs` (new): fixed 45-column flattening of `CdrRecord` — nested optional blocks (`audio`, `termination`, `consent`, `park`, `hold`, `reconnect`, `quality`) become prefixed columns; absent/unmeasured values are **empty cells**, not zeros; enums use the same snake_case wire strings as JSON; RFC 4180 quoting (hand-rolled ~30 lines, no new dependency). Column order is append-only.
- `crates/cdr/src/file.rs`: `FileSink::open_with_format` — CSV writes the header row when the file starts empty, never repeats it on restart-append. `open()` unchanged (JSONL).
- `crates/config`: `RawCdrFileFormat` → `CdrFileFormat` on `CdrFileConfig`; bad values fail at load time naming the variants.
- Runtime `build_file_sink` maps config→sink format (SIGHUP sink rebuild inherits it for free); sink-active log now carries the format.
- Docs: `CONFIG.md` `[cdr]` + a "CSV format" subsection in `DEPLOY.md` → *CDR consumers* (column semantics, format-switch caveat: point at a new `path`); ROADMAP line struck.

## Tests

- csv.rs: header/row column-count lock (45), minimal + fully-populated records by column name, RFC 4180 escaping round-trip, every `TerminationCause`/`Direction` has a wire string.
- file.rs: header-once across reopen + one row per emit; `open()` stays JSONL.
- config: `format = "csv"` compiles, omitted → jsonl, unknown value errors helpfully.
- **End-to-end smoke:** daemon with a CSV config + echo WS server + 1 SIPp call → header + well-formed 45-column row (version 4, `inbound`, `local_shutdown`).
- `cargo test --workspace`: 55 suites green. Clippy `-D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)