### PR TITLE
chore(release): 0.36.0 — CSV CDR output + print-config JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.0] - 2026-07-16
+
+### Added
+
+- **CSV CDR file output** — `[cdr.file].format = "jsonl" | "csv"`
+  (#297). Default `jsonl`, unchanged. `"csv"` writes a fixed 45-column
+  flat view of the CDR record: nested optional blocks (`audio`,
+  `termination`, `consent`, `park`, `hold`, `reconnect`, `quality`)
+  become prefixed columns; absent/unmeasured values are **empty
+  cells**, not zeros; enums use the same snake_case wire strings as
+  JSON; RFC 4180 quoting. A header row is written when the file starts
+  empty (never repeated on restart-append) and columns are append-only
+  across releases. The webhook sink is unaffected (always JSON). When
+  switching an existing file's format, point at a new `path`. See
+  `docs/DEPLOY.md` → *CDR consumers* → *CSV format*.
+- **`print-config --format json`** (#296). Renders the effective
+  compiled config as pretty-printed JSON for tooling (`jq`, deploy
+  diffing) — same sections and redaction semantics as the text output
+  (unset → `null`, hidden secrets → `"<redacted>"`, `--show-secrets`
+  reveals; per-route keys appear only when the route overrides them).
+  Default format stays `text`, byte-identical to before. An inspection
+  view, not a loadable config.
+
 ## [0.35.0] - 2026-07-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3542,7 +3542,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3558,7 +3558,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "base64",
  "bytes",
@@ -3580,7 +3580,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3597,7 +3597,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "regex",
  "serde",
@@ -3616,7 +3616,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3662,7 +3662,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "base64",
  "hmac",
@@ -3685,7 +3685,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3709,7 +3709,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3727,7 +3727,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -3759,7 +3759,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "regex",
  "serde",
@@ -3771,7 +3771,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "schemars",
  "serde",
@@ -3781,7 +3781,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -3826,7 +3826,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -3855,7 +3855,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.35.0.** Production-deployed against real carriers
+**Current release: v0.36.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a


### PR DESCRIPTION
Release-prep commit per RELEASING.md for **v0.36.0**, bundling the two ROADMAP "small follow-ups" merged this cycle:

- **CSV CDR file output** — `[cdr.file].format = "csv"` (#297)
- **`print-config --format json`** (#296)

Changes here: workspace version bump 0.35.0 → 0.36.0, `Cargo.lock` refresh, CHANGELOG `[Unreleased]` → dated `[0.36.0] - 2026-07-16` section (fresh empty Unreleased above), README current-release marker.

Verified locally: `check-version-consistency.py` (plain + `--tag v0.36.0`) and `extract-changelog.py 0.36.0` all pass.

After merge: tag `v0.36.0` on the squash commit → release workflow publishes binaries/.debs/SBOM/signatures/container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)