### PR TITLE
chore(release): 0.37.0 — neural (Silero) VAD backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.0] - 2026-07-16
+
 ### Added
 
 - **Neural (Silero) VAD backend — `[media].vad = "energy" | "neural"`** with a per-route `[route.media].vad` override (strict replace, both directions, validated at config load). `"neural"` runs forge-vad's new Silero backend (forge-media #86: local tract-onnx inference, no network, ~60–80 µs per 32 ms window) for materially fewer acoustic false positives — coughs, keyboard clatter, music-on-hold bleed — before pause-mode barge-in arbitration even arms. Sessions are allocated before codec negotiation, so a neural detector is created at 16 kHz and re-aligned to the **negotiated** bridge rate at setup time (fixing the latent default-16 kHz-on-8 kHz mismatch; the delayed-offer and outbound paths re-align at `apply_answer`). The default `"energy"` keeps pre-0.37 detection byte-identical, including no per-session engine config. **WS protocol, `speech_started`/`speech_stopped` events, and CDR are unchanged** — the backend changes detection quality only. forge-media pin bumped to `1c996ae5fb4f` with `features = ["neural-vad"]` (tract is pure Rust; the static-musl multi-arch release build is the acceptance gate). Closes the siphon-ai half of the ROADMAP P2 "Neural VAD upgrade" item; rollout gate stays real-call false-barge-in rates under `mode = "pause"` + `debounce_ms` via the existing barge-in metrics. See `docs/CONFIG.md` `[media].vad`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3811,7 +3811,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3875,7 +3875,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "base64",
  "bytes",
@@ -3897,7 +3897,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3914,7 +3914,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "regex",
  "serde",
@@ -3933,7 +3933,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3979,7 +3979,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "base64",
  "hmac",
@@ -4002,7 +4002,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4027,7 +4027,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4045,7 +4045,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4063,7 +4063,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4077,7 +4077,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "regex",
  "serde",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "schemars",
  "serde",
@@ -4099,7 +4099,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4126,7 +4126,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -4144,7 +4144,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -4173,7 +4173,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.36.0"
+version = "0.37.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.36.0.** Production-deployed against real carriers
+**Current release: v0.37.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a


### PR DESCRIPTION
Release-prep for **v0.37.0** — the neural (Silero) VAD backend (#300).

- `[workspace.package].version` 0.36.0 → 0.37.0 (+ `Cargo.lock` refresh)
- `CHANGELOG.md`: `## [Unreleased]` → `## [0.37.0] - 2026-07-16`, fresh empty Unreleased above
- `README.md` current-release marker → v0.37.0

Verified locally: `check-version-consistency.py` (plain + `--tag v0.37.0`) and `extract-changelog.py 0.37.0` all pass.

After merge: tag `v0.37.0` on the merge commit per RELEASING.md — the release workflow does the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
