### PR TITLE
fix(ci): aarch64 release build — shim zig's +fullfp16 spelling for tract-linalg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,37 @@ jobs:
           python3 -m pip install --user ziglang
           cargo install cargo-zigbuild --locked
 
+      # tract-linalg (pulled in by forge-vad's neural backend since
+      # 0.37.0) compiles its aarch64 SVE f16 kernels with the GCC/clang
+      # feature spelling `-march=armv8.2-a+sve+fp16`; zig's feature
+      # parser only knows the LLVM name `fullfp16` and hard-errors on
+      # `fp16`. Shim the C compiler for the aarch64 leg: rewrite the
+      # spelling, then exec `cargo-zigbuild zig cc` with the same
+      # `-target` its own generated wrapper would use (cargo-zigbuild
+      # respects a pre-set CC_<target>, see its add_env_if_missing).
+      # Identical codegen — same kernels, same feature bit. Drop once
+      # tract probes the spelling or cargo-zigbuild maps the alias.
+      - name: CC shim — spell +fp16 as +fullfp16 for zig (aarch64)
+        if: matrix.target == 'aarch64-unknown-linux-musl'
+        run: |
+          shim="$RUNNER_TEMP/zigcc-fp16-shim.sh"
+          cat > "$shim" <<'EOF'
+          #!/bin/sh
+          n=$#
+          i=0
+          while [ $i -lt $n ]; do
+            a=$1; shift
+            case "$a" in
+              -march=*) a=$(printf '%s' "$a" | sed 's/+fp16+/+fullfp16+/g; s/+fp16$/+fullfp16/');;
+            esac
+            set -- "$@" "$a"
+            i=$((i+1))
+          done
+          exec cargo-zigbuild zig cc -- -target aarch64-linux-musl "$@"
+          EOF
+          chmod +x "$shim"
+          echo "CC_aarch64_unknown_linux_musl=$shim" >> "$GITHUB_ENV"
+
       - name: Build (release, static musl)
         run: |
           cargo zigbuild --release --locked \


### PR DESCRIPTION
The v0.37.0 release run ([29529483258](https://github.com/thevoiceguy/siphon-ai/actions/runs/29529483258)) failed on the **aarch64-unknown-linux-musl** build leg; the publish/container jobs never ran, so nothing was released.

**Root cause**: `tract-linalg 0.23.4` (pulled in by forge-vad's `neural` backend since #300) compiles its aarch64 SVE f16 kernels with `-march=armv8.2-a+sve+fp16` — the GCC/clang feature spelling. zig's feature parser only knows LLVM's name `fullfp16` and hard-errors: `unknown CPU feature: 'fp16'`. The upstream plan's static-musl gate only ran the x86_64 target, which never sees the flag.

**Fix**: a CC shim on the aarch64 leg only — rewrite `+fp16` → `+fullfp16` inside `-march=` args, then `exec cargo-zigbuild zig cc -- -target aarch64-linux-musl "$@"` (byte-identical to cargo-zigbuild's own generated wrapper, which respects a pre-set `CC_<target>` via `add_env_if_missing`). Identical codegen: same kernels, same FEAT_FP16 bit, just the spelling zig understands.

**Validated locally**:
- `cargo-zigbuild zig cc` reproduces the failure with `+fp16` and compiles the same SVE f16 source cleanly with `+fullfp16`
- full `cargo zigbuild --release --locked -p siphon-ai --target aarch64-unknown-linux-musl` with the shim → statically linked, stripped aarch64 binary
- the workflow step was executed standalone to confirm the heredoc writes a well-formed shim (shebang at column 0)

Temporary by design — drop when tract probes the feature spelling or cargo-zigbuild maps the `fp16` alias. After merge: re-tag `v0.37.0` (never published) on the new main head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
