### PR TITLE
docs(core): re-attach resolve_srtp_mode's doc comment; link upstream fp16 issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,8 @@ jobs:
       # `-target` its own generated wrapper would use (cargo-zigbuild
       # respects a pre-set CC_<target>, see its add_env_if_missing).
       # Identical codegen — same kernels, same feature bit. Drop once
-      # tract probes the spelling or cargo-zigbuild maps the alias.
+      # tract probes the spelling (sonos/tract#2483) or cargo-zigbuild
+      # maps the alias (rust-cross/cargo-zigbuild#456).
       - name: CC shim — spell +fp16 as +fullfp16 for zig (aarch64)
         if: matrix.target == 'aarch64-unknown-linux-musl'
         run: |

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -902,15 +902,6 @@ pub fn resolve_rtp_stats_interval(
     }
 }
 
-/// Resolve the per-call SRTP mode by merging the daemon default
-/// (`[media].srtp`) with the per-route override
-/// (`[route.media].srtp: Option<String>`). The route override is
-/// stored unparsed; we parse it here strictly — unknown tokens are
-/// **not** treated as `Off`, they panic-equivalent by returning
-/// the default with a `warn!` (route validation should catch this
-/// at config compile, but the compiled-route struct can't currently
-/// carry the typed enum without an upstream refactor — track in a
-/// follow-up).
 /// Resolve the per-call VAD backend by merging the daemon default
 /// (`[media].vad`) with the per-route override (`[route.media].vad`).
 /// Strict replace, same semantics as [`resolve_srtp_mode`]. Route
@@ -936,6 +927,15 @@ pub fn resolve_vad(
     }
 }
 
+/// Resolve the per-call SRTP mode by merging the daemon default
+/// (`[media].srtp`) with the per-route override
+/// (`[route.media].srtp: Option<String>`). The route override is
+/// stored unparsed; we parse it here strictly — unknown tokens are
+/// **not** treated as `Off`, they panic-equivalent by returning
+/// the default with a `warn!` (route validation should catch this
+/// at config compile, but the compiled-route struct can't currently
+/// carry the typed enum without an upstream refactor — track in a
+/// follow-up).
 pub fn resolve_srtp_mode(defaults: &BridgeDefaults, route: &CompiledRoute) -> SrtpMode {
     match route.media.srtp.as_deref() {
         None => defaults.srtp_mode,


### PR DESCRIPTION
Two small follow-ups from the v0.37.0 release:

- **Doc-comment fix**: #300 inserted `resolve_vad` (with its own doc comment) between `resolve_srtp_mode`'s doc comment and the function it documents, so rustdoc attached the SRTP text to `resolve_vad`. Moved back where it belongs. No code changes.
- **Upstream issue links** in the release.yml fp16 shim comment, now that they're filed: [sonos/tract#2483](https://github.com/sonos/tract/issues/2483) and [rust-cross/cargo-zigbuild#456](https://github.com/rust-cross/cargo-zigbuild/issues/456). The shim can be dropped when either lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)