### PR TITLE
docs(deploy): fix TLS cert/key permission recipe to match packaged unit

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -235,13 +235,17 @@ before any inbound INVITE is accepted.
 
 ### 4. File permissions for cert/key
 
-The systemd unit runs as the unprivileged `siphon` user; that user
-must be able to *read* the cert and key but should not own them.
+The systemd unit runs as the unprivileged `siphon-ai` user (created
+by the `.deb`). The cert chain is public — root-owned and
+group-readable is right. The **private key is different**: the daemon
+refuses to start if the key has any group- or world-readable bits
+("insecure permissions" error), so it must be `0600` — and therefore
+*owned by* `siphon-ai`, or the daemon can't read it at all.
 
 ```sh
-sudo install -d -m 0750 -o root -g siphon /etc/siphon-ai/tls
-sudo install -m 0640 -o root -g siphon fullchain.pem /etc/siphon-ai/tls/
-sudo install -m 0640 -o root -g siphon privkey.pem   /etc/siphon-ai/tls/
+sudo install -d -m 0750 -o root -g siphon-ai /etc/siphon-ai/tls
+sudo install -m 0640 -o root -g siphon-ai fullchain.pem /etc/siphon-ai/tls/
+sudo install -m 0600 -o siphon-ai -g siphon-ai privkey.pem /etc/siphon-ai/tls/
 ```
 
 `ProtectSystem=strict` in the unit blocks writes outside
@@ -264,9 +268,9 @@ reload](#config-file-reload-0120) below.
 # Let's Encrypt deploy-hook (/etc/letsencrypt/renewal-hooks/deploy/)
 #!/bin/sh
 set -e
-install -m 0640 -o root -g siphon \
+install -m 0640 -o root -g siphon-ai \
     "$RENEWED_LINEAGE/fullchain.pem" /etc/siphon-ai/tls/
-install -m 0640 -o root -g siphon \
+install -m 0600 -o siphon-ai -g siphon-ai \
     "$RENEWED_LINEAGE/privkey.pem"   /etc/siphon-ai/tls/
 systemctl reload siphon-ai
 ```
@@ -374,8 +378,8 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-User=siphon
-Group=siphon
+User=siphon-ai
+Group=siphon-ai
 EnvironmentFile=-/etc/siphon-ai/env
 ExecStart=/usr/local/bin/siphon-ai --config /etc/siphon-ai/siphon-ai.toml
 # SIGHUP triggers SIP/TLS cert hot-reload (0.3.0+). `systemctl


### PR DESCRIPTION
## Problem

Following DEPLOY.md's TLS setup on a fresh v0.37.0 `.deb` install fails at startup **twice in sequence** (reproduced today on a new Debian instance):

1. **Wrong group** — §4's install commands and §5's Let's Encrypt deploy-hook use `-o root -g siphon`, but the packaged unit (`bins/siphon-ai/pkg/siphon-ai.service`) runs as `User=siphon-ai` / `Group=siphon-ai` → `failed to read certificate file: Permission denied (os error 13)`.
2. **Key mode rejected** — the recipe installs `privkey.pem` as 0640 group-readable, but the daemon (via sip-transport's `enforce_secure_key_perms`) refuses any group/world bits on the key → `TLS key ... has insecure permissions 640` fatal at startup.

## Fix

- §4: correct group to `siphon-ai`; key becomes `0600` **owned by** `siphon-ai` (owner-only is enforced, so root-owned can't work for the key); add a sentence explaining why the key's ownership differs from the cert's.
- §5 deploy-hook: same modes/owners so renewals keep the working layout.
- Manual systemd-unit sketch: `User=`/`Group=` aligned with the packaged unit (`siphon-ai`), so §4's commands work for both install paths.

Docs-only; verified layout boots cleanly on the packaged unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfNLtPcqdzAVcAJu1Q1QnT