### PR TITLE
chore(deps): bump siphon-rs to 36c3ac4 — quieter TLS disconnect logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3583,7 +3583,7 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 [[package]]
 name = "sip-auth"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9#f3454c77c3d9d398c8c40c2d1e0b9da3525e17e3"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c#36c3ac4f3c0cfaa0f8c4b7b850cdb55a35e8674b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3606,7 +3606,7 @@ dependencies = [
 [[package]]
 name = "sip-core"
 version = "0.7.6"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9#f3454c77c3d9d398c8c40c2d1e0b9da3525e17e3"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c#36c3ac4f3c0cfaa0f8c4b7b850cdb55a35e8674b"
 dependencies = [
  "bytes",
  "httpdate",
@@ -3619,7 +3619,7 @@ dependencies = [
 [[package]]
 name = "sip-dialog"
 version = "0.3.3"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9#f3454c77c3d9d398c8c40c2d1e0b9da3525e17e3"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c#36c3ac4f3c0cfaa0f8c4b7b850cdb55a35e8674b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3637,7 +3637,7 @@ dependencies = [
 [[package]]
 name = "sip-dns"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9#f3454c77c3d9d398c8c40c2d1e0b9da3525e17e3"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c#36c3ac4f3c0cfaa0f8c4b7b850cdb55a35e8674b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3651,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "sip-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9#f3454c77c3d9d398c8c40c2d1e0b9da3525e17e3"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c#36c3ac4f3c0cfaa0f8c4b7b850cdb55a35e8674b"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -3662,7 +3662,7 @@ dependencies = [
 [[package]]
 name = "sip-identity"
 version = "0.1.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9#f3454c77c3d9d398c8c40c2d1e0b9da3525e17e3"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c#36c3ac4f3c0cfaa0f8c4b7b850cdb55a35e8674b"
 dependencies = [
  "base64",
  "ring",
@@ -3675,7 +3675,7 @@ dependencies = [
 [[package]]
 name = "sip-observe"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9#f3454c77c3d9d398c8c40c2d1e0b9da3525e17e3"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c#36c3ac4f3c0cfaa0f8c4b7b850cdb55a35e8674b"
 dependencies = [
  "once_cell",
  "tracing",
@@ -3684,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "sip-parse"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9#f3454c77c3d9d398c8c40c2d1e0b9da3525e17e3"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c#36c3ac4f3c0cfaa0f8c4b7b850cdb55a35e8674b"
 dependencies = [
  "bytes",
  "httpdate",
@@ -3698,7 +3698,7 @@ dependencies = [
 [[package]]
 name = "sip-ratelimit"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9#f3454c77c3d9d398c8c40c2d1e0b9da3525e17e3"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c#36c3ac4f3c0cfaa0f8c4b7b850cdb55a35e8674b"
 dependencies = [
  "dashmap 5.5.3",
  "parking_lot",
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9#f3454c77c3d9d398c8c40c2d1e0b9da3525e17e3"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c#36c3ac4f3c0cfaa0f8c4b7b850cdb55a35e8674b"
 dependencies = [
  "nom 7.1.3",
  "smol_str",
@@ -3727,7 +3727,7 @@ dependencies = [
 [[package]]
 name = "sip-transaction"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9#f3454c77c3d9d398c8c40c2d1e0b9da3525e17e3"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c#36c3ac4f3c0cfaa0f8c4b7b850cdb55a35e8674b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3746,7 +3746,7 @@ dependencies = [
 [[package]]
 name = "sip-transport"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9#f3454c77c3d9d398c8c40c2d1e0b9da3525e17e3"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c#36c3ac4f3c0cfaa0f8c4b7b850cdb55a35e8674b"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3766,7 +3766,7 @@ dependencies = [
 [[package]]
 name = "sip-uac"
 version = "0.4.2"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9#f3454c77c3d9d398c8c40c2d1e0b9da3525e17e3"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c#36c3ac4f3c0cfaa0f8c4b7b850cdb55a35e8674b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3779,7 +3779,7 @@ dependencies = [
  "sip-dialog",
  "sip-dns",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -3791,7 +3791,7 @@ dependencies = [
 [[package]]
 name = "sip-uas"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9#f3454c77c3d9d398c8c40c2d1e0b9da3525e17e3"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c#36c3ac4f3c0cfaa0f8c4b7b850cdb55a35e8674b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3801,7 +3801,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -3953,7 +3953,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=f3454c77c3d9)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c)",
  "sip-transaction",
  "sip-uac",
  "sip-uas",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,24 +130,24 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 # main branch and replace the rev hashes here (see CLAUDE.md §7.5).
 
 # siphon-rs — RFC 3261 SIP stack
-sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "f3454c77c3d9" }
-sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "f3454c77c3d9" }
-sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "f3454c77c3d9", features = ["tls"] }
-sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "f3454c77c3d9" }
-sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "f3454c77c3d9" }
-sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "f3454c77c3d9" }
-sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "f3454c77c3d9" }
-sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "f3454c77c3d9" }
-sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "f3454c77c3d9" }
+sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "36c3ac4f3c0c" }
+sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "36c3ac4f3c0c" }
+sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "36c3ac4f3c0c", features = ["tls"] }
+sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "36c3ac4f3c0c" }
+sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "36c3ac4f3c0c" }
+sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "36c3ac4f3c0c" }
+sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "36c3ac4f3c0c" }
+sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "36c3ac4f3c0c" }
+sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "36c3ac4f3c0c" }
 # sip-sdp — the SAME sip-sdp sip-uac's SdpAnswerGenerator trait speaks
 # (distinct from forge-media's pinned sip-sdp). Used by the outbound
 # delayed-offer answer generator to hand the UAC a SessionDescription it
 # accepts. Must stay on the same siphon-rs rev as the rest below.
-sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "f3454c77c3d9" }
-sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "f3454c77c3d9" }
+sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "36c3ac4f3c0c" }
+sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "36c3ac4f3c0c" }
 # sip-identity — STIR/SHAKEN Identity-header parsing + PASSporT verification
 # (ES256 + X.509 chain validation). Consumed by the stir-shaken verifier crate.
-sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "f3454c77c3d9" }
+sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "36c3ac4f3c0c" }
 
 # forge-media — RTP / codecs / SDP / DTMF / engine.
 #
@@ -163,7 +163,7 @@ sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "f34
 # runtime (docs/CONFIG.md); tract-onnx is pure Rust, so the static-musl
 # release build is unaffected. Feature-enabled builds need rustc >= 1.91
 # (tract 0.23) — our pinned toolchain is 1.95. siphon-rs stays at
-# f3454c77c3d9. (Prior pins: forge 3c59b5f6e464 = #82-#85 dependency
+# 36c3ac4f3c0c. (Prior pins: forge 3c59b5f6e464 = #82-#85 dependency
 # migrations; forge 5fa76fb38675 = #81.)
 forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "1c996ae5fb4f" }
 forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "1c996ae5fb4f" }


### PR DESCRIPTION
## What

Bumps the siphon-rs pin from `f3454c7` to `36c3ac4`, picking up [siphon-rs #63](https://github.com/thevoiceguy/siphon-rs/pull/63).

## Why

On a Twilio secure trunk in production (v0.37.0), every call was followed ~2.5 min later by:

```
ERROR sip_transport: tls read error e=peer closed connection without sending TLS close_notify
```

Twilio (and anything behind an AWS NLB) reaps idle TCP connections without a TLS `close_notify`; rustls reports that as `UnexpectedEof`. siphon-rs #63 treats it as the routine disconnect it is — `info!` log, no Read-stage error metric — while keeping `error!` + metric for genuine read failures. This is a log-noise fix only; no behavior change on the call path.

## Bump scope

Pure log-level change upstream; no siphon-rs API changes, so the glue layers (`sip-glue`, `media-glue`, `telemetry`) are untouched. All seven `sip-*` crate revs move together.

## Testing (per CLAUDE.md §7.5)

- `cargo build --workspace` + `cargo test --workspace` — green
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `test-harness/sipp-scenarios/run-all.sh` — **all 37 scenarios pass**
- TLS harness (directly exercises the changed session loop):
  - scenario 3 (mTLS WSS SPKI pin) — PASS
  - scenario 4 (SIGHUP cert rotation, survives broken PEM) — PASS

hep-collector-stub has no automated test crate (empty `.gitkeep` dir); HEP paths are covered by the SIPp run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfNLtPcqdzAVcAJu1Q1QnT