### PR TITLE
chore(release): 0.37.1 — quieter TLS disconnects + admin-API doc corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.1] - 2026-07-20
+
 ### Fixed
 
 - **Feature guides no longer document the pre-0.10.0 admin API.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3811,7 +3811,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3875,7 +3875,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "base64",
  "bytes",
@@ -3897,7 +3897,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3914,7 +3914,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "regex",
  "serde",
@@ -3933,7 +3933,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3979,7 +3979,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "base64",
  "hmac",
@@ -4002,7 +4002,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4027,7 +4027,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4045,7 +4045,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4063,7 +4063,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4077,7 +4077,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "regex",
  "serde",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "schemars",
  "serde",
@@ -4099,7 +4099,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4126,7 +4126,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "base64",
  "rcgen",
@@ -4144,7 +4144,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -4173,7 +4173,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.37.0"
+version = "0.37.1"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.37.0.** Production-deployed against real carriers
+**Current release: v0.37.1.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a


### PR DESCRIPTION
Release-prep for **v0.37.1**, per `RELEASING.md` §"Cutting a final release" step 2.

Patch bump — both `[Unreleased]` entries are `Fixed`, no feature work, no
protocol/CDR/config-schema change.

## What ships

- **Idle TLS trunk disconnects no longer log at `ERROR`** (#306, siphon-rs #63).
  The operationally significant one: peers that drop an idle SIP/TLS connection
  without a TLS `close_notify` (Twilio, anything behind an AWS NLB) produced a
  spurious `ERROR` line after essentially every call on a TLS trunk — noise that
  trains operators to ignore error-level logs and trips log-based alerting.
  Fixed on `main` since `dfabf06`, but **needs this release to reach prod**.
- **Feature guides no longer document the pre-0.10.0 admin API** (#308). Six
  docs told operators to call `:9091/admin/v1/…` unauthenticated; `/admin/*` has
  been on the token-gated `[admin]` listener since 0.10.0.

## Mechanics

- `[workspace.package].version` 0.37.0 → **0.37.1**
- `Cargo.lock` refreshed (`cargo check --workspace` — 17 workspace crates)
- `CHANGELOG.md`: `## [Unreleased]` → `## [0.37.1] - 2026-07-20`, fresh empty
  `## [Unreleased]` above it
- `README.md` current-release marker → `v0.37.1`

Verified locally before pushing:

```
python3 scripts/check-version-consistency.py            → Version consistent: 0.37.1.
python3 scripts/check-version-consistency.py --tag v0.37.1 → consistent (tag v0.37.1)
python3 scripts/extract-changelog.py 0.37.1             → notes present
```

Merge this, then `git tag -a v0.37.1` on the merged commit and push the tag to
trigger the `release` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jFDxbuLq15NBUUjgDDgws
