### PR TITLE
fix(admin): faithful request-result metric + call-id listing (#310, #311)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`GET /admin/calls` now returns an object per call, not a bare SIP
+  Call-ID string** (issue #311). Each element is
+  `{call_id, sip_call_id, direction}`: the **bridge** `call_id` (the id
+  `/admin/v1/conferences/*`, `/park`, `/retrieve`, and `/stats` all take,
+  and the value on the WS `start` message + CDR), the **SIP** Call-ID
+  (what `POST /admin/calls/:id/hangup` takes), and `"inbound"` /
+  `"outbound"`. Before this, the only endpoint that enumerated calls
+  returned SIP Call-IDs while every conference endpoint required the
+  bridge id, and **no admin endpoint exposed the mapping** — operator
+  conferencing was undriveable without correlating daemon logs, and the
+  resulting `404 "no active call"` (while `GET /admin/calls` listed the
+  call) read as a liveness bug. The listing is now sourced from the
+  bridge-id-keyed control registry, so it also covers **outbound** calls,
+  which the old inbound-only listing omitted. **This is a breaking
+  response-shape change** to `GET /admin/calls` (array of strings → array
+  of objects); scripts parsing it must be updated. The `404` bodies from
+  the conference/park handlers now name the expected id namespace.
+
+### Fixed
+
+- **`siphon_ai_admin_requests_total` no longer labels failed admin
+  requests `result="ok"`** (issue #310). The counter derived `result`
+  from the auth outcome only, so any authorized request whose handler
+  then returned a non-2xx status was still counted `ok` — a `404` from
+  operating on a stale `call_id`, a `409`, a `503` at a cap. `result` now
+  follows the response status: `not_found` for `404` (a normal
+  conference/park race), `error` for every other handler failure (400 /
+  409 / 429 / 501 / 503), `ok` only for 2xx. The auth layer's
+  `unauthenticated` / `forbidden` are unchanged. Alerting on
+  `result != "ok"` is now a faithful failure signal. `# HELP` text,
+  `docs/DEPLOY.md`, and the audit-stream `result` field updated to match.
+
 ## [0.37.1] - 2026-07-20
 
 ### Fixed

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -76,6 +76,7 @@ use siphon_ai_audit::{
     FilteredSink as AuditFilteredSink, HttpSink as AuditHttpSink,
     HttpSinkConfig as AuditHttpSinkConfig,
 };
+use siphon_ai_bridge::Direction;
 use siphon_ai_cdr::{
     CdrSinkHandle, FileSink, HepCdrSink, MultiSink, NullSink, WebhookSink, WebhookSinkConfig,
 };
@@ -90,7 +91,6 @@ use siphon_ai_core::{
     OutboundOriginator, OutboundService, ParkAdmin, ParkContext, ParkRegistry, ParkSettings,
     ParkTimeoutAction as CoreParkTimeoutAction, StaticCredentials,
 };
-use siphon_ai_bridge::Direction;
 use siphon_ai_media_glue::MediaSetup;
 use siphon_ai_quality::{
     FanoutSink as QualityFanoutSink, FileSink as QualityFileSink, HttpSink as QualityHttpSink,

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -90,6 +90,7 @@ use siphon_ai_core::{
     OutboundOriginator, OutboundService, ParkAdmin, ParkContext, ParkRegistry, ParkSettings,
     ParkTimeoutAction as CoreParkTimeoutAction, StaticCredentials,
 };
+use siphon_ai_bridge::Direction;
 use siphon_ai_media_glue::MediaSetup;
 use siphon_ai_quality::{
     FanoutSink as QualityFanoutSink, FileSink as QualityFileSink, HttpSink as QualityHttpSink,
@@ -101,7 +102,7 @@ use siphon_ai_sip_glue::{
 };
 use siphon_ai_telemetry::{
     admin::{
-        AdminCallRegistry, AdminConference, AdminOutbound, AdminPark, AdminState,
+        AdminCallRegistry, AdminCallRow, AdminConference, AdminOutbound, AdminPark, AdminState,
         CallRegistryHandle, DrainStatus, DrainStatusFn, RegistrationRow,
     },
     install_recorder, AdminServer, AdminTlsConfigFn, HepTelemetry, HepTelemetryBuild,
@@ -1025,6 +1026,7 @@ impl Runtime {
         let admin_state = AdminState {
             call_registry: Some(Arc::new(RuntimeCallRegistry {
                 inner: call_registry_for_admin,
+                control: control_registry.clone(),
             }) as AdminCallRegistry),
             registration_snapshot: Some(Arc::new(move || {
                 registration_mgr_for_admin
@@ -1482,15 +1484,33 @@ async fn build_admin(
     Ok(Some(server))
 }
 
-/// Adapter that exposes `CallRegistry` through the `admin` trait
+/// Adapter that exposes the call registries through the `admin` trait
 /// surface without forcing telemetry to depend on `siphon-ai-core`.
+///
+/// The listing (`GET /admin/calls`) is sourced from the bridge-id-keyed
+/// `control` registry so it covers both inbound and outbound calls and
+/// reports the bridge `call_id` the conference/park/stats endpoints
+/// need (issue #311). `hangup` still resolves the SIP-Call-ID-keyed
+/// inbound `inner` registry — the id namespace that endpoint documents.
 struct RuntimeCallRegistry {
     inner: CallRegistry,
+    control: CallControlRegistry,
 }
 
 impl CallRegistryHandle for RuntimeCallRegistry {
-    fn snapshot_ids(&self) -> Vec<String> {
-        self.inner.snapshot_call_ids()
+    fn snapshot_calls(&self) -> Vec<AdminCallRow> {
+        self.control
+            .snapshot()
+            .into_iter()
+            .map(|c| AdminCallRow {
+                call_id: c.call_id,
+                sip_call_id: c.sip_call_id,
+                direction: match c.direction {
+                    Direction::Inbound => "inbound",
+                    Direction::Outbound => "outbound",
+                },
+            })
+            .collect()
     }
     fn hangup(&self, sip_call_id: &str) -> bool {
         match self.inner.lookup(sip_call_id) {

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -3256,8 +3256,14 @@ impl BridgingAcceptor {
             .with_forge_call_id(prepared.forge_call_id.clone()),
         );
         // Bridge-id handle table for the admin conference API — every
-        // accepted call is reachable by the id operators see.
-        self.control_registry.insert(cleanup_handle.clone());
+        // accepted call is reachable by the id operators see. Carries the
+        // SIP Call-ID + direction so `GET /admin/calls` can report both
+        // id namespaces (issue #311).
+        self.control_registry.insert(
+            cleanup_handle.clone(),
+            prepared.sip_call_id.clone(),
+            Direction::Inbound,
+        );
 
         // Per-route counter is owned-by-route — bounded cardinality
         // by config (operators have tens of routes, not millions).

--- a/crates/core/src/outbound_service.rs
+++ b/crates/core/src/outbound_service.rs
@@ -23,7 +23,7 @@ use arc_swap::ArcSwap;
 use chrono::{DateTime, Utc};
 use forge_core::{CallId, ParticipantId};
 use sip_core::SipUri;
-use siphon_ai_bridge::{BridgeConfig, CallId as BridgeCallId};
+use siphon_ai_bridge::{BridgeConfig, CallId as BridgeCallId, Direction};
 use siphon_ai_cdr::{
     AudioInfo as CdrAudioInfo, CdrRecord, CdrSinkHandle, Direction as CdrDirection,
     TerminationInfo as CdrTerminationInfo, CDR_VERSION,
@@ -590,7 +590,10 @@ async fn run_call(
     };
     let (controller, handle) = CallController::new(cfg);
     // Reachable by the admin conference API for this leg's lifetime.
-    ctx.control_registry.insert(handle);
+    // Carries the SIP Call-ID + direction for the `GET /admin/calls`
+    // listing (issue #311).
+    ctx.control_registry
+        .insert(handle, sip_call_id.clone(), Direction::Outbound);
     let run_result = controller.run().await;
     ctx.control_registry.remove(ctx.bridge_id.as_str());
     match &run_result {

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -45,6 +45,7 @@ use tracing::{debug, warn};
 
 use crate::call::CallHandle;
 use forge_core::CallId as ForgeCallId;
+use siphon_ai_bridge::Direction;
 use siphon_ai_media_glue::MediaDirection;
 
 /// Per-call session state the registry tracks. Beyond the shutdown
@@ -255,9 +256,37 @@ impl ConsultRegistry {
 /// path only *signals* a call — the controller mutates its own state.
 /// Insert at call setup, remove at teardown (not the hot path); lookup
 /// once per admin request.
+///
+/// Alongside the handle it caches the call's SIP `Call-ID` and
+/// [`Direction`] — both fixed for the call's life — so the admin
+/// active-calls listing can report every identifier an operator needs:
+/// the bridge `call_id` (this map's key; what conference / park / stats
+/// consume) *and* the SIP Call-ID (what `POST /admin/calls/:id/hangup`
+/// consumes). Before this the listing exposed only the SIP Call-ID, with
+/// no way to obtain the bridge id the conference API requires (issue
+/// #311).
 #[derive(Debug, Clone, Default)]
 pub struct CallControlRegistry {
-    inner: Arc<RwLock<HashMap<String, CallHandle>>>,
+    inner: Arc<RwLock<HashMap<String, ControlEntry>>>,
+}
+
+/// What [`CallControlRegistry`] stores per call: the command handle plus
+/// the identifiers/direction the admin listing reports.
+#[derive(Debug, Clone)]
+struct ControlEntry {
+    handle: CallHandle,
+    sip_call_id: String,
+    direction: Direction,
+}
+
+/// One active call in the admin `GET /admin/calls` snapshot. `call_id`
+/// is the bridge id (the registry key); `sip_call_id` is the SIP
+/// Call-ID; `direction` is inbound/outbound.
+#[derive(Debug, Clone)]
+pub struct CallSnapshot {
+    pub call_id: String,
+    pub sip_call_id: String,
+    pub direction: Direction,
 }
 
 impl CallControlRegistry {
@@ -273,12 +302,18 @@ impl CallControlRegistry {
         self.inner.read().is_empty()
     }
 
-    /// Register a call's handle under its bridge `call_id`. A
-    /// collision means the id factory produced a duplicate (a bug);
+    /// Register a call's handle under its bridge `call_id`, together
+    /// with its SIP `Call-ID` and [`Direction`] for the admin listing.
+    /// A collision means the id factory produced a duplicate (a bug);
     /// last insert wins with a warning, matching [`CallRegistry`].
-    pub fn insert(&self, handle: CallHandle) {
+    pub fn insert(&self, handle: CallHandle, sip_call_id: impl Into<String>, direction: Direction) {
         let key = handle.call_id().as_str().to_string();
-        if self.inner.write().insert(key.clone(), handle).is_some() {
+        let entry = ControlEntry {
+            handle,
+            sip_call_id: sip_call_id.into(),
+            direction,
+        };
+        if self.inner.write().insert(key.clone(), entry).is_some() {
             warn!(call_id = %key, "control registry insert collided; previous handle dropped");
         } else {
             debug!(call_id = %key, "registered call handle for admin control");
@@ -287,7 +322,25 @@ impl CallControlRegistry {
 
     /// Look up a call's handle by bridge `call_id`.
     pub fn lookup(&self, bridge_call_id: &str) -> Option<CallHandle> {
-        self.inner.read().get(bridge_call_id).cloned()
+        self.inner
+            .read()
+            .get(bridge_call_id)
+            .map(|e| e.handle.clone())
+    }
+
+    /// Snapshot every active call — bridge `call_id`, SIP Call-ID, and
+    /// direction — for the admin `GET /admin/calls` listing. Order is
+    /// unspecified. Covers both inbound and outbound calls.
+    pub fn snapshot(&self) -> Vec<CallSnapshot> {
+        self.inner
+            .read()
+            .iter()
+            .map(|(call_id, e)| CallSnapshot {
+                call_id: call_id.clone(),
+                sip_call_id: e.sip_call_id.clone(),
+                direction: e.direction,
+            })
+            .collect()
     }
 
     /// Drop the entry on the call's way out. Unknown id is a harmless
@@ -510,6 +563,30 @@ mod tests {
         let mut ids = reg.snapshot_call_ids();
         ids.sort();
         assert_eq!(ids, vec!["a@pbx".to_string(), "b@pbx".to_string()]);
+    }
+
+    #[test]
+    fn control_registry_snapshot_reports_both_ids_and_direction() {
+        let reg = CallControlRegistry::new();
+        reg.insert(fresh_handle("siphon-in"), "in@pbx", Direction::Inbound);
+        reg.insert(fresh_handle("siphon-out"), "out@pbx", Direction::Outbound);
+
+        let mut rows = reg.snapshot();
+        rows.sort_by(|a, b| a.call_id.cmp(&b.call_id));
+        assert_eq!(rows.len(), 2);
+
+        // Bridge call_id is the key; SIP Call-ID and direction ride
+        // alongside — the trio the admin listing needs (issue #311).
+        assert_eq!(rows[0].call_id, "siphon-in");
+        assert_eq!(rows[0].sip_call_id, "in@pbx");
+        assert_eq!(rows[0].direction, Direction::Inbound);
+        assert_eq!(rows[1].call_id, "siphon-out");
+        assert_eq!(rows[1].sip_call_id, "out@pbx");
+        assert_eq!(rows[1].direction, Direction::Outbound);
+
+        // lookup still returns the handle by bridge id.
+        assert!(reg.lookup("siphon-out").is_some());
+        assert!(reg.lookup("out@pbx").is_none());
     }
 
     #[test]

--- a/crates/telemetry/src/admin.rs
+++ b/crates/telemetry/src/admin.rs
@@ -132,10 +132,30 @@ pub type DrainStatusFn = Arc<dyn Fn() -> DrainStatus + Send + Sync>;
 /// runtime adapter passes a closure-wrapping object that delegates
 /// to `CallRegistry`.
 pub trait CallRegistryHandle: Send + Sync + 'static {
-    fn snapshot_ids(&self) -> Vec<String>;
+    /// Snapshot every active call for `GET /admin/calls`. Each row
+    /// carries both id namespaces so an operator can drive every admin
+    /// endpoint: the bridge `call_id` (conference / park / stats) and
+    /// the SIP Call-ID (`hangup`). See [`AdminCallRow`].
+    fn snapshot_calls(&self) -> Vec<AdminCallRow>;
     /// Best-effort: returns `true` iff a call with that SIP Call-ID
     /// existed and was signalled to shut down.
     fn hangup(&self, sip_call_id: &str) -> bool;
+}
+
+/// One active call in the `GET /admin/calls` response.
+///
+/// `call_id` is the **bridge** id — the value on the WS `start` message
+/// and the CDR, and the id `/admin/v1/conferences/*`, `/park`,
+/// `/retrieve`, and `/stats` all take. `sip_call_id` is the **SIP**
+/// Call-ID, the id `POST /admin/calls/:id/hangup` takes. Exposing both
+/// (with `direction`) is the fix for issue #311, where the listing gave
+/// only the SIP Call-ID and the bridge id had no admin source.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AdminCallRow {
+    pub call_id: String,
+    pub sip_call_id: String,
+    /// `"inbound"` | `"outbound"`.
+    pub direction: &'static str,
 }
 
 /// Boxed clone-friendly handle the runtime constructs.
@@ -535,8 +555,11 @@ fn list_calls(state: &AdminState) -> Response<Full<Bytes>> {
     let Some(reg) = state.call_registry.as_ref() else {
         return service_unavailable("call registry not installed");
     };
-    let ids = reg.snapshot_ids();
-    json_response(StatusCode::OK, &json!({ "count": ids.len(), "calls": ids }))
+    let calls = reg.snapshot_calls();
+    json_response(
+        StatusCode::OK,
+        &json!({ "count": calls.len(), "calls": calls }),
+    )
 }
 
 fn drain_status(state: &AdminState) -> Response<Full<Bytes>> {
@@ -841,9 +864,10 @@ fn conference_error_response(e: ConferenceAdminError) -> Response<Full<Bytes>> {
         ConferenceAdminError::RoomNotFound => {
             (StatusCode::NOT_FOUND, "no such conference room".to_string())
         }
-        ConferenceAdminError::UnknownCall(c) => {
-            (StatusCode::NOT_FOUND, format!("no active call: {c}"))
-        }
+        ConferenceAdminError::UnknownCall(c) => (
+            StatusCode::NOT_FOUND,
+            format!("no active call with bridge call_id {c:?} (this is the `call_id` field of GET /admin/calls, not sip_call_id)"),
+        ),
     };
     json_response(status, &json!({ "error": msg }))
 }
@@ -980,7 +1004,10 @@ fn park_disabled() -> Response<Full<Bytes>> {
 fn park_error_response(e: ParkAdminError) -> Response<Full<Bytes>> {
     let (status, msg) = match e {
         ParkAdminError::Disabled => return park_disabled(),
-        ParkAdminError::UnknownCall(c) => (StatusCode::NOT_FOUND, format!("no active call: {c}")),
+        ParkAdminError::UnknownCall(c) => (
+            StatusCode::NOT_FOUND,
+            format!("no active call with bridge call_id {c:?} (this is the `call_id` field of GET /admin/calls, not sip_call_id)"),
+        ),
         ParkAdminError::NotParked(c) => (StatusCode::CONFLICT, format!("call is not parked: {c}")),
     };
     json_response(status, &json!({ "error": msg }))
@@ -1021,8 +1048,20 @@ mod tests {
     }
 
     impl CallRegistryHandle for StubRegistry {
-        fn snapshot_ids(&self) -> Vec<String> {
-            self.ids.lock().unwrap().clone()
+        fn snapshot_calls(&self) -> Vec<AdminCallRow> {
+            // The stub tracks SIP Call-IDs (what `hangup` matches on);
+            // synthesize a bridge id for each so the listing shape can
+            // be asserted.
+            self.ids
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|sip| AdminCallRow {
+                    call_id: format!("siphon-{sip}"),
+                    sip_call_id: sip.clone(),
+                    direction: "inbound",
+                })
+                .collect()
         }
         fn hangup(&self, sip_call_id: &str) -> bool {
             let mut ids = self.ids.lock().unwrap();
@@ -1214,6 +1253,16 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
+
+        // Each call is an object carrying BOTH id namespaces + direction
+        // (issue #311) — not a bare SIP Call-ID string.
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let v: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["count"], 2);
+        let first = &v["calls"][0];
+        assert_eq!(first["sip_call_id"], "abc@host");
+        assert_eq!(first["call_id"], "siphon-abc@host");
+        assert_eq!(first["direction"], "inbound");
     }
 
     #[tokio::test]

--- a/crates/telemetry/src/http.rs
+++ b/crates/telemetry/src/http.rs
@@ -458,8 +458,14 @@ async fn handle_admin_request(
             match admin::dispatch(&method, &path, body, &state.admin).await {
                 Some(resp) => {
                     let status = resp.status().as_u16();
+                    // A matched route can still fail at the handler (404 stale
+                    // call_id, 409 conflict, 503 at a cap, …). Classify by the
+                    // response status so `result` reflects the real outcome —
+                    // hardcoding "ok" here flattened every handler-level
+                    // failure to success (issue #310).
+                    let result = admin_result_label(status);
                     info!(peer = %peer, actor = %actor, role, endpoint, status, "admin request");
-                    metrics::counter!(ADMIN_REQUESTS_TOTAL, "endpoint" => endpoint, "role" => role, "result" => "ok").increment(1);
+                    metrics::counter!(ADMIN_REQUESTS_TOTAL, "endpoint" => endpoint, "role" => role, "result" => result).increment(1);
                     siphon_ai_audit::emit(siphon_ai_audit::AuditEvent::admin_request(
                         peer.to_string(),
                         Some(actor.clone()),
@@ -467,7 +473,7 @@ async fn handle_admin_request(
                         method.as_str(),
                         endpoint,
                         status,
-                        "ok",
+                        result,
                         None,
                     ));
                     resp
@@ -490,6 +496,24 @@ async fn handle_admin_request(
                 }
             }
         }
+    }
+}
+
+/// Classify an admin handler's response status into the bounded `result`
+/// label for `siphon_ai_admin_requests_total` (and the audit stream).
+///
+/// The auth layer owns `unauthenticated` (401) and `forbidden` (403); this
+/// covers the statuses a matched-and-authorized handler can return. `404`
+/// is its own value (a normal race — operating on a call/room/binding that
+/// has since gone), and every other non-2xx failure (400/409/429/501/503/
+/// 5xx) collapses to `error` rather than being labelled per raw status —
+/// bounded cardinality (CLAUDE.md §4.5); per-request detail lives in the
+/// audit log and the `status` span field.
+fn admin_result_label(status: u16) -> &'static str {
+    match status {
+        200..=299 => "ok",
+        404 => "not_found",
+        _ => "error",
     }
 }
 
@@ -565,6 +589,24 @@ mod tests {
         .expect("request returns")
         .expect("ok");
         resp.status()
+    }
+
+    #[test]
+    fn admin_result_label_classifies_by_status() {
+        // 2xx successes.
+        assert_eq!(admin_result_label(200), "ok");
+        assert_eq!(admin_result_label(201), "ok");
+        assert_eq!(admin_result_label(202), "ok");
+        // 404 is its own bucket — the case in issue #310 (a matched
+        // handler returning "no active call") must NOT read as ok.
+        assert_eq!(admin_result_label(404), "not_found");
+        // Every other handler-level failure collapses to `error`,
+        // not `ok`, so `result != "ok"` alerting catches them.
+        assert_eq!(admin_result_label(400), "error");
+        assert_eq!(admin_result_label(409), "error");
+        assert_eq!(admin_result_label(429), "error");
+        assert_eq!(admin_result_label(501), "error");
+        assert_eq!(admin_result_label(503), "error");
     }
 
     #[tokio::test]

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -107,7 +107,10 @@ pub const OUTBOUND_SRTP_TOTAL: &str = "siphon_ai_outbound_srtp_total";
 /// Authenticated admin API requests (0.10.0). Labeled by `endpoint`
 /// (the route template, ids collapsed — bounded), `role` (the
 /// authenticated token's role, or `none` when auth failed), and
-/// `result` (`ok`, `unauthenticated`, `forbidden`, `not_found`). One
+/// `result` (`ok`, `unauthenticated`, `forbidden`, `not_found`, `error`).
+/// `not_found` covers both an unknown route and a handler `404` (stale
+/// call/room id); `error` covers every other handler failure (400 / 409 /
+/// 429 / 501 / 503 / 5xx). One
 /// counter per admin call on the `[admin]` listener; pairs with the
 /// structured audit log. Literal must match the call site in
 /// `siphon-ai-telemetry::http`.
@@ -471,7 +474,7 @@ pub fn register_descriptions() {
     );
     describe_counter!(
         ADMIN_REQUESTS_TOTAL,
-        "Authenticated admin API requests, by endpoint (route template), role, and result (ok, unauthenticated, forbidden, not_found)."
+        "Authenticated admin API requests, by endpoint (route template), role, and result (ok, unauthenticated, forbidden, not_found, error)."
     );
     describe_counter!(
         DELAYED_OFFER_TOTAL,

--- a/docs/CONFERENCE.md
+++ b/docs/CONFERENCE.md
@@ -74,15 +74,27 @@ role → `403`. Configure the listener and tokens per `docs/DEPLOY.md` →
 Admin auth & RBAC, and keep it on loopback or a private interface
 (`[admin.tls]` if it must bind somewhere routable).
 
+**`call_id` here is the *bridge* call_id** — the `siphon-…` value on the bot's
+WS `start` message and the CDR, **not** the SIP `Call-ID`. Get it from
+`GET /admin/calls`, whose `call_id` field is exactly this id (its `sip_call_id`
+field is the other namespace, which the conference API rejects):
+
 ```sh
 ADMIN=http://127.0.0.1:9092          # https://… when [admin.tls] is set
+
+# Discover active calls and their bridge call_ids (readonly)
+curl -s -H "Authorization: Bearer $SIPHON_ADMIN_RO" $ADMIN/admin/calls
+# → {"count":2,"calls":[
+#     {"call_id":"siphon-c","sip_call_id":"5924dbcb…@0.0.0.0","direction":"inbound"},
+#     {"call_id":"siphon-d","sip_call_id":"…","direction":"outbound"}]}
 
 # Who's in which room (readonly)
 curl -s -H "Authorization: Bearer $SIPHON_ADMIN_RO" $ADMIN/admin/v1/conferences
 # → {"count":1,"conferences":[{"room_id":"support-7","sample_rate":8000,
 #     "participants":["siphon-a","siphon-b"]}]}
 
-# Pull any active call (inbound or outbound) into a room — creates it if absent
+# Pull any active call (inbound or outbound) into a room — creates it if absent.
+# call_id is the bridge id from /admin/calls above (NOT the sip_call_id).
 curl -X POST $ADMIN/admin/v1/conferences/support-7/participants \
     -H "Authorization: Bearer $SIPHON_ADMIN_OP" \
     -d '{"call_id":"siphon-c"}'        # → 202

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -502,8 +502,8 @@ no/invalid token → `401`.
 
 | Method | Path                          | Body            | Min role | Purpose |
 |--------|-------------------------------|-----------------|----------|---------|
-| GET    | `/admin/calls`                | —               | readonly | List active per-call SIP Call-IDs. |
-| POST   | `/admin/calls/:id/hangup`     | —               | operator | Force-shutdown a specific call by Call-ID. |
+| GET    | `/admin/calls`                | —               | readonly | List active calls (inbound **and** outbound). Each element is `{call_id, sip_call_id, direction}` — the **bridge** `call_id` (what conference / park / `stats` take, and the value on the WS `start` message / CDR), the **SIP** Call-ID (what `hangup` takes), and `"inbound"`/`"outbound"`. Since 0.37.1; before that it returned a bare array of SIP Call-ID strings and exposed no way to obtain the bridge id (issue #311). |
+| POST   | `/admin/calls/:id/hangup`     | —               | operator | Force-shutdown a specific call by its **SIP** `Call-ID` (the `sip_call_id` field from `GET /admin/calls`), inbound calls only. |
 | GET    | `/admin/registrations`        | —               | readonly | Snapshot of every `[[register]]` row and its current state. |
 | POST   | `/admin/v1/registrations/:name/refresh` | —     | operator | **Fire an immediate off-cycle REGISTER** for one binding (0.33.0) — no restart needed when a registrar drops or stales the binding. Also **starts a parked binding** (`register_on_startup = false`). Returns `202` with the accept-time row; the outcome is asynchronous (watch the GET, `siphon_ai_register_attempts_total`, or the `registration_state_changed` webhook). `404` unknown name, `409` while draining. |
 | POST   | `/admin/v1/registrations/:name/restart` | —     | operator | **Full re-registration cycle** (0.33.0): REGISTER `Expires: 0` to clear the registrar-side binding, then a fresh REGISTER — for stale server-side state or contact rebinding after an IP change. A failed unregister is logged and the fresh REGISTER proceeds; only the final attempt drives status. Same responses as `refresh`. |
@@ -572,7 +572,11 @@ Roles, lowest to highest (each inherits everything below it):
 Every request is audited: a structured log line (actor = token **name**,
 role, endpoint template, result, peer address — never the secret) and the
 `siphon_ai_admin_requests_total{endpoint, role, result}` counter
-(`result` ∈ `ok` | `unauthenticated` | `forbidden` | `not_found`).
+(`result` ∈ `ok` | `unauthenticated` | `forbidden` | `not_found` | `error`).
+`result` reflects the **response status**, not just the auth outcome: a
+matched, authorized handler that returns `404` (a stale call/room id) counts
+`not_found`, and any other handler failure (400 / 409 / 429 / 501 / 503)
+counts `error` — so `result != "ok"` is a faithful failure signal.
 
 A bearer token goes on every call:
 
@@ -1134,7 +1138,7 @@ on the metrics crate's defaults (CLAUDE.md §7.4).
 | `siphon_ai_parked_calls_active`         | gauge     | —                                     | Currently-parked calls (0.7.0). Incremented on park, decremented on retrieve or teardown. |
 | `siphon_ai_holds_total`                 | counter   | `result=ok\|failed`                   | Bot-initiated hold/resume re-INVITEs (0.7.2 — the WS server sends `hold`/`resume`). Covers both directions. `failed` = the re-INVITE was rejected / timed out / glared, or hold was rejected (already held by the far end, tap unavailable, not configured); the call stays in its prior media state. Does **not** count far-end (peer-initiated) holds. |
 | `siphon_ai_ws_reconnects_total`         | counter   | `result=recovered\|exhausted`         | WS reconnect episodes mid-call (0.7.3 — `[bridge].ws_reconnect_enabled`). One increment per unexpected drop that entered the reconnect path. `recovered` = re-dialed the same `ws_url` within `ws_reconnect_max_secs`; `exhausted` = the window elapsed (or the call ended mid-gap) and the call tore down (`ws_disconnect`). |
-| `siphon_ai_admin_requests_total`        | counter   | `endpoint`, `role`, `result=ok\|unauthenticated\|forbidden\|not_found` | Admin API requests on the `[admin]` listener (0.10.0). `endpoint` is the bounded route template (e.g. `POST /admin/v1/calls`, ids collapsed to `:id`), `role` is the authenticated token's role (`none` for `unauthenticated`). `unauthenticated` = 401 (missing/bad token); `forbidden` = 403 (role below the endpoint minimum). Pair with the structured audit log (actor = token name) for per-request detail. |
+| `siphon_ai_admin_requests_total`        | counter   | `endpoint`, `role`, `result=ok\|unauthenticated\|forbidden\|not_found\|error` | Admin API requests on the `[admin]` listener (0.10.0). `endpoint` is the bounded route template (e.g. `POST /admin/v1/calls`, ids collapsed to `:id`), `role` is the authenticated token's role (`none` for `unauthenticated`). `unauthenticated` = 401 (missing/bad token); `forbidden` = 403 (role below the endpoint minimum); `not_found` = 404 (unknown route **or** a handler acting on a stale call/room/binding id); `error` = any other handler failure (400 / 409 / 429 / 501 / 503). `result` follows the response status, so `result != "ok"` is a true failure count (fixed in 0.37.1 — it previously flattened all authorized responses to `ok`). Pair with the structured audit log (actor = token name) for per-request detail. |
 | `siphon_ai_webhook_deliveries_total`    | counter   | `sink=lifecycle\|cdr\|audit\|quality`, `result=delivered\|spooled\|rejected\|dropped` | Terminal webhook/CDR/audit/quality delivery outcomes (0.11.0; `audit` added 0.20.0, `quality` 0.31.0). One increment per logical delivery. `delivered` = 2xx; `spooled` = persisted to the durable spool after the in-memory budget; `rejected` = non-retryable 4xx; `dropped` = budget (or spool) exhausted, or payload not serializable. |
 | `siphon_ai_quality_records_total`       | counter   | `kind=interval\|final`               | Quality history records emitted through the `[quality]` sinks (0.31.0). Skipped-empty records don't count. |
 | `siphon_ai_webhook_delivery_attempts_total` | counter | `sink`, `outcome=ok\|transient\|error\|rejected` | Individual HTTP delivery attempts (0.11.0) — a retried delivery ticks several times. `transient` = retryable 5xx/408/429; `error` = connect/timeout; `rejected` = non-retryable 4xx. Divide by `siphon_ai_webhook_deliveries_total` for attempts-per-delivery. |

--- a/docs/PARK.md
+++ b/docs/PARK.md
@@ -61,6 +61,10 @@ on the dedicated **`[admin]` listener** (0.10.0) with a bearer token — not on
 `[observability].http_listen`, which `404`s for `/admin/*`. Park and retrieve
 need **`operator`**; `GET /admin/v1/parked` needs **`readonly`**.
 
+`:id` in `/admin/v1/calls/:id/park` is the **bridge** `call_id` (the `siphon-…`
+value on the WS `start` message / CDR), not the SIP Call-ID. List active calls
+and their bridge ids with `GET /admin/calls` — its `call_id` field is this id.
+
 ```sh
 ADMIN=http://127.0.0.1:9092          # https://… when [admin.tls] is set
 


### PR DESCRIPTION
Fixes **#310** and **#311** — two admin-API defects found in testing, both about operator observability/usability of the `[admin]` listener. Bundled because they overlap in `docs/DEPLOY.md` and `crates/telemetry/src/admin.rs`. (#312 is separate — it's upstream in siphon-rs.)

## #310 — `siphon_ai_admin_requests_total` flattened failures to `result="ok"`

The counter derived `result` from the **auth** outcome only (`http.rs:462` hardcoded `"ok"` for every authorized response), even though it had already captured the real `status`. So a matched, authorized handler returning a non-2xx — a `404` on a stale `call_id`, a `409`, a `503` at a cap — was still counted `ok`, and the documented `not_found` value was emitted only for *unknown routes*, never for a handler `404`.

`result` now follows the response status via a bounded classifier:

| status | result |
|---|---|
| 2xx | `ok` |
| 404 | `not_found` |
| other non-2xx (400/409/429/501/503) | `error` (new value) |

The audit-stream `result` field uses the same label instead of a second hardcoded `"ok"`. Auth-layer `unauthenticated`/`forbidden` unchanged. Cardinality stays bounded (5 values) — per-request detail is in the audit log. `# HELP`, `docs/DEPLOY.md`, and a unit test updated.

## #311 — `GET /admin/calls` returned SIP Call-IDs the conference API rejects

`GET /admin/calls` was the only endpoint enumerating calls, but it returned **SIP Call-IDs** while every `/admin/v1/conferences` (and `/park`, `/retrieve`, `/stats`) endpoint requires the **bridge** `call_id` — and no endpoint exposed the mapping. Operator conferencing was undriveable without correlating `journalctl`, and the resulting `404 "no active call"` (while `/admin/calls` listed the call) read as a liveness bug.

Investigation surfaced that the listing was sourced from an **inbound-only** registry, while the action endpoints resolve against the bridge-id-keyed `CallControlRegistry` that covers both directions.

`GET /admin/calls` now returns objects sourced from the control registry:

```json
{"count":2,"calls":[
  {"call_id":"siphon-f6d3…","sip_call_id":"5924dbcb…@0.0.0.0","direction":"inbound"},
  {"call_id":"siphon-0a1b…","sip_call_id":"…","direction":"outbound"}]}
```

`CallControlRegistry` now caches `sip_call_id` + `Direction` alongside the handle, set at the two insert sites (acceptor → `Inbound`, outbound_service → `Outbound`). `hangup` still resolves the SIP-Call-ID-keyed inbound registry (documented per-endpoint). The conference/park `404` bodies now name the expected id namespace instead of a bare `no active call: <id>`.

### ⚠️ Breaking (admin API only)
`GET /admin/calls` response shape changes from an array of strings to an array of objects. This is **not** the versioned WS protocol (that stays v1; CDR unchanged) — it's the admin control plane. Flagged under `Changed` in the CHANGELOG; scripts parsing `/admin/calls` must update. The listing also now includes **outbound** calls, which the old inbound-only listing omitted.

## Tests
- core: `control_registry_snapshot_reports_both_ids_and_direction` (both ids + direction, lookup still by bridge id)
- telemetry: `list_calls_returns_snapshot` now asserts the object shape; `admin_result_label_classifies_by_status` locks the #310 mapping
- `cargo test` green for core + telemetry + bin; `clippy --all-targets` clean

## Verification
Covered by unit tests at both layers (registry snapshot → serialized listing is a straight map). No protocol/CDR/schema change, so no schema regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jFDxbuLq15NBUUjgDDgws
