### PR TITLE
chore(deps): bump siphon-rs to 3a4fc31 — outbound TLS SNI fix (closes #312)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3583,7 +3583,7 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 [[package]]
 name = "sip-auth"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c#36c3ac4f3c0cfaa0f8c4b7b850cdb55a35e8674b"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3#3a4fc312ade3b7e0fca955aa5ab84fe2c2ea4e68"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3606,7 +3606,7 @@ dependencies = [
 [[package]]
 name = "sip-core"
 version = "0.7.6"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c#36c3ac4f3c0cfaa0f8c4b7b850cdb55a35e8674b"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3#3a4fc312ade3b7e0fca955aa5ab84fe2c2ea4e68"
 dependencies = [
  "bytes",
  "httpdate",
@@ -3619,7 +3619,7 @@ dependencies = [
 [[package]]
 name = "sip-dialog"
 version = "0.3.3"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c#36c3ac4f3c0cfaa0f8c4b7b850cdb55a35e8674b"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3#3a4fc312ade3b7e0fca955aa5ab84fe2c2ea4e68"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3637,7 +3637,7 @@ dependencies = [
 [[package]]
 name = "sip-dns"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c#36c3ac4f3c0cfaa0f8c4b7b850cdb55a35e8674b"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3#3a4fc312ade3b7e0fca955aa5ab84fe2c2ea4e68"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3651,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "sip-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c#36c3ac4f3c0cfaa0f8c4b7b850cdb55a35e8674b"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3#3a4fc312ade3b7e0fca955aa5ab84fe2c2ea4e68"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -3662,7 +3662,7 @@ dependencies = [
 [[package]]
 name = "sip-identity"
 version = "0.1.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c#36c3ac4f3c0cfaa0f8c4b7b850cdb55a35e8674b"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3#3a4fc312ade3b7e0fca955aa5ab84fe2c2ea4e68"
 dependencies = [
  "base64",
  "ring",
@@ -3675,7 +3675,7 @@ dependencies = [
 [[package]]
 name = "sip-observe"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c#36c3ac4f3c0cfaa0f8c4b7b850cdb55a35e8674b"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3#3a4fc312ade3b7e0fca955aa5ab84fe2c2ea4e68"
 dependencies = [
  "once_cell",
  "tracing",
@@ -3684,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "sip-parse"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c#36c3ac4f3c0cfaa0f8c4b7b850cdb55a35e8674b"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3#3a4fc312ade3b7e0fca955aa5ab84fe2c2ea4e68"
 dependencies = [
  "bytes",
  "httpdate",
@@ -3698,7 +3698,7 @@ dependencies = [
 [[package]]
 name = "sip-ratelimit"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c#36c3ac4f3c0cfaa0f8c4b7b850cdb55a35e8674b"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3#3a4fc312ade3b7e0fca955aa5ab84fe2c2ea4e68"
 dependencies = [
  "dashmap 5.5.3",
  "parking_lot",
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c#36c3ac4f3c0cfaa0f8c4b7b850cdb55a35e8674b"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3#3a4fc312ade3b7e0fca955aa5ab84fe2c2ea4e68"
 dependencies = [
  "nom 7.1.3",
  "smol_str",
@@ -3727,7 +3727,7 @@ dependencies = [
 [[package]]
 name = "sip-transaction"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c#36c3ac4f3c0cfaa0f8c4b7b850cdb55a35e8674b"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3#3a4fc312ade3b7e0fca955aa5ab84fe2c2ea4e68"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3746,7 +3746,7 @@ dependencies = [
 [[package]]
 name = "sip-transport"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c#36c3ac4f3c0cfaa0f8c4b7b850cdb55a35e8674b"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3#3a4fc312ade3b7e0fca955aa5ab84fe2c2ea4e68"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3766,7 +3766,7 @@ dependencies = [
 [[package]]
 name = "sip-uac"
 version = "0.4.2"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c#36c3ac4f3c0cfaa0f8c4b7b850cdb55a35e8674b"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3#3a4fc312ade3b7e0fca955aa5ab84fe2c2ea4e68"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3779,7 +3779,7 @@ dependencies = [
  "sip-dialog",
  "sip-dns",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -3791,7 +3791,7 @@ dependencies = [
 [[package]]
 name = "sip-uas"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c#36c3ac4f3c0cfaa0f8c4b7b850cdb55a35e8674b"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3#3a4fc312ade3b7e0fca955aa5ab84fe2c2ea4e68"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3801,7 +3801,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -3953,7 +3953,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=36c3ac4f3c0c)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3)",
  "sip-transaction",
  "sip-uac",
  "sip-uas",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,25 +129,30 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 # later if upstream moves. To bump, run `git ls-remote` for the upstream's
 # main branch and replace the rev hashes here (see CLAUDE.md §7.5).
 
-# siphon-rs — RFC 3261 SIP stack
-sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "36c3ac4f3c0c" }
-sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "36c3ac4f3c0c" }
-sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "36c3ac4f3c0c", features = ["tls"] }
-sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "36c3ac4f3c0c" }
-sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "36c3ac4f3c0c" }
-sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "36c3ac4f3c0c" }
-sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "36c3ac4f3c0c" }
-sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "36c3ac4f3c0c" }
-sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "36c3ac4f3c0c" }
+# siphon-rs — RFC 3261 SIP stack.
+# Bumped 2026-07-20 `36c3ac4f3c0c` → `3a4fc312ade3` = siphon-rs #64: outbound
+# TLS SNI now uses the URI hostname, not the resolved IP (RFC 5922 §4). Fixes
+# the glue-less side of siphon-ai #312 — Twilio Secure Trunking outbound (a
+# hostname trunk with no SRV) failed the TLS handshake because rustls sent the
+# resolved IP as SNI. sip-dns adds `DnsTarget::sni()`; no siphon-ai API change.
+sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3a4fc312ade3" }
+sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3a4fc312ade3" }
+sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3a4fc312ade3", features = ["tls"] }
+sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3a4fc312ade3" }
+sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3a4fc312ade3" }
+sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3a4fc312ade3" }
+sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3a4fc312ade3" }
+sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3a4fc312ade3" }
+sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3a4fc312ade3" }
 # sip-sdp — the SAME sip-sdp sip-uac's SdpAnswerGenerator trait speaks
 # (distinct from forge-media's pinned sip-sdp). Used by the outbound
 # delayed-offer answer generator to hand the UAC a SessionDescription it
 # accepts. Must stay on the same siphon-rs rev as the rest below.
-sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "36c3ac4f3c0c" }
-sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "36c3ac4f3c0c" }
+sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3a4fc312ade3" }
+sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3a4fc312ade3" }
 # sip-identity — STIR/SHAKEN Identity-header parsing + PASSporT verification
 # (ES256 + X.509 chain validation). Consumed by the stir-shaken verifier crate.
-sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "36c3ac4f3c0c" }
+sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3a4fc312ade3" }
 
 # forge-media — RTP / codecs / SDP / DTMF / engine.
 #
@@ -162,9 +167,10 @@ sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "36c
 # `neural-vad` feature here so `[media].vad = "neural"` is selectable at
 # runtime (docs/CONFIG.md); tract-onnx is pure Rust, so the static-musl
 # release build is unaffected. Feature-enabled builds need rustc >= 1.91
-# (tract 0.23) — our pinned toolchain is 1.95. siphon-rs stays at
-# 36c3ac4f3c0c. (Prior pins: forge 3c59b5f6e464 = #82-#85 dependency
-# migrations; forge 5fa76fb38675 = #81.)
+# (tract 0.23) — our pinned toolchain is 1.95. (siphon-rs is pinned
+# separately above; see its own comment for the current rev.) Prior forge
+# pins: forge 3c59b5f6e464 = #82-#85 dependency migrations; forge
+# 5fa76fb38675 = #81.
 forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "1c996ae5fb4f" }
 forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "1c996ae5fb4f" }
 forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "1c996ae5fb4f", default-features = false, features = ["g722", "dtls", "opus", "neural-vad"] }


### PR DESCRIPTION
Bumps the siphon-rs pin `36c3ac4f3c0c` → `3a4fc312ade3` to pick up **[siphon-rs #64](https://github.com/thevoiceguy/siphon-rs/pull/64)** (merged), the outbound-TLS SNI fix.

**Closes #312.**

## Why

On a hostname trunk with no SRV records — Twilio Secure Trunking, `siphon.pstn.twilio.com` — RFC 3263 resolution replaced the URI host with the resolved IP, and the UAC handed that IP to rustls as the `ServerName`. So the handshake presented `sni=54.172.60.3` and cert-verified against the IP; any trunk with a hostname-scoped cert keyed on SNI rejected it, and the call never connected (`result="unreachable"`). Paired with a secure trunk rejecting UDP (`488`), there was **no working outbound transport** — this restores TLS.

## What's in the bump

The fix is entirely upstream in `sip-dns` / `sip-uac`: `DnsTarget` gains an `sni()` accessor carrying the pre-resolution hostname as the TLS reference identity (RFC 5922 §4); the connect address stays the resolved IP. **This pin bump is the only siphon-ai change** — no siphon-ai API, config, protocol, or CDR change. The stale "siphon-rs stays at 36c3ac4" note in the forge-media comment block is corrected.

## Verification

- Workspace **builds and links** against the new rev; `Cargo.lock` updated.
- **Regression:** `core` / `sip-glue` / `config` / `bin` test suites green.
- The A/AAAA-branch → hostname-SNI path itself is covered by siphon-rs #64's unit tests (`DnsTarget` SNI contract + IP-literal case) and by manual validation on the reporter's Twilio trunk. The pin bump can't exercise a live TLS trunk in CI — flagging that honestly.

Not yet released — rides the next tag alongside #313 (once that merges) and the already-cut v0.37.1 TLS-logging fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jFDxbuLq15NBUUjgDDgws
