### PR TITLE
chore(release): 0.37.2 — outbound TLS SNI fix + admin API observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.2] - 2026-07-20
+
 ### Changed
 
 - **`GET /admin/calls` now returns an object per call, not a bare SIP
@@ -28,6 +30,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the conference/park handlers now name the expected id namespace.
 
 ### Fixed
+
+- **Outbound TLS to a hostname trunk now completes — SNI is the URI
+  hostname, not the resolved IP** (issue #312; siphon-rs #64, pin
+  `36c3ac4f3c0c` → `3a4fc312ade3`). On a hostname trunk with no SRV
+  records (Twilio Secure Trunking, `*.pstn.twilio.com`), RFC 3263
+  resolution replaced the URI host with the resolved A-record IP, and the
+  UAC then handed *that IP* to rustls as the TLS `ServerName` — so the
+  handshake presented `sni=<ip>` and cert-verified against the IP. Any
+  trunk serving a hostname-scoped certificate and keying on SNI rejected
+  it, so outbound TLS calls never connected (`result="unreachable"`);
+  combined with a secure trunk rejecting UDP (`488`), there was **no
+  working outbound transport**. Fixed upstream in siphon-rs `sip-dns` /
+  `sip-uac`: a `DnsTarget` now carries the pre-resolution hostname as its
+  TLS reference identity (RFC 5922 §4) and TLS uses it for SNI and
+  certificate-name verification, while the connection still targets the
+  resolved IP — so RFC 3263 address selection is unchanged. This bump is
+  the only siphon-ai change; no siphon-ai API, config, protocol, or CDR
+  change. IP-literal and SRV-addressed trunks are unaffected.
 
 - **`siphon_ai_admin_requests_total` no longer labels failed admin
   requests `result="ok"`** (issue #310). The counter derived `result`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3811,7 +3811,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.37.1"
+version = "0.37.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.37.1"
+version = "0.37.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3875,7 +3875,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.37.1"
+version = "0.37.2"
 dependencies = [
  "base64",
  "bytes",
@@ -3897,7 +3897,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.37.1"
+version = "0.37.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3914,7 +3914,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.37.1"
+version = "0.37.2"
 dependencies = [
  "regex",
  "serde",
@@ -3933,7 +3933,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.37.1"
+version = "0.37.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3979,7 +3979,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.37.1"
+version = "0.37.2"
 dependencies = [
  "base64",
  "hmac",
@@ -4002,7 +4002,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.37.1"
+version = "0.37.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4027,7 +4027,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.37.1"
+version = "0.37.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -4045,7 +4045,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.37.1"
+version = "0.37.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4063,7 +4063,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.37.1"
+version = "0.37.2"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4077,7 +4077,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.37.1"
+version = "0.37.2"
 dependencies = [
  "regex",
  "serde",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.37.1"
+version = "0.37.2"
 dependencies = [
  "schemars",
  "serde",
@@ -4099,7 +4099,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.37.1"
+version = "0.37.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4126,7 +4126,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.37.1"
+version = "0.37.2"
 dependencies = [
  "base64",
  "rcgen",
@@ -4144,7 +4144,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.37.1"
+version = "0.37.2"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -4173,7 +4173,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.37.1"
+version = "0.37.2"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.37.1"
+version = "0.37.2"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.37.1.** Production-deployed against real carriers
+**Current release: v0.37.2.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a


### PR DESCRIPTION
Release-prep for **v0.37.2** per RELEASING.md §2. Patch release carrying the three post-0.37.1 issue fixes now on main:

- **#312** outbound TLS SNI uses the URI hostname, not the resolved IP (siphon-rs #64 pin bump) — unblocks Twilio Secure Trunking outbound. The headline; with v0.37.1's quieter TLS logging this completes the secure-trunking story.
- **#311** `GET /admin/calls` returns `{call_id, sip_call_id, direction}` (breaking response shape) so operator conferencing is driveable.
- **#310** `siphon_ai_admin_requests_total` no longer flattens handler failures to `result="ok"`.

Mechanics: version 0.37.1 → 0.37.2, `Cargo.lock` refreshed, CHANGELOG `[Unreleased]` → `[0.37.2] - 2026-07-20` + fresh empty `[Unreleased]`, README marker moved. `check-version-consistency.py` (+ `--tag v0.37.2`) and `extract-changelog.py 0.37.2` green locally.

Merge, then tag `v0.37.2` on the merge commit to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jFDxbuLq15NBUUjgDDgws