### PR TITLE
fix(outbound): send configured caller-ID as INVITE From (#316)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Outbound INVITE now carries the configured caller-ID in its From
+  header** (issue #316; siphon-rs pin bump for `IntegratedUAC::
+  invite_with_from`). Both `[[gateway]].from` and the per-originate
+  `from` were honored for the WS `start` message and the CDR but **never
+  reached the INVITE** — the UAC stamped its own local identity, so every
+  outbound INVITE went out as `sip:siphon@<public_address>`. Any trunk
+  that validates caller-ID (Twilio Secure Trunking, essentially every
+  commercial provider) declined the call. The resolved caller-ID is now
+  parsed and threaded through `OutboundOriginator::place` /
+  `place_delayed` into a new per-call UAC From override, for both early
+  and delayed offer. A malformed per-request `from` is rejected `400`
+  (`BadFrom`) before a concurrency permit is taken; the gateway `from`
+  stays validated at config load. This bug was **masked by #312** — before
+  0.37.2 outbound TLS never completed the handshake, so the provider never
+  parsed the From; with TLS fixed, this was the next wall. No protocol,
+  config-schema, or CDR change (the WS/CDR `from` was already correct).
+
 ## [0.37.2] - 2026-07-20
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3583,7 +3583,7 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 [[package]]
 name = "sip-auth"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3#3a4fc312ade3b7e0fca955aa5ab84fe2c2ea4e68"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=fcaff011f9c6#fcaff011f9c6d75300ce0466f115a5ff33c710ef"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3606,7 +3606,7 @@ dependencies = [
 [[package]]
 name = "sip-core"
 version = "0.7.6"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3#3a4fc312ade3b7e0fca955aa5ab84fe2c2ea4e68"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=fcaff011f9c6#fcaff011f9c6d75300ce0466f115a5ff33c710ef"
 dependencies = [
  "bytes",
  "httpdate",
@@ -3619,7 +3619,7 @@ dependencies = [
 [[package]]
 name = "sip-dialog"
 version = "0.3.3"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3#3a4fc312ade3b7e0fca955aa5ab84fe2c2ea4e68"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=fcaff011f9c6#fcaff011f9c6d75300ce0466f115a5ff33c710ef"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3637,7 +3637,7 @@ dependencies = [
 [[package]]
 name = "sip-dns"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3#3a4fc312ade3b7e0fca955aa5ab84fe2c2ea4e68"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=fcaff011f9c6#fcaff011f9c6d75300ce0466f115a5ff33c710ef"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3651,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "sip-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3#3a4fc312ade3b7e0fca955aa5ab84fe2c2ea4e68"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=fcaff011f9c6#fcaff011f9c6d75300ce0466f115a5ff33c710ef"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -3662,7 +3662,7 @@ dependencies = [
 [[package]]
 name = "sip-identity"
 version = "0.1.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3#3a4fc312ade3b7e0fca955aa5ab84fe2c2ea4e68"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=fcaff011f9c6#fcaff011f9c6d75300ce0466f115a5ff33c710ef"
 dependencies = [
  "base64",
  "ring",
@@ -3675,7 +3675,7 @@ dependencies = [
 [[package]]
 name = "sip-observe"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3#3a4fc312ade3b7e0fca955aa5ab84fe2c2ea4e68"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=fcaff011f9c6#fcaff011f9c6d75300ce0466f115a5ff33c710ef"
 dependencies = [
  "once_cell",
  "tracing",
@@ -3684,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "sip-parse"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3#3a4fc312ade3b7e0fca955aa5ab84fe2c2ea4e68"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=fcaff011f9c6#fcaff011f9c6d75300ce0466f115a5ff33c710ef"
 dependencies = [
  "bytes",
  "httpdate",
@@ -3698,7 +3698,7 @@ dependencies = [
 [[package]]
 name = "sip-ratelimit"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3#3a4fc312ade3b7e0fca955aa5ab84fe2c2ea4e68"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=fcaff011f9c6#fcaff011f9c6d75300ce0466f115a5ff33c710ef"
 dependencies = [
  "dashmap 5.5.3",
  "parking_lot",
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3#3a4fc312ade3b7e0fca955aa5ab84fe2c2ea4e68"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=fcaff011f9c6#fcaff011f9c6d75300ce0466f115a5ff33c710ef"
 dependencies = [
  "nom 7.1.3",
  "smol_str",
@@ -3727,7 +3727,7 @@ dependencies = [
 [[package]]
 name = "sip-transaction"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3#3a4fc312ade3b7e0fca955aa5ab84fe2c2ea4e68"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=fcaff011f9c6#fcaff011f9c6d75300ce0466f115a5ff33c710ef"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3746,7 +3746,7 @@ dependencies = [
 [[package]]
 name = "sip-transport"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3#3a4fc312ade3b7e0fca955aa5ab84fe2c2ea4e68"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=fcaff011f9c6#fcaff011f9c6d75300ce0466f115a5ff33c710ef"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3766,7 +3766,7 @@ dependencies = [
 [[package]]
 name = "sip-uac"
 version = "0.4.2"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3#3a4fc312ade3b7e0fca955aa5ab84fe2c2ea4e68"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=fcaff011f9c6#fcaff011f9c6d75300ce0466f115a5ff33c710ef"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3779,7 +3779,7 @@ dependencies = [
  "sip-dialog",
  "sip-dns",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=fcaff011f9c6)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -3791,7 +3791,7 @@ dependencies = [
 [[package]]
 name = "sip-uas"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3#3a4fc312ade3b7e0fca955aa5ab84fe2c2ea4e68"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=fcaff011f9c6#fcaff011f9c6d75300ce0466f115a5ff33c710ef"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3801,7 +3801,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=fcaff011f9c6)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -3953,7 +3953,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=3a4fc312ade3)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=fcaff011f9c6)",
  "sip-transaction",
  "sip-uac",
  "sip-uas",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,29 +130,31 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 # main branch and replace the rev hashes here (see CLAUDE.md §7.5).
 
 # siphon-rs — RFC 3261 SIP stack.
-# Bumped 2026-07-20 `36c3ac4f3c0c` → `3a4fc312ade3` = siphon-rs #64: outbound
-# TLS SNI now uses the URI hostname, not the resolved IP (RFC 5922 §4). Fixes
-# the glue-less side of siphon-ai #312 — Twilio Secure Trunking outbound (a
-# hostname trunk with no SRV) failed the TLS handshake because rustls sent the
-# resolved IP as SNI. sip-dns adds `DnsTarget::sni()`; no siphon-ai API change.
-sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3a4fc312ade3" }
-sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3a4fc312ade3" }
-sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3a4fc312ade3", features = ["tls"] }
-sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3a4fc312ade3" }
-sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3a4fc312ade3" }
-sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3a4fc312ade3" }
-sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3a4fc312ade3" }
-sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3a4fc312ade3" }
-sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3a4fc312ade3" }
+# Bumped 2026-07-20 `3a4fc312ade3` → `fcaff011f9c6` = siphon-rs #65:
+# `IntegratedUAC::invite_with_from` — a per-call From override for outbound
+# INVITE. Fixes the glue-less side of siphon-ai #316 — outbound origination
+# stamped the daemon's local identity as From, so caller-ID-validating trunks
+# (Twilio Secure Trunking) declined the call. Additive UAC API; the outbound
+# service now threads the resolved gateway/request caller-ID into the INVITE.
+# (Prior: `3a4fc312ade3` = #64 TLS-SNI-is-hostname, siphon-ai #312.)
+sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "fcaff011f9c6" }
+sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "fcaff011f9c6" }
+sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "fcaff011f9c6", features = ["tls"] }
+sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "fcaff011f9c6" }
+sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "fcaff011f9c6" }
+sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "fcaff011f9c6" }
+sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "fcaff011f9c6" }
+sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "fcaff011f9c6" }
+sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "fcaff011f9c6" }
 # sip-sdp — the SAME sip-sdp sip-uac's SdpAnswerGenerator trait speaks
 # (distinct from forge-media's pinned sip-sdp). Used by the outbound
 # delayed-offer answer generator to hand the UAC a SessionDescription it
 # accepts. Must stay on the same siphon-rs rev as the rest below.
-sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3a4fc312ade3" }
-sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3a4fc312ade3" }
+sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "fcaff011f9c6" }
+sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "fcaff011f9c6" }
 # sip-identity — STIR/SHAKEN Identity-header parsing + PASSporT verification
 # (ES256 + X.509 chain validation). Consumed by the stir-shaken verifier crate.
-sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "3a4fc312ade3" }
+sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "fcaff011f9c6" }
 
 # forge-media — RTP / codecs / SDP / DTMF / engine.
 #

--- a/crates/core/src/outbound.rs
+++ b/crates/core/src/outbound.rs
@@ -407,24 +407,30 @@ impl OutboundOriginator {
     ///
     /// ACK is sent automatically by the UAC on a 2xx; the returned
     /// [`OutboundCall`] carries the confirmed dialog to BYE at teardown.
-    #[instrument(skip(self, target, req, tap), fields(call_id = %req.call_id))]
+    #[instrument(skip(self, target, from, req, tap), fields(call_id = %req.call_id))]
     pub async fn place(
         &self,
         target: SipUri,
+        from: SipUri,
         req: OutboundOfferRequest,
         tap: TapOptions,
     ) -> Result<OutboundCall, OutboundError> {
         let call_id = req.call_id.clone();
-        debug!(target = %target.as_str(), "placing outbound call");
+        debug!(target = %target.as_str(), from = %from.as_str(), "placing outbound call");
 
         // (1) Allocate the session + build the offer (media-glue). A failure
         //     here never created a session, or media-glue rolled it back.
         let offer = self.media.originate_offer(req).await?;
 
-        // (2) Send the INVITE with our offer in the body.
+        // (2) Send the INVITE with our offer in the body and the caller-ID
+        //     as the From header (issue #316) — the trunk validates it.
         let handle = match self
             .uac
-            .invite(RequestTarget::Uri(target), Some(&offer.offer_sdp))
+            .invite_with_from(
+                RequestTarget::Uri(target),
+                Some(&offer.offer_sdp),
+                Some(from),
+            )
             .await
         {
             Ok(h) => h,
@@ -476,18 +482,23 @@ impl OutboundOriginator {
     /// offerless INVITE): `Preferred` answers the peer's SDES offer when
     /// present, `Required` fails the call on a plaintext peer offer.
     /// DTLS-SRTP offers aren't answered here (a follow-up).
-    #[instrument(skip(self, target, req, tap), fields(call_id = %req.call_id))]
+    #[instrument(skip(self, target, from, req, tap), fields(call_id = %req.call_id))]
     pub async fn place_delayed(
         &self,
         target: SipUri,
+        from: SipUri,
         req: OutboundOfferRequest,
         tap: TapOptions,
     ) -> Result<OutboundCall, OutboundError> {
         let call_id = req.call_id.clone();
-        debug!(target = %target.as_str(), "placing outbound delayed-offer call");
+        debug!(target = %target.as_str(), from = %from.as_str(), "placing outbound delayed-offer call");
 
-        // (1) Send the offerless INVITE.
-        let handle = match self.uac.invite(RequestTarget::Uri(target), None).await {
+        // (1) Send the offerless INVITE with the caller-ID as From (#316).
+        let handle = match self
+            .uac
+            .invite_with_from(RequestTarget::Uri(target), None, Some(from))
+            .await
+        {
             Ok(h) => h,
             Err(e) => {
                 self.stop_session(&call_id).await;

--- a/crates/core/src/outbound_service.rs
+++ b/crates/core/src/outbound_service.rs
@@ -227,6 +227,16 @@ impl OutboundOriginateHandle for OutboundService {
         let target = SipUri::parse(&target_str)
             .map_err(|e| OriginateRejection::BadTarget(format!("{target_str}: {e}")))?;
 
+        // Caller-ID for the INVITE From header (issue #316). Per-request
+        // `from` overrides the gateway default; the gateway's `from` is
+        // validated at config load, so only a bad per-request override
+        // reaches `BadFrom` here. Validated before a permit is consumed.
+        // The parsed URI drives the SIP From; the string still feeds the
+        // WS `start` message + CDR via `ctx.from`.
+        let from = req.from.clone().unwrap_or_else(|| gw.from.clone());
+        let from_uri = SipUri::parse(&from)
+            .map_err(|e| OriginateRejection::BadFrom(format!("{from}: {e}")))?;
+
         // Recording for this leg (0.26.0): per-request override beats the
         // gateway default. Same vocabulary as [recording].mode; anything
         // else — or recording without a configured [recording].dir — is a
@@ -290,7 +300,6 @@ impl OutboundOriginateHandle for OutboundService {
             pong_timeout: self.defaults.ws_pong_timeout,
             start_deadline: self.defaults.server_start_deadline,
         };
-        let from = req.from.clone().unwrap_or_else(|| gw.from.clone());
         let to = req.to.clone();
         let gateway = req.gateway.clone();
         let delayed_offer = req.delayed_offer;
@@ -351,9 +360,11 @@ impl OutboundOriginateHandle for OutboundService {
                 }))
                 .await;
             let result = if delayed_offer {
-                originator.place_delayed(target, offer_req, tap).await
+                originator
+                    .place_delayed(target, from_uri, offer_req, tap)
+                    .await
             } else {
-                originator.place(target, offer_req, tap).await
+                originator.place(target, from_uri, offer_req, tap).await
             };
             let result_label = outbound_result_label(&result);
             metrics::counter!(OUTBOUND_CALLS_TOTAL, "result" => result_label).increment(1);

--- a/crates/telemetry/src/admin.rs
+++ b/crates/telemetry/src/admin.rs
@@ -209,6 +209,10 @@ pub enum OriginateRejection {
     /// Bad `recording` value, or recording requested with no
     /// `[recording].dir` configured → 400 (0.26.0).
     BadRecording(String),
+    /// The per-request `from` caller-ID didn't form a valid SIP URI → 400
+    /// (0.37.x). The gateway `from` is validated at config load, so this
+    /// only fires for a bad override in the originate request.
+    BadFrom(String),
 }
 
 /// The outbound-origination entry point the admin endpoint calls. Defined
@@ -743,6 +747,9 @@ fn originate_call(state: &AdminState, body: &Bytes) -> Response<Full<Bytes>> {
                 ),
                 OriginateRejection::BadRecording(r) => {
                     (StatusCode::BAD_REQUEST, format!("bad recording: {r}"))
+                }
+                OriginateRejection::BadFrom(f) => {
+                    (StatusCode::BAD_REQUEST, format!("bad from: {f}"))
                 }
             };
             json_response(status, &json!({ "error": msg }))
@@ -1405,6 +1412,10 @@ mod tests {
             (
                 OriginateRejection::RateLimited,
                 StatusCode::TOO_MANY_REQUESTS,
+            ),
+            (
+                OriginateRejection::BadFrom("x".into()),
+                StatusCode::BAD_REQUEST,
             ),
         ] {
             let state = outbound_state(Err(rej.clone()));

--- a/docs/OUTBOUND.md
+++ b/docs/OUTBOUND.md
@@ -85,7 +85,7 @@ billable endpoint). A missing or invalid token is `401`; a `readonly` or
 | `to` | yes | Destination (E.164 / SIP user). Becomes the Request-URI user at the gateway's proxy. |
 | `gateway` | yes | A `[[gateway]]` name. `404` if unknown. |
 | `ws_url` | no | WS server for this call. Falls back to `[bridge].ws_url`; `400` if neither is set. |
-| `from` | no | Caller-ID override (full `sip:` URI). Falls back to the gateway's `from`. |
+| `from` | no | Caller-ID override (full `sip:` URI) — becomes the INVITE **From** header the trunk validates, so it must be a number your provider accepts (an owned/verified caller-ID). Falls back to the gateway's `from`. A malformed value is rejected `400`. |
 | `delayed_offer` | no | Place the call as a delayed offer (RFC 3264, 0.9.0): INVITE without SDP, answer the peer's offer in the ACK. Default `false`. |
 | `recording` | no | Recording override for this leg (0.26.0): `"off"` / `"always"` / `"on_demand"`. Falls back to the gateway's `recording` default (itself `"off"`). `400` for other values or when recording is requested with no `[recording].dir` configured. Recorded outbound legs behave exactly like inbound: same dir/encryption/format/upload, `recording_*` on the CDR, on-demand WS controls. |
 


### PR DESCRIPTION
Fixes **#316** — outbound origination never set the SIP **From** header from the configured caller-ID, so every outbound INVITE went out as the daemon's local identity (`sip:siphon@<public_address>`) and caller-ID-validating trunks (Twilio Secure Trunking, essentially every commercial provider) declined the call.

Depends on **siphon-rs #65** (merged) — pin bumped `3a4fc312ade3` → `fcaff011f9c6`.

## Root cause

`[[gateway]].from` and the per-originate `from` were honored for the WS `start` message and the CDR, but the value never reached the INVITE: `OutboundOriginator::place` / `place_delayed` called `uac.invite(...)` with only the target + SDP, so the UAC stamped its own local identity as From. The bot and CDR showed the *correct* caller-ID while the wire was wrong — actively misleading during diagnosis.

**Masked by #312:** before v0.37.2 outbound TLS never completed the handshake, so the provider never parsed the From. With TLS fixed, this was the next wall — a secure trunk rejects UDP (`488`) *and* declined TLS on the From, so there was no working outbound path.

## Fix

- **siphon-rs #65** added `IntegratedUAC::invite_with_from` — a per-call From override threaded as an argument (concurrency-safe, unlike the shared `set_from_uri`).
- **This PR** resolves the caller-ID (`req.from` ?? `gw.from`), parses it to a `SipUri`, and threads it through `place` / `place_delayed` into `invite_with_from`, for both early and delayed offer. A malformed per-request `from` is rejected `400` (`BadFrom`) before a concurrency permit is taken; the gateway `from` stays validated at config load.
- No protocol, config-schema, or CDR change (the WS/CDR `from` was already correct).

## Verification

- **End-to-end wire capture** (manual harness, gateway `from = "sip:harness@127.0.0.1"`, no per-request override) — the INVITE on the wire now reads:
  ```
  From: <sip:harness@127.0.0.1>;tag=…
  ```
  (pre-fix it was the daemon local identity). Confirmed via SIPp `-trace_msg` against the real daemon over UDP.
- **siphon-rs unit test** `create_invite_with_from_overrides_from_uri_per_call` — the override reaches the From, the default path still carries the local identity, the local tag is preserved.
- **siphon-ai** `originate_maps_rejections_to_status` extended with `BadFrom → 400`.
- Workspace builds/links against the merged rev; `core` / `telemetry` / `bin` suites green; `fmt` + `clippy` clean.

Note: I did *not* add a SIPp From assertion to `outbound_uas_answer.xml` — the wire capture above already proves the behaviour, and the UAC unit test is the durable guard. The outbound SIPp scenarios continue to validate the answer path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jFDxbuLq15NBUUjgDDgws
