### PR TITLE
chore(release): 0.37.3 — outbound INVITE caller-ID (From header)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.3] - 2026-07-21
+
 ### Fixed
 
 - **Outbound INVITE now carries the configured caller-ID in its From

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3811,7 +3811,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.37.2"
+version = "0.37.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.37.2"
+version = "0.37.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3875,7 +3875,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.37.2"
+version = "0.37.3"
 dependencies = [
  "base64",
  "bytes",
@@ -3897,7 +3897,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.37.2"
+version = "0.37.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3914,7 +3914,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.37.2"
+version = "0.37.3"
 dependencies = [
  "regex",
  "serde",
@@ -3933,7 +3933,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.37.2"
+version = "0.37.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3979,7 +3979,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.37.2"
+version = "0.37.3"
 dependencies = [
  "base64",
  "hmac",
@@ -4002,7 +4002,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.37.2"
+version = "0.37.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4027,7 +4027,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.37.2"
+version = "0.37.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -4045,7 +4045,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.37.2"
+version = "0.37.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4063,7 +4063,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.37.2"
+version = "0.37.3"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4077,7 +4077,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.37.2"
+version = "0.37.3"
 dependencies = [
  "regex",
  "serde",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.37.2"
+version = "0.37.3"
 dependencies = [
  "schemars",
  "serde",
@@ -4099,7 +4099,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.37.2"
+version = "0.37.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4126,7 +4126,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.37.2"
+version = "0.37.3"
 dependencies = [
  "base64",
  "rcgen",
@@ -4144,7 +4144,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.37.2"
+version = "0.37.3"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -4173,7 +4173,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.37.2"
+version = "0.37.3"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.37.2"
+version = "0.37.3"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.37.2.** Production-deployed against real carriers
+**Current release: v0.37.3.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a


### PR DESCRIPTION
Release-prep for **v0.37.3** per RELEASING.md §2. Patch release carrying the single post-0.37.2 fix now on main:

- **#316** — outbound INVITE now stamps the configured gateway/request caller-ID as its From header (was the daemon's local identity `sip:siphon@<public_address>`, which caller-ID-validating trunks decline). siphon-rs #65 `invite_with_from` + siphon-ai #317. **Verified on the wire** (`From: <sip:harness@127.0.0.1>`).

Together with **v0.37.2** (#312 TLS SNI), this completes the outbound **Twilio Secure Trunking** path: TLS connects *and* the From is accepted.

Mechanics: version 0.37.2 → 0.37.3, `Cargo.lock` refreshed (version strings only; siphon-rs pin unchanged at fcaff01), CHANGELOG `[Unreleased]` → `[0.37.3] - 2026-07-21` + fresh empty `[Unreleased]`, README marker moved. `check-version-consistency.py` (+ `--tag v0.37.3`) and `extract-changelog.py 0.37.3` green locally.

Merge, then tag `v0.37.3` on the merge commit to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jFDxbuLq15NBUUjgDDgws