### PR TITLE
feat(quality): TX packet/octet counters and RR cumulative-lost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **TX-side packet counters across the quality telemetry** (issue #320;
+  requires the forge-media pin bump to `f6151edf2724` =
+  [forge-media#93](https://github.com/thevoiceguy/forge-media/pull/93),
+  which publishes the underlying numbers on the `ForgeEvent` bus). Every
+  quality surface was `rx_*` only, so an operator could see what SiphonAI
+  *received* but never what it *sent* — "the outbound leg was clean" was a
+  ratio with no denominator behind it. Three fields close the gap:
+  `tx_packets_sent` and `tx_octets_sent` (locally measured on the
+  SiphonAI→caller stream, cumulative since call start; octets are RTP
+  payload only, the same basis as an RTCP SR's sender octet count), and
+  `tx_packets_lost_reported` (the far end's own **absolute** count of
+  packets it lost on that stream, from the latest RR's cumulative-lost
+  field). Together they express the sentence operators actually ask for
+  after a bad call: *"we sent 1,914 packets; the far end reported 12
+  lost."* `tx_packets_lost_reported` is **signed** — RFC 3550 §6.4.1
+  defines it that way because duplicates can push the peer's
+  packets-received past packets-expected, so consumers must parse it as a
+  signed integer and not clamp; a negative value is real information (a
+  duplicating path). Surfaces: the `rtp_stats` WS event (additive optional
+  fields, **protocol stays v1** as with the 0.30.0 `rx_*` addition), the
+  CDR `quality` block, `/admin/v1/calls/:id/stats`, and the `[quality]`
+  history records. CDR schema **stays at version 4** — additive optional
+  fields within an existing block, per CLAUDE.md §7.7 and the
+  `verstat_attest` / `recording_id` precedent (the v4 bump was for
+  introducing the block itself). CSV gains three append-only columns
+  (`quality_tx_packets_sent`, `quality_tx_octets_sent`,
+  `quality_tx_packets_lost_reported`) at the end of the header, so
+  position-keyed ingestors are unaffected. Motivated by a real 0.37.3
+  outbound call over a Twilio Secure trunk where `rx_packets_lost` 115 /
+  `rx_packets_received` 1914 was visible but the clean TX direction could
+  not be quantified in packets. Docs: `PROTOCOL.md` §3.8, `DEPLOY.md`;
+  schema regenerated; both server SDKs updated in lockstep.
+
+### Fixed
+
+- **`packet_loss_ratio` is documented correctly: it is a per-interval
+  figure, not a cumulative one** (issue #320, secondary item). The CDR
+  `quality` block's `avg/max_packet_loss_ratio` (`crates/cdr/src/schema.rs`),
+  `PROTOCOL.md` §3.8, and `DEPLOY.md` all described these as the
+  "RR-reported **cumulative**-loss ratio". They are derived from the RR's
+  `fraction_lost` field, which measures loss over the interval since the
+  *previous* report (RFC 3550 §6.4.1) — so `avg_packet_loss_ratio` is a
+  mean of interval fractions, and an operator reconciling it against a
+  carrier's cumulative figure would never get matching numbers. **The
+  emitted values are unchanged**; only the descriptions were wrong. The
+  field was deliberately *not* recomputed from the newly available
+  cumulative counter — that would silently change a published number for
+  existing consumers. Use `tx_packets_lost_reported / tx_packets_sent`
+  for a true whole-call loss rate.
+
 ## [0.37.3] - 2026-07-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "forge-codecs"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1c996ae5fb4f#1c996ae5fb4f06faa6c094d05bf09de64bd9b50e"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=f6151edf2724#f6151edf27243feff1cfaa3d37e9fe7194a2e06d"
 dependencies = [
  "audiopus",
  "ezk-g722",
@@ -1022,7 +1022,7 @@ dependencies = [
 [[package]]
 name = "forge-core"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1c996ae5fb4f#1c996ae5fb4f06faa6c094d05bf09de64bd9b50e"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=f6151edf2724#f6151edf27243feff1cfaa3d37e9fe7194a2e06d"
 dependencies = [
  "chrono",
  "serde",
@@ -1037,7 +1037,7 @@ dependencies = [
 [[package]]
 name = "forge-dtmf"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1c996ae5fb4f#1c996ae5fb4f06faa6c094d05bf09de64bd9b50e"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=f6151edf2724#f6151edf27243feff1cfaa3d37e9fe7194a2e06d"
 dependencies = [
  "chrono",
  "forge-core",
@@ -1049,7 +1049,7 @@ dependencies = [
 [[package]]
 name = "forge-engine"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1c996ae5fb4f#1c996ae5fb4f06faa6c094d05bf09de64bd9b50e"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=f6151edf2724#f6151edf27243feff1cfaa3d37e9fe7194a2e06d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1079,7 +1079,7 @@ dependencies = [
 [[package]]
 name = "forge-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1c996ae5fb4f#1c996ae5fb4f06faa6c094d05bf09de64bd9b50e"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=f6151edf2724#f6151edf27243feff1cfaa3d37e9fe7194a2e06d"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -1092,7 +1092,7 @@ dependencies = [
 [[package]]
 name = "forge-injection"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1c996ae5fb4f#1c996ae5fb4f06faa6c094d05bf09de64bd9b50e"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=f6151edf2724#f6151edf27243feff1cfaa3d37e9fe7194a2e06d"
 dependencies = [
  "forge-core",
  "rubato",
@@ -1105,7 +1105,7 @@ dependencies = [
 [[package]]
 name = "forge-mixer"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1c996ae5fb4f#1c996ae5fb4f06faa6c094d05bf09de64bd9b50e"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=f6151edf2724#f6151edf27243feff1cfaa3d37e9fe7194a2e06d"
 dependencies = [
  "bytes",
  "dashmap 6.2.1",
@@ -1119,7 +1119,7 @@ dependencies = [
 [[package]]
 name = "forge-recorder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1c996ae5fb4f#1c996ae5fb4f06faa6c094d05bf09de64bd9b50e"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=f6151edf2724#f6151edf27243feff1cfaa3d37e9fe7194a2e06d"
 dependencies = [
  "bytes",
  "forge-core",
@@ -1133,7 +1133,7 @@ dependencies = [
 [[package]]
 name = "forge-resampler"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1c996ae5fb4f#1c996ae5fb4f06faa6c094d05bf09de64bd9b50e"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=f6151edf2724#f6151edf27243feff1cfaa3d37e9fe7194a2e06d"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -1142,7 +1142,7 @@ dependencies = [
 [[package]]
 name = "forge-rtp"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1c996ae5fb4f#1c996ae5fb4f06faa6c094d05bf09de64bd9b50e"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=f6151edf2724#f6151edf27243feff1cfaa3d37e9fe7194a2e06d"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm 0.11.0",
@@ -1167,14 +1167,14 @@ dependencies = [
 [[package]]
 name = "forge-sdp"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1c996ae5fb4f#1c996ae5fb4f06faa6c094d05bf09de64bd9b50e"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=f6151edf2724#f6151edf27243feff1cfaa3d37e9fe7194a2e06d"
 dependencies = [
  "base64",
  "chrono",
  "forge-core",
  "forge-rtp",
  "rand 0.10.1",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=1c996ae5fb4f)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=f6151edf2724)",
  "smol_str",
  "thiserror 2.0.18",
 ]
@@ -1182,7 +1182,7 @@ dependencies = [
 [[package]]
 name = "forge-transcoder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1c996ae5fb4f#1c996ae5fb4f06faa6c094d05bf09de64bd9b50e"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=f6151edf2724#f6151edf27243feff1cfaa3d37e9fe7194a2e06d"
 dependencies = [
  "bytes",
  "forge-codecs",
@@ -1195,7 +1195,7 @@ dependencies = [
 [[package]]
 name = "forge-vad"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1c996ae5fb4f#1c996ae5fb4f06faa6c094d05bf09de64bd9b50e"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=f6151edf2724#f6151edf27243feff1cfaa3d37e9fe7194a2e06d"
 dependencies = [
  "thiserror 2.0.18",
  "tract-onnx",
@@ -3709,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1c996ae5fb4f#1c996ae5fb4f06faa6c094d05bf09de64bd9b50e"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=f6151edf2724#f6151edf27243feff1cfaa3d37e9fe7194a2e06d"
 dependencies = [
  "nom 7.1.3",
  "smol_str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,29 +164,36 @@ sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "fca
 # AI logic belongs in the WS server, never here. See CLAUDE.md §4.1 and the
 # upstream gate at https://github.com/thevoiceguy/forge-media/pull/39.
 #
-# forge-media is pinned to a `main` rev. Bumped 2026-07-16 to 1c996ae5fb4f
-# = forge-media #86: neural (Silero) VAD backend. forge-engine gains the
-# `neural-vad` feature here so `[media].vad = "neural"` is selectable at
-# runtime (docs/CONFIG.md); tract-onnx is pure Rust, so the static-musl
-# release build is unaffected. Feature-enabled builds need rustc >= 1.91
-# (tract 0.23) — our pinned toolchain is 1.95. (siphon-rs is pinned
-# separately above; see its own comment for the current rev.) Prior forge
-# pins: forge 3c59b5f6e464 = #82-#85 dependency migrations; forge
+# forge-media is pinned to a `main` rev. Bumped 2026-07-21 to f6151edf2724
+# = forge-media #93: TX packet/octet counters and RR cumulative-lost on the
+# event bus. `MediaStatsSnapshot` gains `tx_packets_sent` / `tx_octets_sent`
+# and `RtcpReportReceived` gains `cumulative_lost` / `extended_highest_seq`,
+# which is what makes siphon-ai #320's TX-side quality telemetry possible —
+# neither number was previously reachable from glue. Note two behaviour
+# changes that ride along: `MediaStatsSnapshot` now also publishes for a leg
+# that only *sends* (harmless here — our leg B is synthetic and carries no
+# RTP either way, see tap.rs "Single-leg model"), and forge's
+# `ParticipantStats::bytes_sent` now counts RTP payload octets uniformly
+# rather than mixing payload and wire lengths across send paths.
+# Feature-enabled builds need rustc >= 1.91 (tract 0.23) — our pinned
+# toolchain is 1.95. (siphon-rs is pinned separately above; see its own
+# comment for the current rev.) Prior forge pins: forge 1c996ae5fb4f = #86
+# neural VAD; forge 3c59b5f6e464 = #82-#85 dependency migrations; forge
 # 5fa76fb38675 = #81.
-forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "1c996ae5fb4f" }
-forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "1c996ae5fb4f" }
-forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "1c996ae5fb4f", default-features = false, features = ["g722", "dtls", "opus", "neural-vad"] }
-forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "1c996ae5fb4f" }
-forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "1c996ae5fb4f" }
-forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "1c996ae5fb4f" }
-forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "1c996ae5fb4f" }
-forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "1c996ae5fb4f" }
+forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "f6151edf2724" }
+forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "f6151edf2724" }
+forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "f6151edf2724", default-features = false, features = ["g722", "dtls", "opus", "neural-vad"] }
+forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "f6151edf2724" }
+forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "f6151edf2724" }
+forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "f6151edf2724" }
+forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "f6151edf2724" }
+forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "f6151edf2724" }
 # Conference rooms (0.7.0): forge-mixer is the per-room AudioMixer;
 # forge-injection provides ToneGenerator (join/leave tones now, MOH
 # for park later). Deliberately NOT forge-conference — its DTMF
 # IVR/PIN/host-control layer is unused per DEV_PLAN_0.7.0.md §9.4.
-forge-mixer     = { git = "https://github.com/thevoiceguy/forge-media", rev = "1c996ae5fb4f" }
-forge-injection = { git = "https://github.com/thevoiceguy/forge-media", rev = "1c996ae5fb4f" }
+forge-mixer     = { git = "https://github.com/thevoiceguy/forge-media", rev = "f6151edf2724" }
+forge-injection = { git = "https://github.com/thevoiceguy/forge-media", rev = "f6151edf2724" }
 
 # hep-rs — HEP3 codec, transport, HepSink trait. Owned by the same
 # author as siphon-rs and forge-media; lives in its own repo.

--- a/crates/bridge/src/conn.rs
+++ b/crates/bridge/src/conn.rs
@@ -235,6 +235,13 @@ pub enum OutgoingEvent {
         rx_packets_out_of_order: Option<u64>,
         /// Cumulative duplicate receives.
         rx_packets_duplicate: Option<u64>,
+        /// Cumulative RTP packets sent toward the caller (0.38.0).
+        tx_packets_sent: Option<u64>,
+        /// Cumulative RTP payload octets sent toward the caller (0.38.0).
+        tx_octets_sent: Option<u64>,
+        /// Far end's own absolute count of packets lost on the stream we
+        /// sent, from the latest RR (RFC 3550 §6.4.1). Signed (0.38.0).
+        tx_packets_lost_reported: Option<i64>,
         /// Transport-only MOS-CQE estimate in `[1.0, 5.0]`.
         mos_estimate: Option<f32>,
     },
@@ -917,6 +924,9 @@ fn build_bridge_out(event: OutgoingEvent, call_id: CallId, seq: Seq) -> BridgeOu
             rx_packets_lost,
             rx_packets_out_of_order,
             rx_packets_duplicate,
+            tx_packets_sent,
+            tx_octets_sent,
+            tx_packets_lost_reported,
             mos_estimate,
         } => BridgeOut::RtpStats {
             call_id,
@@ -929,6 +939,9 @@ fn build_bridge_out(event: OutgoingEvent, call_id: CallId, seq: Seq) -> BridgeOu
             rx_packets_lost,
             rx_packets_out_of_order,
             rx_packets_duplicate,
+            tx_packets_sent,
+            tx_octets_sent,
+            tx_packets_lost_reported,
             mos_estimate,
         },
         OutgoingEvent::Stop { reason } => BridgeOut::Stop {

--- a/crates/bridge/src/protocol.rs
+++ b/crates/bridge/src/protocol.rs
@@ -150,6 +150,13 @@ pub enum BridgeOut {
     /// stream SiphonAI sends), while the `rx_*` fields are **locally
     /// measured** on the stream SiphonAI receives from the caller. A
     /// congested path is often asymmetric — compare the two sides.
+    ///
+    /// The `tx_*` fields (0.38.0) complete the picture: `tx_packets_sent`
+    /// / `tx_octets_sent` are locally measured on what SiphonAI put on
+    /// the wire, and `tx_packets_lost_reported` is the far end's own
+    /// absolute loss total for that stream. Before these existed the
+    /// transmit direction had only ratios, so "the outbound leg was
+    /// clean" could never be backed by a packet count.
     RtpStats {
         call_id: CallId,
         seq: Seq,
@@ -188,6 +195,38 @@ pub enum BridgeOut {
         /// or `null` (0.30.0).
         #[serde(skip_serializing_if = "Option::is_none", default)]
         rx_packets_duplicate: Option<u64>,
+        /// RTP packets SiphonAI transmitted toward the caller (WS-server
+        /// audio played out, plus injected RFC 2833 DTMF), **cumulative
+        /// since call start**. `null` until the first local media-stats
+        /// snapshot (0.38.0).
+        ///
+        /// This is the denominator `packet_loss_ratio` never had: the
+        /// remote-reported loss fields describe *this* stream.
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        tx_packets_sent: Option<u64>,
+        /// RTP *payload* octets transmitted toward the caller, excluding
+        /// RTP headers and SRTP overhead (RFC 3550 §6.4.1
+        /// sender-octet-count basis). Cumulative, or `null` (0.38.0).
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        tx_octets_sent: Option<u64>,
+        /// The far end's own **absolute** count of packets it lost on the
+        /// SiphonAI→caller stream, taken from the latest RTCP RR's
+        /// cumulative-lost field (RFC 3550 §6.4.1). `null` until the
+        /// first RR arrives (0.38.0).
+        ///
+        /// May be **negative** — RFC 3550 defines the field as signed
+        /// because duplicates can push the far end's packets-received
+        /// past packets-expected. Consumers should parse it as a signed
+        /// integer and not clamp: a negative value is real information
+        /// (a duplicating path), not an error.
+        ///
+        /// Contrast `packet_loss_ratio`, which comes from the RR's
+        /// `fraction_lost` and covers only the interval since the
+        /// previous report. Pair this field with `tx_packets_sent` for a
+        /// whole-call loss rate that reconciles against a carrier's own
+        /// cumulative figure.
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        tx_packets_lost_reported: Option<i64>,
         /// Transport-only MOS-CQE estimate in `[1.0, 5.0]` (simplified
         /// E-model from local RX jitter/loss plus RTCP RTT — the same
         /// math heplify-server applies to HEP QoS chunks, so Homer-side
@@ -1109,6 +1148,9 @@ mod tests {
             rx_packets_lost: None,
             rx_packets_out_of_order: None,
             rx_packets_duplicate: None,
+            tx_packets_sent: None,
+            tx_octets_sent: None,
+            tx_packets_lost_reported: None,
             mos_estimate: None,
         };
         let v: serde_json::Value =
@@ -1127,6 +1169,9 @@ mod tests {
             "rx_packets_lost",
             "rx_packets_out_of_order",
             "rx_packets_duplicate",
+            "tx_packets_sent",
+            "tx_octets_sent",
+            "tx_packets_lost_reported",
             "mos_estimate",
         ] {
             assert!(!obj.contains_key(k), "{k} must be absent when None");
@@ -1157,6 +1202,45 @@ mod tests {
         assert_eq!(rx_packets_out_of_order, Some(2));
         assert_eq!(rx_packets_duplicate, Some(1));
         assert_eq!(mos_estimate, Some(4.2));
+    }
+
+    #[test]
+    fn bridge_out_rtp_stats_with_tx_fields() {
+        // 0.38.0: the transmit direction finally has counts, not just
+        // ratios — "we sent 1,914 packets; the far end reported 12 lost."
+        let raw = r#"{ "type": "rtp_stats", "call_id": "c", "seq": 51, "jitter_ms": 12.5, "packet_loss_ratio": 0.004, "rtcp_rtt_ms": 42.0, "tx_packets_sent": 1914, "tx_octets_sent": 306240, "tx_packets_lost_reported": 12, "mos_estimate": 4.2 }"#;
+        let msg: BridgeOut = assert_round_trip(raw);
+        let BridgeOut::RtpStats {
+            tx_packets_sent,
+            tx_octets_sent,
+            tx_packets_lost_reported,
+            ..
+        } = msg
+        else {
+            panic!("expected RtpStats");
+        };
+        assert_eq!(tx_packets_sent, Some(1914));
+        assert_eq!(tx_octets_sent, Some(306_240));
+        assert_eq!(tx_packets_lost_reported, Some(12));
+    }
+
+    #[test]
+    fn bridge_out_rtp_stats_negative_cumulative_lost_round_trips() {
+        // RFC 3550 §6.4.1 makes cumulative-lost signed: duplicates can
+        // push the far end's packets-received past packets-expected. A
+        // consumer parsing this as unsigned would read -3 as ~16.7M, so
+        // pin the sign through a full serialize/deserialize cycle.
+        let raw =
+            r#"{ "type": "rtp_stats", "call_id": "c", "seq": 9, "tx_packets_lost_reported": -3 }"#;
+        let msg: BridgeOut = assert_round_trip(raw);
+        let BridgeOut::RtpStats {
+            tx_packets_lost_reported,
+            ..
+        } = msg
+        else {
+            panic!("expected RtpStats");
+        };
+        assert_eq!(tx_packets_lost_reported, Some(-3));
     }
 
     #[test]

--- a/crates/cdr/src/csv.rs
+++ b/crates/cdr/src/csv.rs
@@ -35,12 +35,14 @@ quality_avg_packet_loss_ratio,quality_max_packet_loss_ratio,\
 quality_avg_rtcp_rtt_ms,\
 quality_rx_packets_received,quality_rx_packets_lost,\
 quality_rx_packets_out_of_order,quality_rx_packets_duplicate,\
-quality_mos_estimate_min,quality_mos_estimate_avg";
+quality_mos_estimate_min,quality_mos_estimate_avg,\
+quality_tx_packets_sent,quality_tx_octets_sent,\
+quality_tx_packets_lost_reported";
 
 /// Number of columns in [`HEADER`] (and every row). Only asserted in
 /// tests — production code appends by name, not position.
 #[cfg(test)]
-pub(crate) const COLUMNS: usize = 45;
+pub(crate) const COLUMNS: usize = 48;
 
 /// RFC 4180 field escaping: quote when the value contains a comma,
 /// quote, or line break; double embedded quotes.
@@ -163,8 +165,14 @@ pub fn record_to_row(r: &CdrRecord) -> String {
     cell!(opt o, q.and_then(|q| q.rx_packets_out_of_order));
     cell!(opt o, q.and_then(|q| q.rx_packets_duplicate));
     cell!(opt o, q.and_then(|q| q.mos_estimate_min));
+    // 0.38.0 TX columns append after the 0.30.0 quality block rather
+    // than sitting next to their rx_* counterparts: HEADER order is
+    // append-only so position-keyed ingestors survive the addition.
+    cell!(opt o, q.and_then(|q| q.mos_estimate_avg));
+    cell!(opt o, q.and_then(|q| q.tx_packets_sent));
+    cell!(opt o, q.and_then(|q| q.tx_octets_sent));
     // Last column: no trailing comma.
-    if let Some(v) = q.and_then(|q| q.mos_estimate_avg) {
+    if let Some(v) = q.and_then(|q| q.tx_packets_lost_reported) {
         let _ = write!(o, "{v}");
     }
 
@@ -307,6 +315,9 @@ mod tests {
             rx_packets_lost: Some(12),
             rx_packets_out_of_order: Some(3),
             rx_packets_duplicate: Some(0),
+            tx_packets_sent: Some(14_900),
+            tx_octets_sent: Some(2_384_000),
+            tx_packets_lost_reported: Some(12),
             mos_estimate_min: Some(3.9),
             mos_estimate_avg: Some(4.3),
         });

--- a/crates/cdr/src/schema.rs
+++ b/crates/cdr/src/schema.rs
@@ -218,7 +218,17 @@ pub struct QualityInfo {
     pub avg_jitter_ms: Option<f32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_jitter_ms: Option<f32>,
-    /// Mean / max of the RR-reported cumulative-loss ratio `[0.0, 1.0]`.
+    /// Mean / max of the RR-reported **per-interval** loss ratio
+    /// `[0.0, 1.0]`. Each sample is one RR's `fraction_lost` — loss over
+    /// the interval since the previous report (RFC 3550 §6.4.1) — so
+    /// this is a mean of interval fractions, **not** the call's
+    /// cumulative loss ratio. Reconciling against a carrier's cumulative
+    /// figure needs [`Self::tx_packets_lost_reported`] over
+    /// [`Self::tx_packets_sent`] instead.
+    ///
+    /// (Corrected in 0.38.0 — through 0.37.x these were documented as
+    /// the "RR-reported cumulative-loss ratio", which they never were.
+    /// The values are unchanged; only the description was wrong.)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub avg_packet_loss_ratio: Option<f32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -235,6 +245,24 @@ pub struct QualityInfo {
     pub rx_packets_out_of_order: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rx_packets_duplicate: Option<u64>,
+    /// End-of-call totals from the local transmit side
+    /// (SiphonAI→caller): RTP packets and *payload* octets we put on the
+    /// wire (0.38.0). `tx_octets_sent` excludes RTP headers and SRTP
+    /// overhead (RFC 3550 §6.4.1 sender-octet-count basis).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tx_packets_sent: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tx_octets_sent: Option<u64>,
+    /// The far end's own **absolute** count of packets lost on the
+    /// stream SiphonAI sent, from the call's last RTCP RR (RFC 3550
+    /// §6.4.1 cumulative-lost). Signed — a negative value is legitimate
+    /// when duplicates push the far end's packets-received past
+    /// packets-expected, so consumers should not clamp it (0.38.0).
+    ///
+    /// With [`Self::tx_packets_sent`] this answers the question the
+    /// block could not before: "we sent N, the far end lost M."
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tx_packets_lost_reported: Option<i64>,
     /// Worst / mean transport-only MOS-CQE estimate over the call
     /// (`[1.0, 5.0]`; see PROTOCOL.md §3.8 `mos_estimate`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -460,6 +488,9 @@ mod tests {
             rx_packets_lost: Some(12),
             rx_packets_out_of_order: Some(3),
             rx_packets_duplicate: Some(0),
+            tx_packets_sent: Some(14_900),
+            tx_octets_sent: Some(2_384_000),
+            tx_packets_lost_reported: Some(12),
             mos_estimate_min: Some(3.9),
             mos_estimate_avg: Some(4.3),
         });

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -2315,6 +2315,9 @@ pub(crate) fn quality_info(q: crate::call::QualityOutcome) -> siphon_ai_cdr::Qua
         rx_packets_lost: q.stats.rx.map(|rx| rx.packets_lost),
         rx_packets_out_of_order: q.stats.rx.map(|rx| rx.packets_out_of_order),
         rx_packets_duplicate: q.stats.rx.map(|rx| rx.packets_duplicate),
+        tx_packets_sent: q.stats.tx.map(|tx| tx.packets_sent),
+        tx_octets_sent: q.stats.tx.map(|tx| tx.octets_sent),
+        tx_packets_lost_reported: q.stats.tx_packets_lost_reported,
         mos_estimate_min: q.stats.mos_min,
         mos_estimate_avg: q.stats.mos_avg,
     }

--- a/crates/media-glue/src/rtp_stats.rs
+++ b/crates/media-glue/src/rtp_stats.rs
@@ -36,6 +36,28 @@
 //! two viewpoints ride the same `rtp_stats` wire event so consumers
 //! can spot asymmetric paths. A transport-only MOS-CQE estimate is
 //! derived from the RX side + RTCP RTT (see [`mos_estimate`]).
+//!
+//! ## TX side (0.38.0)
+//!
+//! Until 0.38.0 the transmit direction had ratios but no counts: an
+//! operator could see `packet_loss_ratio` but never answer "how many
+//! packets did we actually put on the wire?" — a ratio with no
+//! denominator behind it. Two numbers close that gap, both riding
+//! events forge already emits (upstream forge-media #93):
+//!
+//! - [`TxStats`] — `packets_sent` / `octets_sent` from the same
+//!   `MediaStatsSnapshot` that carries the RX counters, measured
+//!   locally on what we transmitted.
+//! - [`RtpStatsSnapshot::tx_packets_lost_reported`] — the RR's
+//!   *cumulative* lost count, i.e. the far end's own absolute total for
+//!   the stream we sent.
+//!
+//! Together they express the sentence operators actually ask for after
+//! a bad call: "we sent 1,914 packets; the far end reported 12 lost."
+//! Note that `packet_loss_ratio` is **not** that number — it comes from
+//! the RR's `fraction_lost`, which is loss over the interval since the
+//! previous report, so averaging it across a call yields a mean of
+//! interval fractions rather than a cumulative figure.
 
 use std::time::Duration;
 
@@ -48,6 +70,21 @@ pub struct RxStats {
     pub packets_lost: u64,
     pub packets_out_of_order: u64,
     pub packets_duplicate: u64,
+}
+
+/// Locally-measured transmit-side counters, cached verbatim from the
+/// latest `MediaStatsSnapshot` (0.38.0). Cumulative since call start.
+///
+/// Counts what SiphonAI put on the wire toward the caller: WS-server
+/// audio played out, plus any injected RFC 2833 DTMF. This is the
+/// denominator the RR-reported loss figures were always missing — see
+/// [`RtpStatsSnapshot::tx_packets_lost_reported`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TxStats {
+    pub packets_sent: u64,
+    /// RTP *payload* octets, excluding RTP headers and SRTP overhead
+    /// (RFC 3550 §6.4.1 sender-octet-count basis).
+    pub octets_sent: u64,
 }
 
 impl RxStats {
@@ -100,6 +137,22 @@ pub struct RtpStatsSnapshot {
     /// Latest locally-measured RX counters; `None` until the first
     /// `MediaStatsSnapshot` arrives (0.30.0).
     pub rx: Option<RxStats>,
+    /// Latest locally-measured TX counters; `None` until the first
+    /// `MediaStatsSnapshot` arrives (0.38.0).
+    pub tx: Option<TxStats>,
+    /// The far end's own *absolute* count of packets it lost on the
+    /// stream we sent, from the latest RR's cumulative-lost field
+    /// (RFC 3550 §6.4.1). `None` until the first RR arrives (0.38.0).
+    ///
+    /// Signed, and not a mistake: RFC 3550 defines the field as a
+    /// signed 24-bit quantity because duplicates can push the far
+    /// end's packets-received past packets-expected, so a healthy
+    /// stream can legitimately report a small negative total.
+    ///
+    /// Distinct from [`Self::packet_loss_ratio`], which is derived from
+    /// the RR's `fraction_lost` — an *interval* measure. Pair this with
+    /// [`Self::tx`]'s `packets_sent` for a whole-call loss rate.
+    pub tx_packets_lost_reported: Option<i64>,
     /// Transport-only MOS-CQE estimate; populated whenever `rx` is
     /// (RTT contributes when known, else 0 — see [`mos_estimate`]).
     pub mos_estimate: Option<f32>,
@@ -113,13 +166,24 @@ pub struct QualitySummary {
     /// Mean / max RR-reported jitter across the call's RTCP reports.
     pub avg_jitter_ms: Option<f32>,
     pub max_jitter_ms: Option<f32>,
-    /// Mean / max RR-reported cumulative-loss ratio.
+    /// Mean / max of the RR-reported *per-interval* loss ratio (each
+    /// sample is one RR's `fraction_lost`, i.e. loss since the previous
+    /// report). A mean of interval fractions — **not** the call's
+    /// cumulative loss ratio; for that use
+    /// [`Self::tx_packets_lost_reported`] over [`Self::tx`]'s
+    /// `packets_sent`.
     pub avg_packet_loss_ratio: Option<f32>,
     pub max_packet_loss_ratio: Option<f32>,
     /// Mean RTCP RTT across reports that carried one.
     pub avg_rtcp_rtt_ms: Option<f32>,
     /// Latest (cumulative) local receive-side counters.
     pub rx: Option<RxStats>,
+    /// Latest (cumulative) local transmit-side counters (0.38.0).
+    pub tx: Option<TxStats>,
+    /// Far end's absolute cumulative-lost count for the stream we sent,
+    /// from the last RR of the call (0.38.0). Signed per RFC 3550
+    /// §6.4.1 — see [`RtpStatsSnapshot::tx_packets_lost_reported`].
+    pub tx_packets_lost_reported: Option<i64>,
     /// Worst / mean transport-only MOS estimate, sampled once per
     /// local media-stats snapshot.
     pub mos_min: Option<f32>,
@@ -130,7 +194,10 @@ impl QualitySummary {
     /// True when no signal ever produced a sample — the CDR omits the
     /// whole block then.
     pub fn is_empty(&self) -> bool {
-        self.avg_jitter_ms.is_none() && self.rx.is_none() && self.avg_rtcp_rtt_ms.is_none()
+        self.avg_jitter_ms.is_none()
+            && self.rx.is_none()
+            && self.tx.is_none()
+            && self.avg_rtcp_rtt_ms.is_none()
     }
 }
 
@@ -175,6 +242,8 @@ pub struct RtpStatsTracker {
     last_packet_loss_ratio: Option<f32>,
     last_rtt_ms: Option<f32>,
     last_rx: Option<RxStats>,
+    last_tx: Option<TxStats>,
+    last_tx_packets_lost_reported: Option<i64>,
     agg: QualityAggregates,
 }
 
@@ -187,6 +256,8 @@ impl RtpStatsTracker {
             last_packet_loss_ratio: None,
             last_rtt_ms: None,
             last_rx: None,
+            last_tx: None,
+            last_tx_packets_lost_reported: None,
             agg: QualityAggregates::default(),
         }
     }
@@ -201,18 +272,25 @@ impl RtpStatsTracker {
         self.interval
     }
 
-    /// forge reported a `RtcpReportReceived` — cache the three RR-derived
+    /// forge reported a `RtcpReportReceived` — cache the RR-derived
     /// fields. `rtt_ms = None` is preserved as-is (we don't want the
     /// snapshot's `rtt_ms` to flip to `Some(0.0)` when forge can't yet
     /// compute RTT).
+    ///
+    /// `cumulative_lost` is the RR's whole-stream loss total, cached
+    /// verbatim (newest RR supersedes — it's cumulative, not a delta).
+    /// Unlike `rtt_ms` it is always present on an RR, so no
+    /// preserve-the-old-value dance is needed.
     pub fn note_rtcp_report(
         &mut self,
         jitter_ms: f32,
         packet_loss_ratio: f32,
+        cumulative_lost: i64,
         rtt_ms: Option<f32>,
     ) {
         self.last_jitter_ms = Some(jitter_ms);
         self.last_packet_loss_ratio = Some(packet_loss_ratio);
+        self.last_tx_packets_lost_reported = Some(cumulative_lost);
         if rtt_ms.is_some() {
             self.last_rtt_ms = rtt_ms;
         }
@@ -251,11 +329,16 @@ impl RtpStatsTracker {
     }
 
     /// forge published a `MediaStatsSnapshot` — cache the locally-
-    /// measured RX counters verbatim (they're cumulative; the newest
-    /// snapshot supersedes the previous one), and take one MOS sample
-    /// for the whole-call aggregates.
-    pub fn note_media_stats(&mut self, rx: RxStats) {
+    /// measured RX and TX counters verbatim (they're cumulative; the
+    /// newest snapshot supersedes the previous one), and take one MOS
+    /// sample for the whole-call aggregates.
+    ///
+    /// MOS is RX-only by construction: it scores what *we* heard, and
+    /// the TX counters carry no jitter/loss of their own (the far end's
+    /// view of our stream arrives via RRs instead).
+    pub fn note_media_stats(&mut self, rx: RxStats, tx: TxStats) {
         self.last_rx = Some(rx);
+        self.last_tx = Some(tx);
         let mos = mos_estimate(
             rx.jitter_ms,
             rx.loss_percent(),
@@ -281,6 +364,8 @@ impl RtpStatsTracker {
             avg_rtcp_rtt_ms: (self.agg.rtt_n > 0)
                 .then(|| (self.agg.rtt_sum / self.agg.rtt_n as f64) as f32),
             rx: self.last_rx,
+            tx: self.last_tx,
+            tx_packets_lost_reported: self.last_tx_packets_lost_reported,
             mos_min: (self.agg.mos_n > 0).then_some(self.agg.mos_min),
             mos_avg: (self.agg.mos_n > 0)
                 .then(|| (self.agg.mos_sum / self.agg.mos_n as f64) as f32),
@@ -303,6 +388,8 @@ impl RtpStatsTracker {
             packet_loss_ratio: self.last_packet_loss_ratio,
             rtt_ms: self.last_rtt_ms,
             rx: self.last_rx,
+            tx: self.last_tx,
+            tx_packets_lost_reported: self.last_tx_packets_lost_reported,
             mos_estimate: mos,
         }
     }
@@ -327,6 +414,7 @@ mod tests {
         t.note_rtcp_report(
             17.2,  /* jitter ms */
             0.025, /* 2.5% loss */
+            12,    /* cumulative lost */
             Some(42.0),
         );
         let snap = t.snapshot();
@@ -341,8 +429,8 @@ mod tests {
         // (e.g., a window with no matching SR) shouldn't wipe it.
         // This matches the §A.7 reality: RTT is sparse.
         let mut t = RtpStatsTracker::new(Some(Duration::from_secs(5)));
-        t.note_rtcp_report(10.0, 0.01, Some(35.0));
-        t.note_rtcp_report(11.0, 0.02, None);
+        t.note_rtcp_report(10.0, 0.01, 4, Some(35.0));
+        t.note_rtcp_report(11.0, 0.02, 9, None);
         let snap = t.snapshot();
         assert_eq!(snap.rtt_ms, Some(35.0));
         // …but jitter and loss DO update on every RR.
@@ -354,7 +442,7 @@ mod tests {
         // QualityRestored is a threshold event for jitter/loss only.
         // rtt_ms is an absolute measurement and shouldn't be reset.
         let mut t = RtpStatsTracker::new(Some(Duration::from_secs(5)));
-        t.note_rtcp_report(50.0, 0.1, Some(80.0));
+        t.note_rtcp_report(50.0, 0.1, 120, Some(80.0));
         t.note_quality_restored();
         let snap = t.snapshot();
         assert_eq!(snap.jitter_ms, Some(0.0));
@@ -428,6 +516,13 @@ mod tests {
         }
     }
 
+    fn tx(packets_sent: u64, octets_sent: u64) -> TxStats {
+        TxStats {
+            packets_sent,
+            octets_sent,
+        }
+    }
+
     #[test]
     fn fresh_tracker_has_no_rx_or_mos() {
         let t = RtpStatsTracker::new(Some(Duration::from_secs(5)));
@@ -439,7 +534,7 @@ mod tests {
     #[test]
     fn media_stats_populates_rx_and_mos() {
         let mut t = RtpStatsTracker::new(Some(Duration::from_secs(5)));
-        t.note_media_stats(rx(3.5, 1500, 6));
+        t.note_media_stats(rx(3.5, 1500, 6), tx(1914, 306_240));
         let snap = t.snapshot();
         assert_eq!(snap.rx, Some(rx(3.5, 1500, 6)));
         let mos = snap.mos_estimate.expect("MOS once RX data exists");
@@ -450,17 +545,85 @@ mod tests {
     fn newer_media_stats_supersede_older() {
         // Counters are cumulative — latest snapshot wins outright.
         let mut t = RtpStatsTracker::new(Some(Duration::from_secs(5)));
-        t.note_media_stats(rx(3.5, 500, 2));
-        t.note_media_stats(rx(4.0, 1500, 6));
+        t.note_media_stats(rx(3.5, 500, 2), tx(500, 80_000));
+        t.note_media_stats(rx(4.0, 1500, 6), tx(1914, 306_240));
         assert_eq!(t.snapshot().rx, Some(rx(4.0, 1500, 6)));
+    }
+
+    #[test]
+    fn fresh_tracker_has_no_tx_data() {
+        let t = RtpStatsTracker::new(Some(Duration::from_secs(5)));
+        let snap = t.snapshot();
+        assert!(snap.tx.is_none());
+        assert!(snap.tx_packets_lost_reported.is_none());
+    }
+
+    #[test]
+    fn media_stats_populates_tx_counters() {
+        let mut t = RtpStatsTracker::new(Some(Duration::from_secs(5)));
+        t.note_media_stats(rx(3.5, 1500, 6), tx(1914, 306_240));
+        assert_eq!(t.snapshot().tx, Some(tx(1914, 306_240)));
+    }
+
+    #[test]
+    fn newer_tx_counters_supersede_older() {
+        // Cumulative, like the RX side — latest snapshot wins outright.
+        let mut t = RtpStatsTracker::new(Some(Duration::from_secs(5)));
+        t.note_media_stats(rx(3.5, 500, 2), tx(500, 80_000));
+        t.note_media_stats(rx(4.0, 1500, 6), tx(1914, 306_240));
+        assert_eq!(t.snapshot().tx, Some(tx(1914, 306_240)));
+    }
+
+    #[test]
+    fn rr_populates_cumulative_lost_and_newest_wins() {
+        // Unlike rtt_ms (sparse, preserve-on-None), cumulative_lost
+        // rides every RR, so the newest value simply replaces.
+        let mut t = RtpStatsTracker::new(Some(Duration::from_secs(5)));
+        t.note_rtcp_report(10.0, 0.01, 4, Some(35.0));
+        assert_eq!(t.snapshot().tx_packets_lost_reported, Some(4));
+        t.note_rtcp_report(11.0, 0.02, 9, None);
+        assert_eq!(t.snapshot().tx_packets_lost_reported, Some(9));
+    }
+
+    #[test]
+    fn negative_cumulative_lost_survives() {
+        // RFC 3550 §6.4.1 permits a negative total when duplicates push
+        // the far end's packets-received past packets-expected. Clamping
+        // it to zero would hide a genuinely duplicating path, so the
+        // sign rides through to the wire.
+        let mut t = RtpStatsTracker::new(Some(Duration::from_secs(5)));
+        t.note_rtcp_report(10.0, 0.0, -3, None);
+        assert_eq!(t.snapshot().tx_packets_lost_reported, Some(-3));
+    }
+
+    #[test]
+    fn tx_counters_reach_the_quality_summary() {
+        // The CDR / quality-history path reads the summary, not the
+        // snapshot — both halves have to be wired.
+        let mut t = RtpStatsTracker::new(Some(Duration::from_secs(5)));
+        t.note_rtcp_report(10.0, 0.01, 12, None);
+        t.note_media_stats(rx(3.5, 1500, 6), tx(1914, 306_240));
+        let s = t.quality_summary();
+        assert_eq!(s.tx, Some(tx(1914, 306_240)));
+        assert_eq!(s.tx_packets_lost_reported, Some(12));
+        assert!(!s.is_empty());
+    }
+
+    #[test]
+    fn tx_alone_is_not_an_empty_summary() {
+        // A send-only stretch (we transmitted, nothing came back yet)
+        // still has something worth putting in the CDR.
+        let mut t = RtpStatsTracker::new(Some(Duration::from_secs(5)));
+        t.note_media_stats(rx(0.0, 0, 0), tx(500, 80_000));
+        assert!(!t.quality_summary().is_empty());
     }
 
     #[test]
     fn rx_does_not_disturb_remote_reported_fields() {
         // The two viewpoints are independent halves of the same event.
         let mut t = RtpStatsTracker::new(Some(Duration::from_secs(5)));
-        t.note_rtcp_report(17.2, 0.025, Some(42.0));
-        t.note_media_stats(rx(3.5, 1500, 6));
+        t.note_rtcp_report(17.2, 0.025, 12, Some(42.0));
+        t.note_media_stats(rx(3.5, 1500, 6), tx(1914, 306_240));
         let snap = t.snapshot();
         assert_eq!(snap.jitter_ms, Some(17.2));
         assert_eq!(snap.rtt_ms, Some(42.0));
@@ -509,7 +672,7 @@ mod tests {
         // Degenerate: snapshot before any packet counted. No panic,
         // 0% loss.
         let mut t = RtpStatsTracker::new(Some(Duration::from_secs(5)));
-        t.note_media_stats(rx(0.0, 0, 0));
+        t.note_media_stats(rx(0.0, 0, 0), tx(0, 0));
         let mos = t.snapshot().mos_estimate.expect("computable");
         assert!(mos > 4.0);
     }

--- a/crates/media-glue/src/tap.rs
+++ b/crates/media-glue/src/tap.rs
@@ -62,7 +62,7 @@ use std::time::{Duration, Instant};
 
 use crate::idle::{IdleDetector, IdleEvent};
 use crate::room::{RoomEvent, RoomMembership, RoomSender};
-use crate::rtp_stats::{QualityReport, RtpStatsTracker, RxStats};
+use crate::rtp_stats::{QualityReport, RtpStatsTracker, RxStats, TxStats};
 
 use forge_core::{CallId, DtmfDetectionMethod, DtmfEventKind, EventBus, ForgeError, ForgeEvent};
 use forge_dtmf::DtmfDigit;
@@ -1223,37 +1223,57 @@ impl MediaTap {
                                     call_id: cid,
                                     jitter_ms,
                                     packet_loss_ratio,
+                                    cumulative_lost,
                                     rtt_ms,
                                     ..
                                 } if cid == &self.call_id => {
                                     self.rtp_stats.note_rtcp_report(
                                         *jitter_ms,
                                         *packet_loss_ratio,
+                                        i64::from(*cumulative_lost),
                                         *rtt_ms,
                                     );
                                     self.publish_quality();
                                 }
-                                // Locally-measured RX-side counters
-                                // (0.30.0). No leg filter beyond the
-                                // call_id: in bridge mode exactly one
-                                // leg (the SIP peer) receives RTP, so
-                                // only that leg publishes snapshots.
+                                // Locally-measured RX- and TX-side
+                                // counters (0.30.0 / 0.38.0).
+                                //
+                                // Filtered to leg A, the SIP peer: per
+                                // the "Single-leg model" note above, B
+                                // is synthetic and never carries RTP,
+                                // so A is the only leg that describes
+                                // this call. forge publishes per leg
+                                // and its own emit guard widened in
+                                // forge-media #93 (send-only legs now
+                                // qualify), so pinning the leg here
+                                // keeps a future two-leg forge from
+                                // interleaving two cumulative series
+                                // into one tracker.
                                 ForgeEvent::MediaStatsSnapshot {
                                     call_id: cid,
+                                    leg: forge_core::MediaLeg::A,
                                     rx_packets_received,
                                     rx_packets_lost,
                                     rx_packets_out_of_order,
                                     rx_packets_duplicate,
                                     rx_jitter_ms,
+                                    tx_packets_sent,
+                                    tx_octets_sent,
                                     ..
                                 } if cid == &self.call_id => {
-                                    self.rtp_stats.note_media_stats(RxStats {
-                                        jitter_ms: *rx_jitter_ms,
-                                        packets_received: *rx_packets_received,
-                                        packets_lost: *rx_packets_lost,
-                                        packets_out_of_order: *rx_packets_out_of_order,
-                                        packets_duplicate: *rx_packets_duplicate,
-                                    });
+                                    self.rtp_stats.note_media_stats(
+                                        RxStats {
+                                            jitter_ms: *rx_jitter_ms,
+                                            packets_received: *rx_packets_received,
+                                            packets_lost: *rx_packets_lost,
+                                            packets_out_of_order: *rx_packets_out_of_order,
+                                            packets_duplicate: *rx_packets_duplicate,
+                                        },
+                                        TxStats {
+                                            packets_sent: *tx_packets_sent,
+                                            octets_sent: *tx_octets_sent,
+                                        },
+                                    );
                                     self.publish_quality();
                                 }
                                 ForgeEvent::QualityDegraded {
@@ -1934,6 +1954,9 @@ impl MediaTap {
                         rx_packets_lost: snap.rx.map(|rx| rx.packets_lost),
                         rx_packets_out_of_order: snap.rx.map(|rx| rx.packets_out_of_order),
                         rx_packets_duplicate: snap.rx.map(|rx| rx.packets_duplicate),
+                        tx_packets_sent: snap.tx.map(|tx| tx.packets_sent),
+                        tx_octets_sent: snap.tx.map(|tx| tx.octets_sent),
+                        tx_packets_lost_reported: snap.tx_packets_lost_reported,
                         mos_estimate: snap.mos_estimate,
                     };
                     if let Err(e) = events_tx.try_send(out) {

--- a/crates/quality/src/record.rs
+++ b/crates/quality/src/record.rs
@@ -77,6 +77,9 @@ mod tests {
             rx_packets_lost: Some(12),
             rx_packets_out_of_order: Some(3),
             rx_packets_duplicate: Some(0),
+            tx_packets_sent: Some(14_900),
+            tx_octets_sent: Some(2_384_000),
+            tx_packets_lost_reported: Some(12),
             mos_estimate_min: Some(3.9),
             mos_estimate_avg: Some(4.3),
         }

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -753,6 +753,9 @@ practice — restart is simpler).
     "rx_packets_lost": 12,
     "rx_packets_out_of_order": 3,
     "rx_packets_duplicate": 0,
+    "tx_packets_sent": 14900,
+    "tx_octets_sent": 2384000,
+    "tx_packets_lost_reported": 12,
     "mos_estimate_min": 3.9,
     "mos_estimate_avg": 4.3
   }
@@ -861,10 +864,30 @@ that never produced data is omitted, not zeroed, so `"clean"` and
 - `quality.avg/max_jitter_ms`, `avg/max_packet_loss_ratio`,
   `avg_rtcp_rtt_ms` — aggregates over the call's RTCP Receiver Reports
   (remote-reported: how the far end received SiphonAI's stream).
+  **`avg/max_packet_loss_ratio` are means/maxima of per-interval
+  fractions**, each sample being one RR's `fraction_lost` (loss since the
+  previous report, RFC 3550 §6.4.1) — *not* the call's cumulative loss
+  ratio, and they will not reconcile against a carrier's cumulative
+  figure. Through 0.37.x these were documented as cumulative; the values
+  never changed, only the description was wrong. For a whole-call loss
+  rate use `tx_packets_lost_reported / tx_packets_sent`.
 - `quality.rx_packets_*` — end-of-call totals measured locally on the
   caller→SiphonAI stream (received / lost / out-of-order / duplicate).
+- `quality.tx_packets_sent` / `tx_octets_sent` (0.38.0) — end-of-call
+  totals measured locally on the SiphonAI→caller stream. `tx_octets_sent`
+  counts RTP **payload** octets only (no headers, no SRTP overhead), the
+  same basis as an RTCP SR's sender octet count.
+- `quality.tx_packets_lost_reported` (0.38.0) — the far end's own
+  absolute count of packets it lost on that stream, from the call's last
+  RR. With `tx_packets_sent` this gives operators the sentence they
+  actually ask for after a bad call: *"we sent 14,900 packets; the far
+  end reported 12 lost."* **Signed** — a negative value is legitimate
+  (duplicates pushing the peer's received count past expected), so don't
+  clamp it.
 - `quality.mos_estimate_min/avg` — worst / mean transport-only MOS-CQE
-  estimate (1.0–5.0; see PROTOCOL.md §3.8 `mos_estimate`).
+  estimate (1.0–5.0; see PROTOCOL.md §3.8 `mos_estimate`). RX-only by
+  construction: it scores what SiphonAI heard, so the `tx_*` counters
+  don't feed it.
 
 Outbound originated calls (0.6.0, `POST /admin/v1/calls`) produce the same
 record with `direction: "outbound"` — the schema stays at version 1 (the
@@ -911,6 +934,9 @@ the top level, with framing fields:
   "rx_packets_lost": 4,
   "rx_packets_out_of_order": 1,
   "rx_packets_duplicate": 0,
+  "tx_packets_sent": 4850,
+  "tx_octets_sent": 776000,
+  "tx_packets_lost_reported": 2,
   "mos_estimate_min": 4.1,
   "mos_estimate_avg": 4.3
 }

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -361,6 +361,8 @@ hung call or connectivity issue; typical reaction is to hang up.
   "jitter_ms": 12.5, "packet_loss_ratio": 0.004, "rtcp_rtt_ms": 42.0,
   "rx_jitter_ms": 3.75, "rx_packets_received": 1500, "rx_packets_lost": 6,
   "rx_packets_out_of_order": 2, "rx_packets_duplicate": 1,
+  "tx_packets_sent": 1914, "tx_octets_sent": 306240,
+  "tx_packets_lost_reported": 12,
   "mos_estimate": 4.2 }
 ```
 
@@ -369,8 +371,8 @@ per-route override; `0` disables). The cadence mirrors RTCP's compound-
 report interval (RFC 3550 §6.2) so values track the underlying RTCP
 arrivals.
 
-Two viewpoints ride together (the `rx_*` fields and `mos_estimate` are
-additive in 0.30.0; protocol stays v1):
+Three viewpoints ride together (the `rx_*` fields and `mos_estimate` are
+additive in 0.30.0, the `tx_*` fields in 0.38.0; protocol stays v1):
 
 - `jitter_ms` / `packet_loss_ratio` / `rtcp_rtt_ms` are
   **remote-reported** — derived from the far end's RTCP Receiver
@@ -379,6 +381,21 @@ additive in 0.30.0; protocol stays v1):
   *receives* from the caller. A congested path is often asymmetric;
   compare the two sides to tell "they hear us badly" from "we hear
   them badly."
+- `tx_*` fields describe the stream SiphonAI *sends*:
+  `tx_packets_sent` / `tx_octets_sent` are locally measured, and
+  `tx_packets_lost_reported` is the far end's own absolute loss total
+  for that stream. Together they answer the question the remote-reported
+  ratios alone never could: **"we sent 1,914 packets; the far end
+  reported 12 lost."**
+
+> **`packet_loss_ratio` is a per-interval figure, not a cumulative one.**
+> It comes from the RR's `fraction_lost` field, which measures loss since
+> the *previous* report (RFC 3550 §6.4.1). Averaging it over a call gives
+> a mean of interval fractions, which will not reconcile against a
+> carrier's cumulative loss count. For a whole-call loss rate, divide
+> `tx_packets_lost_reported` by `tx_packets_sent`. (Through 0.37.x this
+> field was mis-documented as cumulative; the values never changed, only
+> the description was wrong.)
 
 Fields are JSON `null` (omitted) until the corresponding source has
 produced its first data for the call:
@@ -386,19 +403,29 @@ produced its first data for the call:
 | Field                | Type            | Notes |
 |----------------------|-----------------|-------|
 | `jitter_ms`          | float \| null   | Estimated inter-arrival jitter (remote-reported). `null` if no RTCP RR has arrived yet. After a `QualityRestored` event in forge, this resets to `0.0` — distinct from `null`. |
-| `packet_loss_ratio`  | float \| null   | Loss as a ratio in `[0.0, 1.0]` (NOT a percent), remote-reported. Same `null` / `0.0` distinction. |
+| `packet_loss_ratio`  | float \| null   | Loss as a ratio in `[0.0, 1.0]` (NOT a percent), remote-reported, covering **only the interval since the previous RR** (RFC 3550 `fraction_lost`). Same `null` / `0.0` distinction. Not cumulative — see the note above. |
 | `rtcp_rtt_ms`        | float \| null   | Mean round-trip time over the reporting window. `null` until forge originates its own RTCP SRs (deferred to 0.3.1). Distinct from `0.0`, which is degenerate; once populated, the field is sticky — a window with no fresh RTT sample preserves the last measurement rather than reverting to `null`. |
 | `rx_jitter_ms`       | float \| null   | Locally-computed interarrival jitter (RFC 3550 §6.4.1) on the caller→SiphonAI stream. `null` until the first local media-stats snapshot (~5 s in). |
 | `rx_packets_received`| int \| null     | Unique RTP packets received from the caller, **cumulative since call start** (duplicates excluded). |
 | `rx_packets_lost`    | int \| null     | Sequence-gap loss on the receive side, cumulative. Late arrivals repair the count retroactively, so it may decrease between snapshots. |
 | `rx_packets_out_of_order` | int \| null | Packets that arrived after a newer sequence number had been seen, cumulative. |
 | `rx_packets_duplicate` | int \| null   | Re-receives of a recently seen sequence number, cumulative. |
-| `mos_estimate`       | float \| null   | Transport-only MOS-CQE estimate in `[1.0, 5.0]`: simplified E-model over local RX jitter/loss plus RTCP RTT — the same math heplify-server applies to SiphonAI's HEP QoS chunks, so Homer-side and WS-side scores agree. Transport impairment only (no codec/content scoring). `null` until RX data exists; slightly optimistic while `rtcp_rtt_ms` is still `null`. |
+| `tx_packets_sent`    | int \| null     | RTP packets SiphonAI transmitted toward the caller — WS-server audio played out plus injected RFC 2833 DTMF — **cumulative since call start**. `null` until the first local media-stats snapshot (~5 s in). |
+| `tx_octets_sent`     | int \| null     | RTP **payload** octets transmitted, cumulative. Excludes RTP headers and SRTP overhead (same basis as an RTCP SR's sender octet count), so this is smaller than the bytes seen on the wire. |
+| `tx_packets_lost_reported` | int \| null | The far end's own **absolute** count of packets it lost on the SiphonAI→caller stream, from the latest RR's cumulative-lost field. `null` until the first RR arrives. **May be negative** — RFC 3550 defines it as signed because duplicates can push the peer's packets-received past packets-expected. Parse as a signed integer and don't clamp: a negative value means a duplicating path, not an error. |
+| `mos_estimate`       | float \| null   | Transport-only MOS-CQE estimate in `[1.0, 5.0]`: simplified E-model over local RX jitter/loss plus RTCP RTT — the same math heplify-server applies to SiphonAI's HEP QoS chunks, so Homer-side and WS-side scores agree. Transport impairment only (no codec/content scoring). `null` until RX data exists; slightly optimistic while `rtcp_rtt_ms` is still `null`. MOS is RX-only by construction — it scores what SiphonAI heard, so the `tx_*` counters do not feed it. |
 
-The `rx_packets_*` counters are cumulative — diff successive snapshots
-for rates. Codec and sample-rate are constant for a call — consumers
-should correlate to the `start` message (§3.1) rather than expecting
-them on every snapshot.
+The `rx_packets_*` and `tx_*` counters are cumulative — diff successive
+snapshots for rates. Codec and sample-rate are constant for a call —
+consumers should correlate to the `start` message (§3.1) rather than
+expecting them on every snapshot.
+
+Note that `tx_packets_sent` and `tx_packets_lost_reported` refresh on
+different clocks: the former on SiphonAI's local media-stats cadence, the
+latter only when an RR arrives (typically every 5 s, but entirely at the
+peer's discretion). A loss rate computed from one snapshot is therefore
+approximate mid-call; at end of call both have settled and the CDR
+`quality` block carries the final pair.
 
 ### 3.9 `stop` — call ended
 

--- a/schemas/siphon-ai.v1.json
+++ b/schemas/siphon-ai.v1.json
@@ -687,7 +687,7 @@
           "type": "object"
         },
         {
-          "description": "Periodic snapshot of RTP / RTCP quality, emitted every\n`[bridge].rtp_stats_interval_ms` (default 5 s, configurable\nper-route; `0` disables). Fields are JSON `null` until forge\nhas reported its first quality assessment for the call.\nCodec / sample rate are constant for the call — consumers\nshould correlate to the `start` message.\n\nTwo viewpoints ride together (0.30.0): the original three fields\nare **remote-reported** (RTCP RRs: how the far end receives the\nstream SiphonAI sends), while the `rx_*` fields are **locally\nmeasured** on the stream SiphonAI receives from the caller. A\ncongested path is often asymmetric — compare the two sides.",
+          "description": "Periodic snapshot of RTP / RTCP quality, emitted every\n`[bridge].rtp_stats_interval_ms` (default 5 s, configurable\nper-route; `0` disables). Fields are JSON `null` until forge\nhas reported its first quality assessment for the call.\nCodec / sample rate are constant for the call — consumers\nshould correlate to the `start` message.\n\nTwo viewpoints ride together (0.30.0): the original three fields\nare **remote-reported** (RTCP RRs: how the far end receives the\nstream SiphonAI sends), while the `rx_*` fields are **locally\nmeasured** on the stream SiphonAI receives from the caller. A\ncongested path is often asymmetric — compare the two sides.\n\nThe `tx_*` fields (0.38.0) complete the picture: `tx_packets_sent`\n/ `tx_octets_sent` are locally measured on what SiphonAI put on\nthe wire, and `tx_packets_lost_reported` is the far end's own\nabsolute loss total for that stream. Before these existed the\ntransmit direction had only ratios, so \"the outbound leg was\nclean\" could never be backed by a packet count.",
           "properties": {
             "call_id": {
               "$ref": "#/$defs/CallId"
@@ -772,6 +772,32 @@
               "format": "uint64",
               "minimum": 0,
               "type": "integer"
+            },
+            "tx_octets_sent": {
+              "description": "RTP *payload* octets transmitted toward the caller, excluding\nRTP headers and SRTP overhead (RFC 3550 §6.4.1\nsender-octet-count basis). Cumulative, or `null` (0.38.0).",
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "tx_packets_lost_reported": {
+              "description": "The far end's own **absolute** count of packets it lost on the\nSiphonAI→caller stream, taken from the latest RTCP RR's\ncumulative-lost field (RFC 3550 §6.4.1). `null` until the\nfirst RR arrives (0.38.0).\n\nMay be **negative** — RFC 3550 defines the field as signed\nbecause duplicates can push the far end's packets-received\npast packets-expected. Consumers should parse it as a signed\ninteger and not clamp: a negative value is real information\n(a duplicating path), not an error.\n\nContrast `packet_loss_ratio`, which comes from the RR's\n`fraction_lost` and covers only the interval since the\nprevious report. Pair this field with `tx_packets_sent` for a\nwhole-call loss rate that reconciles against a carrier's own\ncumulative figure.",
+              "format": "int64",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "tx_packets_sent": {
+              "description": "RTP packets SiphonAI transmitted toward the caller (WS-server\naudio played out, plus injected RFC 2833 DTMF), **cumulative\nsince call start**. `null` until the first local media-stats\nsnapshot (0.38.0).\n\nThis is the denominator `packet_loss_ratio` never had: the\nremote-reported loss fields describe *this* stream.",
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "type": {
               "const": "rtp_stats",

--- a/sdks/python/src/siphon_ai_server/events.py
+++ b/sdks/python/src/siphon_ai_server/events.py
@@ -193,7 +193,10 @@ class RtpStats:
     call_id: str
     seq: int
     # Remote-reported (RTCP RRs): how the far end receives the stream
-    # SiphonAI sends.
+    # SiphonAI sends. packet_loss_ratio covers only the interval since
+    # the previous RR (RFC 3550 fraction_lost) -- averaging it across a
+    # call does NOT give the cumulative loss ratio. Use
+    # tx_packets_lost_reported / tx_packets_sent for that.
     jitter_ms: float | None = None
     packet_loss_ratio: float | None = None
     rtcp_rtt_ms: float | None = None
@@ -204,7 +207,18 @@ class RtpStats:
     rx_packets_lost: int | None = None
     rx_packets_out_of_order: int | None = None
     rx_packets_duplicate: int | None = None
-    # Transport-only MOS-CQE estimate in [1.0, 5.0] (0.30.0).
+    # Locally measured on the SiphonAI->caller stream (0.38.0),
+    # cumulative since call start. tx_octets_sent counts RTP payload
+    # octets only -- no headers, no SRTP overhead.
+    tx_packets_sent: int | None = None
+    tx_octets_sent: int | None = None
+    # The far end's own absolute count of packets it lost on the stream
+    # SiphonAI sends, from the latest RR (0.38.0). SIGNED: RFC 3550
+    # allows a negative total when duplicates push the peer's
+    # packets-received past packets-expected -- don't clamp it.
+    tx_packets_lost_reported: int | None = None
+    # Transport-only MOS-CQE estimate in [1.0, 5.0] (0.30.0). RX-only by
+    # construction -- the tx_* counters don't feed it.
     mos_estimate: float | None = None
 
 

--- a/sdks/python/tests/test_events.py
+++ b/sdks/python/tests/test_events.py
@@ -24,6 +24,7 @@ sys.path.insert(0, str(REPO / "sdks" / "python" / "src"))
 from siphon_ai_server import events  # noqa: E402
 from siphon_ai_server.events import (  # noqa: E402
     BargeInResolved,
+    RtpStats,
     SpeechStarted,
     Start,
     UnknownEvent,
@@ -194,6 +195,35 @@ class ToleranceTest(unittest.TestCase):
         )
         self.assertTrue(armed.decision_pending)
         self.assertEqual(armed.decision_deadline_ms, 500)
+
+    def test_rtp_stats_tx_fields(self) -> None:
+        # Pre-0.38.0 shape: no tx_* fields on the wire.
+        plain = parse_event(
+            '{"type": "rtp_stats", "call_id": "c", "seq": 4,'
+            ' "packet_loss_ratio": 0.004}'
+        )
+        self.assertIsInstance(plain, RtpStats)
+        self.assertIsNone(plain.tx_packets_sent)
+        self.assertIsNone(plain.tx_packets_lost_reported)
+        # 0.38.0: the transmit direction has counts, not just ratios.
+        full = parse_event(
+            '{"type": "rtp_stats", "call_id": "c", "seq": 5,'
+            ' "tx_packets_sent": 1914, "tx_octets_sent": 306240,'
+            ' "tx_packets_lost_reported": 12}'
+        )
+        self.assertEqual(full.tx_packets_sent, 1914)
+        self.assertEqual(full.tx_octets_sent, 306240)
+        self.assertEqual(full.tx_packets_lost_reported, 12)
+
+    def test_rtp_stats_cumulative_lost_may_be_negative(self) -> None:
+        # RFC 3550 6.4.1 signs the field: duplicates can push the peer's
+        # packets-received past packets-expected. Parsing it as unsigned
+        # would turn -3 into ~16.7M, so pin the sign.
+        event = parse_event(
+            '{"type": "rtp_stats", "call_id": "c", "seq": 6,'
+            ' "tx_packets_lost_reported": -3}'
+        )
+        self.assertEqual(event.tx_packets_lost_reported, -3)
 
     def test_barge_in_resolved_parses_every_outcome(self) -> None:
         for outcome in ("confirmed", "rejected", "timeout"):

--- a/sdks/typescript/src/events.ts
+++ b/sdks/typescript/src/events.ts
@@ -112,6 +112,11 @@ export interface RtpStats extends Base {
   type: "rtp_stats";
   /** Remote-reported (RTCP RR): how the far end receives SiphonAI's stream. */
   jitter_ms?: number | null;
+  /**
+   * Loss ratio over the *interval* since the previous RR (RFC 3550
+   * `fraction_lost`) — averaging this across a call does NOT yield the
+   * cumulative loss ratio. Use `tx_packets_lost_reported / tx_packets_sent`.
+   */
   packet_loss_ratio?: number | null;
   rtcp_rtt_ms?: number | null;
   /** Locally measured on the caller→SiphonAI stream (0.30.0). */
@@ -121,7 +126,24 @@ export interface RtpStats extends Base {
   rx_packets_lost?: number | null;
   rx_packets_out_of_order?: number | null;
   rx_packets_duplicate?: number | null;
-  /** Transport-only MOS-CQE estimate in [1.0, 5.0] (0.30.0). */
+  /**
+   * Locally measured on the SiphonAI→caller stream (0.38.0), cumulative
+   * since call start. `tx_octets_sent` counts RTP payload octets only —
+   * no headers, no SRTP overhead.
+   */
+  tx_packets_sent?: number | null;
+  tx_octets_sent?: number | null;
+  /**
+   * The far end's own absolute count of packets it lost on the stream
+   * SiphonAI sends, from the latest RR (0.38.0). **Signed** — RFC 3550
+   * allows a negative total when duplicates push the peer's
+   * packets-received past packets-expected, so don't clamp it.
+   */
+  tx_packets_lost_reported?: number | null;
+  /**
+   * Transport-only MOS-CQE estimate in [1.0, 5.0] (0.30.0). RX-only by
+   * construction — the `tx_*` counters don't feed it.
+   */
   mos_estimate?: number | null;
 }
 

--- a/sdks/typescript/test/events.test.ts
+++ b/sdks/typescript/test/events.test.ts
@@ -156,6 +156,32 @@ test("pause-mode barge-in shapes parse typed (0.32.0)", () => {
   }
 });
 
+test("rtp_stats tx counters parse typed (0.38.0)", () => {
+  // Pre-0.38.0 shape: tx_* fields simply absent.
+  const plain = parseEvent(
+    '{"type":"rtp_stats","call_id":"c","seq":4,"packet_loss_ratio":0.004}',
+  );
+  assert.ok(plain.type === "rtp_stats");
+  assert.equal(plain.tx_packets_sent, undefined);
+
+  const full = parseEvent(
+    '{"type":"rtp_stats","call_id":"c","seq":5,"tx_packets_sent":1914,"tx_octets_sent":306240,"tx_packets_lost_reported":12}',
+  );
+  assert.ok(full.type === "rtp_stats");
+  assert.equal(full.tx_packets_sent, 1914);
+  assert.equal(full.tx_octets_sent, 306240);
+  assert.equal(full.tx_packets_lost_reported, 12);
+
+  // RFC 3550 §6.4.1 signs cumulative-lost: duplicates can push the
+  // peer's packets-received past packets-expected. Reading it as
+  // unsigned would turn -3 into ~16.7M.
+  const dup = parseEvent(
+    '{"type":"rtp_stats","call_id":"c","seq":6,"tx_packets_lost_reported":-3}',
+  );
+  assert.ok(dup.type === "rtp_stats");
+  assert.equal(dup.tx_packets_lost_reported, -3);
+});
+
 test("unknown type wraps, unknown fields pass through, malformed throws", () => {
   const unknown = parseEvent('{"type": "yodel", "call_id": "c"}');
   assert.equal(unknown.type, "unknown");


### PR DESCRIPTION
Closes #320. Upstream half: [thevoiceguy/forge-media#93](https://github.com/thevoiceguy/forge-media/pull/93) (merged).

## What this does

Every quality surface was `rx_*` only, so an operator could see what SiphonAI *received* but never what it *sent*. "The outbound leg was clean" was a ratio with no denominator behind it. Three fields close that gap:

| Field | Source | Meaning |
|---|---|---|
| `tx_packets_sent` | `MediaStatsSnapshot` (local) | RTP packets transmitted toward the caller, cumulative |
| `tx_octets_sent` | `MediaStatsSnapshot` (local) | RTP **payload** octets — no headers, no SRTP overhead (SR sender-octet-count basis) |
| `tx_packets_lost_reported` | RTCP RR `cumulative_lost` | The far end's own **absolute** loss total for that stream |

Together they express the sentence operators ask for after a bad call: *"we sent 1,914 packets; the far end reported 12 lost."*

**Surfaces:** `rtp_stats` WS event, CDR `quality` block, `/admin/v1/calls/:id/stats`, `[quality]` history records. The last two come for free — `/stats` serializes `QualityInfo` and `QualityRecord` `#[serde(flatten)]`s it.

## Versioning decisions (both flagged in the issue as "confirm at review")

- **Protocol stays v1.** Additive optional fields, same as the 0.30.0 `rx_*` addition.
- **CDR stays at version 4.** Additive optional fields *within an existing block*, per CLAUDE.md §7.7 and the `verstat_attest` / `recording_id` precedent. The v4 bump was for introducing the `quality` block itself; the 0.9.5 new-block precedent doesn't apply to fields inside one. Easy to change if you'd rather consumers gate on `version >= 5`.
- **CSV columns append at the end of the header** (after `quality_mos_estimate_avg`), not next to their `rx_*` counterparts, so position-keyed ingestors survive.

## `tx_packets_lost_reported` is signed — deliberately

RFC 3550 §6.4.1 defines cumulative-lost as signed because duplicates can push the peer's packets-received past packets-expected. A consumer parsing it as unsigned reads `-3` as ~16.7M. This is pinned by a round-trip test in the Rust protocol tests and in both SDK suites, and called out in `PROTOCOL.md`, the CDR schema doc, and both SDK type definitions.

## The `packet_loss_ratio` doc fix (issue's secondary item)

`crates/cdr/src/schema.rs`, `PROTOCOL.md` §3.8, and `DEPLOY.md` all described `avg/max_packet_loss_ratio` as the "RR-reported **cumulative**-loss ratio". They're derived from `fraction_lost`, which is loss over the interval since the previous report — so the average is a mean of interval fractions and was never going to reconcile against a carrier's cumulative figure.

The issue offered two options; I took the conservative one: **corrected the wording, left the values alone.** Recomputing the field from the now-available cumulative counter would silently change a published number for existing consumers. `tx_packets_lost_reported / tx_packets_sent` is the true whole-call rate, and it's documented as such. Say the word if you'd rather recompute.

## One thing the issue didn't anticipate

The `MediaStatsSnapshot` arm is now **pinned to leg A**. It previously had no leg filter, relying on "in bridge mode exactly one leg receives RTP". forge-media#93 widened forge's emit guard so a *send-only* leg now publishes too. That's harmless today — per tap.rs's "Single-leg model" our leg B is synthetic and carries no RTP in either direction, which I verified before bumping the pin — but the unfiltered arm would interleave two cumulative series into one tracker if forge ever drove B. Pinning the leg makes the documented invariant enforced rather than assumed.

## Upstream bump

`1c996ae5fb4f` → `f6151edf2724`. Two forge behaviour changes ride along, both noted in the `Cargo.toml` comment: the widened `MediaStatsSnapshot` emit guard (above), and `ParticipantStats::bytes_sent` now counting RTP payload octets uniformly instead of mixing payload and wire lengths across send paths — which is what makes `tx_octets_sent` a well-defined number.

## Testing

Per CLAUDE.md §7.5 (upstream bump requires the full suite):

- `cargo test --workspace --locked` — **1021 passed, 0 failed**
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `python3 scripts/check-protocol-schema.py` — schema ↔ Rust consistent, 43 PROTOCOL.md examples validate
- Python SDK — 16 passed; TypeScript SDK — 10 passed (both gained tx-field + negative-value tests)
- SIPp `run-all.sh` — **all 37 scenarios pass** on this branch with the forge-media bump applied.

No new metrics: the existing cumulative `rx_packets_*` counters have none either (only the instantaneous `rx_jitter_ms` is recorded as a histogram), and a histogram over a monotonic counter is meaningless. Happy to add gauges if you want them in Prometheus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGrL8HBEfyq5sigAdLriRq
