### PR TITLE
chore(sipp): preflight the echo WS server instead of failing mid-run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   not be quantified in packets. Docs: `PROTOCOL.md` §3.8, `DEPLOY.md`;
   schema regenerated; both server SDKs updated in lockstep.
 
+### Changed
+
+- **SIPp harness**: `run-all.sh` now preflights the echo WS server the
+  same way it already preflights `sipp` and the daemon binary, exiting
+  `2` with start-up instructions instead of running the suite without
+  it. Previously a missing server produced eight scenario failures
+  scattered across five phases (`basic_call_then_bye`,
+  `session_timer_echo`, `reinvite_hold_resume`,
+  `reinvite_unsupported_codec_488`, `session_progress_then_answer`,
+  `stir_shaken_attestation_pass`, `digest_auth_caller`,
+  `recording_writes_valid_wav`) — every scenario whose call must reach
+  ACTIVE aborts on an unexpected BYE when the daemon tears the call down
+  after the bridge can't connect, while scenarios that reject before
+  bridging (488 / 428 / 403 / 503, CANCEL) still pass. The split reads
+  like a signalling regression rather than a missing prerequisite, and a
+  baseline-vs-branch comparison reproduces it identically on both sides,
+  which makes the wrong conclusion look confirmed. CI was already
+  immune — `.github/workflows/test.yml` starts the server and waits for
+  the bind before invoking the script — so this closes the gap for local
+  runs only; the check is a no-op in CI. The shared echo-server port is
+  now a single `ECHO_WS_PORT` constant interpolated into the six
+  generated configs that use it, matching the `*_WS_PORT` convention the
+  private-echo-server phases already follow (it stays pinned to 8765 by
+  `configs/local-dev.toml`, which the main phase runs against).
+
 ### Fixed
 
 - **`packet_loss_ratio` is documented correctly: it is a per-interval

--- a/test-harness/sipp-scenarios/run-all.sh
+++ b/test-harness/sipp-scenarios/run-all.sh
@@ -5,7 +5,8 @@
 # the script starts a fresh daemon on an ephemeral port, runs each
 # scenario in series, captures failures, and tears the daemon down.
 #
-# Prerequisites:
+# Prerequisites (all three are checked up front; a missing one exits 2
+# with instructions rather than failing scenarios mid-run):
 #   * sip-tester (sipp) on PATH        (apt install sip-tester)
 #   * SiphonAI binary built             (cargo build -p siphon-ai)
 #   * An echo WS server on :8765       (examples/echo-ws-server-python/)
@@ -39,6 +40,12 @@ DAEMON_PORT=5070     # SiphonAI's listen port (matches local-dev.toml)
 # sequentially so one fixed port/token is reused.
 ADMIN_API_PORT=9191
 ADMIN_TOKEN="sipp-harness-admin"
+# Port of the caller-supplied echo WS server (see the header). Not freely
+# changeable: the main phase runs against configs/local-dev.toml, whose
+# `[bridge] ws_url` pins 8765 independently of this script. The auxiliary
+# phases that generate their own config interpolate this value below;
+# those that spawn a private echo server use their own ports instead.
+ECHO_WS_PORT=8765
 DAEMON_BIN="${DAEMON_BIN:-$REPO_ROOT/target/debug/siphon-ai}"
 DAEMON_CONFIG="${SIPHON_AI_CONFIG:-$REPO_ROOT/configs/local-dev.toml}"
 
@@ -64,6 +71,39 @@ if [[ ! -x "$DAEMON_BIN" ]]; then
 fi
 if [[ ! -f "$DAEMON_CONFIG" ]]; then
     echo "config not found at $DAEMON_CONFIG — set SIPHON_AI_CONFIG or create configs/local-dev.toml" >&2
+    exit 2
+fi
+
+# The echo WS server is a prerequisite, not something we start (see the
+# header). Its absence used to go undetected until mid-run, then show up
+# as eight failures scattered across five phases: every scenario whose
+# call must reach ACTIVE aborts on an unexpected BYE, because the daemon
+# tears the call down when the bridge can't connect, while scenarios that
+# reject before bridging (488 / 428 / 403 / 503, CANCEL) still pass. That
+# split reads like a signalling regression rather than "you forgot to
+# start a server" — and the baseline-vs-branch comparison you'd reach for
+# next reproduces it identically on both sides, which makes the wrong
+# conclusion look confirmed.
+#
+# CI already guards this (.github/workflows/test.yml starts the server and
+# waits for the bind before invoking us), so the check is a no-op there —
+# it exists for local runs, which had no such protection.
+if ! (exec 3<>"/dev/tcp/127.0.0.1/$ECHO_WS_PORT") 2>/dev/null; then
+    cat >&2 <<MSG
+no echo WS server listening on 127.0.0.1:$ECHO_WS_PORT
+
+The scenarios that bridge audio need one. From the repo root:
+
+  python3 -m venv examples/echo-ws-server-python/.venv
+  examples/echo-ws-server-python/.venv/bin/pip install -r \\
+      examples/echo-ws-server-python/requirements.txt
+  examples/echo-ws-server-python/.venv/bin/python \\
+      examples/echo-ws-server-python/server.py \\
+      --bind 127.0.0.1:$ECHO_WS_PORT &
+
+Auxiliary phases that spawn a private echo server are unaffected; only
+the phases pointed at 127.0.0.1:$ECHO_WS_PORT depend on this one.
+MSG
     exit 2
 fi
 
@@ -150,7 +190,7 @@ mode = "session_progress"
 [media]
 codecs = ["pcmu"]
 [bridge]
-ws_url = "ws://127.0.0.1:8765/"
+ws_url = "ws://127.0.0.1:$ECHO_WS_PORT/"
 [[route]]
 name = "default"
 [route.match]
@@ -225,7 +265,7 @@ listen = "127.0.0.1:$DAEMON_PORT"
 [media]
 codecs = ["pcmu"]
 [bridge]
-ws_url = "ws://127.0.0.1:8765/"
+ws_url = "ws://127.0.0.1:$ECHO_WS_PORT/"
 [security]
 min_attestation = "A"
 [security.stir_shaken]
@@ -298,7 +338,7 @@ password = "s3cret-sipp"
 [media]
 codecs = ["pcmu"]
 [bridge]
-ws_url = "ws://127.0.0.1:8765/"
+ws_url = "ws://127.0.0.1:$ECHO_WS_PORT/"
 [[route]]
 name = "default"
 [route.match]
@@ -343,7 +383,7 @@ burst = 1
 [media]
 codecs = ["pcmu"]
 [bridge]
-ws_url = "ws://127.0.0.1:8765/"
+ws_url = "ws://127.0.0.1:$ECHO_WS_PORT/"
 [[route]]
 name = "default"
 [route.match]
@@ -387,7 +427,7 @@ listen = "127.0.0.1:$DAEMON_PORT"
 [media]
 codecs = ["pcmu"]
 [bridge]
-ws_url = "ws://127.0.0.1:8765/"
+ws_url = "ws://127.0.0.1:$ECHO_WS_PORT/"
 [recording]
 mode = "always"
 dir = "$REC_DIR"
@@ -2158,7 +2198,7 @@ listen = "127.0.0.1:$DAEMON_PORT"
 [media]
 codecs = ["pcmu"]
 [bridge]
-ws_url = "ws://127.0.0.1:8765/"
+ws_url = "ws://127.0.0.1:$ECHO_WS_PORT/"
 [[register]]
 name = "pbx-a"
 server = "127.0.0.1"


### PR DESCRIPTION
Follow-up to the investigation in #321. Test-harness only — no daemon, protocol, or config changes.

## The problem

`run-all.sh` preflights two of its three documented prerequisites (`sipp` on PATH, the daemon binary) but never checked the third: an echo WS server on `:8765`. Without it the suite ran anyway and produced **eight failures scattered across five phases**:

`basic_call_then_bye`, `session_timer_echo`, `reinvite_hold_resume`, `reinvite_unsupported_codec_488`, `session_progress_then_answer`, `stir_shaken_attestation_pass`, `digest_auth_caller`, `recording_writes_valid_wav`

The split is what makes it nasty. Every scenario whose call must reach ACTIVE aborts on an unexpected BYE — the daemon tears the call down when the bridge can't connect — while every scenario that rejects *before* bridging (488 / 428 / 403 / 503, CANCEL) still passes. So you get a plausible-looking partial failure across unrelated feature areas (re-INVITE, session timers, STIR/SHAKEN, digest auth, recording), which reads like a signalling regression rather than "you forgot to start a server."

It gets worse if you then do the obvious thing and diff against a baseline: an identically-misconfigured `main` reproduces the identical eight failures, which correctly rules out your change and incorrectly looks like confirmation that the failures are pre-existing repo breakage. That is exactly the wrong turn I took in #321 before checking the script header — the eight "pre-existing failures" I reported there were entirely my missing prerequisite, and all 37 scenarios pass once the server is up.

## The fix

Check it alongside the other two and exit `2` with start-up instructions:

```
no echo WS server listening on 127.0.0.1:8765

The scenarios that bridge audio need one. From the repo root:

  python3 -m venv examples/echo-ws-server-python/.venv
  examples/echo-ws-server-python/.venv/bin/pip install -r \
      examples/echo-ws-server-python/requirements.txt
  examples/echo-ws-server-python/.venv/bin/python \
      examples/echo-ws-server-python/server.py \
      --bind 127.0.0.1:8765 &

Auxiliary phases that spawn a private echo server are unaffected; only
the phases pointed at 127.0.0.1:8765 depend on this one.
```

Probe is bash's `/dev/tcp` — no new dependency, and the script is already bash-only.

**CI is unaffected.** `.github/workflows/test.yml` already starts the server and polls for the bind before invoking the script, with a comment making the same argument this PR makes ("Failure here surfaces as a connection-refused in the daemon log, which is much harder to debug"). That guard just never existed on the local path. The new check is a no-op in CI.

## Secondary: single-source the shared port

The shared echo port is now `ECHO_WS_PORT`, interpolated into the six generated configs that referenced `8765` literally. This matches the convention the private-echo-server phases already follow (`$OB_WS_PORT`, `$PK_WS_PORT`, `$CF_WS_PORT`, …) — the shared ones were the odd ones out.

It is **not** freely changeable, and the constant's comment says so: the main phase runs against `configs/local-dev.toml`, which pins `ws://127.0.0.1:8765/` independently of this script. I left that file alone rather than widening the change. If you'd rather not have a constant that can't actually be re-pointed, I'm happy to drop this half and hardcode `8765` in the check.

## Testing

Both paths, on this branch:

- **Server down** → exits `2` with the message above, before starting any daemon.
- **Server up** → `all 37 scenarios passed`, exit `0`. That includes all six phases whose generated config I re-interpolated (`session_progress`, `stir_shaken`, `digest_auth`, `admission`, `recording`, `registration_admin`), so the substitution is confirmed live, not just by inspection.
- `bash -n` clean. (shellcheck isn't installed here, so it hasn't been run.)

## Note on merge order

Branched from `main`, so it's independent of #321 — but both touch the `## [Unreleased]` block in `CHANGELOG.md` and will conflict trivially whichever lands second.

## Considered and not done

Having the script **start** the echo server itself, the way every auxiliary phase already does. It'd be more convenient, but it would silently take over port 8765 from whatever a developer already had running there, and it contradicts the header's contract that the server is caller-supplied. Failing loudly seemed like the smaller, more obviously-correct change. Say the word if you'd prefer auto-start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGrL8HBEfyq5sigAdLriRq
