### PR TITLE
chore(release): 0.38.0 — TX-side quality counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.0] - 2026-07-21
+
 ### Added
 
 - **TX-side packet counters across the quality telemetry** (issue #320;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3811,7 +3811,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.37.3"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.37.3"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3875,7 +3875,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.37.3"
+version = "0.38.0"
 dependencies = [
  "base64",
  "bytes",
@@ -3897,7 +3897,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.37.3"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3914,7 +3914,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.37.3"
+version = "0.38.0"
 dependencies = [
  "regex",
  "serde",
@@ -3933,7 +3933,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.37.3"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3979,7 +3979,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.37.3"
+version = "0.38.0"
 dependencies = [
  "base64",
  "hmac",
@@ -4002,7 +4002,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.37.3"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4027,7 +4027,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.37.3"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4045,7 +4045,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.37.3"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4063,7 +4063,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.37.3"
+version = "0.38.0"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4077,7 +4077,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.37.3"
+version = "0.38.0"
 dependencies = [
  "regex",
  "serde",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.37.3"
+version = "0.38.0"
 dependencies = [
  "schemars",
  "serde",
@@ -4099,7 +4099,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.37.3"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4126,7 +4126,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.37.3"
+version = "0.38.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -4144,7 +4144,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.37.3"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -4173,7 +4173,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.37.3"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.37.3"
+version = "0.38.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.37.3.** Production-deployed against real carriers
+**Current release: v0.38.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a


### PR DESCRIPTION
Release-prep for **0.38.0**, per [RELEASING.md](RELEASING.md) step 2. Mechanical — no code changes.

## What moves

The three things the `version consistency` gate keeps in lockstep, plus the lockfile:

| File | Change |
|---|---|
| `Cargo.toml` | `[workspace.package].version` → `0.38.0` |
| `CHANGELOG.md` | `## [Unreleased]` → `## [0.38.0] - 2026-07-21`, fresh empty `## [Unreleased]` above |
| `README.md` | `**Current release: v0.38.0.**` |
| `Cargo.lock` | refreshed by a workspace build |

Same four-file scope as the 0.37.3 release commit (15a069c).

## What's in the release

- **TX-side quality counters** (#320, needs forge-media#93) — `tx_packets_sent`, `tx_octets_sent`, `tx_packets_lost_reported` across `rtp_stats`, the CDR `quality` block, `/admin/v1/calls/:id/stats`, and the quality history records.
- **`packet_loss_ratio` doc correction** — it's a per-interval figure, not cumulative. Values unchanged; only the description was wrong.
- **SIPp harness preflight** (#322) — dev-facing.

## Why minor, not patch

New user-visible telemetry fields. Nothing breaking: the WS protocol stays **v1** and the CDR schema stays at **version 4** (both additive-optional), and the new CSV columns append at the end of the header so position-keyed ingestors are unaffected.

A nice side effect: the `(0.38.0)` annotations already written into `PROTOCOL.md`, the CDR schema doc, and both SDKs become accurate at this commit rather than forward-referencing.

## SDK versions left alone

`sdks/python` and `sdks/typescript` are both at `0.28.0` and version independently — the consistency gate doesn't cover them and the 0.37.3 release commit didn't touch them. Flagging in case you'd rather they track the daemon; that'd be a separate decision.

## Verified locally

All three runbook commands, plus the full suite:

```
check-version-consistency.py                -> Version consistent: 0.38.0.
check-version-consistency.py --tag v0.38.0  -> Version consistent: 0.38.0 (tag v0.38.0).
extract-changelog.py 0.38.0                 -> notes extract, correctly bounded before 0.37.3
cargo test --workspace --locked             -> 1021 passed, 0 failed
cargo clippy --workspace --all-targets -- -D warnings -> clean
```

## Next step is yours

Per runbook step 3, the tag goes on the **merged** release commit and is what triggers the public release — binaries, `.deb`s, SBOM, cosign signatures, the GitHub release marked Latest, and `ghcr.io/thevoiceguy/siphon-ai:v0.38.0` + `:latest`:

```sh
git checkout main && git pull
git tag -a v0.38.0 -m "v0.38.0 — TX-side quality counters"
git push origin v0.38.0
```

I've deliberately not tagged. Say the word after merging and I'll push it, or run the two lines yourself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGrL8HBEfyq5sigAdLriRq
