### PR TITLE
fix(admin): label GET /admin/v1/drain in siphon_ai_admin_requests_total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`GET /admin/v1/drain` is now labelled in `siphon_ai_admin_requests_total`** (issue #319). The route is dispatched and served correctly but had no arm in `route_label()`, so it fell through to `endpoint="unknown"` — the only served admin route missing from the table. Two consequences: successful drain polls were indistinguishable from unrecognised paths (both `endpoint="unknown"`, separated only by `result`), polluting the reasonable "someone is probing the admin API" signal a dashboard keys on `endpoint="unknown"`; and drain — the endpoint a deploy script polls hardest during a rollout, likely the highest-rate admin request on the box — was the one route with no per-endpoint visibility. Metric-label only; no functional, auth, RBAC, or response-body change.
+
+  While fixing it, `min_role()` turned out to be missing the same route. That table's doc requires it to mirror `admin::dispatch`, and without an arm the drain path only reached `ReadOnly` by falling through to `authorize`'s unknown-path default — the right answer (and the one `docs/DEPLOY.md` already documents) for the wrong reason, and silently wrong had that default ever been tightened. Both tables now carry the route, so behaviour is unchanged and no longer accidental.
+
+  New `every_served_route_has_a_bounded_label` test walks all ten static dispatcher routes plus the nine dynamic templates and asserts each has a non-`"unknown"` label, that a static route's label is exactly `"METHOD /path"` (catching a copy-pasted arm pointing at the wrong template), that a dynamic route's label is a template rather than a concrete path and leaks no id into the metric label, and that every served route has an explicit `min_role` arm. The prior `route_label` coverage was only the two `:name` registration templates.
+
 ## [0.38.0] - 2026-07-21
 
 ### Added

--- a/crates/telemetry/src/auth.rs
+++ b/crates/telemetry/src/auth.rs
@@ -201,7 +201,13 @@ pub fn min_role(method: &hyper::Method, path: &str) -> Option<Role> {
         | (&Method::GET, "/admin/registrations")
         | (&Method::GET, "/admin/log")
         | (&Method::GET, "/admin/v1/conferences")
-        | (&Method::GET, "/admin/v1/parked") => Some(Role::ReadOnly),
+        | (&Method::GET, "/admin/v1/parked")
+        // Drain status is a plain GET snapshot, same as the list routes
+        // above. It resolved to ReadOnly before this arm existed, but
+        // only by falling through to `authorize`'s unknown-path default —
+        // i.e. the right answer for the wrong reason, and silently wrong
+        // had the default ever been tightened.
+        | (&Method::GET, "/admin/v1/drain") => Some(Role::ReadOnly),
 
         // ── Admin (billable / config / observability-blinding) ──
         (&Method::PUT, "/admin/log")
@@ -261,6 +267,7 @@ pub fn route_label(method: &hyper::Method, path: &str) -> &'static str {
         (&Method::GET, "/admin/v1/conferences") => "GET /admin/v1/conferences",
         (&Method::POST, "/admin/v1/conferences") => "POST /admin/v1/conferences",
         (&Method::GET, "/admin/v1/parked") => "GET /admin/v1/parked",
+        (&Method::GET, "/admin/v1/drain") => "GET /admin/v1/drain",
         (m, p)
             if *m == Method::POST && p.starts_with("/admin/calls/") && p.ends_with("/hangup") =>
         {
@@ -483,5 +490,81 @@ mod tests {
         );
         // Unknown admin path → no min role.
         assert_eq!(min_role(&Method::GET, "/admin/nope"), None);
+    }
+
+    /// Every route the admin dispatcher serves must produce a real
+    /// `endpoint` label. `docs/DEPLOY.md` documents the label as "the
+    /// bounded route template", and dashboards key on
+    /// `endpoint="unknown"` as a probing signal — so a served route
+    /// falling through to `"unknown"` both loses its own visibility and
+    /// pollutes that signal. `GET /admin/v1/drain` did exactly this, and
+    /// it's the route a deploy script polls hardest during a rollout.
+    ///
+    /// This list must mirror the static arms of `admin::dispatch`. It is
+    /// spelled out rather than derived because the dispatcher's arms
+    /// aren't introspectable — but a new route added there without a
+    /// label here now fails a test instead of silently degrading a
+    /// metric.
+    #[test]
+    fn every_served_route_has_a_bounded_label() {
+        let statics = [
+            (Method::GET, "/admin/calls"),
+            (Method::GET, "/admin/registrations"),
+            (Method::GET, "/admin/log"),
+            (Method::PUT, "/admin/log"),
+            (Method::POST, "/admin/hep/test"),
+            (Method::POST, "/admin/v1/calls"),
+            (Method::GET, "/admin/v1/conferences"),
+            (Method::POST, "/admin/v1/conferences"),
+            (Method::GET, "/admin/v1/parked"),
+            (Method::GET, "/admin/v1/drain"),
+        ];
+        for (method, path) in &statics {
+            let label = route_label(method, path);
+            assert_ne!(label, "unknown", "{method} {path} is served but unlabelled");
+            // A static route's label is exactly "METHOD /path" — catches a
+            // copy-pasted arm pointing at the wrong template.
+            assert_eq!(label, format!("{method} {path}"), "label mismatch");
+            // `min_role`'s doc requires it to mirror dispatch too. Without
+            // an explicit arm a served route still *works* — `authorize`
+            // defaults an unknown path to ReadOnly — so the omission is
+            // invisible until someone tightens that default.
+            assert!(
+                min_role(method, path).is_some(),
+                "{method} {path} is served but has no explicit min_role arm"
+            );
+        }
+
+        // Dynamic routes collapse to a template, so they're checked for
+        // non-"unknown" and for carrying a placeholder rather than the
+        // concrete id (an unbounded label would blow up cardinality).
+        let dynamics = [
+            (Method::POST, "/admin/calls/abc123/hangup"),
+            (Method::POST, "/admin/v1/registrations/pbx-a/refresh"),
+            (Method::POST, "/admin/v1/registrations/pbx-a/restart"),
+            (Method::GET, "/admin/v1/calls/abc123/stats"),
+            (Method::POST, "/admin/v1/calls/abc123/park"),
+            (Method::POST, "/admin/v1/calls/abc123/retrieve"),
+            (Method::POST, "/admin/v1/conferences/room1/participants"),
+            (
+                Method::DELETE,
+                "/admin/v1/conferences/room1/participants/c1",
+            ),
+            (Method::DELETE, "/admin/v1/conferences/room1"),
+        ];
+        for (method, path) in &dynamics {
+            let label = route_label(method, path);
+            assert_ne!(label, "unknown", "{method} {path} is served but unlabelled");
+            assert!(
+                label.contains(':'),
+                "{method} {path} → {label:?} must be a template, not a concrete path"
+            );
+            for concrete in ["abc123", "pbx-a", "room1", "c1"] {
+                assert!(
+                    !label.contains(concrete),
+                    "{label:?} leaks the concrete id {concrete:?} into a metric label"
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #319.

## The fix

```rust
(&Method::GET, "/admin/v1/drain") => "GET /admin/v1/drain",
```

`/admin/v1/drain` is dispatched and served correctly but had no arm in `route_label()`, so it fell through to `endpoint="unknown"` — the only served admin route missing from the table. Successful drain polls were indistinguishable from unrecognised paths, and drain is the endpoint a deploy script polls hardest during a rollout.

Metric-label only: no functional, auth, RBAC, or response-body change.

## Also found: `min_role()` was missing the same route

Not in the issue, but same root cause and same file, so I fixed it here.

`min_role()`'s doc says it **must mirror the routes in `admin::dispatch`**. Drain had no arm there either, so it only reached `ReadOnly` by falling through to `authorize()`'s unknown-path default:

```rust
let required = min_role(method, path).unwrap_or(Role::ReadOnly);
```

That produces the correct role — and the one `docs/DEPLOY.md:523` already documents for this endpoint — but for the wrong reason. It would have become silently wrong the moment anyone tightened that default, which is a plausible hardening change. **Behaviour is unchanged by this PR**; it just stops being accidental.

## Test

`every_served_route_has_a_bounded_label` walks all **10** static dispatcher routes and **9** dynamic templates, asserting:

- no route yields `"unknown"`
- a static route's label is exactly `"METHOD /path"` — catches a copy-pasted arm pointing at the wrong template
- a dynamic route's label is a template (`contains(':')`) and leaks no concrete id (`abc123`, `pbx-a`, `room1`, `c1`) into a metric label, which would blow up cardinality
- every served route has an explicit `min_role` arm

Prior `route_label` coverage was the two `:name` registration templates only.

I verified it actually catches the regression: with the drain arm removed it fails with `GET /admin/v1/drain is served but unlabelled`.

The static list is spelled out rather than derived — the dispatcher's match arms aren't introspectable from a test. That's noted in a comment; it doesn't prevent the next route from being added without a label, but it does turn that into a test failure rather than a silently degraded metric.

## Testing

- `cargo test --workspace --locked` → **1022 passed, 0 failed**
- `cargo clippy -p siphon-ai-telemetry --all-targets -- -D warnings` → clean
- `cargo fmt --all --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGrL8HBEfyq5sigAdLriRq
