### PR TITLE
chore(release): 0.39.0 — outbound teardown + admin/protocol corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.39.0] - 2026-07-22
+
 ### Fixed
 
 - **`GET /admin/v1/drain` is now labelled in `siphon_ai_admin_requests_total`** (issue #319). The route is dispatched and served correctly but had no arm in `route_label()`, so it fell through to `endpoint="unknown"` — the only served admin route missing from the table. Two consequences: successful drain polls were indistinguishable from unrecognised paths (both `endpoint="unknown"`, separated only by `result`), polluting the reasonable "someone is probing the admin API" signal a dashboard keys on `endpoint="unknown"`; and drain — the endpoint a deploy script polls hardest during a rollout, likely the highest-rate admin request on the box — was the one route with no per-endpoint visibility. Metric-label only; no functional, auth, RBAC, or response-body change.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3811,7 +3811,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3860,7 +3860,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3876,7 +3876,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "base64",
  "bytes",
@@ -3898,7 +3898,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3915,7 +3915,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "regex",
  "serde",
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3980,7 +3980,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "base64",
  "hmac",
@@ -4003,7 +4003,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4028,7 +4028,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4046,7 +4046,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4064,7 +4064,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4078,7 +4078,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "regex",
  "serde",
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "schemars",
  "serde",
@@ -4100,7 +4100,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4127,7 +4127,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -4145,7 +4145,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.38.0"
+version = "0.39.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.38.0.** Production-deployed against real carriers
+**Current release: v0.39.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a


### PR DESCRIPTION
Release-prep for **0.39.0**, per [RELEASING.md](RELEASING.md) step 2. Mechanical — no code changes.

## What moves

| File | Change |
|---|---|
| `Cargo.toml` | `[workspace.package].version` → `0.39.0` |
| `CHANGELOG.md` | `## [Unreleased]` → `## [0.39.0] - 2026-07-22`, fresh empty `## [Unreleased]` above |
| `README.md` | `**Current release: v0.39.0.**` |
| `Cargo.lock` | refreshed by a workspace build |

Same four-file scope as the 0.37.3 and 0.38.0 release commits.

## What's in the release

Three issue-driven fixes:

- **#324** — a far-end BYE now tears down an outbound call. Two independent causes: the gateway UAC's dialog store wasn't shared with the UAS (`481` from dispatch), and outbound legs were never in the registry the BYE handler resolves against. Requires siphon-rs [#67](https://github.com/thevoiceguy/siphon-rs/pull/67), pinned at `6fd432270bb8`.
- **#325** — `PROTOCOL.md` §3.10 cited `media.rtp_idle_timeout_ms`, a key that doesn't exist.
- **#319** — `GET /admin/v1/drain` was counted as `endpoint="unknown"`.

## ⚠️ Two behaviour changes ride along (from #324)

Both intentional and reviewed, but worth naming again at release time since they're what makes this a minor rather than a patch:

1. **Graceful drain now counts and waits for in-flight outbound calls.** `/admin/v1/drain`'s `active_calls` includes them, and a drain no longer walks past them. If you alert on that number, it will move.
2. **A peer re-INVITE on an outbound leg now returns `501`**, not the `481` an unregistered dialog produced.

No protocol or CDR schema change: WS protocol stays **v1**, CDR stays at **version 4**.

## SDK versions left alone

`sdks/python` and `sdks/typescript` remain at `0.28.0` — versioned independently, not covered by the consistency gate, untouched by the last two release commits. Same flag as last time in case you'd rather they track the daemon.

## Verified locally

```
check-version-consistency.py                -> Version consistent: 0.39.0.
check-version-consistency.py --tag v0.39.0  -> Version consistent: 0.39.0 (tag v0.39.0).
extract-changelog.py 0.39.0                 -> all 3 fixes, correctly bounded before 0.38.0
cargo test --workspace --locked             -> 1022 passed, 0 failed
cargo clippy --workspace --all-targets -- -D warnings -> clean
cargo fmt --all --check / check-doc-links / check-protocol-schema -> clean
test-harness/sipp-scenarios/run-all.sh      -> all 38 scenarios passed
```

I ran the SIPp suite as well as the unit tests here, since this release carries the outbound-teardown change and the new `outbound_remote_bye` scenario.

## Next step is yours

Per runbook step 3, the tag goes on the **merged** release commit and triggers the public release — binaries, `.deb`s, SBOM, cosign signatures, the GitHub release marked Latest, and `ghcr.io/thevoiceguy/siphon-ai:v0.39.0` + `:latest`:

```sh
git checkout main && git pull
git tag -a v0.39.0 -m "v0.39.0 — outbound teardown + admin/protocol corrections"
git push origin v0.39.0
```

I haven't tagged. Say the word after merging and I'll push it and verify the published artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGrL8HBEfyq5sigAdLriRq
