### PR TITLE
fix(quality): bump forge-media — rx_packets_lost stops reporting ring duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`rx_packets_lost` no longer reports the ring duration as packet loss** (issue #330; fixed upstream by [forge-media#94](https://github.com/thevoiceguy/forge-media/pull/94), pin bumped `f6151edf2724` → `24e20ae1e8ac`). On a trunk that sends ringback as early media, `rx_packets_lost` was set once at answer to `ring_seconds × 50` and never moved again — 621 on a 12.42 s ring, 127 on a 2.5 s ring — which pinned the transport `mos_estimate` to **1.0, the floor of the scale**, for the whole call. The effect was inverted from reality (the longer a call rang, the worse its reported quality, so the calls that rang longest looked worst to anyone triaging complaints) and it propagated into the CDR `quality` block and Homer's HEP QoS, contaminating historical quality data and any MOS-based alerting at the source. `avg/max_packet_loss_ratio` stayed correctly at `0.0` throughout, so the two loss signals in the same record actively disagreed.
+
+  Root cause was in forge's `RxStreamStats`, which carried a single sequence baseline with no SSRC field at all. The trunk switches SSRC at the answer while keeping the sequence counter continuous, so a baseline anchored in the ringback era survived into the answered stream and charged the whole ring against it. Diagnosed from a production capture (4 SSRCs on one 5-tuple, seq 773→3333, 2561 packets, zero wire loss) and pinned upstream by a regression test that replays those real sequence numbers — 748 phantom lost with the fix disabled, matching the capture's 14.96 s ring × 50, and 0 with it. No siphon-ai code change; the counters this daemon already reads simply stop being wrong.
+
+  Still open upstream as [forge-media#95](https://github.com/thevoiceguy/forge-media/issues/95): the early-media packets are received but never counted at all, so `rx_packets_received` continues to undercount by the ringback burst, and a trunk that keeps one SSRC across the answer would still mis-report loss.
+
 ## [0.39.0] - 2026-07-22
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "forge-codecs"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=f6151edf2724#f6151edf27243feff1cfaa3d37e9fe7194a2e06d"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=24e20ae1e8ac#24e20ae1e8ac46e318b196ba031a544090958273"
 dependencies = [
  "audiopus",
  "ezk-g722",
@@ -1022,7 +1022,7 @@ dependencies = [
 [[package]]
 name = "forge-core"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=f6151edf2724#f6151edf27243feff1cfaa3d37e9fe7194a2e06d"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=24e20ae1e8ac#24e20ae1e8ac46e318b196ba031a544090958273"
 dependencies = [
  "chrono",
  "serde",
@@ -1037,7 +1037,7 @@ dependencies = [
 [[package]]
 name = "forge-dtmf"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=f6151edf2724#f6151edf27243feff1cfaa3d37e9fe7194a2e06d"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=24e20ae1e8ac#24e20ae1e8ac46e318b196ba031a544090958273"
 dependencies = [
  "chrono",
  "forge-core",
@@ -1049,7 +1049,7 @@ dependencies = [
 [[package]]
 name = "forge-engine"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=f6151edf2724#f6151edf27243feff1cfaa3d37e9fe7194a2e06d"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=24e20ae1e8ac#24e20ae1e8ac46e318b196ba031a544090958273"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1079,7 +1079,7 @@ dependencies = [
 [[package]]
 name = "forge-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=f6151edf2724#f6151edf27243feff1cfaa3d37e9fe7194a2e06d"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=24e20ae1e8ac#24e20ae1e8ac46e318b196ba031a544090958273"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -1092,7 +1092,7 @@ dependencies = [
 [[package]]
 name = "forge-injection"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=f6151edf2724#f6151edf27243feff1cfaa3d37e9fe7194a2e06d"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=24e20ae1e8ac#24e20ae1e8ac46e318b196ba031a544090958273"
 dependencies = [
  "forge-core",
  "rubato",
@@ -1105,7 +1105,7 @@ dependencies = [
 [[package]]
 name = "forge-mixer"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=f6151edf2724#f6151edf27243feff1cfaa3d37e9fe7194a2e06d"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=24e20ae1e8ac#24e20ae1e8ac46e318b196ba031a544090958273"
 dependencies = [
  "bytes",
  "dashmap 6.2.1",
@@ -1119,7 +1119,7 @@ dependencies = [
 [[package]]
 name = "forge-recorder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=f6151edf2724#f6151edf27243feff1cfaa3d37e9fe7194a2e06d"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=24e20ae1e8ac#24e20ae1e8ac46e318b196ba031a544090958273"
 dependencies = [
  "bytes",
  "forge-core",
@@ -1133,7 +1133,7 @@ dependencies = [
 [[package]]
 name = "forge-resampler"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=f6151edf2724#f6151edf27243feff1cfaa3d37e9fe7194a2e06d"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=24e20ae1e8ac#24e20ae1e8ac46e318b196ba031a544090958273"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -1142,7 +1142,7 @@ dependencies = [
 [[package]]
 name = "forge-rtp"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=f6151edf2724#f6151edf27243feff1cfaa3d37e9fe7194a2e06d"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=24e20ae1e8ac#24e20ae1e8ac46e318b196ba031a544090958273"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm 0.11.0",
@@ -1167,14 +1167,14 @@ dependencies = [
 [[package]]
 name = "forge-sdp"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=f6151edf2724#f6151edf27243feff1cfaa3d37e9fe7194a2e06d"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=24e20ae1e8ac#24e20ae1e8ac46e318b196ba031a544090958273"
 dependencies = [
  "base64",
  "chrono",
  "forge-core",
  "forge-rtp",
  "rand 0.10.1",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=f6151edf2724)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=24e20ae1e8ac)",
  "smol_str",
  "thiserror 2.0.18",
 ]
@@ -1182,7 +1182,7 @@ dependencies = [
 [[package]]
 name = "forge-transcoder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=f6151edf2724#f6151edf27243feff1cfaa3d37e9fe7194a2e06d"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=24e20ae1e8ac#24e20ae1e8ac46e318b196ba031a544090958273"
 dependencies = [
  "bytes",
  "forge-codecs",
@@ -1195,7 +1195,7 @@ dependencies = [
 [[package]]
 name = "forge-vad"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=f6151edf2724#f6151edf27243feff1cfaa3d37e9fe7194a2e06d"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=24e20ae1e8ac#24e20ae1e8ac46e318b196ba031a544090958273"
 dependencies = [
  "thiserror 2.0.18",
  "tract-onnx",
@@ -3709,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=6fd432270bb8#6fd432270bb8c557edf9446e8b7c860749fae077"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=24e20ae1e8ac#24e20ae1e8ac46e318b196ba031a544090958273"
 dependencies = [
  "nom 7.1.3",
  "smol_str",
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=f6151edf2724#f6151edf27243feff1cfaa3d37e9fe7194a2e06d"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=6fd432270bb8#6fd432270bb8c557edf9446e8b7c860749fae077"
 dependencies = [
  "nom 7.1.3",
  "smol_str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,36 +169,40 @@ sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "6fd
 # AI logic belongs in the WS server, never here. See CLAUDE.md §4.1 and the
 # upstream gate at https://github.com/thevoiceguy/forge-media/pull/39.
 #
-# forge-media is pinned to a `main` rev. Bumped 2026-07-21 to f6151edf2724
-# = forge-media #93: TX packet/octet counters and RR cumulative-lost on the
-# event bus. `MediaStatsSnapshot` gains `tx_packets_sent` / `tx_octets_sent`
-# and `RtcpReportReceived` gains `cumulative_lost` / `extended_highest_seq`,
-# which is what makes siphon-ai #320's TX-side quality telemetry possible —
-# neither number was previously reachable from glue. Note two behaviour
-# changes that ride along: `MediaStatsSnapshot` now also publishes for a leg
-# that only *sends* (harmless here — our leg B is synthetic and carries no
-# RTP either way, see tap.rs "Single-leg model"), and forge's
-# `ParticipantStats::bytes_sent` now counts RTP payload octets uniformly
-# rather than mixing payload and wire lengths across send paths.
+# forge-media is pinned to a `main` rev. Bumped 2026-07-22 to 24e20ae1e8ac
+# = forge-media #94: per-SSRC receive-side stream stats. `RxStreamStats` had
+# no SSRC field and compared sequence numbers across sources that RFC 3550
+# §8 gives independent sequence spaces; it now re-baselines when the SSRC
+# changes, carrying prior streams' real loss forward. Fixes siphon-ai #330:
+# a trunk that sends ringback as early media and switches SSRC at the answer
+# left the baseline anchored in the ringback era, so `rx_packets_lost` came
+# out as `ring_seconds x 50`, frozen for the call, pinning the transport MOS
+# estimate to 1.0 on every call with a normal ring time — and feeding that
+# into the CDR `quality` block and Homer's HEP QoS. No API change here; the
+# counters this daemon already reads simply stop being wrong.
+# Not fixed upstream and tracked as forge-media #95: the early-media packets
+# are received but never counted at all, so `rx_packets_received` still
+# undercounts by the ringback burst, and a trunk that keeps one SSRC across
+# the answer would still mis-report loss.
 # Feature-enabled builds need rustc >= 1.91 (tract 0.23) — our pinned
 # toolchain is 1.95. (siphon-rs is pinned separately above; see its own
 # comment for the current rev.) Prior forge pins: forge 1c996ae5fb4f = #86
 # neural VAD; forge 3c59b5f6e464 = #82-#85 dependency migrations; forge
 # 5fa76fb38675 = #81.
-forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "f6151edf2724" }
-forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "f6151edf2724" }
-forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "f6151edf2724", default-features = false, features = ["g722", "dtls", "opus", "neural-vad"] }
-forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "f6151edf2724" }
-forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "f6151edf2724" }
-forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "f6151edf2724" }
-forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "f6151edf2724" }
-forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "f6151edf2724" }
+forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "24e20ae1e8ac" }
+forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "24e20ae1e8ac" }
+forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "24e20ae1e8ac", default-features = false, features = ["g722", "dtls", "opus", "neural-vad"] }
+forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "24e20ae1e8ac" }
+forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "24e20ae1e8ac" }
+forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "24e20ae1e8ac" }
+forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "24e20ae1e8ac" }
+forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "24e20ae1e8ac" }
 # Conference rooms (0.7.0): forge-mixer is the per-room AudioMixer;
 # forge-injection provides ToneGenerator (join/leave tones now, MOH
 # for park later). Deliberately NOT forge-conference — its DTMF
 # IVR/PIN/host-control layer is unused per DEV_PLAN_0.7.0.md §9.4.
-forge-mixer     = { git = "https://github.com/thevoiceguy/forge-media", rev = "f6151edf2724" }
-forge-injection = { git = "https://github.com/thevoiceguy/forge-media", rev = "f6151edf2724" }
+forge-mixer     = { git = "https://github.com/thevoiceguy/forge-media", rev = "24e20ae1e8ac" }
+forge-injection = { git = "https://github.com/thevoiceguy/forge-media", rev = "24e20ae1e8ac" }
 
 # hep-rs — HEP3 codec, transport, HepSink trait. Owned by the same
 # author as siphon-rs and forge-media; lives in its own repo.


### PR DESCRIPTION
Closes #330. Pin bump only — no siphon-ai code change. Upstream fix: [forge-media#94](https://github.com/thevoiceguy/forge-media/pull/94) (merged), `f6151edf2724` → `24e20ae1e8ac`.

## What was wrong

`rx_packets_lost` was set once at answer to `ring_seconds × 50` and never moved again — 621 on a 12.42 s ring, 127 on a 2.5 s ring — pinning the transport `mos_estimate` to **1.0, the floor of the scale**, for the whole call.

Root cause was upstream: forge's `RxStreamStats` carried a single sequence baseline with **no SSRC field at all**. The trunk switches SSRC at the answer while keeping the sequence counter continuous, so a baseline anchored in the ringback era survived into the answered stream and charged the entire ring against it.

## How it was confirmed

From the production capture, not inferred — inbound audio flow, 4 SSRCs on one 5-tuple:

```
t=+ 0.00s  SSRC 0x10FCD7B3  seq  773      (ringback)
t=+14.96s  SSRC 0x00F44679  seq 1521      <- answer
t=+14.98s  SSRC 0x5618A94F  seq 1522 .. 3333
```

2561 packets, sequence 773–3333, **zero gaps and zero wire loss**. The upstream regression test replays those real sequence numbers: **748** phantom lost with the fix disabled — exactly the capture's `14.96 s × 50` — and **0** with it.

## ⚠️ Half of #330's mechanism is still open upstream

Filed as [forge-media#95](https://github.com/thevoiceguy/forge-media/issues/95). The early-media packets are *received but never counted at all* — only the first one reaches the stats. Consequences that survive this fix:

- `rx_packets_received` still undercounts by the whole ringback burst (~749 packets on the captured call).
- A trunk that keeps **one SSRC** across the answer would still produce the original fabricated-loss signature, with no obvious signal.
- Whatever drops those packets plausibly drops the audio too, so early media may not be reaching the recorder / bridge / VAD either — unverified, noted in #95.

I closed #330 here because the reported symptom (loss figure and MOS floor) is fixed and verified. Say the word if you'd rather it stay open until #95 lands.

## Testing

- `cargo test --workspace --locked` → **1022 passed, 0 failed**
- `cargo fmt --all --check`, `check-version-consistency.py` → clean
- SIPp `run-all.sh` → **38/38** (run because the bump touches the media receive path)
- `Cargo.lock` resolves to `24e20ae1e8ac46e318b196ba031a544090958273`, matching forge-media `main`

Not covered: no SIPp scenario reproduces #330 end-to-end — that needs early media whose SSRC changes at answer, i.e. two tone pcaps with distinct SSRCs. The upstream unit test pins the arithmetic precisely against real capture data; a live scenario would additionally pin the plumbing. Happy to add one if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGrL8HBEfyq5sigAdLriRq
