### PR TITLE
chore(deps): bump forge-media to 6e3fcd2e7c6f — corrected #330 mechanism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "forge-codecs"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=24e20ae1e8ac#24e20ae1e8ac46e318b196ba031a544090958273"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=6e3fcd2e7c6f#6e3fcd2e7c6f35d6b02a54fbd3361010abb7f638"
 dependencies = [
  "audiopus",
  "ezk-g722",
@@ -1022,7 +1022,7 @@ dependencies = [
 [[package]]
 name = "forge-core"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=24e20ae1e8ac#24e20ae1e8ac46e318b196ba031a544090958273"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=6e3fcd2e7c6f#6e3fcd2e7c6f35d6b02a54fbd3361010abb7f638"
 dependencies = [
  "chrono",
  "serde",
@@ -1037,7 +1037,7 @@ dependencies = [
 [[package]]
 name = "forge-dtmf"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=24e20ae1e8ac#24e20ae1e8ac46e318b196ba031a544090958273"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=6e3fcd2e7c6f#6e3fcd2e7c6f35d6b02a54fbd3361010abb7f638"
 dependencies = [
  "chrono",
  "forge-core",
@@ -1049,7 +1049,7 @@ dependencies = [
 [[package]]
 name = "forge-engine"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=24e20ae1e8ac#24e20ae1e8ac46e318b196ba031a544090958273"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=6e3fcd2e7c6f#6e3fcd2e7c6f35d6b02a54fbd3361010abb7f638"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1079,7 +1079,7 @@ dependencies = [
 [[package]]
 name = "forge-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=24e20ae1e8ac#24e20ae1e8ac46e318b196ba031a544090958273"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=6e3fcd2e7c6f#6e3fcd2e7c6f35d6b02a54fbd3361010abb7f638"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -1092,7 +1092,7 @@ dependencies = [
 [[package]]
 name = "forge-injection"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=24e20ae1e8ac#24e20ae1e8ac46e318b196ba031a544090958273"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=6e3fcd2e7c6f#6e3fcd2e7c6f35d6b02a54fbd3361010abb7f638"
 dependencies = [
  "forge-core",
  "rubato",
@@ -1105,7 +1105,7 @@ dependencies = [
 [[package]]
 name = "forge-mixer"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=24e20ae1e8ac#24e20ae1e8ac46e318b196ba031a544090958273"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=6e3fcd2e7c6f#6e3fcd2e7c6f35d6b02a54fbd3361010abb7f638"
 dependencies = [
  "bytes",
  "dashmap 6.2.1",
@@ -1119,7 +1119,7 @@ dependencies = [
 [[package]]
 name = "forge-recorder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=24e20ae1e8ac#24e20ae1e8ac46e318b196ba031a544090958273"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=6e3fcd2e7c6f#6e3fcd2e7c6f35d6b02a54fbd3361010abb7f638"
 dependencies = [
  "bytes",
  "forge-core",
@@ -1133,7 +1133,7 @@ dependencies = [
 [[package]]
 name = "forge-resampler"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=24e20ae1e8ac#24e20ae1e8ac46e318b196ba031a544090958273"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=6e3fcd2e7c6f#6e3fcd2e7c6f35d6b02a54fbd3361010abb7f638"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -1142,7 +1142,7 @@ dependencies = [
 [[package]]
 name = "forge-rtp"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=24e20ae1e8ac#24e20ae1e8ac46e318b196ba031a544090958273"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=6e3fcd2e7c6f#6e3fcd2e7c6f35d6b02a54fbd3361010abb7f638"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm 0.11.0",
@@ -1167,14 +1167,14 @@ dependencies = [
 [[package]]
 name = "forge-sdp"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=24e20ae1e8ac#24e20ae1e8ac46e318b196ba031a544090958273"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=6e3fcd2e7c6f#6e3fcd2e7c6f35d6b02a54fbd3361010abb7f638"
 dependencies = [
  "base64",
  "chrono",
  "forge-core",
  "forge-rtp",
  "rand 0.10.1",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=24e20ae1e8ac)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=6e3fcd2e7c6f)",
  "smol_str",
  "thiserror 2.0.18",
 ]
@@ -1182,7 +1182,7 @@ dependencies = [
 [[package]]
 name = "forge-transcoder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=24e20ae1e8ac#24e20ae1e8ac46e318b196ba031a544090958273"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=6e3fcd2e7c6f#6e3fcd2e7c6f35d6b02a54fbd3361010abb7f638"
 dependencies = [
  "bytes",
  "forge-codecs",
@@ -1195,7 +1195,7 @@ dependencies = [
 [[package]]
 name = "forge-vad"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=24e20ae1e8ac#24e20ae1e8ac46e318b196ba031a544090958273"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=6e3fcd2e7c6f#6e3fcd2e7c6f35d6b02a54fbd3361010abb7f638"
 dependencies = [
  "thiserror 2.0.18",
  "tract-onnx",
@@ -3709,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=24e20ae1e8ac#24e20ae1e8ac46e318b196ba031a544090958273"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=6e3fcd2e7c6f#6e3fcd2e7c6f35d6b02a54fbd3361010abb7f638"
 dependencies = [
  "nom 7.1.3",
  "smol_str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,8 +169,16 @@ sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "6fd
 # AI logic belongs in the WS server, never here. See CLAUDE.md §4.1 and the
 # upstream gate at https://github.com/thevoiceguy/forge-media/pull/39.
 #
-# forge-media is pinned to a `main` rev. Bumped 2026-07-22 to 24e20ae1e8ac
-# = forge-media #94: per-SSRC receive-side stream stats. `RxStreamStats` had
+# forge-media is pinned to a `main` rev. Bumped 2026-07-22 to 6e3fcd2e7c6f
+# = forge-media #96, a docs/test-only correction on top of #94: the #330
+# mechanism is a sequence discontinuity at the stream change, NOT uncounted
+# early media (measured — a call with ringback and no post-answer media
+# reports the ringback packets in `rx_packets_received`). No behaviour
+# change; the pin moves so the released tree references a forge-media whose
+# CHANGELOG states the diagnosis correctly.
+#
+# The substantive fix is #94 (24e20ae1e8ac), unchanged and still in effect:
+# per-SSRC receive-side stream stats. `RxStreamStats` had
 # no SSRC field and compared sequence numbers across sources that RFC 3550
 # §8 gives independent sequence spaces; it now re-baselines when the SSRC
 # changes, carrying prior streams' real loss forward. Fixes siphon-ai #330:
@@ -180,29 +188,27 @@ sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "6fd
 # estimate to 1.0 on every call with a normal ring time — and feeding that
 # into the CDR `quality` block and Homer's HEP QoS. No API change here; the
 # counters this daemon already reads simply stop being wrong.
-# Not fixed upstream and tracked as forge-media #95: the early-media packets
-# are received but never counted at all, so `rx_packets_received` still
-# undercounts by the ringback burst, and a trunk that keeps one SSRC across
-# the answer would still mis-report loss.
+# (forge-media #95 previously tracked an "early media goes uncounted"
+# follow-up; it was closed invalid — that premise was measured false.)
 # Feature-enabled builds need rustc >= 1.91 (tract 0.23) — our pinned
 # toolchain is 1.95. (siphon-rs is pinned separately above; see its own
 # comment for the current rev.) Prior forge pins: forge 1c996ae5fb4f = #86
 # neural VAD; forge 3c59b5f6e464 = #82-#85 dependency migrations; forge
 # 5fa76fb38675 = #81.
-forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "24e20ae1e8ac" }
-forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "24e20ae1e8ac" }
-forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "24e20ae1e8ac", default-features = false, features = ["g722", "dtls", "opus", "neural-vad"] }
-forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "24e20ae1e8ac" }
-forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "24e20ae1e8ac" }
-forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "24e20ae1e8ac" }
-forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "24e20ae1e8ac" }
-forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "24e20ae1e8ac" }
+forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "6e3fcd2e7c6f" }
+forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "6e3fcd2e7c6f" }
+forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "6e3fcd2e7c6f", default-features = false, features = ["g722", "dtls", "opus", "neural-vad"] }
+forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "6e3fcd2e7c6f" }
+forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "6e3fcd2e7c6f" }
+forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "6e3fcd2e7c6f" }
+forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "6e3fcd2e7c6f" }
+forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "6e3fcd2e7c6f" }
 # Conference rooms (0.7.0): forge-mixer is the per-room AudioMixer;
 # forge-injection provides ToneGenerator (join/leave tones now, MOH
 # for park later). Deliberately NOT forge-conference — its DTMF
 # IVR/PIN/host-control layer is unused per DEV_PLAN_0.7.0.md §9.4.
-forge-mixer     = { git = "https://github.com/thevoiceguy/forge-media", rev = "24e20ae1e8ac" }
-forge-injection = { git = "https://github.com/thevoiceguy/forge-media", rev = "24e20ae1e8ac" }
+forge-mixer     = { git = "https://github.com/thevoiceguy/forge-media", rev = "6e3fcd2e7c6f" }
+forge-injection = { git = "https://github.com/thevoiceguy/forge-media", rev = "6e3fcd2e7c6f" }
 
 # hep-rs — HEP3 codec, transport, HepSink trait. Owned by the same
 # author as siphon-rs and forge-media; lives in its own repo.


### PR DESCRIPTION
Bumps forge-media `24e20ae1e8ac` → `6e3fcd2e7c6f` ([forge-media#96](https://github.com/thevoiceguy/forge-media/pull/96), merged). **No behaviour change in either repo** — #96 is docs and tests only.

## Why bump at all

So the released tree references a forge-media whose CHANGELOG states the #330 diagnosis correctly. #94's write-up claimed the phantom loss came from early-media packets being received but never counted; that was measured false (a call with 7 s of ringback and no post-answer media reports `rx_packets_received=222`, zero latch rejections, zero SRTP unprotect failures). #96 corrects the wording and rewrites the regression test to model the real mechanism — a sequence discontinuity at the stream change — still reproducing the reported signature with the fix disabled.

The substantive fix remains #94, unchanged and in effect.

## Also in this diff

The `Cargo.toml` comment block drops its reference to forge-media #95, which was filed entirely on the uncounted-packets premise and is now closed invalid. Leaving a pointer to a closed-invalid issue in the pin rationale would mislead the next person to read it.

No `[Unreleased]` CHANGELOG entry: nothing user-visible changed. The existing #330 entry describes the baseline surviving into the answered stream, which is mechanism-agnostic and still accurate.

## Testing

- `cargo test --workspace --locked` → **1027 passed, 0 failed**
- `cargo fmt --all --check` → clean
- `Cargo.lock` resolves to `6e3fcd2e7c6f35d6b02a54fbd3361010abb7f638`, matching forge-media `main`

Merging this unblocks the 0.40.0 cut; I'll open the release-prep PR immediately after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGrL8HBEfyq5sigAdLriRq
