### PR TITLE
chore(release): 0.40.0 — CDR answered_at + caller_hangup, quality fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.40.0] - 2026-07-22
+
 ### Added
 
 - **CDR `answered_at` — connected duration is now derivable** (issue #331; **CDR schema v4 → v5**). A record carried `started_at`, `ended_at` and `duration_ms` but no answer timestamp, and for outbound calls `started_at` is stamped when the origination request is accepted — *before the INVITE goes out*. So `duration_ms` silently measured INVITE-to-end including ring time, and connected duration was not derivable from a v4 record in any form. The overstatement is exactly the ring duration, so it is unbounded and varies per call: ~1.4 s on an instant pickup, ~12.4 s on a call that rang that long — more than half again on a 21 s conversation. Carriers bill from answer, so anyone rating or reconciling against an invoice was systematically over by an amount correlated with how long each call rang, with nothing in the record signalling it. Unanswered calls were also indistinguishable from very short answered ones on duration alone.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3811,7 +3811,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3860,7 +3860,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3876,7 +3876,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "base64",
  "bytes",
@@ -3898,7 +3898,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3915,7 +3915,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "regex",
  "serde",
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3980,7 +3980,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "base64",
  "hmac",
@@ -4003,7 +4003,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4028,7 +4028,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4046,7 +4046,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4064,7 +4064,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4078,7 +4078,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "regex",
  "serde",
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "schemars",
  "serde",
@@ -4100,7 +4100,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4127,7 +4127,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -4145,7 +4145,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.39.0"
+version = "0.40.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.39.0.** Production-deployed against real carriers
+**Current release: v0.40.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a


### PR DESCRIPTION
Release-prep for **0.40.0**, per [RELEASING.md](RELEASING.md) step 2. Mechanical — no code changes.

## What moves

| File | Change |
|---|---|
| `Cargo.toml` | `[workspace.package].version` → `0.40.0` |
| `CHANGELOG.md` | `## [Unreleased]` → `## [0.40.0] - 2026-07-22`, fresh empty `## [Unreleased]` above |
| `README.md` | `**Current release: v0.40.0.**` |
| `Cargo.lock` | refreshed by a workspace build |

Same four-file scope as the 0.37.3 / 0.38.0 / 0.39.0 release commits.

## What's in the release

Headline is **CDR schema v4 → v5**:

- **#331** — `answered_at`: connected duration was not derivable from a v4 record; `duration_ms` silently includes ring/setup time.
- **#332** — `caller_hangup`: a far-end BYE recorded `local_shutdown`, indistinguishable from admin force-hangup / CANCEL / session expiry.

Also:

- **#330** — `rx_packets_lost` no longer reports the ring duration as loss (per-SSRC receive stats, forge-media #94/#96).
- **#333** — a sink enabled under a disabled master switch now warns at startup instead of failing silently (`[cdr]`, `[audit]`, `[quality]`).

## ⚠️ Behaviour changes to surface in the release notes

Both intentional and reviewed, but naming them again since they're what makes this a minor:

1. **`caller_hangup` splits out of `local_shutdown`.** `siphon_ai_calls_total{cause}` redistributes — remote hangups move out of `local_shutdown`, and `local_shutdown` now means admin force-hangup / CANCEL / session expiry only. A dashboard split by cause will show the shift.
2. **New startup warnings** when a sub-sink is enabled under a disabled master. Purely additive log lines, but a deploy that greps startup output for `WARN` will see them.

CDR schema **v4 → v5**; consumers gate on `version >= 5`. WS protocol stays **v1**.

## SDK versions left alone

`sdks/python` and `sdks/typescript` remain at `0.28.0` — versioned independently, not covered by the consistency gate, untouched by prior release commits.

## Verified locally

```
check-version-consistency.py                -> Version consistent: 0.40.0.
check-version-consistency.py --tag v0.40.0  -> Version consistent: 0.40.0 (tag v0.40.0).
extract-changelog.py 0.40.0                 -> 5 entries, correctly bounded before 0.39.0
cargo test --workspace --locked             -> 1027 passed, 0 failed
cargo clippy --workspace --all-targets -- -D warnings -> clean
cargo fmt --all --check / check-doc-links   -> clean
test-harness/sipp-scenarios/run-all.sh      -> all 38 scenarios passed
```

## Next step is yours

Per runbook step 3, the tag goes on the **merged** release commit and triggers the public release — binaries, `.deb`s, SBOM, cosign signatures, the GitHub release marked Latest, and `ghcr.io/thevoiceguy/siphon-ai:v0.40.0` + `:latest`:

```sh
git checkout main && git pull
git tag -a v0.40.0 -m "v0.40.0 — CDR answered_at + caller_hangup, quality fixes"
git push origin v0.40.0
```

I haven't tagged. Say the word after merging and I'll push it and verify the published artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGrL8HBEfyq5sigAdLriRq
