### PR TITLE
fix(outbound): refuse origination while draining for shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Graceful drain now refuses outbound origination** (issue #343). During drain (SIGTERM → draining), `POST /admin/v1/calls` was not gated: it returned `202` and actually placed an INVITE, dialing the PSTN even late in the drain window. The new call wasn't tracked by the drain and was orphaned when the process exited — no clean teardown, no CDR — and since origination is the one admin action that spends money, a deploy overlapping an operator- or automation-driven originate would strand a real call. New inbound INVITEs were already 503'd during drain; outbound was the gap. `originate` now consults the same `DrainFlag` the inbound routing handler uses and refuses with `503 Service Unavailable` (new `OriginateRejection::Draining`), checked first — before gateway validation or a concurrency permit — so a draining daemon returns `Draining`, not `UnknownGateway`, and sends no INVITE.
+
 ## [0.40.0] - 2026-07-22
 
 ### Added

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -936,6 +936,9 @@ impl Runtime {
             // graceful drain now counts and waits for outbound calls,
             // which it previously walked straight past.
             service = service.with_call_registry(acceptor.registry().clone());
+            // Refuse origination while draining, same DrainFlag the
+            // inbound routing handler uses to 503 new INVITEs (#343).
+            service = service.with_drain(drain.clone());
             // Hold music for the WS-reconnect gap on outbound legs (0.7.3) —
             // the same [media].moh_file the inbound acceptor uses.
             service = service.with_moh_file(media.moh_file.clone());

--- a/crates/core/src/outbound_service.rs
+++ b/crates/core/src/outbound_service.rs
@@ -121,6 +121,12 @@ pub struct OutboundService {
     /// `[recording.storage]` upload settings, shared with the acceptor's
     /// teardown enqueue.
     recording_upload: Option<std::sync::Arc<siphon_ai_http::upload::UploadSettings>>,
+    /// The daemon-wide graceful-shutdown flag (0.41.0). While draining,
+    /// `originate` refuses new calls with [`OriginateRejection::Draining`]
+    /// — the same `DrainFlag` the inbound acceptor consults to 503 new
+    /// INVITEs. `None` in tests / when the runtime never installs one, in
+    /// which case origination is never gated (issue #343).
+    drain: Option<siphon_ai_sip_glue::DrainFlag>,
 }
 
 impl OutboundService {
@@ -149,7 +155,15 @@ impl OutboundService {
             moh_file: None,
             recording: RecordingConfig::default(),
             recording_upload: None,
+            drain: None,
         }
+    }
+
+    /// Share the daemon's graceful-shutdown flag so origination is
+    /// refused while draining (issue #343). Unset → never gated.
+    pub fn with_drain(mut self, drain: siphon_ai_sip_glue::DrainFlag) -> Self {
+        self.drain = Some(drain);
+        self
     }
 
     /// Install the `[recording]` config so outbound legs can record
@@ -229,6 +243,16 @@ impl OutboundService {
 
 impl OutboundOriginateHandle for OutboundService {
     fn originate(&self, req: OriginateRequest) -> Result<String, OriginateRejection> {
+        // Refuse new origination while draining — first, before any
+        // validation or a permit is consumed. Origination is the one
+        // admin action that dials the PSTN, and a call started now would
+        // be orphaned when the process exits (no clean teardown, no CDR);
+        // the drain wait doesn't even track it. This mirrors the inbound
+        // acceptor 503'ing new INVITEs during drain (issue #343).
+        if self.drain.as_ref().is_some_and(|d| d.is_draining()) {
+            return Err(OriginateRejection::Draining);
+        }
+
         // Snapshot the gateway table for this origination. The guard
         // lives to the end of this (synchronous) method, past every
         // `gw` read; the spawned call captures only the cloned
@@ -906,5 +930,64 @@ mod tests {
             outbound_result_label(&Err(OutboundError::Transport("dns".into()))),
             "unreachable"
         );
+    }
+
+    fn bare_service() -> OutboundService {
+        OutboundService::new(
+            HashMap::new(),
+            OutboundGuard::new(2, None),
+            BridgeDefaults::default(),
+            crate::acceptor::default_call_id_factory(),
+            Arc::new(siphon_ai_cdr::NullSink),
+            Arc::new(siphon_ai_webhooks::NullSink),
+            ConsultRegistry::new(),
+        )
+    }
+
+    fn originate_req() -> OriginateRequest {
+        OriginateRequest {
+            to: "+13125550000".into(),
+            gateway: "g".into(),
+            ws_url: Some("ws://127.0.0.1:9/".into()),
+            from: None,
+            delayed_offer: false,
+            recording: None,
+        }
+    }
+
+    /// Origination is refused while draining, and the check fires *before*
+    /// the unknown-gateway lookup — a draining daemon says `Draining`, not
+    /// `UnknownGateway`, even with no gateways configured (issue #343).
+    #[test]
+    fn originate_refused_while_draining() {
+        let drain = siphon_ai_sip_glue::DrainFlag::new();
+        let svc = bare_service().with_drain(drain.clone());
+
+        // Not draining yet: falls through to the real validation, which
+        // here rejects the (absent) gateway — proving the gate is open.
+        assert!(matches!(
+            svc.originate(originate_req()),
+            Err(OriginateRejection::UnknownGateway(_))
+        ));
+
+        drain.begin();
+        assert!(
+            matches!(
+                svc.originate(originate_req()),
+                Err(OriginateRejection::Draining)
+            ),
+            "draining must refuse before gateway validation"
+        );
+    }
+
+    /// With no DrainFlag installed, origination is never gated on drain —
+    /// existing single-purpose embedders and tests are unaffected.
+    #[test]
+    fn originate_not_gated_without_drain_flag() {
+        let svc = bare_service();
+        assert!(matches!(
+            svc.originate(originate_req()),
+            Err(OriginateRejection::UnknownGateway(_))
+        ));
     }
 }

--- a/crates/telemetry/src/admin.rs
+++ b/crates/telemetry/src/admin.rs
@@ -213,6 +213,12 @@ pub enum OriginateRejection {
     /// (0.37.x). The gateway `from` is validated at config load, so this
     /// only fires for a bad override in the originate request.
     BadFrom(String),
+    /// The daemon is draining for graceful shutdown → 503 (0.41.0,
+    /// issue #343). Origination is the one admin action that dials the
+    /// PSTN, so it is refused during drain the same way new inbound
+    /// INVITEs are 503'd — a call started now would be orphaned when the
+    /// process exits.
+    Draining,
 }
 
 /// The outbound-origination entry point the admin endpoint calls. Defined
@@ -751,6 +757,10 @@ fn originate_call(state: &AdminState, body: &Bytes) -> Response<Full<Bytes>> {
                 OriginateRejection::BadFrom(f) => {
                     (StatusCode::BAD_REQUEST, format!("bad from: {f}"))
                 }
+                OriginateRejection::Draining => (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "draining for shutdown; not accepting new calls".to_string(),
+                ),
             };
             json_response(status, &json!({ "error": msg }))
         }


### PR DESCRIPTION
Closes #343.

## The bug

During graceful drain (SIGTERM → draining), `POST /admin/v1/calls` was ungated: it returned `202` and actually placed an INVITE — dialing the PSTN even late in the drain window. The call wasn't tracked by the drain and was orphaned when the process exited (no clean teardown, no CDR). New *inbound* INVITEs were already 503'd during drain; outbound origination — the one admin action that spends money — was the gap.

## The fix

`OutboundService` gains the same `DrainFlag` the inbound routing handler already holds (`bins/siphon-ai/src/runtime.rs`: `service.with_drain(drain.clone())` — the *identical* flag instance, not a copy). `originate()` checks it **first**, before gateway validation or a concurrency permit, and refuses with a new `OriginateRejection::Draining` → `503 Service Unavailable`, no INVITE sent.

Checking first matters: a draining daemon with a typo'd gateway name should say `Draining`, not `UnknownGateway`, and must not do any work before refusing.

## Tests

- `originate_refused_while_draining` — with a gateway table that's *empty*, a non-draining call falls through to `UnknownGateway` (gate open), and after `drain.begin()` the same call returns `Draining`. That ordering — `Draining` beating `UnknownGateway` on an absent gateway — is the proof the gate fires before validation.
- `originate_not_gated_without_drain_flag` — an un-installed flag never gates, so existing embedders/tests are unaffected.

`cargo test --workspace --locked` → **1029 passed, 0 failed**; clippy `-D warnings` clean; fmt clean.

## Note on verification

The gate is a synchronous predicate, and the unit test exercises exactly the branch that matters, wired to the same `DrainFlag` the issue itself confirms already works for inbound 503s during drain. I attempted a live end-to-end (SIGTERM a daemon with a held call, then originate mid-drain) but couldn't reliably hold a loopback call alive across the 30 s drain window — the call kept ending ~1 s in, closing the admin listener before the originate landed. That's a harness limitation, not a question about the gate: the flag flips (proven by the inbound path), and this change makes the service read it. I chose not to keep fighting the harness once the logic was airtight at the unit level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGrL8HBEfyq5sigAdLriRq
