### PR TITLE
chore(release): 0.41.0 — outbound HEP, record-routing BYE, drain safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.41.0] - 2026-07-24
+
 ### Fixed
 
 - **Force-hangup on a call answered through a record-routing trunk now releases the caller** (issue #342; fixed upstream by [siphon-rs#69](https://github.com/thevoiceguy/siphon-rs/pull/69), pin bumped `50866b1599a7` → `fbdf132a11d6`). A local teardown — `POST /admin/calls/:id/hangup`, a WS `hangup` (`server_hangup`), or a bridge-ended stop — tore down siphon's media and wrote the CDR but left the caller in **dead air** until the carrier's session timer fired (~60 s on Twilio). Only a far-end-initiated BYE (`caller_hangup`) was unaffected. Root cause was in siphon-rs: `IntegratedUAC::bye` and `bye_via_flow` were the only in-dialog senders that skipped `prepare_in_dialog_request`, so the closing BYE went out with **no `Route` headers** and the carrier's private media-gateway address as Request-URI. A record-routing edge can't correlate that and answers `481 Call/Transaction Does Not Exist`, so the BYE never reached the PSTN. Measured live on the Twilio trunk: the daemon's real BYE drew a 481, while a hand-crafted BYE carrying the two `Record-Route` hops + the dialog local URI drew a 200 and released the stranded leg immediately. This looked TLS-specific only because the local TCP test peer doesn't Record-Route — the real condition is a record-routing peer. No siphon-ai code change; the fix routes both BYE methods through the dialog route set exactly as `reinvite`/`send_update`/`send_refer_via_flow` already do (empty route set → byte-identical, so direct peers are unaffected), and sources the BYE `From` from the dialog's local URI (RFC 3261 §12.2.1.1). Load-bearing regression test upstream (`bye_via_flow_carries_route_set_and_dialog_local_uri`), CI-proven red without the fix.
@@ -2652,7 +2654,8 @@ the WebSocket server's job.
 - Reference WebSocket servers in `examples/`: echo (Python / Node),
   an OpenAI Realtime bridge, and a Deepgram + LLM voice bot.
 
-[Unreleased]: https://github.com/thevoiceguy/siphon-ai/compare/v0.37.0...HEAD
+[Unreleased]: https://github.com/thevoiceguy/siphon-ai/compare/v0.41.0...HEAD
+[0.41.0]: https://github.com/thevoiceguy/siphon-ai/compare/v0.40.0...v0.41.0
 [0.14.1]: https://github.com/thevoiceguy/siphon-ai/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/thevoiceguy/siphon-ai/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/thevoiceguy/siphon-ai/compare/v0.12.2...v0.13.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3721,7 +3721,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=fbdf132a11d6#fbdf132a11d6fdfe233c882c668ef38f66ab3eeb"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=6e3fcd2e7c6f#6e3fcd2e7c6f35d6b02a54fbd3361010abb7f638"
 dependencies = [
  "nom 7.1.3",
  "smol_str",
@@ -3730,7 +3730,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=6e3fcd2e7c6f#6e3fcd2e7c6f35d6b02a54fbd3361010abb7f638"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=fbdf132a11d6#fbdf132a11d6fdfe233c882c668ef38f66ab3eeb"
 dependencies = [
  "nom 7.1.3",
  "smol_str",
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "base64",
  "bytes",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3927,7 +3927,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "regex",
  "serde",
@@ -3946,7 +3946,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "base64",
  "hmac",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4040,7 +4040,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4058,7 +4058,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4076,7 +4076,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "regex",
  "serde",
@@ -4102,7 +4102,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "schemars",
  "serde",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -4157,7 +4157,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -4186,7 +4186,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.40.0"
+version = "0.41.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.40.0.** Production-deployed against real carriers
+**Current release: v0.41.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a


### PR DESCRIPTION
## Release 0.41.0

Cuts **0.41.0**. Four real-world fixes accumulated under `[Unreleased]` since 0.40.0 — all already merged to `main`:

| Issue | Fix | Merged via |
|---|---|---|
| **#341** | Outbound-originated calls now emit a SIP HEP ladder (client connection pool had zero HEP emission) | siphon-rs #68 → siphon-ai #347 |
| **#342** | Force-hangup over a record-routing trunk now releases the caller — the in-dialog BYE carries the dialog route set (was going out with no `Route` and a private-gateway Request-URI, drawing a 481 from Twilio → dead air) | siphon-rs #69 → siphon-ai #349 |
| **#343** | Graceful drain now refuses outbound origination with `503` (`OriginateRejection::Draining`) instead of dialing the PSTN mid-drain | siphon-ai #345 |
| **#344** | Drain-forced calls now keep their CDR — file record *and* HEP chunk (two races: registry deregister-before-emit, and HEP worker abort-not-drain) | siphon-ai #346 + hep-rs #2 |

### Release-prep contents
- `[workspace.package].version` `0.40.0` → `0.41.0` (+ `Cargo.lock` refresh — internal crates inherit the bump)
- `CHANGELOG.md`: `[Unreleased]` dated to `## [0.41.0] - 2026-07-24`, fresh empty `[Unreleased]` above it, compare links added/corrected (the `[Unreleased]` ref was stale at `v0.37.0...HEAD`)
- `README.md` current-release marker → `v0.41.0`

### Gates (all pass locally)
`check-version-consistency.py` (+ `--tag v0.41.0`) · `extract-changelog.py 0.41.0` · `cargo fmt --check` · `check-doc-links.py` · `cargo clippy --workspace --all-targets --locked -D warnings` · `cargo test --workspace --locked`

Pins at release: siphon-rs `fbdf132a11d6`, forge-media `6e3fcd2e7c6f`, hep-rs `91e689b`.

After merge: tag `v0.41.0` on the merge commit and push to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
