### PR TITLE
fix(deps): bump siphon-rs — TLS pool reuses connection across SNI (#342 outbound half)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Locally terminated *outbound* calls now BYE the carrier; hold works on outbound legs** (completes issue #342 — the outbound half; fixed upstream by [siphon-rs#70](https://github.com/thevoiceguy/siphon-rs/pull/70), pin bumped `fbdf132a11d6` → `5c7cf20beb50`). #342/0.41.0 fixed the *inbound* teardown BYE (route set), but the same stranding persisted on **outbound** calls: hanging one up locally (admin hangup, WS `server_hangup`, drain, controller exit) sent **no BYE**, leaving the callee in dead air until the carrier's ~60 s session timer, and a bot-initiated `hold`/transfer re-INVITE silently failed. Found black-box testing 0.41.0 on the live Twilio trunk. Root cause was in siphon-rs: `TlsPool::send_tls` keyed connection reuse by `(peer_addr, SNI)`. An outbound call's INVITE opens its connection with the request-URI **hostname** SNI, but an in-dialog request (BYE / re-INVITE / REFER) derives its SNI from the peer's `Record-Route` — an **IP literal** for a carrier edge — so it missed the hostname-keyed connection and dialed a **fresh** connect, which the edge refuses and whose IP-SNI handshake fails the edge's hostname cert (`outbound TLS connect … transport error`); the request never reached the wire. Inbound legs were unaffected because they reuse their inbound connection explicitly via a `flow`. The fix makes `send_tls` fall back to reusing any live connection to the same peer `addr` on an exact-key miss (RFC 5923 connection reuse); the TCP pool already keyed by `addr` alone. No siphon-ai code change. Load-bearing regression test upstream (`send_tls_reuses_connection_to_same_addr_across_sni`), CI-proven red without the fix.
+
 ## [0.41.0] - 2026-07-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3595,7 +3595,7 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 [[package]]
 name = "sip-auth"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=fbdf132a11d6#fbdf132a11d6fdfe233c882c668ef38f66ab3eeb"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50#5c7cf20beb5069592724482632749fb18dbe1e94"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3618,7 +3618,7 @@ dependencies = [
 [[package]]
 name = "sip-core"
 version = "0.7.6"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=fbdf132a11d6#fbdf132a11d6fdfe233c882c668ef38f66ab3eeb"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50#5c7cf20beb5069592724482632749fb18dbe1e94"
 dependencies = [
  "bytes",
  "httpdate",
@@ -3631,7 +3631,7 @@ dependencies = [
 [[package]]
 name = "sip-dialog"
 version = "0.3.3"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=fbdf132a11d6#fbdf132a11d6fdfe233c882c668ef38f66ab3eeb"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50#5c7cf20beb5069592724482632749fb18dbe1e94"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3649,7 +3649,7 @@ dependencies = [
 [[package]]
 name = "sip-dns"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=fbdf132a11d6#fbdf132a11d6fdfe233c882c668ef38f66ab3eeb"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50#5c7cf20beb5069592724482632749fb18dbe1e94"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3663,7 +3663,7 @@ dependencies = [
 [[package]]
 name = "sip-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=fbdf132a11d6#fbdf132a11d6fdfe233c882c668ef38f66ab3eeb"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50#5c7cf20beb5069592724482632749fb18dbe1e94"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -3674,7 +3674,7 @@ dependencies = [
 [[package]]
 name = "sip-identity"
 version = "0.1.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=fbdf132a11d6#fbdf132a11d6fdfe233c882c668ef38f66ab3eeb"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50#5c7cf20beb5069592724482632749fb18dbe1e94"
 dependencies = [
  "base64",
  "ring",
@@ -3687,7 +3687,7 @@ dependencies = [
 [[package]]
 name = "sip-observe"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=fbdf132a11d6#fbdf132a11d6fdfe233c882c668ef38f66ab3eeb"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50#5c7cf20beb5069592724482632749fb18dbe1e94"
 dependencies = [
  "once_cell",
  "tracing",
@@ -3696,7 +3696,7 @@ dependencies = [
 [[package]]
 name = "sip-parse"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=fbdf132a11d6#fbdf132a11d6fdfe233c882c668ef38f66ab3eeb"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50#5c7cf20beb5069592724482632749fb18dbe1e94"
 dependencies = [
  "bytes",
  "httpdate",
@@ -3710,7 +3710,7 @@ dependencies = [
 [[package]]
 name = "sip-ratelimit"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=fbdf132a11d6#fbdf132a11d6fdfe233c882c668ef38f66ab3eeb"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50#5c7cf20beb5069592724482632749fb18dbe1e94"
 dependencies = [
  "dashmap 5.5.3",
  "parking_lot",
@@ -3730,7 +3730,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=fbdf132a11d6#fbdf132a11d6fdfe233c882c668ef38f66ab3eeb"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50#5c7cf20beb5069592724482632749fb18dbe1e94"
 dependencies = [
  "nom 7.1.3",
  "smol_str",
@@ -3739,7 +3739,7 @@ dependencies = [
 [[package]]
 name = "sip-transaction"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=fbdf132a11d6#fbdf132a11d6fdfe233c882c668ef38f66ab3eeb"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50#5c7cf20beb5069592724482632749fb18dbe1e94"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3758,7 +3758,7 @@ dependencies = [
 [[package]]
 name = "sip-transport"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=fbdf132a11d6#fbdf132a11d6fdfe233c882c668ef38f66ab3eeb"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50#5c7cf20beb5069592724482632749fb18dbe1e94"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3778,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "sip-uac"
 version = "0.4.2"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=fbdf132a11d6#fbdf132a11d6fdfe233c882c668ef38f66ab3eeb"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50#5c7cf20beb5069592724482632749fb18dbe1e94"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3791,7 +3791,7 @@ dependencies = [
  "sip-dialog",
  "sip-dns",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=fbdf132a11d6)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -3803,7 +3803,7 @@ dependencies = [
 [[package]]
 name = "sip-uas"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=fbdf132a11d6#fbdf132a11d6fdfe233c882c668ef38f66ab3eeb"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50#5c7cf20beb5069592724482632749fb18dbe1e94"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3813,7 +3813,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=fbdf132a11d6)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -3966,7 +3966,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=fbdf132a11d6)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50)",
  "sip-transaction",
  "sip-uac",
  "sip-uas",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,37 +130,39 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 # main branch and replace the rev hashes here (see CLAUDE.md §7.5).
 
 # siphon-rs — RFC 3261 SIP stack.
-# Bumped 2026-07-24 `50866b1599a7` → `fbdf132a11d6` = siphon-rs #69: the
-# in-dialog BYE now carries the dialog route set. `IntegratedUAC::bye` and
-# `bye_via_flow` were the only in-dialog senders that skipped
-# `prepare_in_dialog_request`, so a local-teardown BYE went out with no Route
-# headers and the carrier's private gateway as Request-URI — a record-routing
-# edge (Twilio) answered 481 and never relayed it, stranding the caller in
-# dead air until session-expires (siphon-ai #342). No API change (the `&Dialog`
-# signatures are kept; the route set is applied on a clone); an empty route set
-# is byte-identical to before, so direct peers are unaffected.
-# (Prior: `50866b1599a7` = #68 pool SIP HEP, siphon-ai #341;
+# Bumped 2026-07-24 `fbdf132a11d6` → `5c7cf20beb50` = siphon-rs #70: the TLS
+# pool reuses a peer's connection across SNI for in-dialog requests. #69 fixed
+# the route set on the in-dialog BYE (inbound half of #342), but the OUTBOUND
+# half remained: `TlsPool::send_tls` keyed reuse by (addr, SNI), and an
+# outbound leg's in-dialog request (BYE / hold re-INVITE / REFER) derives its
+# SNI from the peer's Record-Route — an IP literal — so it missed the
+# hostname-keyed dialog connection and dialed a fresh connect the carrier edge
+# refuses (and whose IP-SNI handshake fails the hostname cert). So locally
+# terminated outbound calls sent NO BYE (callee stranded) and hold failed.
+# send_tls now falls back to any live connection to the same addr (RFC 5923).
+# (Prior: `fbdf132a11d6` = #69 in-dialog BYE route set, siphon-ai #342 inbound;
+#  `50866b1599a7` = #68 pool SIP HEP, siphon-ai #341;
 #  `6fd432270bb8` = #67 dialog_manager share, siphon-ai #324;
 #  `fcaff011f9c6` = #65 invite_with_from, siphon-ai #316;
 #  `3a4fc312ade3` = #64 TLS-SNI-is-hostname, siphon-ai #312.)
-sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "fbdf132a11d6" }
-sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "fbdf132a11d6" }
-sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "fbdf132a11d6", features = ["tls"] }
-sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "fbdf132a11d6" }
-sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "fbdf132a11d6" }
-sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "fbdf132a11d6" }
-sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "fbdf132a11d6" }
-sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "fbdf132a11d6" }
-sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "fbdf132a11d6" }
+sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "5c7cf20beb50" }
+sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "5c7cf20beb50" }
+sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "5c7cf20beb50", features = ["tls"] }
+sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "5c7cf20beb50" }
+sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "5c7cf20beb50" }
+sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "5c7cf20beb50" }
+sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "5c7cf20beb50" }
+sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "5c7cf20beb50" }
+sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "5c7cf20beb50" }
 # sip-sdp — the SAME sip-sdp sip-uac's SdpAnswerGenerator trait speaks
 # (distinct from forge-media's pinned sip-sdp). Used by the outbound
 # delayed-offer answer generator to hand the UAC a SessionDescription it
 # accepts. Must stay on the same siphon-rs rev as the rest below.
-sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "fbdf132a11d6" }
-sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "fbdf132a11d6" }
+sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "5c7cf20beb50" }
+sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "5c7cf20beb50" }
 # sip-identity — STIR/SHAKEN Identity-header parsing + PASSporT verification
 # (ES256 + X.509 chain validation). Consumed by the stir-shaken verifier crate.
-sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "fbdf132a11d6" }
+sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "5c7cf20beb50" }
 
 # forge-media — RTP / codecs / SDP / DTMF / engine.
 #


### PR DESCRIPTION
## Summary

Bumps the siphon-rs pin to [siphon-rs#70](https://github.com/thevoiceguy/siphon-rs/pull/70) (`fbdf132a11d6` → `5c7cf20beb50`), which fixes the **outbound half of #342**.

#342 / 0.41.0 fixed the *inbound* teardown BYE (route set). But black-box testing 0.41.0 on the live Twilio trunk surfaced that the same stranding persisted on **outbound** calls:

- Hanging up an outbound call **locally** (admin hangup, WS `server_hangup`, drain, controller exit) sent **no BYE** → the callee sat in dead air until the carrier's ~60 s session timer.
- A bot-initiated `hold` / transfer re-INVITE on an outbound leg **silently failed** (`error{hold_failed}`, re-INVITE never on the wire).

## Root cause (siphon-rs, measured via debug journal + HEP)

`TlsPool::send_tls` keys connection reuse by `(peer_addr, SNI)`. An outbound INVITE opens its connection with the request-URI **hostname** SNI; an in-dialog request derives its SNI from the peer's `Record-Route` — an **IP literal** for a carrier edge — so it misses the hostname-keyed connection and dials a **fresh** connect. That fails twice: the edge accepts only the original signaling connection, and the fresh handshake presents the IP as SNI and is rejected by the edge's hostname cert. The request never reaches the wire. Inbound legs were unaffected because they reuse their inbound connection explicitly via a `flow`.

## The fix

`send_tls` now falls back to reusing any live connection to the same peer `addr` on an exact-key miss (RFC 5923 connection reuse). The TCP pool already keyed by `addr` alone. Load-bearing test upstream (`send_tls_reuses_connection_to_same_addr_across_sni`), CI-proven red without the fix.

## Changes here

- `Cargo.toml`: 12 `sip-*` revs `fbdf132a11d6` → `5c7cf20beb50` + rewritten pin-comment block.
- `Cargo.lock`: refreshed to the new rev (hand-edited; git sources carry no checksum and #70 changed no dependency graph, so only the rev/SHA strings move — `cargo test --workspace --locked` in CI validates it).
- `CHANGELOG.md`: `[Unreleased] > Fixed` entry.

No siphon-ai source change. `check-doc-links.py` passes locally; fmt/clippy/`--locked` test gates run in CI.

## Note on #342

#342 was closed by the inbound fix (#349). This completes its **outbound** half — the issue's stated scope explicitly flagged WS `hangup`/bridge-ended teardown, and a comment there confirmed outbound `server_hangup` stranding. Happy to reopen/reclose #342 for bookkeeping, or track the outbound half here — your call. The live box picks up the fix once a new `.deb` built against this pin is installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
