### PR TITLE
chore(release): 0.41.1 — outbound BYE over TLS (completes #342)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.41.1] - 2026-07-24
+
 ### Fixed
 
 - **Locally terminated *outbound* calls now BYE the carrier; hold works on outbound legs** (completes issue #342 — the outbound half; fixed upstream by [siphon-rs#70](https://github.com/thevoiceguy/siphon-rs/pull/70), pin bumped `fbdf132a11d6` → `5c7cf20beb50`). #342/0.41.0 fixed the *inbound* teardown BYE (route set), but the same stranding persisted on **outbound** calls: hanging one up locally (admin hangup, WS `server_hangup`, drain, controller exit) sent **no BYE**, leaving the callee in dead air until the carrier's ~60 s session timer, and a bot-initiated `hold`/transfer re-INVITE silently failed. Found black-box testing 0.41.0 on the live Twilio trunk. Root cause was in siphon-rs: `TlsPool::send_tls` keyed connection reuse by `(peer_addr, SNI)`. An outbound call's INVITE opens its connection with the request-URI **hostname** SNI, but an in-dialog request (BYE / re-INVITE / REFER) derives its SNI from the peer's `Record-Route` — an **IP literal** for a carrier edge — so it missed the hostname-keyed connection and dialed a **fresh** connect, which the edge refuses and whose IP-SNI handshake fails the edge's hostname cert (`outbound TLS connect … transport error`); the request never reached the wire. Inbound legs were unaffected because they reuse their inbound connection explicitly via a `flow`. The fix makes `send_tls` fall back to reusing any live connection to the same peer `addr` on an exact-key miss (RFC 5923 connection reuse); the TCP pool already keyed by `addr` alone. No siphon-ai code change. Load-bearing regression test upstream (`send_tls_reuses_connection_to_same_addr_across_sni`), CI-proven red without the fix.
@@ -2658,7 +2660,8 @@ the WebSocket server's job.
 - Reference WebSocket servers in `examples/`: echo (Python / Node),
   an OpenAI Realtime bridge, and a Deepgram + LLM voice bot.
 
-[Unreleased]: https://github.com/thevoiceguy/siphon-ai/compare/v0.41.0...HEAD
+[Unreleased]: https://github.com/thevoiceguy/siphon-ai/compare/v0.41.1...HEAD
+[0.41.1]: https://github.com/thevoiceguy/siphon-ai/compare/v0.41.0...v0.41.1
 [0.41.0]: https://github.com/thevoiceguy/siphon-ai/compare/v0.40.0...v0.41.0
 [0.14.1]: https://github.com/thevoiceguy/siphon-ai/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/thevoiceguy/siphon-ai/compare/v0.13.0...v0.14.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3721,7 +3721,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=6e3fcd2e7c6f#6e3fcd2e7c6f35d6b02a54fbd3361010abb7f638"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50#5c7cf20beb5069592724482632749fb18dbe1e94"
 dependencies = [
  "nom 7.1.3",
  "smol_str",
@@ -3730,7 +3730,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50#5c7cf20beb5069592724482632749fb18dbe1e94"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=6e3fcd2e7c6f#6e3fcd2e7c6f35d6b02a54fbd3361010abb7f638"
 dependencies = [
  "nom 7.1.3",
  "smol_str",
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "base64",
  "bytes",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3927,7 +3927,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "regex",
  "serde",
@@ -3946,7 +3946,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "base64",
  "hmac",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4040,7 +4040,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4058,7 +4058,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4076,7 +4076,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "regex",
  "serde",
@@ -4102,7 +4102,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "schemars",
  "serde",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "base64",
  "rcgen",
@@ -4157,7 +4157,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -4186,7 +4186,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.41.0"
+version = "0.41.1"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.41.0.** Production-deployed against real carriers
+**Current release: v0.41.1.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a


### PR DESCRIPTION
## Release 0.41.1

Patch release. One fix accumulated under `[Unreleased]` since 0.41.0 — already merged to `main`:

| Issue | Fix | Merged via |
|---|---|---|
| **#342 (outbound half)** | Locally terminated *outbound* calls now BYE the carrier, and `hold`/transfer re-INVITE works on outbound legs. 0.41.0 fixed the inbound teardown BYE (route set); the same dead-air stranding persisted on outbound calls because `TlsPool::send_tls` keyed connection reuse by `(peer_addr, SNI)` — an in-dialog BYE derives its SNI from the peer's `Record-Route` (an IP literal for a carrier edge), missing the hostname-keyed connection and dialing a fresh connect the edge refuses. Now falls back to reusing any live connection to the same peer `addr` on an exact-key miss (RFC 5923). Found black-box testing 0.41.0 on the live Twilio trunk. | siphon-rs #70 → this pin bump `fbdf132a11d6` → `5c7cf20beb50` |

### Release-prep contents
- `[workspace.package].version` `0.41.0` → `0.41.1` (+ `Cargo.lock` refresh — internal crates inherit)
- `CHANGELOG.md`: `[Unreleased]` dated to `## [0.41.1] - 2026-07-24`, fresh empty `[Unreleased]`, compare links added/corrected
- `README.md` current-release marker → `v0.41.1`

### Gates (all pass locally)
`check-version-consistency.py` (+ `--tag v0.41.1`) · `extract-changelog.py 0.41.1` · `cargo fmt --check` · `check-doc-links.py` · `cargo clippy --workspace --all-targets --locked -D warnings` · `cargo test --workspace --locked`

Pins at release: siphon-rs `5c7cf20beb50`, forge-media `6e3fcd2e7c6f`, hep-rs `91e689b`.

After merge: tag `v0.41.1` on the merge commit and push to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
