### PR TITLE
fix(outbound): advance CSeq across in-dialog requests (closes #353)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Outbound in-dialog requests now carry monotonically increasing CSeqs (hold → resume → BYE no longer collide)** (issue #353). On an **outbound** call, every in-dialog request after the initial INVITE — a bot `hold`, then `resume`, and the closing BYE on local teardown — went out with the **same `CSeq: 2`** instead of `2, 3, 4, …`. The carrier rejected the malformed sequence: the duplicate-CSeq **BYE drew `408 Request Timeout`** (callee stranded in dead air until the carrier's ~60 s session timer — the #342 symptom, resurfacing for the re-INVITEd-call case), and the duplicate-CSeq **resume re-INVITE** was indistinguishable from a retransmission of the hold, so a resume could never apply `a=sendrecv` and the call stayed one-way/held. Only observable **after** 0.41.1, because before it none of these outbound in-dialog requests reached the wire (#342). Root cause: the outbound leg resolved each in-dialog request's dialog from a **frozen snapshot taken at answer** (`DialogSource::Direct(Box<Dialog>)`) — so `send_reinvite` advanced the CSeq on a throwaway per-request clone (and re-inserted into the gateway UAC's *private* `DialogManager`, which the snapshot never reads), and every `resolve()` restarted from `local_cseq == 1`. Inbound legs were immune: they resolve from the shared `DialogManager` the UAC re-inserts into. The fix holds the outbound leg's confirmed dialog behind a single shared, advancing handle (`Arc<Mutex<Dialog>>`) that the transfer REFER, hold/resume re-INVITE, and teardown BYE all resolve from and **commit back to**, so the local CSeq increases monotonically across the call. No siphon-rs change. Load-bearing regression test (`direct_source_commit_advances_the_shared_cseq`), CI-proven red without the fix (it reproduces the `2, 2, 2` collision).
+
 ## [0.41.1] - 2026-07-24
 
 ### Fixed

--- a/crates/core/src/call.rs
+++ b/crates/core/src/call.rs
@@ -2629,6 +2629,10 @@ async fn run_transfer_inner(
                 .await
         }
     };
+    // The REFER consumed a local CSeq; persist it so an outbound leg's
+    // teardown BYE continues the sequence (no-op for inbound, which
+    // persists through the shared DialogManager) (#353).
+    ctx.control.commit(&dialog);
     match sent {
         Ok((response, _subscription)) => {
             let status = response.code();
@@ -2693,7 +2697,13 @@ async fn drive_hold_reinvite(
     };
     let mut glare_retried = false;
     loop {
-        match ctx.control.send_reinvite(&mut dialog, offer_sdp).await {
+        let result = ctx.control.send_reinvite(&mut dialog, offer_sdp).await;
+        // The send consumed a local CSeq (advanced in `prepare_in_dialog_request`
+        // before the response, so it's spent whatever the outcome). Persist it
+        // to the shared dialog so the next request — resume, another hold, or
+        // the teardown BYE — continues the sequence instead of reusing it (#353).
+        ctx.control.commit(&dialog);
+        match result {
             Ok(response) => {
                 let status = response.code();
                 if (200..300).contains(&status) {

--- a/crates/core/src/outbound_service.rs
+++ b/crates/core/src/outbound_service.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 use arc_swap::ArcSwap;
 use chrono::{DateTime, Utc};
 use forge_core::{CallId, ParticipantId};
+use parking_lot::Mutex;
 use sip_core::SipUri;
 use siphon_ai_bridge::{BridgeConfig, CallId as BridgeCallId, Direction};
 use siphon_ai_cdr::{
@@ -617,10 +618,20 @@ async fn run_call(
     // the dialog we hold directly — each gateway UAC keeps a private
     // DialogManager, so the shared lookup the inbound path uses
     // can't see this dialog.
+    // One shared, advancing dialog for every in-dialog request on this
+    // leg — transfer REFER, hold/resume re-INVITE, and the teardown BYE
+    // below all resolve from and commit back to it, so its local CSeq
+    // increases monotonically. A frozen per-request snapshot left the
+    // CSeq stuck at 1, so hold/resume/BYE all reused `CSeq 2` and the
+    // carrier 408'd the duplicate-CSeq BYE (issue #353).
+    let shared_dialog = Arc::new(Mutex::new(dialog));
     let transfer = TransferContext {
         control: DialogControl {
             uac: originator.uac(),
-            source: DialogSource::Direct(Box::new(dialog.clone())),
+            source: DialogSource::Direct {
+                sip_call_id: sip_call_id.clone(),
+                dialog: shared_dialog.clone(),
+            },
             // Outbound legs dialed out themselves, so the gateway UAC's
             // dispatcher can reach the peer without flow reuse.
             flow: None,
@@ -635,7 +646,10 @@ async fn run_call(
     let hold = Some(HoldContext {
         control: DialogControl {
             uac: originator.uac(),
-            source: DialogSource::Direct(Box::new(dialog.clone())),
+            source: DialogSource::Direct {
+                sip_call_id: sip_call_id.clone(),
+                dialog: shared_dialog.clone(),
+            },
             flow: None,
         },
         hold_offer_sdp: rewrite_sdp_direction(&accepted.offer_sdp, MediaDirection::SendOnly),
@@ -714,7 +728,13 @@ async fn run_call(
     // a far-end BYE was answered 481 and never reached the controller
     // at all, so this branch was unreachable in the case that needs it.
     if !cleanup_handle.remote_bye_received() {
-        originator.hangup(&dialog).await;
+        // Resolve the dialog as it stands now — any hold/resume re-INVITE
+        // has advanced its local CSeq, and the BYE must continue that
+        // sequence (not restart at 2) or a record-routing carrier 408s
+        // the duplicate (issue #353). Clone out from under the lock; the
+        // BYE itself must not hold it across the await.
+        let final_dialog = shared_dialog.lock().clone();
+        originator.hangup(&final_dialog).await;
     }
     originator.stop_session(&call_id).await;
     drop(call_handle); // stop keepalives / session-timer tasks

--- a/crates/core/src/transfer.rs
+++ b/crates/core/src/transfer.rs
@@ -30,6 +30,7 @@
 
 use std::sync::Arc;
 
+use parking_lot::Mutex;
 use sip_core::SipUri;
 use sip_dialog::{Dialog, DialogManager};
 use sip_uac::integrated::IntegratedUAC;
@@ -49,10 +50,20 @@ pub enum DialogSource {
         dialog_manager: Arc<DialogManager>,
     },
     /// Outbound leg: the originate path holds the confirmed dialog
-    /// directly (each gateway UAC has its own private DialogManager,
-    /// so the shared one can't resolve it). Snapshot taken at answer;
-    /// the CSeq-divergence note below applies the same way.
-    Direct(Box<Dialog>),
+    /// directly (each gateway UAC has its own private DialogManager, so
+    /// the shared one can't resolve it). Held behind a shared, advancing
+    /// handle rather than a frozen snapshot: every in-dialog request on
+    /// this leg — hold, resume, REFER, and the teardown BYE — resolves
+    /// from and commits back to the *same* `Dialog`, so its local CSeq
+    /// increases monotonically (2, 3, 4, …). A frozen per-request clone
+    /// left `local_cseq` stuck at 1, so every request reused `CSeq 2`
+    /// and the carrier 408'd the duplicate-CSeq BYE (issue #353). The
+    /// call-id is carried alongside so `sip_call_id()` needn't take the
+    /// lock just to log.
+    Direct {
+        sip_call_id: String,
+        dialog: Arc<Mutex<Dialog>>,
+    },
 }
 
 impl DialogSource {
@@ -64,7 +75,22 @@ impl DialogSource {
                 sip_call_id,
                 dialog_manager,
             } => dialog_manager.find_by_call_id(sip_call_id),
-            DialogSource::Direct(dialog) => Some(*dialog.clone()),
+            DialogSource::Direct { dialog, .. } => Some(dialog.lock().clone()),
+        }
+    }
+
+    /// Persist a dialog whose local CSeq was just consumed by an
+    /// in-dialog request, so the next request on this leg continues the
+    /// sequence instead of restarting from the answer-time snapshot.
+    ///
+    /// `Managed` legs already persist through the UAC's shared
+    /// `DialogManager` (each in-dialog send re-inserts the advanced
+    /// dialog), so this is a no-op there. `Direct` (outbound) legs hold
+    /// the dialog here and must be written back — without it every
+    /// hold/resume/BYE reused `CSeq 2` (issue #353).
+    pub(crate) fn commit(&self, dialog: &Dialog) {
+        if let DialogSource::Direct { dialog: shared, .. } = self {
+            *shared.lock() = dialog.clone();
         }
     }
 
@@ -81,7 +107,7 @@ impl DialogSource {
     fn sip_call_id(&self) -> &str {
         match self {
             DialogSource::Managed { sip_call_id, .. } => sip_call_id,
-            DialogSource::Direct(dialog) => dialog.id().call_id(),
+            DialogSource::Direct { sip_call_id, .. } => sip_call_id,
         }
     }
 }
@@ -108,6 +134,13 @@ pub struct DialogControl {
 }
 
 impl DialogControl {
+    /// Persist a dialog whose local CSeq an in-dialog request just
+    /// advanced, so the next request on this leg continues the sequence
+    /// (issue #353). No-op for inbound legs. See [`DialogSource::commit`].
+    pub(crate) fn commit(&self, dialog: &sip_dialog::Dialog) {
+        self.source.commit(dialog)
+    }
+
     /// Per-task dialog clone, or `None` if the dialog is gone.
     pub(crate) fn resolve(&self) -> Option<sip_dialog::Dialog> {
         self.source.resolve()
@@ -320,10 +353,44 @@ mod tests {
         // Outbound legs: the dialog is held directly; run_call's
         // teardown owns the BYE, so the transfer task must not send
         // a second one.
-        let src = DialogSource::Direct(Box::new(consult_dialog("out@siphon", "l", "r")));
+        let src = DialogSource::Direct {
+            sip_call_id: "out@siphon".into(),
+            dialog: Arc::new(Mutex::new(consult_dialog("out@siphon", "l", "r"))),
+        };
         let dialog = src.resolve().expect("direct always resolves");
         assert_eq!(dialog.id().call_id(), "out@siphon");
         assert!(!src.bye_after_refer());
+    }
+
+    #[test]
+    fn direct_source_commit_advances_the_shared_cseq() {
+        // Regression for #353: a Direct leg must persist an advanced
+        // dialog so successive in-dialog requests (hold, resume, BYE)
+        // carry strictly increasing CSeqs instead of all reusing 2.
+        let src = DialogSource::Direct {
+            sip_call_id: "out@siphon".into(),
+            dialog: Arc::new(Mutex::new(consult_dialog("out@siphon", "l", "r"))),
+        };
+        let base = src.resolve().unwrap().local_cseq();
+        // Model the real wiring: the transfer control, hold control, and
+        // teardown are *separate* `DialogSource`s (`#[derive(Clone)]`)
+        // over the SAME `Arc<Mutex<Dialog>>`. Each hold/resume/BYE
+        // resolves through its own clone, consumes one CSeq, and commits
+        // — and the advance must be visible through every other clone.
+        let hold_ctl = src.clone();
+        let resume_ctl = src.clone();
+        let teardown = src.clone();
+        let mut seen = Vec::new();
+        for ctl in [&hold_ctl, &resume_ctl, &teardown] {
+            let mut d = ctl.resolve().unwrap();
+            seen.push(d.next_local_cseq());
+            ctl.commit(&d);
+        }
+        assert_eq!(
+            seen,
+            vec![base + 1, base + 2, base + 3],
+            "a committed send on one clone must advance the CSeq the others see"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Fix #353 — outbound in-dialog CSeq collision (hold/resume/BYE all reuse `CSeq 2`)

Closes #353.

### The bug
On an **outbound** call, every in-dialog request after the initial INVITE reused the **same `CSeq: 2`** instead of `2, 3, 4, …`:
- the duplicate-CSeq **BYE** drew `408 Request Timeout` → callee stranded in dead air until the carrier's ~60 s session timer (the #342 symptom, resurfacing for the re-INVITEd-call case);
- the duplicate-CSeq **resume re-INVITE** looked like a retransmission of the hold → the carrier may never apply `a=sendrecv`, leaving the call one-way/held.

Only observable **after 0.41.1**, because before it none of these outbound in-dialog requests reached the wire (#342). Reported from live black-box testing on the Twilio TLS trunk, with a full HEP SIP ladder.

### Root cause (confirmed in code)
The outbound leg resolved each in-dialog request's dialog from a **frozen snapshot taken at answer** — `DialogSource::Direct(Box<Dialog>)`. `send_reinvite` takes `&mut dialog`, advances the CSeq via `prepare_in_dialog_request`, and re-inserts the advance into the **gateway UAC's private `DialogManager`** — which `DialogSource::Direct` never reads. So every `resolve()` handed back a fresh clone with `local_cseq == 1`, and `create_bye` (`local_cseq + 1`) then produced `CSeq 2` again. Three separate frozen copies existed: the transfer control, the hold control, and the teardown `hangup(&dialog)`.

Inbound legs were immune: `DialogSource::Managed` resolves from the shared `DialogManager` that the UAC re-inserts the advance into.

### The fix (siphon-ai only — no siphon-rs change)
Hold the outbound leg's confirmed dialog behind a single shared, advancing `Arc<Mutex<Dialog>>`. The transfer REFER, hold/resume re-INVITE, and teardown BYE all **resolve from and commit back to** it, so `local_cseq` increases monotonically (`2, 3, 4`) across the call. A new `DialogSource::commit(&Dialog)` writes the advance back for `Direct`; it's a no-op for `Managed`, which already persists through the shared manager. The lock is only ever held to clone in / write out — never across an `.await`.

Verified from siphon-rs source that `send_reinvite` nets exactly one CSeq advance on the caller's `&mut dialog` (via `prepare_in_dialog_request`) and `create_bye` uses `local_cseq + 1`, so persisting the mutated dialog between requests yields the correct `2, 3, 4` sequence.

### Test — load-bearing
`direct_source_commit_advances_the_shared_cseq` models the real wiring: the transfer/hold/teardown controls are separate `DialogSource`s over the same `Arc`, and it asserts three committed sends produce `[base+1, base+2, base+3]`. **CI-proven red without the fix** — with `commit` neutered it reproduces the exact bug signature `left: [2, 2, 2]` vs `right: [2, 3, 4]`.

### Gates (all pass locally)
`cargo test --workspace --locked` (0 failures) · `cargo clippy --workspace --all-targets --locked -D warnings` · `cargo fmt --check` · `check-doc-links.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
