### PR TITLE
chore(release): 0.41.2 — outbound in-dialog CSeq fix (#353)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.41.2] - 2026-07-24
+
 ### Fixed
 
 - **Outbound in-dialog requests now carry monotonically increasing CSeqs (hold → resume → BYE no longer collide)** (issue #353). On an **outbound** call, every in-dialog request after the initial INVITE — a bot `hold`, then `resume`, and the closing BYE on local teardown — went out with the **same `CSeq: 2`** instead of `2, 3, 4, …`. The carrier rejected the malformed sequence: the duplicate-CSeq **BYE drew `408 Request Timeout`** (callee stranded in dead air until the carrier's ~60 s session timer — the #342 symptom, resurfacing for the re-INVITEd-call case), and the duplicate-CSeq **resume re-INVITE** was indistinguishable from a retransmission of the hold, so a resume could never apply `a=sendrecv` and the call stayed one-way/held. Only observable **after** 0.41.1, because before it none of these outbound in-dialog requests reached the wire (#342). Root cause: the outbound leg resolved each in-dialog request's dialog from a **frozen snapshot taken at answer** (`DialogSource::Direct(Box<Dialog>)`) — so `send_reinvite` advanced the CSeq on a throwaway per-request clone (and re-inserted into the gateway UAC's *private* `DialogManager`, which the snapshot never reads), and every `resolve()` restarted from `local_cseq == 1`. Inbound legs were immune: they resolve from the shared `DialogManager` the UAC re-inserts into. The fix holds the outbound leg's confirmed dialog behind a single shared, advancing handle (`Arc<Mutex<Dialog>>`) that the transfer REFER, hold/resume re-INVITE, and teardown BYE all resolve from and **commit back to**, so the local CSeq increases monotonically across the call. No siphon-rs change. Load-bearing regression test (`direct_source_commit_advances_the_shared_cseq`), CI-proven red without the fix (it reproduces the `2, 2, 2` collision).
@@ -2664,7 +2666,8 @@ the WebSocket server's job.
 - Reference WebSocket servers in `examples/`: echo (Python / Node),
   an OpenAI Realtime bridge, and a Deepgram + LLM voice bot.
 
-[Unreleased]: https://github.com/thevoiceguy/siphon-ai/compare/v0.41.1...HEAD
+[Unreleased]: https://github.com/thevoiceguy/siphon-ai/compare/v0.41.2...HEAD
+[0.41.2]: https://github.com/thevoiceguy/siphon-ai/compare/v0.41.1...v0.41.2
 [0.41.1]: https://github.com/thevoiceguy/siphon-ai/compare/v0.41.0...v0.41.1
 [0.41.0]: https://github.com/thevoiceguy/siphon-ai/compare/v0.40.0...v0.41.0
 [0.14.1]: https://github.com/thevoiceguy/siphon-ai/compare/v0.14.0...v0.14.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.41.1"
+version = "0.41.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.41.1"
+version = "0.41.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.41.1"
+version = "0.41.2"
 dependencies = [
  "base64",
  "bytes",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.41.1"
+version = "0.41.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3927,7 +3927,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.41.1"
+version = "0.41.2"
 dependencies = [
  "regex",
  "serde",
@@ -3946,7 +3946,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.41.1"
+version = "0.41.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.41.1"
+version = "0.41.2"
 dependencies = [
  "base64",
  "hmac",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.41.1"
+version = "0.41.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4040,7 +4040,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.41.1"
+version = "0.41.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -4058,7 +4058,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.41.1"
+version = "0.41.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4076,7 +4076,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.41.1"
+version = "0.41.2"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.41.1"
+version = "0.41.2"
 dependencies = [
  "regex",
  "serde",
@@ -4102,7 +4102,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.41.1"
+version = "0.41.2"
 dependencies = [
  "schemars",
  "serde",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.41.1"
+version = "0.41.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.41.1"
+version = "0.41.2"
 dependencies = [
  "base64",
  "rcgen",
@@ -4157,7 +4157,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.41.1"
+version = "0.41.2"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -4186,7 +4186,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.41.1"
+version = "0.41.2"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.41.1"
+version = "0.41.2"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.41.1.** Production-deployed against real carriers
+**Current release: v0.41.2.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a


### PR DESCRIPTION
## Release 0.41.2

Patch release. One fix accumulated under `[Unreleased]` since 0.41.1 — already merged to `main` (#354):

| Issue | Fix |
|---|---|
| **#353** | Outbound in-dialog requests (bot `hold`, `resume`, teardown BYE) now carry monotonically increasing CSeqs (`2, 3, 4`) instead of all reusing `CSeq 2`. The duplicate-CSeq BYE drew a carrier `408` (callee in dead air ~60 s); the duplicate-CSeq resume looked like a hold retransmission. The outbound leg's confirmed dialog is now held behind one shared, advancing `Arc<Mutex<Dialog>>` that the transfer REFER, hold/resume re-INVITE, and teardown BYE all resolve from and commit back to. No siphon-rs change. |

### Release-prep contents
- `[workspace.package].version` `0.41.1` → `0.41.2` (+ `Cargo.lock` refresh — internal crates inherit)
- `CHANGELOG.md`: `[Unreleased]` dated to `## [0.41.2] - 2026-07-24`, fresh empty `[Unreleased]`, compare links added/corrected
- `README.md` current-release marker → `v0.41.2`

### Gates (all pass locally)
`check-version-consistency.py` (+ `--tag v0.41.2`) · `extract-changelog.py 0.41.2` · `cargo fmt --check` · `check-doc-links.py` · `cargo clippy --workspace --all-targets --locked -D warnings` · `cargo test --workspace --locked` (0 failures)

Pins unchanged: siphon-rs `5c7cf20beb50`, forge-media `6e3fcd2e7c6f`, hep-rs `91e689b`.

After merge: tag `v0.41.2` on the merge commit and push to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
