### PR TITLE
fix(cdr,docs): record transfers as termination.cause=transfer (#356); correct post-REFER NOTIFY docs (#357)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **CDR now records a transfer as `termination.cause = "transfer"`** (issue #356; **CDR schema v5 → v6**). When the WS server transferred a call away (`transfer` → the peer accepted the REFER), the WS emitted `stop { reason: "transfer" }` but the CDR recorded `termination.cause = "local_shutdown"` — so the billing-grade, durable record couldn't tell a hand-off from an admin force-hangup, a CANCEL, or an RFC 4028 session-expiry. This is the same WS-vs-CDR divergence that #332 fixed for `caller_hangup`. New `Transfer` variant on `CallTermination` / the CDR `TerminationCause` (serialises `"transfer"`, matching the WS `stop` reason); the controller now sets it on a successful REFER instead of `LocalShutdown`. Additive for parsers that treat `termination.cause` as an open string, but the schema `version` bumps to 6 so a consumer that exhaustively matches the v5 cause set can gate on it. Verified live: the transfer that recorded `local_shutdown` before now records `transfer`.
+
+- **Docs: post-REFER NOTIFY behavior corrected** (issue #357). `docs/PROTOCOL.md` §4.4 claimed NOTIFYs the peer sends after a transfer REFER "are accepted but not surfaced over the WS." In fact, because SiphonAI uses the REFER + BYE pattern it tears the dialog down immediately and does not maintain the implicit refer subscription (RFC 3515), so such a NOTIFY lands on a terminated dialog and is answered `405 Method Not Allowed`. The doc now states this accurately. Behavior is unchanged and the transfer is unaffected (the referred-to peer completes it independently); full RFC 3515 subscription handling that would `200` the NOTIFY is a possible future enhancement, not shipped here.
+
 ## [0.41.2] - 2026-07-24
 
 ### Fixed

--- a/crates/cdr/src/csv.rs
+++ b/crates/cdr/src/csv.rs
@@ -372,6 +372,7 @@ mod tests {
             TerminationCause::DrainForced,
             TerminationCause::BridgeEnded,
             TerminationCause::TapEnded,
+            TerminationCause::Transfer,
             TerminationCause::AckTimeout,
             TerminationCause::MissingSdpAnswer,
             TerminationCause::InvalidSdpAnswer,

--- a/crates/cdr/src/schema.rs
+++ b/crates/cdr/src/schema.rs
@@ -63,7 +63,7 @@ use serde::{Deserialize, Serialize};
 /// bumps rather than riding as a silent addition — a strict consumer that
 /// exhaustively matches the v4 cause set will not recognise it, the same
 /// reasoning that drove v2 and v3.
-pub const CDR_VERSION: u32 = 5;
+pub const CDR_VERSION: u32 = 6;
 
 /// One call's complete record. Always serialised as a single JSON
 /// object on a single line for JSONL file sinks.
@@ -397,6 +397,14 @@ pub enum TerminationCause {
     BridgeEnded,
     /// Media tap sub-task ended first (RTP ended, tap detached).
     TapEnded,
+    /// The call was transferred away: the server sent `transfer` and the
+    /// peer accepted the REFER (2xx), so SiphonAI released this leg (v6,
+    /// 0.41.x; issue #356). The WS `stop` message has always reported
+    /// this correctly as `transfer` — before v6 the CDR collapsed it into
+    /// [`Self::LocalShutdown`], so the durable/billing record couldn't
+    /// tell a hand-off from an admin force-hangup (same divergence #332
+    /// fixed for `caller_hangup`).
+    Transfer,
 
     // ─── Delayed-offer negotiation failures (v2, 0.9.5) ───────────
     // These end a call that was half-established (200 OK with our
@@ -484,6 +492,8 @@ mod tests {
         assert_eq!(v, serde_json::json!("local_shutdown"));
         let v = serde_json::to_value(TerminationCause::DrainForced).unwrap();
         assert_eq!(v, serde_json::json!("drain_forced"));
+        let v = serde_json::to_value(TerminationCause::Transfer).unwrap();
+        assert_eq!(v, serde_json::json!("transfer"));
     }
 
     #[test]
@@ -508,14 +518,14 @@ mod tests {
     }
 
     #[test]
-    fn version_field_is_present_and_is_5() {
-        // Bumped to 5 in 0.40.0 (`answered_at` + the `caller_hangup`
-        // cause — see the module versioning note). Was 4 in 0.30.0 (the
-        // `quality` block), 3 in 0.17.0 (`drain_forced`) and 2 in 0.9.5
-        // (delayed-offer failure causes).
-        assert_eq!(CDR_VERSION, 5);
+    fn version_field_is_present_and_is_6() {
+        // Bumped to 6 in 0.41.x (the `transfer` termination cause — issue
+        // #356). Was 5 in 0.40.0 (`answered_at` + `caller_hangup`), 4 in
+        // 0.30.0 (the `quality` block), 3 in 0.17.0 (`drain_forced`) and 2
+        // in 0.9.5 (delayed-offer failure causes).
+        assert_eq!(CDR_VERSION, 6);
         let v: serde_json::Value = serde_json::to_value(sample()).unwrap();
-        assert_eq!(v["version"], serde_json::json!(5));
+        assert_eq!(v["version"], serde_json::json!(6));
     }
 
     /// `answered_at` is what makes connected duration derivable; absent

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -2409,6 +2409,7 @@ pub(crate) fn termination_label(cause: CdrTerminationCause) -> &'static str {
         CdrTerminationCause::DrainForced => "drain_forced",
         CdrTerminationCause::BridgeEnded => "bridge_ended",
         CdrTerminationCause::TapEnded => "tap_ended",
+        CdrTerminationCause::Transfer => "transfer",
         // Delayed-offer negotiation failures (v2). These don't reach the
         // active-call CDR path (they're emitted directly), but the match
         // must be exhaustive.
@@ -2486,6 +2487,7 @@ fn map_cause(t: CallTermination) -> CdrTerminationCause {
         CallTermination::DrainForced => CdrTerminationCause::DrainForced,
         CallTermination::BridgeEnded => CdrTerminationCause::BridgeEnded,
         CallTermination::TapEnded => CdrTerminationCause::TapEnded,
+        CallTermination::Transfer => CdrTerminationCause::Transfer,
     }
 }
 

--- a/crates/core/src/call.rs
+++ b/crates/core/src/call.rs
@@ -238,6 +238,12 @@ pub enum CallTermination {
     /// The media tap sub-task ended first (call media stopped, tap
     /// detached).
     TapEnded,
+    /// The call was transferred away: the server sent
+    /// [`BridgeIn::Transfer`] and the peer accepted the REFER, so this
+    /// leg is released. Reported to the WS as `stop { reason:
+    /// "transfer" }` and, since issue #356, distinctly on the CDR
+    /// (`transfer`) rather than collapsed into [`Self::LocalShutdown`].
+    Transfer,
 }
 
 /// Summary of one completed call.
@@ -1560,7 +1566,7 @@ impl CallController {
                             if transfer.as_ref().is_some_and(|t| t.control.source.bye_after_refer()) {
                                 handle.mark_remote_bye();
                             }
-                            termination = CallTermination::LocalShutdown;
+                            termination = CallTermination::Transfer;
                             let _ = control_out_tx
                                 .send(OutgoingEvent::Stop { reason: StopReason::Transfer })
                                 .await;

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -724,7 +724,7 @@ practice — restart is simpler).
 
 ```json
 {
-  "version": 5,
+  "version": 6,
   "call_id": "siphon-6ce27797cc0a4997b90cbae2f46ce7a4",
   "sip_call_id": "1-2651348@127.0.0.1",
   "started_at":  "2026-05-12T18:10:32.481Z",
@@ -768,7 +768,10 @@ practice — restart is simpler).
 `version` 5), `"server_hangup"`, `"local_shutdown"` (admin force-hangup,
 CANCEL, or RFC 4028 session expiry — before 0.40.0 this also absorbed
 remote hangups), `"drain_forced"` (force-ended at the graceful-shutdown
-drain deadline, 0.17.0 — CDR `version` 3), `"bridge_ended"`, `"tap_ended"`.
+drain deadline, 0.17.0 — CDR `version` 3), `"bridge_ended"`, `"tap_ended"`,
+`"transfer"` (the server transferred the call away and the peer accepted
+the REFER — 0.41.x, CDR `version` 6; matches the WS `stop` reason, which
+had reported it correctly all along).
 `tap_disconnect` adds `"inactivity_timeout"` when the RTP watchdog fired.
 
 `duration_ms` is `ended_at - started_at` — **wall-clock including ring /
@@ -1136,7 +1139,7 @@ on the metrics crate's defaults (CLAUDE.md §7.4).
 | Metric                                  | Type      | Labels                                | What it measures |
 |-----------------------------------------|-----------|---------------------------------------|------------------|
 | `siphon_ai_invites_total`               | counter   | `result=accepted\|rejected\|rejected_attestation\|no_match` | INVITEs by acceptance outcome. `rejected_attestation` is a STIR/SHAKEN policy reject (`min_attestation` gate or `require_identity`) — separately alertable from ordinary routing/media `rejected`. |
-| `siphon_ai_calls_total`                 | counter   | `cause=caller_hangup\|server_hangup\|local_shutdown\|drain_forced\|bridge_ended\|tap_ended` | Ended calls by termination cause. `caller_hangup` (0.40.0) = the far end sent BYE, split out of `local_shutdown`, which now means admin force-hangup / CANCEL / session expiry only. `drain_forced` (0.17.0) = force-ended at the graceful-shutdown drain deadline. |
+| `siphon_ai_calls_total`                 | counter   | `cause=caller_hangup\|server_hangup\|local_shutdown\|drain_forced\|bridge_ended\|tap_ended\|transfer` | Ended calls by termination cause. `caller_hangup` (0.40.0) = the far end sent BYE, split out of `local_shutdown`, which now means admin force-hangup / CANCEL / session expiry only. `drain_forced` (0.17.0) = force-ended at the graceful-shutdown drain deadline. `transfer` (0.41.x) = the call was handed off via REFER. |
 | `siphon_ai_calls_active`                | gauge     | —                                     | Currently-running calls. |
 | `siphon_ai_route_match_total`           | counter   | `route`                               | Calls per matched route. |
 | `siphon_ai_verstat_total`               | counter   | `result=passed\|failed\|unsigned`     | STIR/SHAKEN verification outcomes per inbound INVITE. Emitted only when `[security.stir_shaken].enabled = true`. `passed` = every check held; `failed` = `Identity` header present but verification didn't fully pass; `unsigned` = no `Identity` header. |

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -630,11 +630,15 @@ After a successful hangup, SiphonAI sends `stop` with
 `target` MUST be a SIP or SIPS URI. SiphonAI sends a blind REFER with
 that target. On a 2xx final response, SiphonAI sends BYE on the same
 dialog (the "REFER + BYE" pattern from RFC 5589 §6.1), then emits
-`stop` with `reason: "transfer"` and closes the WebSocket. NOTIFYs
-that the PBX sends after the REFER are accepted but not surfaced over
-the WS in v1. On a non-2xx response (or a local failure — bad target
-URI, dialog gone), SiphonAI emits `error { code: "transfer_failed" }`
-and the call continues.
+`stop` with `reason: "transfer"` and closes the WebSocket. Because that
+BYE tears the dialog down immediately, SiphonAI does **not** maintain
+the implicit refer subscription (RFC 3515): any NOTIFY the peer sends
+after the REFER lands on an already-terminated dialog and is answered
+`405 Method Not Allowed`. This is not surfaced over the WS and does not
+affect the transfer, which the referred-to peer completes on its own.
+On a non-2xx response (or a local failure — bad target URI, dialog
+gone), SiphonAI emits `error { code: "transfer_failed" }` and the call
+continues.
 
 **Attended transfer** (0.6.1, additive — version stays `"1"`): add
 `replaces_call_id` naming an **answered outbound call** (a consult leg


### PR DESCRIPTION
## Summary

Two fixes found while live-testing **blind transfer** on 0.41.2 (both were filed as issues from that test):

### #356 — CDR records a transfer as `termination.cause = "transfer"` (CDR schema **v5 → v6**)
A transfer (`transfer` → peer accepts the REFER) emits `stop { reason: "transfer" }` on the WS, but the CDR recorded `termination.cause = "local_shutdown"` — so the billing-grade record couldn't distinguish a hand-off from an admin force-hangup / CANCEL / RFC 4028 session-expiry. This is the same WS-vs-CDR divergence **#332** fixed for `caller_hangup`.

- New `Transfer` variant on `CallTermination` (core) and `TerminationCause` (cdr), serialising `"transfer"` to match the WS `stop` reason.
- The controller sets it on a successful REFER (`call.rs`, `TransferOutcome::Accepted`) instead of `LocalShutdown`.
- `map_cause` + `termination_label` + the CSV wire-string list updated; `CDR_VERSION` 5 → 6.
- Additive for open-string parsers; the version bump lets a consumer that exhaustively matches the v5 cause set gate on it.
- **Verified live on 0.41.2:** the blind transfer that recorded `local_shutdown` before this change records `transfer` after.

### #357 — docs: post-REFER NOTIFY behavior corrected
`PROTOCOL.md` §4.4 claimed post-REFER NOTIFYs "are accepted." In fact, because SiphonAI uses the REFER + BYE pattern it tears the dialog down immediately and doesn't maintain the RFC 3515 implicit subscription, so such a NOTIFY lands on a terminated dialog and is answered `405 Method Not Allowed`. The doc now states this. Behavior is unchanged and the transfer is unaffected (the peer completes it independently). Full RFC 3515 subscription handling that would `200` the NOTIFY is a possible future enhancement, not shipped here.

## Tests

- `termination_cause_uses_snake_case_on_wire` now asserts `Transfer → "transfer"`; the CSV cause list includes it; the `CallTermination → TerminationCause` map is compiler-exhaustive (a missing arm won't build).
- The one-line controller change (`LocalShutdown → Transfer`) is verified **live** rather than via a controller success-path mock — that path needs a real REFER round-trip (an `IntegratedUAC` accepting the REFER), which isn't cheaply mockable. The pre-fix live CDR showed `local_shutdown`; post-fix it shows `transfer`.

No siphon-rs change; no WS-protocol-schema or SDK change (the WS `stop` reason already carried `transfer`). `check-doc-links.py` passes; fmt/clippy/`cargo test --workspace --locked` run in CI.

Closes #356, #357.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
