### PR TITLE
chore(release): 0.42.0 — transfer CDR cause, refer-NOTIFY 200, SRTCP per-SSRC replay fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.42.0] - 2026-07-25
+
 ### Fixed
 
 - **SRTP calls no longer log false "SRTCP replay attack detected" warnings when the peer's RTCP SSRC changes** (fixed upstream by [forge-media#98](https://github.com/thevoiceguy/forge-media/pull/98), pin bumped `6e3fcd2e7c6f` → `003b5e1be563`). The SRTP receive context kept a **single** SRTCP replay window keyed only by the SRTCP index, but RFC 3711 §3.4 replay protection is **per-SSRC** — each SSRC has its own index space. When the inbound RTCP SSRC changed mid-call (Twilio does this transitioning from ringback/early media to the answered stream), the new SSRC's fresh low indices were rejected by the shared window as replays until they climbed past the old SSRC's high-water mark: spurious `SRTCP unprotect failed … replay attack detected` WARNs on normal secure-trunk calls, false positives in `forge_srtcp_replay_attacks_blocked_total`, and dropped RTCP reports (feeding the RTT/quality stats) during the changeover. The SRTCP sibling of the per-SSRC RTP-stats fix (#94, shipped in 0.40.0's pin). Upstream replaces the shared window with a per-SSRC `ReplayWindow` map, creates/advances a window **only after successful authentication** (forged packets can't grow the map or advance any window), and keeps genuine per-SSRC replays blocked — regression-tested upstream (`test_srtcp_replay_window_is_per_ssrc`, red before the fix). No siphon-ai code change; no API change.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.41.2"
+version = "0.42.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.41.2"
+version = "0.42.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.41.2"
+version = "0.42.0"
 dependencies = [
  "base64",
  "bytes",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.41.2"
+version = "0.42.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3927,7 +3927,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.41.2"
+version = "0.42.0"
 dependencies = [
  "regex",
  "serde",
@@ -3946,7 +3946,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.41.2"
+version = "0.42.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.41.2"
+version = "0.42.0"
 dependencies = [
  "base64",
  "hmac",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.41.2"
+version = "0.42.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4040,7 +4040,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.41.2"
+version = "0.42.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4058,7 +4058,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.41.2"
+version = "0.42.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4076,7 +4076,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.41.2"
+version = "0.42.0"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.41.2"
+version = "0.42.0"
 dependencies = [
  "regex",
  "serde",
@@ -4102,7 +4102,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.41.2"
+version = "0.42.0"
 dependencies = [
  "schemars",
  "serde",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.41.2"
+version = "0.42.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.41.2"
+version = "0.42.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -4157,7 +4157,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.41.2"
+version = "0.42.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -4186,7 +4186,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.41.2"
+version = "0.42.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.41.2"
+version = "0.42.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.41.2.** Production-deployed against real carriers
+**Current release: v0.42.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a


### PR DESCRIPTION
Release-prep per RELEASING.md: version 0.41.2 → **0.42.0**, dated CHANGELOG section, README marker, lock refresh. All three local consistency checks pass (`check-version-consistency.py`, `--tag v0.42.0`, `extract-changelog.py`).

Contents since v0.41.2:

| Change | PR | Issue |
|---|---|---|
| CDR `termination.cause = "transfer"` (**CDR schema v5 → v6**) | #358 | #356 |
| Post-REFER refer NOTIFYs answered `200 OK` (was `405`); NOTIFY in `Allow`; `siphon_ai_notify_total` | #359 | #357 |
| forge-media pin → `003b5e1` = forge#98 per-SSRC SRTCP replay windows (false "replay attack" WARNs on Twilio SRTP calls) | #360 | forge#97 |

Minor (not patch) because the CDR schema `version` bump gates strict consumers that exhaustively match the v5 cause set. Protocol stays v1.

After merge: tag `v0.42.0` on the merge commit and push — the release workflow does the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AuuaS1kh9bZramYLr91UBs