### PR TITLE
feat(admin): serve every admin route under /admin/v1; unversioned paths become deprecated aliases (closes #362)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **All admin endpoints are now served under `/admin/v1/` — the five pre-0.6.0 routes gained v1 forms, and their original unversioned paths remain as deprecated aliases** (issue #362). The admin API had grown in two generations: the original endpoints (`GET /admin/calls`, `POST /admin/calls/:id/hangup`, `GET /admin/registrations`, `GET|PUT /admin/log`, `POST /admin/hep/test`) were unversioned, while everything since 0.6.0 lived under `/admin/v1/`. Closely related verbs on the same collection sat in different namespaces — originate at `POST /admin/v1/calls`, then the obvious `GET /admin/v1/calls` 404'd because the list was at `GET /admin/calls`. The five legacy routes are now also served at `/admin/v1/calls`, `/admin/v1/registrations`, `/admin/v1/log`, and `/admin/v1/hep/test` (same handlers, same roles, same responses); the unversioned paths keep working indefinitely as deprecated aliases (earliest removal 1.0), and `siphon_ai_admin_requests_total{endpoint=…}` labels alias and v1 traffic separately so a dashboard can watch legacy usage drain before anyone retires them. The new **`POST /admin/v1/calls/:id/hangup`** takes the **bridge `call_id`** — the same id its `/park`, `/retrieve`, and `/stats` siblings take — so the rule is now uniform: everything under `/admin/v1/calls/:id/…` takes the bridge id. The legacy alias keeps its SIP Call-ID semantics unchanged; neither endpoint guesses namespaces (a wrong-namespace id is a plain 404), and `GET …/calls` returns both ids per row. Also fixed in the docs: `POST /admin/calls/:id/hangup` was described as "inbound calls only" — stale since the 0.41.x outbound-BYE fixes (#342/#353); it force-releases outbound calls too (live-verified on 0.42.0).
+
 ## [0.42.0] - 2026-07-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -270,14 +270,14 @@ cargo test --workspace
 |---|---|---|
 | Liveness / readiness | `GET /health`, `GET /ready` | `[observability]` (open) |
 | Prometheus metrics | `GET /metrics` | `[observability]` (open; optional bearer token via `metrics_token`) |
-| Active calls | `GET /admin/calls` | `[admin]` (auth) |
+| Active calls | `GET /admin/v1/calls` | `[admin]` (auth) |
 | Per-call live quality stats | `GET /admin/v1/calls/<id>/stats` | `[admin]` (auth) |
-| Per-call hangup | `POST /admin/calls/<id>/hangup` | `[admin]` (auth) |
+| Per-call hangup | `POST /admin/v1/calls/<id>/hangup` | `[admin]` (auth) |
 | Outbound origination | `POST /admin/v1/calls` | `[admin]` (auth) |
 | Registration refresh / restart | `POST /admin/v1/registrations/<name>/refresh\|restart` | `[admin]` (auth) |
 | Conference / park control | `/admin/v1/conferences`, `/admin/v1/parked` | `[admin]` (auth) |
-| Runtime log filter | `PUT /admin/log` | `[admin]` (auth) |
-| HEP test packet | `POST /admin/hep/test` | `[admin]` (auth) |
+| Runtime log filter | `PUT /admin/v1/log` | `[admin]` (auth) |
+| HEP test packet | `POST /admin/v1/hep/test` | `[admin]` (auth) |
 | Drain status (during shutdown) | `GET /admin/v1/drain` | `[admin]` (auth) |
 | CDR file (JSONL or CSV) | `/var/log/siphon-ai/cdr.jsonl` | — |
 | Lifecycle webhooks | `[webhooks]` block in the TOML | — |

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -1501,7 +1501,7 @@ async fn build_admin(
 /// Adapter that exposes the call registries through the `admin` trait
 /// surface without forcing telemetry to depend on `siphon-ai-core`.
 ///
-/// The listing (`GET /admin/calls`) is sourced from the bridge-id-keyed
+/// The listing (`GET /admin/v1/calls`) is sourced from the bridge-id-keyed
 /// `control` registry so it covers both inbound and outbound calls and
 /// reports the bridge `call_id` the conference/park/stats endpoints
 /// need (issue #311). `hangup` still resolves the SIP-Call-ID-keyed

--- a/crates/bridge/src/conn.rs
+++ b/crates/bridge/src/conn.rs
@@ -729,7 +729,7 @@ async fn run_loop(
                         // Debug-level: every received control message
                         // (Clear, Mark, Hangup, Transfer, SendDtmf).
                         // §11.8 Q9 in DEV_PLAN.md — operators bump
-                        // `siphon_ai_bridge=debug` via /admin/log to
+                        // `siphon_ai_bridge=debug` via /admin/v1/log to
                         // see exactly what the WS server sent. Audio
                         // frames live one notch lower (trace).
                         tracing::debug!(?parsed, "ws inbound control");

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -3273,7 +3273,7 @@ impl BridgingAcceptor {
         );
         // Bridge-id handle table for the admin conference API — every
         // accepted call is reachable by the id operators see. Carries the
-        // SIP Call-ID + direction so `GET /admin/calls` can report both
+        // SIP Call-ID + direction so `GET /admin/v1/calls` can report both
         // id namespaces (issue #311).
         self.control_registry.insert(
             cleanup_handle.clone(),

--- a/crates/core/src/outbound_service.rs
+++ b/crates/core/src/outbound_service.rs
@@ -686,7 +686,7 @@ async fn run_call(
     // Arc-of-AtomicBool).
     let cleanup_handle = handle.clone();
     // Reachable by the admin conference API for this leg's lifetime.
-    // Carries the SIP Call-ID + direction for the `GET /admin/calls`
+    // Carries the SIP Call-ID + direction for the `GET /admin/v1/calls`
     // listing (issue #311).
     ctx.control_registry
         .insert(handle, sip_call_id.clone(), Direction::Outbound);

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -261,7 +261,7 @@ impl ConsultRegistry {
 /// [`Direction`] — both fixed for the call's life — so the admin
 /// active-calls listing can report every identifier an operator needs:
 /// the bridge `call_id` (this map's key; what conference / park / stats
-/// consume) *and* the SIP Call-ID (what `POST /admin/calls/:id/hangup`
+/// consume) *and* the SIP Call-ID (what the legacy `POST /admin/calls/:id/hangup` alias
 /// consumes). Before this the listing exposed only the SIP Call-ID, with
 /// no way to obtain the bridge id the conference API requires (issue
 /// #311).
@@ -279,7 +279,7 @@ struct ControlEntry {
     direction: Direction,
 }
 
-/// One active call in the admin `GET /admin/calls` snapshot. `call_id`
+/// One active call in the admin `GET /admin/v1/calls` snapshot. `call_id`
 /// is the bridge id (the registry key); `sip_call_id` is the SIP
 /// Call-ID; `direction` is inbound/outbound.
 #[derive(Debug, Clone)]
@@ -329,7 +329,7 @@ impl CallControlRegistry {
     }
 
     /// Snapshot every active call — bridge `call_id`, SIP Call-ID, and
-    /// direction — for the admin `GET /admin/calls` listing. Order is
+    /// direction — for the admin `GET /admin/v1/calls` listing. Order is
     /// unspecified. Covers both inbound and outbound calls.
     pub fn snapshot(&self) -> Vec<CallSnapshot> {
         self.inner

--- a/crates/telemetry/src/admin.rs
+++ b/crates/telemetry/src/admin.rs
@@ -6,14 +6,23 @@
 //!
 //! ## Endpoints
 //!
+//! All routes live under `/admin/v1/` (canonical since 0.43.0, #362).
+//! The five pre-0.6.0 routes are also served at their original
+//! unversioned paths as **deprecated aliases** — same handlers, kept
+//! for existing ops tooling, earliest removal 1.0. The one semantic
+//! difference: `POST /admin/calls/:id/hangup` (legacy) takes the
+//! **SIP** Call-ID, while `POST /admin/v1/calls/:id/hangup` takes the
+//! **bridge** `call_id` like every other `/admin/v1/calls/:id/…`
+//! route. `GET …/calls` returns both ids per row.
+//!
 //! | Method | Path                          | Purpose                              |
 //! |--------|-------------------------------|--------------------------------------|
-//! | GET    | `/admin/calls`                | List active per-call SIP Call-IDs    |
-//! | POST   | `/admin/calls/:id/hangup`     | Force-shutdown a call by Call-ID     |
-//! | GET    | `/admin/registrations`        | Snapshot of every `[[register]]` row |
-//! | GET    | `/admin/log`                  | Current `tracing` filter directive   |
-//! | PUT    | `/admin/log`                  | Replace the filter (body = directive)|
-//! | POST   | `/admin/hep/test`             | Emit a probe HEP log packet          |
+//! | GET    | `/admin/v1/calls`             | List active calls (both id namespaces; alias `GET /admin/calls`) |
+//! | POST   | `/admin/v1/calls/:id/hangup`  | Force-shutdown by bridge `call_id` (0.43.0; alias `POST /admin/calls/:sip_call_id/hangup`) |
+//! | GET    | `/admin/v1/registrations`     | Snapshot of every `[[register]]` row (alias `GET /admin/registrations`) |
+//! | GET    | `/admin/v1/log`               | Current `tracing` filter directive (alias `GET /admin/log`) |
+//! | PUT    | `/admin/v1/log`               | Replace the filter (body = directive; alias `PUT /admin/log`) |
+//! | POST   | `/admin/v1/hep/test`          | Emit a probe HEP log packet (alias `POST /admin/hep/test`) |
 //! | POST   | `/admin/v1/calls`             | Originate an outbound call (0.6.0)    |
 //! | GET    | `/admin/v1/conferences`       | List conference rooms + members (0.7.0) |
 //! | POST   | `/admin/v1/conferences`       | Pre-create a room (0.7.0)            |
@@ -132,22 +141,24 @@ pub type DrainStatusFn = Arc<dyn Fn() -> DrainStatus + Send + Sync>;
 /// runtime adapter passes a closure-wrapping object that delegates
 /// to `CallRegistry`.
 pub trait CallRegistryHandle: Send + Sync + 'static {
-    /// Snapshot every active call for `GET /admin/calls`. Each row
+    /// Snapshot every active call for `GET /admin/v1/calls`. Each row
     /// carries both id namespaces so an operator can drive every admin
-    /// endpoint: the bridge `call_id` (conference / park / stats) and
-    /// the SIP Call-ID (`hangup`). See [`AdminCallRow`].
+    /// endpoint: the bridge `call_id` (v1 hangup / conference / park /
+    /// stats) and the SIP Call-ID (legacy `hangup` alias). See
+    /// [`AdminCallRow`].
     fn snapshot_calls(&self) -> Vec<AdminCallRow>;
     /// Best-effort: returns `true` iff a call with that SIP Call-ID
     /// existed and was signalled to shut down.
     fn hangup(&self, sip_call_id: &str) -> bool;
 }
 
-/// One active call in the `GET /admin/calls` response.
+/// One active call in the `GET /admin/v1/calls` response.
 ///
 /// `call_id` is the **bridge** id — the value on the WS `start` message
-/// and the CDR, and the id `/admin/v1/conferences/*`, `/park`,
-/// `/retrieve`, and `/stats` all take. `sip_call_id` is the **SIP**
-/// Call-ID, the id `POST /admin/calls/:id/hangup` takes. Exposing both
+/// and the CDR, and the id every `/admin/v1/calls/:id/…` route
+/// (`/hangup`, `/park`, `/retrieve`, `/stats`) and `/admin/v1/conferences/*`
+/// take. `sip_call_id` is the **SIP** Call-ID, the id the deprecated
+/// `POST /admin/calls/:id/hangup` alias takes. Exposing both
 /// (with `direction`) is the fix for issue #311, where the listing gave
 /// only the SIP Call-ID and the bridge id had no admin source.
 #[derive(Debug, Clone, serde::Serialize)]
@@ -419,11 +430,15 @@ pub async fn dispatch(
     }
 
     let resp = match (method, path) {
-        (&hyper::Method::GET, "/admin/calls") => list_calls(state),
-        (&hyper::Method::GET, "/admin/registrations") => list_registrations(state),
-        (&hyper::Method::GET, "/admin/log") => get_log_filter(state),
-        (&hyper::Method::PUT, "/admin/log") => set_log_filter(state, &body),
-        (&hyper::Method::POST, "/admin/hep/test") => hep_test(state),
+        // Unversioned paths are deprecated aliases of the /admin/v1/
+        // forms (#362) — same handler, kept for pre-0.6.0 ops tooling.
+        (&hyper::Method::GET, "/admin/calls" | "/admin/v1/calls") => list_calls(state),
+        (&hyper::Method::GET, "/admin/registrations" | "/admin/v1/registrations") => {
+            list_registrations(state)
+        }
+        (&hyper::Method::GET, "/admin/log" | "/admin/v1/log") => get_log_filter(state),
+        (&hyper::Method::PUT, "/admin/log" | "/admin/v1/log") => set_log_filter(state, &body),
+        (&hyper::Method::POST, "/admin/hep/test" | "/admin/v1/hep/test") => hep_test(state),
         (&hyper::Method::POST, "/admin/v1/calls") => originate_call(state, &body),
         (&hyper::Method::GET, "/admin/v1/conferences") => list_conferences(state),
         (&hyper::Method::POST, "/admin/v1/conferences") => create_conference(state, &body),
@@ -485,11 +500,26 @@ pub async fn dispatch(
             call_stats(state, id)
         }
         (m, p)
+            if *m == hyper::Method::POST
+                && p.starts_with("/admin/v1/calls/")
+                && p.ends_with("/hangup") =>
+        {
+            // /admin/v1/calls/:id/hangup — bridge call_id, like its
+            // /park, /retrieve and /stats siblings (#362).
+            let id = p
+                .strip_prefix("/admin/v1/calls/")
+                .and_then(|s| s.strip_suffix("/hangup"))
+                .unwrap_or("");
+            hangup_call_by_bridge_id(state, id)
+        }
+        (m, p)
             if m == hyper::Method::POST
                 && p.starts_with("/admin/calls/")
                 && p.ends_with("/hangup") =>
         {
-            // /admin/calls/:id/hangup — pull the id from the middle.
+            // /admin/calls/:id/hangup (deprecated alias) — pull the id
+            // from the middle. Unlike the v1 form this takes the SIP
+            // Call-ID; scripts written against it keep working.
             let id = p
                 .strip_prefix("/admin/calls/")
                 .and_then(|s| s.strip_suffix("/hangup"))
@@ -598,6 +628,42 @@ fn call_stats(state: &AdminState, call_id: &str) -> Response<Full<Bytes>> {
         None => json_response(
             StatusCode::NOT_FOUND,
             &json!({ "error": "no active call with that call_id" }),
+        ),
+    }
+}
+
+/// `POST /admin/v1/calls/:id/hangup` (0.43.0, #362) — force-shutdown
+/// by **bridge** `call_id`, the id every other `/admin/v1/calls/:id/…`
+/// route takes. Resolved to the SIP Call-ID through the registry
+/// snapshot because the registry (and the legacy alias) key hangup by
+/// SIP Call-ID. A wrong-namespace id is just an unknown id → 404.
+fn hangup_call_by_bridge_id(state: &AdminState, call_id: &str) -> Response<Full<Bytes>> {
+    if call_id.is_empty() {
+        return json_response(
+            StatusCode::BAD_REQUEST,
+            &json!({ "error": "empty call_id" }),
+        );
+    }
+    let Some(reg) = state.call_registry.as_ref() else {
+        return service_unavailable("call registry not installed");
+    };
+    let calls = reg.snapshot_calls();
+    let row = calls.into_iter().find(|r| r.call_id == call_id);
+    // The snapshot can race the call ending before `hangup` lands —
+    // both misses collapse to the same 404 the caller must handle
+    // anyway ("call already gone").
+    match row {
+        Some(row) if reg.hangup(&row.sip_call_id) => json_response(
+            StatusCode::OK,
+            &json!({
+                "shutdown_signalled": true,
+                "call_id": call_id,
+                "sip_call_id": row.sip_call_id,
+            }),
+        ),
+        _ => json_response(
+            StatusCode::NOT_FOUND,
+            &json!({ "shutdown_signalled": false, "call_id": call_id }),
         ),
     }
 }
@@ -1303,6 +1369,96 @@ mod tests {
         .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(stub.hung_up.lock().unwrap().len(), 1);
+    }
+
+    /// The five pre-0.6.0 routes and their /admin/v1/ aliases (#362)
+    /// must dispatch to the same handler. Handler behavior is covered
+    /// by the per-handler tests; this pins the *routing*: on an empty
+    /// state each pair returns the same non-404 status (a broken alias
+    /// would fall through to 404).
+    #[tokio::test]
+    async fn v1_aliases_route_like_the_legacy_paths() {
+        use hyper::Method;
+        let pairs = [
+            (Method::GET, "/admin/calls", "/admin/v1/calls"),
+            (
+                Method::GET,
+                "/admin/registrations",
+                "/admin/v1/registrations",
+            ),
+            (Method::GET, "/admin/log", "/admin/v1/log"),
+            (Method::PUT, "/admin/log", "/admin/v1/log"),
+            (Method::POST, "/admin/hep/test", "/admin/v1/hep/test"),
+        ];
+        for (method, legacy, v1) in pairs {
+            let s1 = dispatch(&method, legacy, Bytes::new(), &empty_state())
+                .await
+                .expect("legacy path is an admin route")
+                .status();
+            let s2 = dispatch(&method, v1, Bytes::new(), &empty_state())
+                .await
+                .expect("v1 alias is an admin route")
+                .status();
+            assert_eq!(s1, s2, "{method} {legacy} vs {v1} diverged");
+            assert_ne!(s2, StatusCode::NOT_FOUND, "{method} {v1} fell through");
+        }
+    }
+
+    /// `POST /admin/v1/calls/:id/hangup` takes the **bridge** id and
+    /// resolves it to the SIP Call-ID the registry keys on (#362).
+    #[tokio::test]
+    async fn v1_hangup_takes_the_bridge_id() {
+        let stub = Arc::new(StubRegistry {
+            ids: Mutex::new(vec!["abc@host".into()]),
+            hung_up: Mutex::new(vec![]),
+        });
+        let state = AdminState {
+            call_registry: Some(stub.clone() as AdminCallRegistry),
+            ..AdminState::default()
+        };
+
+        // The stub synthesizes bridge id "siphon-<sip>" per row.
+        let resp = dispatch(
+            &hyper::Method::POST,
+            "/admin/v1/calls/siphon-abc@host/hangup",
+            Bytes::new(),
+            &state,
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: Value =
+            serde_json::from_slice(&resp.into_body().collect().await.unwrap().to_bytes()).unwrap();
+        assert_eq!(body["shutdown_signalled"], true);
+        assert_eq!(body["call_id"], "siphon-abc@host");
+        assert_eq!(body["sip_call_id"], "abc@host");
+        // The registry was driven by the resolved SIP Call-ID.
+        assert_eq!(*stub.hung_up.lock().unwrap(), vec!["abc@host".to_string()]);
+    }
+
+    /// A SIP Call-ID on the v1 route is a wrong-namespace id → 404.
+    /// (Deliberate: neither endpoint guesses which namespace an id is
+    /// from.)
+    #[tokio::test]
+    async fn v1_hangup_rejects_a_sip_call_id() {
+        let stub = Arc::new(StubRegistry {
+            ids: Mutex::new(vec!["abc@host".into()]),
+            hung_up: Mutex::new(vec![]),
+        });
+        let state = AdminState {
+            call_registry: Some(stub.clone() as AdminCallRegistry),
+            ..AdminState::default()
+        };
+        let resp = dispatch(
+            &hyper::Method::POST,
+            "/admin/v1/calls/abc@host/hangup",
+            Bytes::new(),
+            &state,
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        assert!(stub.hung_up.lock().unwrap().is_empty(), "nothing hung up");
     }
 
     #[tokio::test]

--- a/crates/telemetry/src/auth.rs
+++ b/crates/telemetry/src/auth.rs
@@ -288,7 +288,9 @@ pub fn route_label(method: &hyper::Method, path: &str) -> &'static str {
             "POST /admin/calls/:id/hangup"
         }
         (m, p)
-            if *m == Method::POST && p.starts_with("/admin/v1/calls/") && p.ends_with("/hangup") =>
+            if *m == Method::POST
+                && p.starts_with("/admin/v1/calls/")
+                && p.ends_with("/hangup") =>
         {
             "POST /admin/v1/calls/:id/hangup"
         }

--- a/crates/telemetry/src/auth.rs
+++ b/crates/telemetry/src/auth.rs
@@ -197,9 +197,11 @@ pub fn min_role(method: &hyper::Method, path: &str) -> Option<Role> {
     use hyper::Method;
     match (method, path) {
         // ── ReadOnly ──
-        (&Method::GET, "/admin/calls")
-        | (&Method::GET, "/admin/registrations")
-        | (&Method::GET, "/admin/log")
+        // Unversioned paths are deprecated aliases of the /admin/v1/
+        // forms (#362) — each pair maps to the same role by definition.
+        (&Method::GET, "/admin/calls" | "/admin/v1/calls")
+        | (&Method::GET, "/admin/registrations" | "/admin/v1/registrations")
+        | (&Method::GET, "/admin/log" | "/admin/v1/log")
         | (&Method::GET, "/admin/v1/conferences")
         | (&Method::GET, "/admin/v1/parked")
         // Drain status is a plain GET snapshot, same as the list routes
@@ -210,8 +212,8 @@ pub fn min_role(method: &hyper::Method, path: &str) -> Option<Role> {
         | (&Method::GET, "/admin/v1/drain") => Some(Role::ReadOnly),
 
         // ── Admin (billable / config / observability-blinding) ──
-        (&Method::PUT, "/admin/log")
-        | (&Method::POST, "/admin/hep/test")
+        (&Method::PUT, "/admin/log" | "/admin/v1/log")
+        | (&Method::POST, "/admin/hep/test" | "/admin/v1/hep/test")
         | (&Method::POST, "/admin/v1/calls") => Some(Role::Admin),
 
         // ── Operator (live-call control) ──
@@ -231,8 +233,12 @@ pub fn min_role(method: &hyper::Method, path: &str) -> Option<Role> {
 /// match (ids in the path). Mirrors the tail of `admin::dispatch`.
 fn operator_pattern(method: &hyper::Method, path: &str) -> bool {
     use hyper::Method;
-    // /admin/calls/:id/hangup
+    // /admin/calls/:id/hangup (legacy alias, SIP Call-ID)
     (*method == Method::POST && path.starts_with("/admin/calls/") && path.ends_with("/hangup"))
+        // /admin/v1/calls/:id/hangup (bridge call_id, #362)
+        || (*method == Method::POST
+            && path.starts_with("/admin/v1/calls/")
+            && path.ends_with("/hangup"))
         // /admin/v1/registrations/:name/refresh|restart (0.33.0)
         || (*method == Method::POST
             && path.starts_with("/admin/v1/registrations/")
@@ -258,11 +264,19 @@ fn operator_pattern(method: &hyper::Method, path: &str) -> bool {
 pub fn route_label(method: &hyper::Method, path: &str) -> &'static str {
     use hyper::Method;
     match (method, path) {
+        // Legacy aliases and their /admin/v1/ forms (#362) get distinct
+        // labels on purpose — the split lets a dashboard watch legacy-path
+        // traffic drain to zero before the aliases are ever retired.
         (&Method::GET, "/admin/calls") => "GET /admin/calls",
+        (&Method::GET, "/admin/v1/calls") => "GET /admin/v1/calls",
         (&Method::GET, "/admin/registrations") => "GET /admin/registrations",
+        (&Method::GET, "/admin/v1/registrations") => "GET /admin/v1/registrations",
         (&Method::GET, "/admin/log") => "GET /admin/log",
+        (&Method::GET, "/admin/v1/log") => "GET /admin/v1/log",
         (&Method::PUT, "/admin/log") => "PUT /admin/log",
+        (&Method::PUT, "/admin/v1/log") => "PUT /admin/v1/log",
         (&Method::POST, "/admin/hep/test") => "POST /admin/hep/test",
+        (&Method::POST, "/admin/v1/hep/test") => "POST /admin/v1/hep/test",
         (&Method::POST, "/admin/v1/calls") => "POST /admin/v1/calls",
         (&Method::GET, "/admin/v1/conferences") => "GET /admin/v1/conferences",
         (&Method::POST, "/admin/v1/conferences") => "POST /admin/v1/conferences",
@@ -272,6 +286,11 @@ pub fn route_label(method: &hyper::Method, path: &str) -> &'static str {
             if *m == Method::POST && p.starts_with("/admin/calls/") && p.ends_with("/hangup") =>
         {
             "POST /admin/calls/:id/hangup"
+        }
+        (m, p)
+            if *m == Method::POST && p.starts_with("/admin/v1/calls/") && p.ends_with("/hangup") =>
+        {
+            "POST /admin/v1/calls/:id/hangup"
         }
         (m, p)
             if *m == Method::POST
@@ -470,6 +489,33 @@ mod tests {
             ),
             Some(Role::Operator)
         );
+        // v1 aliases (#362) carry the same role as their legacy forms,
+        // and the v1 hangup (bridge-id) is operator like the legacy one.
+        assert_eq!(
+            min_role(&Method::GET, "/admin/v1/calls"),
+            Some(Role::ReadOnly)
+        );
+        assert_eq!(
+            min_role(&Method::GET, "/admin/v1/registrations"),
+            Some(Role::ReadOnly)
+        );
+        assert_eq!(
+            min_role(&Method::GET, "/admin/v1/log"),
+            Some(Role::ReadOnly)
+        );
+        assert_eq!(min_role(&Method::PUT, "/admin/v1/log"), Some(Role::Admin));
+        assert_eq!(
+            min_role(&Method::POST, "/admin/v1/hep/test"),
+            Some(Role::Admin)
+        );
+        assert_eq!(
+            min_role(&Method::POST, "/admin/v1/calls/abc/hangup"),
+            Some(Role::Operator)
+        );
+        assert_eq!(
+            route_label(&Method::POST, "/admin/v1/calls/abc/hangup"),
+            "POST /admin/v1/calls/:id/hangup"
+        );
         // Registration write actions (0.33.0) are operator-tier, and
         // their labels are templated (bounded cardinality).
         assert_eq!(
@@ -509,10 +555,15 @@ mod tests {
     fn every_served_route_has_a_bounded_label() {
         let statics = [
             (Method::GET, "/admin/calls"),
+            (Method::GET, "/admin/v1/calls"),
             (Method::GET, "/admin/registrations"),
+            (Method::GET, "/admin/v1/registrations"),
             (Method::GET, "/admin/log"),
+            (Method::GET, "/admin/v1/log"),
             (Method::PUT, "/admin/log"),
+            (Method::PUT, "/admin/v1/log"),
             (Method::POST, "/admin/hep/test"),
+            (Method::POST, "/admin/v1/hep/test"),
             (Method::POST, "/admin/v1/calls"),
             (Method::GET, "/admin/v1/conferences"),
             (Method::POST, "/admin/v1/conferences"),
@@ -540,6 +591,7 @@ mod tests {
         // concrete id (an unbounded label would blow up cardinality).
         let dynamics = [
             (Method::POST, "/admin/calls/abc123/hangup"),
+            (Method::POST, "/admin/v1/calls/abc123/hangup"),
             (Method::POST, "/admin/v1/registrations/pbx-a/refresh"),
             (Method::POST, "/admin/v1/registrations/pbx-a/restart"),
             (Method::GET, "/admin/v1/calls/abc123/stats"),

--- a/docs/CONFERENCE.md
+++ b/docs/CONFERENCE.md
@@ -76,14 +76,14 @@ Admin auth & RBAC, and keep it on loopback or a private interface
 
 **`call_id` here is the *bridge* call_id** — the `siphon-…` value on the bot's
 WS `start` message and the CDR, **not** the SIP `Call-ID`. Get it from
-`GET /admin/calls`, whose `call_id` field is exactly this id (its `sip_call_id`
+`GET /admin/v1/calls`, whose `call_id` field is exactly this id (its `sip_call_id`
 field is the other namespace, which the conference API rejects):
 
 ```sh
 ADMIN=http://127.0.0.1:9092          # https://… when [admin.tls] is set
 
 # Discover active calls and their bridge call_ids (readonly)
-curl -s -H "Authorization: Bearer $SIPHON_ADMIN_RO" $ADMIN/admin/calls
+curl -s -H "Authorization: Bearer $SIPHON_ADMIN_RO" $ADMIN/admin/v1/calls
 # → {"count":2,"calls":[
 #     {"call_id":"siphon-c","sip_call_id":"5924dbcb…@0.0.0.0","direction":"inbound"},
 #     {"call_id":"siphon-d","sip_call_id":"…","direction":"outbound"}]}
@@ -94,7 +94,7 @@ curl -s -H "Authorization: Bearer $SIPHON_ADMIN_RO" $ADMIN/admin/v1/conferences
 #     "participants":["siphon-a","siphon-b"]}]}
 
 # Pull any active call (inbound or outbound) into a room — creates it if absent.
-# call_id is the bridge id from /admin/calls above (NOT the sip_call_id).
+# call_id is the bridge id from /admin/v1/calls above (NOT the sip_call_id).
 curl -X POST $ADMIN/admin/v1/conferences/support-7/participants \
     -H "Authorization: Bearer $SIPHON_ADMIN_OP" \
     -d '{"call_id":"siphon-c"}'        # → 202

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -870,7 +870,7 @@ key  = "${cred:admin_tls_key}"           # PEM private key
 | `token`          | table array | ≥ 1 required   | At least one `[[admin.token]]`; an `[admin]` block with no tokens is a fatal config error. |
 | `token[].name`   | string      | required       | Unique, non-empty label recorded as the audit-log actor. Duplicate names are a fatal error. |
 | `token[].token`  | string      | required       | The bearer secret (non-empty). Hashed (SHA-256) at load, compared in constant time, never logged. Use `${VAR}` / `${file:…}` / `${cred:…}` to keep it out of the file. |
-| `token[].role`   | enum        | required       | `readonly` (GET/list) ⊂ `operator` (hangup, park/retrieve, conference CRUD) ⊂ `admin` (origination, `PUT /admin/log`, `hep/test`). Unknown value → fatal error. |
+| `token[].role`   | enum        | required       | `readonly` (GET/list) ⊂ `operator` (hangup, park/retrieve, conference CRUD) ⊂ `admin` (origination, `PUT /admin/v1/log`, `hep/test`). Unknown value → fatal error. |
 | `tls.cert`       | path        | required if `[admin.tls]` | PEM certificate chain. Present `[admin.tls]` with a missing/empty `cert` → fatal error. |
 | `tls.key`        | path        | required if `[admin.tls]` | PEM private key. Loaded at startup (fail-loud) and **hot-reloaded on `SIGHUP`** alongside `[sip.tls]`, so cert rotation needs no restart. |
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -500,16 +500,21 @@ The **Min role** column is the lowest role a token needs to reach the
 endpoint (roles nest: `readonly` ⊂ `operator` ⊂ `admin`). Below it → `403`;
 no/invalid token → `401`.
 
+All endpoints live under `/admin/v1/` (canonical since 0.43.0, issue #362).
+The five routes that predate 0.6.0 are **also** served at their original
+unversioned paths as deprecated aliases — see
+[Deprecated unversioned aliases](#deprecated-unversioned-aliases) below.
+
 | Method | Path                          | Body            | Min role | Purpose |
 |--------|-------------------------------|-----------------|----------|---------|
-| GET    | `/admin/calls`                | —               | readonly | List active calls (inbound **and** outbound). Each element is `{call_id, sip_call_id, direction}` — the **bridge** `call_id` (what conference / park / `stats` take, and the value on the WS `start` message / CDR), the **SIP** Call-ID (what `hangup` takes), and `"inbound"`/`"outbound"`. Since 0.37.1; before that it returned a bare array of SIP Call-ID strings and exposed no way to obtain the bridge id (issue #311). |
-| POST   | `/admin/calls/:id/hangup`     | —               | operator | Force-shutdown a specific call by its **SIP** `Call-ID` (the `sip_call_id` field from `GET /admin/calls`), inbound calls only. |
-| GET    | `/admin/registrations`        | —               | readonly | Snapshot of every `[[register]]` row and its current state. |
+| GET    | `/admin/v1/calls`             | —               | readonly | List active calls (inbound **and** outbound). Each element is `{call_id, sip_call_id, direction}` — the **bridge** `call_id` (what every other `/admin/v1/calls/:id/…` route and the conference endpoints take, and the value on the WS `start` message / CDR), the **SIP** Call-ID (what the deprecated `hangup` alias takes), and `"inbound"`/`"outbound"`. Since 0.37.1; before that it returned a bare array of SIP Call-ID strings and exposed no way to obtain the bridge id (issue #311). |
+| POST   | `/admin/v1/calls/:id/hangup`  | —               | operator | Force-shutdown a specific call by its **bridge** `call_id` (0.43.0) — the same id `/park`, `/retrieve` and `/stats` take. Works for inbound and outbound calls; the daemon BYEs the peer and tears the call down. `200 {shutdown_signalled: true, call_id, sip_call_id}`; `404` when no active call has that id. |
+| GET    | `/admin/v1/registrations`     | —               | readonly | Snapshot of every `[[register]]` row and its current state. |
 | POST   | `/admin/v1/registrations/:name/refresh` | —     | operator | **Fire an immediate off-cycle REGISTER** for one binding (0.33.0) — no restart needed when a registrar drops or stales the binding. Also **starts a parked binding** (`register_on_startup = false`). Returns `202` with the accept-time row; the outcome is asynchronous (watch the GET, `siphon_ai_register_attempts_total`, or the `registration_state_changed` webhook). `404` unknown name, `409` while draining. |
 | POST   | `/admin/v1/registrations/:name/restart` | —     | operator | **Full re-registration cycle** (0.33.0): REGISTER `Expires: 0` to clear the registrar-side binding, then a fresh REGISTER — for stale server-side state or contact rebinding after an IP change. A failed unregister is logged and the fresh REGISTER proceeds; only the final attempt drives status. Same responses as `refresh`. |
-| GET    | `/admin/log`                  | —               | readonly | Current `tracing` filter directive. |
-| PUT    | `/admin/log`                  | text directive  | admin    | Replace the filter (e.g., `siphon_ai=info,siphon_ai_bridge=debug`). Returns the previous filter. |
-| POST   | `/admin/hep/test`             | —               | admin    | Emit a probe HEP log packet. |
+| GET    | `/admin/v1/log`               | —               | readonly | Current `tracing` filter directive. |
+| PUT    | `/admin/v1/log`               | text directive  | admin    | Replace the filter (e.g., `siphon_ai=info,siphon_ai_bridge=debug`). Returns the previous filter. |
+| POST   | `/admin/v1/hep/test`          | —               | admin    | Emit a probe HEP log packet. |
 | POST   | `/admin/v1/calls`             | JSON (below)    | admin    | **Originate an outbound call** (0.6.0). Returns `202 {"call_id": "..."}`; the call proceeds asynchronously. `501` when `[outbound]` is disabled. |
 | GET    | `/admin/v1/conferences`       | —               | readonly | **List conference rooms** + members (0.7.0). `501` when `[conference]` is disabled. |
 | POST   | `/admin/v1/conferences`       | JSON (opt.)     | operator | **Pre-create a room** (0.7.0). Body `{room_id?, sample_rate?}`; returns `201 {"room_id": "..."}`. |
@@ -521,6 +526,25 @@ no/invalid token → `401`.
 | POST   | `/admin/v1/calls/:id/retrieve`| JSON (opt.)     | operator | **Retrieve a parked call** (0.7.0). Body `{ws_url?}`; `202` (dispatched). `404` unknown call, `409` if the call isn't parked. `501` when `[park]` is disabled. |
 | GET    | `/admin/v1/calls/:id/stats`   | —               | readonly | **Live per-call quality snapshot** (0.31.0). `:id` is the bridge `call_id` (the one on the WS `start` message / CDR). Returns `{call_id, sampled_at, …}` with the CDR `quality` block's fields flattened in — whatever is measured *right now*, unmeasured fields omitted. `404` when no active call has that id (ended calls answer through the CDR / `[quality]` records). |
 | GET    | `/admin/v1/drain`             | —               | readonly | **Graceful-shutdown drain status** (0.17.0). Returns `{draining, active_calls, drain_timeout_secs, remaining_secs}` — `remaining_secs` is the countdown to the deadline (non-null only while draining). Lets a deploy script confirm a pod entered drain and watch it empty. |
+
+### Deprecated unversioned aliases
+
+The five routes that predate the `/admin/v1/` namespace (0.6.0) are still
+served at their original unversioned paths — same handlers, same roles, same
+responses. Existing scripts keep working; new tooling should use the v1
+forms. The aliases will not be removed before a 1.0.
+
+| Deprecated alias | Canonical route | Difference |
+|------------------|-----------------|------------|
+| `GET /admin/calls` | `GET /admin/v1/calls` | none |
+| `POST /admin/calls/:id/hangup` | `POST /admin/v1/calls/:id/hangup` | **id namespace**: the alias takes the **SIP** Call-ID (`sip_call_id` from the listing); the v1 route takes the **bridge** `call_id`. Neither accepts the other's id (a wrong-namespace id is a `404`) — the listing returns both, so use whichever endpoint matches the id you hold. |
+| `GET /admin/registrations` | `GET /admin/v1/registrations` | none |
+| `GET`/`PUT /admin/log` | `GET`/`PUT /admin/v1/log` | none |
+| `POST /admin/hep/test` | `POST /admin/v1/hep/test` | none |
+
+The `siphon_ai_admin_requests_total{endpoint=…}` metric labels the alias and
+the v1 form separately, so a dashboard can watch legacy-path traffic drain to
+zero before anyone considers retiring the aliases.
 
 ### Admin auth & RBAC
 
@@ -567,7 +591,7 @@ Roles, lowest to highest (each inherits everything below it):
 |------------|--------|
 | `readonly` | All `GET` / list endpoints (calls, registrations, log, conferences, parked). |
 | `operator` | Everything `readonly` can, plus hangup, park / retrieve, and conference create / end / add / remove. |
-| `admin`    | Everything `operator` can, plus **billable** origination (`POST /admin/v1/calls`), `PUT /admin/log`, and `POST /admin/hep/test`. |
+| `admin`    | Everything `operator` can, plus **billable** origination (`POST /admin/v1/calls`), `PUT /admin/v1/log`, and `POST /admin/v1/hep/test`. |
 
 Every request is audited: a structured log line (actor = token **name**,
 role, endpoint template, result, peer address — never the secret) and the
@@ -582,7 +606,7 @@ A bearer token goes on every call:
 
 ```sh
 ADMIN=http://127.0.0.1:9092          # https://… when [admin.tls] is set
-curl -s -H "Authorization: Bearer $SIPHON_ADMIN_RO" $ADMIN/admin/calls
+curl -s -H "Authorization: Bearer $SIPHON_ADMIN_RO" $ADMIN/admin/v1/calls
 # missing/invalid token → 401 + WWW-Authenticate: Bearer
 # token below the endpoint's min role → 403
 ```
@@ -672,12 +696,12 @@ Example: bump bridge logging to debug for an incident, then revert.
 ```sh
 ADMIN=http://127.0.0.1:9092
 # GET is readonly; PUT (mutates the running filter) is admin.
-prev=$(curl -s -H "Authorization: Bearer $SIPHON_ADMIN_RO" $ADMIN/admin/log)
+prev=$(curl -s -H "Authorization: Bearer $SIPHON_ADMIN_RO" $ADMIN/admin/v1/log)
 curl -X PUT -H "Authorization: Bearer $SIPHON_ADMIN_ADMIN" \
-    --data 'siphon_ai=info,siphon_ai_bridge=debug' $ADMIN/admin/log
+    --data 'siphon_ai=info,siphon_ai_bridge=debug' $ADMIN/admin/v1/log
 # … reproduce the issue …
 curl -X PUT -H "Authorization: Bearer $SIPHON_ADMIN_ADMIN" \
-    --data "$prev" $ADMIN/admin/log
+    --data "$prev" $ADMIN/admin/v1/log
 ```
 
 ### `/admin/v1/parked` — park admin (0.7.0)

--- a/docs/INSTALL_DEBIAN13.md
+++ b/docs/INSTALL_DEBIAN13.md
@@ -351,7 +351,7 @@ curl -s http://127.0.0.1:9091/ready      # → "ready"
 # /admin/* is NOT on the metrics port (it 404s there since 0.10.0) — it's
 # on the [admin] listener, behind a bearer token. Skip if [admin] is unset.
 curl -s -H "Authorization: Bearer $SIPHON_ADMIN_RO" \
-    http://127.0.0.1:9092/admin/calls
+    http://127.0.0.1:9092/admin/v1/calls
 # → {"calls":[],"count":0}
 ```
 
@@ -390,18 +390,19 @@ sudo journalctl -u siphon-ai -f
 # /admin/* lives on the [admin] listener (0.10.0) + bearer token.
 ADMIN=http://127.0.0.1:9092
 
-# Bump bridge debug for an incident (PUT /admin/log needs `admin` role)
-prev=$(curl -s -H "Authorization: Bearer $SIPHON_ADMIN_ADMIN" $ADMIN/admin/log)
+# Bump bridge debug for an incident (PUT /admin/v1/log needs `admin` role)
+prev=$(curl -s -H "Authorization: Bearer $SIPHON_ADMIN_ADMIN" $ADMIN/admin/v1/log)
 curl -X PUT --data 'siphon_ai=info,siphon_ai_bridge=debug' \
-    -H "Authorization: Bearer $SIPHON_ADMIN_ADMIN" $ADMIN/admin/log
+    -H "Authorization: Bearer $SIPHON_ADMIN_ADMIN" $ADMIN/admin/v1/log
 # (… reproduce, then revert …)
 curl -X PUT --data "$prev" \
-    -H "Authorization: Bearer $SIPHON_ADMIN_ADMIN" $ADMIN/admin/log
+    -H "Authorization: Bearer $SIPHON_ADMIN_ADMIN" $ADMIN/admin/v1/log
 
-# Force-hangup a specific call (list = readonly, hangup = operator)
-curl -s -H "Authorization: Bearer $SIPHON_ADMIN_RO" $ADMIN/admin/calls
+# Force-hangup a specific call (list = readonly, hangup = operator).
+# <call-id> is the bridge `call_id` field from the listing.
+curl -s -H "Authorization: Bearer $SIPHON_ADMIN_RO" $ADMIN/admin/v1/calls
 curl -X POST -H "Authorization: Bearer $SIPHON_ADMIN_OP" \
-    $ADMIN/admin/calls/<sip-call-id>/hangup
+    $ADMIN/admin/v1/calls/<call-id>/hangup
 
 # Restart cleanly
 sudo systemctl restart siphon-ai

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -269,10 +269,10 @@ at default INFO; flip them at runtime via:
 
 ```sh
 # /admin/* is on the [admin] listener (0.10.0), not the metrics port;
-# PUT /admin/log needs an `admin`-role bearer token.
+# PUT /admin/v1/log needs an `admin`-role bearer token.
 curl -X PUT --data 'siphon_ai=info,siphon_ai_bridge=debug' \
    -H "Authorization: Bearer $SIPHON_ADMIN_ADMIN" \
-   http://127.0.0.1:9092/admin/log
+   http://127.0.0.1:9092/admin/v1/log
 ```
 
 The admin endpoint replies with the previous filter so an
@@ -340,7 +340,7 @@ busy spans (`sip_uas`, `sip_transaction`, `sip_transport`,
 | `forge`              | Frame-by-frame RTP / VAD events (very chatty)                 |
 
 All of the above are reachable without restart via
-`PUT /admin/log`.
+`PUT /admin/v1/log`.
 
 ## Draining for a deploy / restart (0.17.0)
 

--- a/docs/PARK.md
+++ b/docs/PARK.md
@@ -63,7 +63,7 @@ need **`operator`**; `GET /admin/v1/parked` needs **`readonly`**.
 
 `:id` in `/admin/v1/calls/:id/park` is the **bridge** `call_id` (the `siphon-…`
 value on the WS `start` message / CDR), not the SIP Call-ID. List active calls
-and their bridge ids with `GET /admin/calls` — its `call_id` field is this id.
+and their bridge ids with `GET /admin/v1/calls` — its `call_id` field is this id.
 
 ```sh
 ADMIN=http://127.0.0.1:9092          # https://… when [admin.tls] is set

--- a/docs/REGISTRATION.md
+++ b/docs/REGISTRATION.md
@@ -161,7 +161,7 @@ curl -X POST -H "Authorization: Bearer $TOKEN" \
 
 Both return `202` with the binding's accept-time row — the REGISTER
 round-trip is asynchronous. Watch the outcome on any of:
-`GET /admin/registrations` (status flips), the metrics below
+`GET /admin/v1/registrations` (status flips), the metrics below
 (`register_attempts_total` ticks), or the `registration_state_changed`
 webhook. `404` = unknown name; `409` = the daemon is draining.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -204,7 +204,7 @@ barrier and make the contract testable:
 
 ## P2 — Registration management (admin) — ✅ delivered in v0.33.0
 
-Extends the read-only `GET /admin/registrations` (0.10.0) with two
+Extends the read-only `GET /admin/v1/registrations` (0.10.0) with two
 per-binding write actions (operator role, audit-logged, no new config —
 design note `DESIGN_REGISTRATION_ADMIN.md`):
 

--- a/scripts/install-debian13.sh
+++ b/scripts/install-debian13.sh
@@ -413,7 +413,7 @@ The daemon is running. SIP listens on UDP $SIP_PORT, RTP on
 $RTP_PORT_MIN-$RTP_PORT_MAX, and Prometheus + admin on $OBS_LISTEN.
 
 Tail logs:        sudo journalctl -u siphon-ai -f
-Active calls:     curl -s http://$obs_host_port/admin/calls | jq
+Active calls:     curl -s http://$obs_host_port/admin/v1/calls | jq
 Metrics:          curl -s http://$obs_host_port/metrics | grep siphon_ai_
 Recent CDRs:      sudo tail -n 5 /var/log/siphon-ai/cdr.jsonl | jq
 CDR rotation:     /etc/logrotate.d/siphon-ai-cdr (daily, 30 keeps)


### PR DESCRIPTION
Closes #362.

## What

The five pre-0.6.0 admin routes gain canonical `/admin/v1/` forms; their original unversioned paths remain as **deprecated aliases** (same handlers, same RBAC roles, same responses — earliest removal 1.0):

| Deprecated alias | Canonical |
|---|---|
| `GET /admin/calls` | `GET /admin/v1/calls` |
| `POST /admin/calls/:sip_call_id/hangup` | `POST /admin/v1/calls/:call_id/hangup` *(new — bridge id)* |
| `GET /admin/registrations` | `GET /admin/v1/registrations` |
| `GET`/`PUT /admin/log` | `GET`/`PUT /admin/v1/log` |
| `POST /admin/hep/test` | `POST /admin/v1/hep/test` |

The one intentional semantic difference: the **v1 hangup takes the bridge `call_id`**, like its `/park`, `/retrieve`, `/stats` siblings — so the rule is now uniform (*everything under `/admin/v1/calls/:id/…` takes the bridge id*). The legacy alias keeps SIP Call-ID semantics unchanged. Neither endpoint guesses namespaces: a wrong-namespace id is a plain 404, and `GET …/calls` returns both ids per row.

## Observability

`route_label` gives the aliases and v1 forms **distinct** `endpoint` labels in `siphon_ai_admin_requests_total`, so a dashboard can watch legacy-path traffic drain to zero before the aliases are ever retired. All new paths have explicit `min_role` arms (readonly/operator/admin identical to their legacy twins).

## Docs

- `DEPLOY.md`: table is v1-canonical + new *Deprecated unversioned aliases* section; also **drops the stale "inbound calls only" claim on hangup** — outbound force-hangup has worked since the 0.41.x BYE fixes (#342/#353) and was live-verified on 0.42.0.
- README, CONFIG, CONFERENCE, PARK, OPERATIONS, REGISTRATION, ROADMAP, INSTALL_DEBIAN13, install script: examples moved to v1 forms.
- `DEV_PLAN.md` left untouched (historical plan document).

## Tests

- `v1_aliases_route_like_the_legacy_paths` — routing parity for all five pairs (dispatch returns identical statuses; no alias falls through to 404).
- `v1_hangup_takes_the_bridge_id` — resolves bridge id → SIP Call-ID via the registry snapshot, asserts the response carries both ids.
- `v1_hangup_rejects_a_sip_call_id` — wrong-namespace id → 404, nothing hung up.
- `min_role` / `route_label` assertions + the served-routes table test (`every_served_route_has_a_bounded_label`) extended with all six new routes.
- The SIPp harness intentionally stays on the legacy paths — it now doubles as live regression coverage for the aliases.

No protocol, CDR, or config changes. Purely additive on the wire; the only behavior change is new URLs answering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qeGnsmBASZxgBjkoijWw2