### PR TITLE
chore(release): 0.44.0 — outbound playout queue: §5.5 backpressure + mark correctness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.44.0] - 2026-07-26
+
 ### Fixed
 
 - **`clear` now drops pending `mark`s and rebases the playout clock — post-clear marks fire on time** (issue #365; PROTOCOL.md §4.1 violation). Marks were detached wall-clock timers (`tokio::spawn` + `sleep_until(first_push + frames × 20 ms)`) that nothing could cancel or re-time: a mark pending at clear-time **fired anyway** (telling the server the caller heard audio that was discarded), and because `clear` never reset the frame-count anchor, every mark sent **after** a clear fired **late by the entire flushed duration** — cumulative across repeated clears, breaking turn-taking in exactly the barge-in-driven calls that use marks most. Marks are now **queue-riders owned by the tap** (PROTOCOL.md §4.1's model): they hold their position in the outbound queue, arm against the playout clock when the audio ahead of them has been handed to the media engine, and die with the queue on `clear` / `auto_clear` / mute / park — every flush path now also rebases the playout clock (`clear` previously skipped it; the pause-arbitration paths already did this). Integration tests mirror the issue's timeline (burst → mark → clear → mark) and are CI-proven red on the pre-fix tap.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "base64",
  "bytes",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3927,7 +3927,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "regex",
  "serde",
@@ -3946,7 +3946,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "base64",
  "hmac",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4040,7 +4040,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4058,7 +4058,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4076,7 +4076,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "regex",
  "serde",
@@ -4102,7 +4102,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "schemars",
  "serde",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -4157,7 +4157,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -4186,7 +4186,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.43.0"
+version = "0.44.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.43.0.** Production-deployed against real carriers
+**Current release: v0.44.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a


### PR DESCRIPTION
Release-prep per RELEASING.md: version 0.43.0 → **0.44.0**, dated CHANGELOG section, README marker, lock refresh. All three local consistency checks pass.

Contents since v0.43.0: PR #367 (issues #365 + #366) — the tap-owned outbound queue: `clear` drops pending marks + rebases the playout clock, and PROTOCOL §5.5's 200 ms drop-oldest backpressure now exists (with its metric). Minor bump because the §5.5 enforcement is observable behavior for servers streaming faster than realtime. Protocol stays v1, CDR stays v6.

After merge: tag `v0.44.0` on the merge commit and push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AuuaS1kh9bZramYLr91UBs