### PR TITLE
chore(deps): bump siphon-rs to ead16f9 — per-request From tag (siphon-rs #72)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,7 +842,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1708,7 +1708,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2822,7 +2822,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2860,7 +2860,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -3268,7 +3268,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3595,7 +3595,7 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 [[package]]
 name = "sip-auth"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50#5c7cf20beb5069592724482632749fb18dbe1e94"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ead16f9bf9b7#ead16f9bf9b719f965329527842b97dd10ffa708"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3618,7 +3618,7 @@ dependencies = [
 [[package]]
 name = "sip-core"
 version = "0.7.6"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50#5c7cf20beb5069592724482632749fb18dbe1e94"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ead16f9bf9b7#ead16f9bf9b719f965329527842b97dd10ffa708"
 dependencies = [
  "bytes",
  "httpdate",
@@ -3631,7 +3631,7 @@ dependencies = [
 [[package]]
 name = "sip-dialog"
 version = "0.3.3"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50#5c7cf20beb5069592724482632749fb18dbe1e94"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ead16f9bf9b7#ead16f9bf9b719f965329527842b97dd10ffa708"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3649,7 +3649,7 @@ dependencies = [
 [[package]]
 name = "sip-dns"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50#5c7cf20beb5069592724482632749fb18dbe1e94"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ead16f9bf9b7#ead16f9bf9b719f965329527842b97dd10ffa708"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3663,7 +3663,7 @@ dependencies = [
 [[package]]
 name = "sip-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50#5c7cf20beb5069592724482632749fb18dbe1e94"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ead16f9bf9b7#ead16f9bf9b719f965329527842b97dd10ffa708"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -3674,7 +3674,7 @@ dependencies = [
 [[package]]
 name = "sip-identity"
 version = "0.1.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50#5c7cf20beb5069592724482632749fb18dbe1e94"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ead16f9bf9b7#ead16f9bf9b719f965329527842b97dd10ffa708"
 dependencies = [
  "base64",
  "ring",
@@ -3687,7 +3687,7 @@ dependencies = [
 [[package]]
 name = "sip-observe"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50#5c7cf20beb5069592724482632749fb18dbe1e94"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ead16f9bf9b7#ead16f9bf9b719f965329527842b97dd10ffa708"
 dependencies = [
  "once_cell",
  "tracing",
@@ -3696,7 +3696,7 @@ dependencies = [
 [[package]]
 name = "sip-parse"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50#5c7cf20beb5069592724482632749fb18dbe1e94"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ead16f9bf9b7#ead16f9bf9b719f965329527842b97dd10ffa708"
 dependencies = [
  "bytes",
  "httpdate",
@@ -3710,7 +3710,7 @@ dependencies = [
 [[package]]
 name = "sip-ratelimit"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50#5c7cf20beb5069592724482632749fb18dbe1e94"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ead16f9bf9b7#ead16f9bf9b719f965329527842b97dd10ffa708"
 dependencies = [
  "dashmap 5.5.3",
  "parking_lot",
@@ -3730,7 +3730,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50#5c7cf20beb5069592724482632749fb18dbe1e94"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ead16f9bf9b7#ead16f9bf9b719f965329527842b97dd10ffa708"
 dependencies = [
  "nom 7.1.3",
  "smol_str",
@@ -3739,7 +3739,7 @@ dependencies = [
 [[package]]
 name = "sip-transaction"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50#5c7cf20beb5069592724482632749fb18dbe1e94"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ead16f9bf9b7#ead16f9bf9b719f965329527842b97dd10ffa708"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3758,7 +3758,7 @@ dependencies = [
 [[package]]
 name = "sip-transport"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50#5c7cf20beb5069592724482632749fb18dbe1e94"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ead16f9bf9b7#ead16f9bf9b719f965329527842b97dd10ffa708"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3778,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "sip-uac"
 version = "0.4.2"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50#5c7cf20beb5069592724482632749fb18dbe1e94"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ead16f9bf9b7#ead16f9bf9b719f965329527842b97dd10ffa708"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3791,7 +3791,7 @@ dependencies = [
  "sip-dialog",
  "sip-dns",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=ead16f9bf9b7)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -3803,7 +3803,7 @@ dependencies = [
 [[package]]
 name = "sip-uas"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50#5c7cf20beb5069592724482632749fb18dbe1e94"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=ead16f9bf9b7#ead16f9bf9b719f965329527842b97dd10ffa708"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3813,7 +3813,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=ead16f9bf9b7)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -3966,7 +3966,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=5c7cf20beb50)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=ead16f9bf9b7)",
  "sip-transaction",
  "sip-uac",
  "sip-uas",
@@ -4564,7 +4564,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5552,7 +5552,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,39 +130,37 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 # main branch and replace the rev hashes here (see CLAUDE.md §7.5).
 
 # siphon-rs — RFC 3261 SIP stack.
-# Bumped 2026-07-24 `fbdf132a11d6` → `5c7cf20beb50` = siphon-rs #70: the TLS
-# pool reuses a peer's connection across SNI for in-dialog requests. #69 fixed
-# the route set on the in-dialog BYE (inbound half of #342), but the OUTBOUND
-# half remained: `TlsPool::send_tls` keyed reuse by (addr, SNI), and an
-# outbound leg's in-dialog request (BYE / hold re-INVITE / REFER) derives its
-# SNI from the peer's Record-Route — an IP literal — so it missed the
-# hostname-keyed dialog connection and dialed a fresh connect the carrier edge
-# refuses (and whose IP-SNI handshake fails the hostname cert). So locally
-# terminated outbound calls sent NO BYE (callee stranded) and hold failed.
-# send_tls now falls back to any live connection to the same addr (RFC 5923).
-# (Prior: `fbdf132a11d6` = #69 in-dialog BYE route set, siphon-ai #342 inbound;
+# Bumped 2026-07-27 `5c7cf20beb50` → `ead16f9bf9b7` = siphon-rs #72: the UAC
+# generates the From tag per request instead of minting one at construction
+# and reusing it for the process lifetime (RFC 3261 §8.1.1.3 / §19.3 — a live
+# trunk capture showed 7 unrelated calls sharing one From tag over 86 min).
+# REGISTER deliberately keeps a stable per-registrar tag (§10.2) so refresh
+# series present one (Call-ID, From tag) identity; IntegratedUAC's early-dialog
+# placeholder DialogId now reads the tag off the on-wire request.
+# (Prior: `5c7cf20beb50` = #70 TLS pool cross-SNI reuse, siphon-ai #342 outbound;
+#  `fbdf132a11d6` = #69 in-dialog BYE route set, siphon-ai #342 inbound;
 #  `50866b1599a7` = #68 pool SIP HEP, siphon-ai #341;
 #  `6fd432270bb8` = #67 dialog_manager share, siphon-ai #324;
 #  `fcaff011f9c6` = #65 invite_with_from, siphon-ai #316;
 #  `3a4fc312ade3` = #64 TLS-SNI-is-hostname, siphon-ai #312.)
-sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "5c7cf20beb50" }
-sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "5c7cf20beb50" }
-sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "5c7cf20beb50", features = ["tls"] }
-sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "5c7cf20beb50" }
-sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "5c7cf20beb50" }
-sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "5c7cf20beb50" }
-sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "5c7cf20beb50" }
-sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "5c7cf20beb50" }
-sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "5c7cf20beb50" }
+sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ead16f9bf9b7" }
+sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ead16f9bf9b7" }
+sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ead16f9bf9b7", features = ["tls"] }
+sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ead16f9bf9b7" }
+sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ead16f9bf9b7" }
+sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ead16f9bf9b7" }
+sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ead16f9bf9b7" }
+sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ead16f9bf9b7" }
+sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ead16f9bf9b7" }
 # sip-sdp — the SAME sip-sdp sip-uac's SdpAnswerGenerator trait speaks
 # (distinct from forge-media's pinned sip-sdp). Used by the outbound
 # delayed-offer answer generator to hand the UAC a SessionDescription it
 # accepts. Must stay on the same siphon-rs rev as the rest below.
-sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "5c7cf20beb50" }
-sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "5c7cf20beb50" }
+sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ead16f9bf9b7" }
+sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ead16f9bf9b7" }
 # sip-identity — STIR/SHAKEN Identity-header parsing + PASSporT verification
 # (ES256 + X.509 chain validation). Consumed by the stir-shaken verifier crate.
-sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "5c7cf20beb50" }
+sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "ead16f9bf9b7" }
 
 # forge-media — RTP / codecs / SDP / DTMF / engine.
 #


### PR DESCRIPTION
## Summary

Bumps the siphon-rs pin `5c7cf20beb50` → `ead16f9bf9b7` to pick up [siphon-rs #72](https://github.com/thevoiceguy/siphon-rs/pull/72): the UAC now generates the From tag **per request** instead of minting one at construction and reusing it for the process lifetime (RFC 3261 §8.1.1.3 / §19.3). Previously every outbound INVITE / OPTIONS / SUBSCRIBE / MESSAGE / PUBLISH / unsolicited NOTIFY from a node shared one From tag until restart — a live trunk capture showed 7 unrelated calls with a single tag over 86 minutes.

Upstream details that matter to us:
- REGISTER keeps a deliberately **stable per-registrar tag** (§10.2), keyed and capped like `register_call_ids`, so refresh series still present one `(Call-ID, From tag)` identity.
- `IntegratedUAC`'s early-dialog placeholder `DialogId` now reads the tag off the on-wire request (`request_from_tag`), replacing the removed `helper.local_tag`.

No siphon-ai code changes required — nothing in this repo touched the removed field (our `local_tag()` uses are the unchanged `DialogId` accessor).

## Verification

- `cargo test --workspace` — all green
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- Full SIPp integration suite: **38/38 scenarios passed** (echo server on `:8765`), including outbound origination, attended transfer, registration, delayed offer SRTP/DTLS, and graceful drain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rb4N8Rwff1PVdG3XiLn6Cj