### PR TITLE
chore(release): 0.45.0 — CDR ws_disconnect cause (v7) + per-request From tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.45.0] - 2026-07-27
+
 ### Fixed
 
 - **CDR now records an unexpected mid-call WS drop as `termination.cause = "ws_disconnect"`** (issue #369; **CDR schema v6 → v7**). PROTOCOL.md §5.7 has always promised that a WS connection closing before any `stop` exchange produces a CDR recording `ws_disconnect` — but the CDR had no such cause: a crashed WS server, a network cut, a keepalive timeout, a bare socket close (even a clean 1000 with no `hangup`), and a reconnect window that elapsed without recovering all collapsed into `bridge_ended`, the same value an orderly SiphonAI-side session ending produces. The only trace of the difference was substring-matching the free-text `termination.bridge_disconnect` diagnostic, which has no stability contract. Same WS-vs-CDR divergence class as #356 (`transfer`) and #332 (`caller_hangup`) — the durable, billing/ops-grade side was the lossy one. New `WsDisconnect` variant on `CallTermination` / the CDR `TerminationCause` (serialises `"ws_disconnect"`, matching the WS `stop` reason); the controller classifies every bridge-first ending through one helper whose drop set deliberately equals reconnect eligibility (`ServerClosed` or any connection error → `ws_disconnect`; `stop`-sent, controller-hung-up, `server_too_slow`, `protocol_error` stay `bridge_ended`), so give-up reconnects land on `ws_disconnect` too. `siphon_ai_calls_total` gains the `cause="ws_disconnect"` label — alert on it; it means the WS server crashed or the network failed, not that a call ended. PROTOCOL.md §5.7 step 4 also named a `stop_reason` CDR field that never existed under any option — corrected to `termination.cause`.
+
+- **Outbound requests no longer reuse one From tag for the process lifetime** (fixed upstream by [siphon-rs#72](https://github.com/thevoiceguy/siphon-rs/pull/72), pin bumped `5c7cf20beb50` → `ead16f9bf9b7`). `UserAgentClient` minted a single `local_tag` at construction and stamped it on every out-of-dialog request until restart, so all outbound INVITEs (and OPTIONS, SUBSCRIBE, MESSAGE, PUBLISH, unsolicited NOTIFY) from a node shared one From tag — RFC 3261 §8.1.1.3 requires a fresh tag per request and §19.3 fresh randomness per tag; a live trunk capture showed 7 unrelated calls with 7 Call-IDs and a single tag over 86 minutes. Upstream now mints a tag per request, with REGISTER as the deliberate exception: a stable per-registrar tag (capped map, like the reused Call-ID) so a refresh series presents one `(Call-ID, From tag)` identity per §10.2. No siphon-ai code change.
 
 ## [0.44.0] - 2026-07-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "base64",
  "bytes",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3927,7 +3927,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "regex",
  "serde",
@@ -3946,7 +3946,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "base64",
  "hmac",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4040,7 +4040,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4058,7 +4058,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4076,7 +4076,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "regex",
  "serde",
@@ -4102,7 +4102,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "schemars",
  "serde",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -4157,7 +4157,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -4186,7 +4186,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.44.0"
+version = "0.45.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.44.0.** Production-deployed against real carriers
+**Current release: v0.45.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a


### PR DESCRIPTION
Release-prep commit per RELEASING.md: version bump to **0.45.0**, CHANGELOG `[Unreleased]` → dated `[0.45.0] - 2026-07-27` (adding the missing entry for the #370 siphon-rs#72 pin bump), README marker updated, Cargo.lock refreshed.

Ships:
- **#369 / PR #371** — CDR schema **v7**: unexpected mid-call WS drops (crashed server, network cut, keepalive timeout, bare close, exhausted reconnect) record `termination.cause = "ws_disconnect"` instead of collapsing into `bridge_ended`; new `siphon_ai_calls_total{cause="ws_disconnect"}` label; PROTOCOL.md §5.7 phantom `stop_reason` field corrected.
- **PR #370** — siphon-rs pin `ead16f9` (siphon-rs#72): per-request From tags (RFC 3261 §8.1.1.3/§19.3), REGISTER keeps a stable per-registrar tag.

Preflight verified locally: `check-version-consistency.py` (plain and `--tag v0.45.0`), `extract-changelog.py 0.45.0`.

After merge: tag `v0.45.0` on the merge commit and push — the release workflow does the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rb4N8Rwff1PVdG3XiLn6Cj