### PR TITLE
chore(release): 0.45.1 — outbound calls join the shared call metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.45.1] - 2026-07-27
+
 ### Fixed
 
 - **Outbound calls now count in the shared call instruments: `siphon_ai_calls_total{cause}`, `siphon_ai_calls_active`, and `siphon_ai_call_duration_seconds`** (issue #373). All three were updated only on the inbound teardown path, and `siphon_ai_outbound_calls_total{result}` classifies call **setup** only (`answered`/`declined`/…) — so once an outbound call was answered, its termination cause reached no metric at all, and `siphon_ai_calls_active` ignored the leg entirely (live-confirmed: 2 active calls, gauge reading 1). The practical bite: 0.45.0's "alert on `cause="ws_disconnect"`" never fired for outbound legs — origination-heavy deployments, exactly the ones most exposed to their own WS server crashing, got no signal. Both teardown paths now end calls through one shared helper (gauge down, cause counted, wall-clock duration recorded — the same block the acceptor always ran), and an outbound leg joins `calls_active` at answer, mirroring inbound's join-at-accept. Additive to the time series: no labels changed, existing inbound-only dashboards simply start seeing the outbound legs they were silently missing. DEPLOY.md metric table now states the direction coverage for all four metrics.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "base64",
  "bytes",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3927,7 +3927,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "regex",
  "serde",
@@ -3946,7 +3946,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "base64",
  "hmac",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4040,7 +4040,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4058,7 +4058,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4076,7 +4076,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "regex",
  "serde",
@@ -4102,7 +4102,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "schemars",
  "serde",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "base64",
  "rcgen",
@@ -4157,7 +4157,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -4186,7 +4186,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.45.0"
+version = "0.45.1"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.45.0.** Production-deployed against real carriers
+**Current release: v0.45.1.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a


### PR DESCRIPTION
Release-prep per RELEASING.md: version bump to **0.45.1**, CHANGELOG `[Unreleased]` → dated `[0.45.1] - 2026-07-27`, README marker, Cargo.lock refreshed.

Ships **#373 / PR #374**: outbound calls now count in `siphon_ai_calls_total{cause}`, `siphon_ai_calls_active`, and `siphon_ai_call_duration_seconds` — closing the gap where 0.45.0's `cause="ws_disconnect"` alert never fired for outbound legs.

Preflight verified locally: `check-version-consistency.py --tag v0.45.1`, `extract-changelog.py 0.45.1`.

After merge: tag `v0.45.1` on the merge commit and push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rb4N8Rwff1PVdG3XiLn6Cj