### PR TITLE
chore(release): 0.45.3 — inbound TCP/TLS flow teardown fix + opt-in CRLF keepalive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.45.3] - 2026-07-28
+
 ### Fixed
 
 - **In-dialog requests on an inbound TCP/TLS leg no longer die at Timer B after a carrier idle-closes the connection** (fixed upstream by [siphon-rs#74](https://github.com/thevoiceguy/siphon-rs/pull/74), pin bumped `ead16f9bf9b7` → `4e7d5d7d0bd7`). An inbound session's writer task was stopped only by sender-drop, but the `Flow` clones held by dialogs outlive the session — so after a carrier idle-closed a quiet signaling connection (~2 min observed on Twilio Secure Trunking) the socket sat in CLOSE-WAIT forever (one leaked fd per connection) and its writer channel kept accepting: every in-dialog request on the leg — hold re-INVITE, REFER, the teardown BYE — was written into the half-closed socket and died at Timer B ~32 s later, leaving the caller in dead air until the carrier's own cleanup. Upstream now shuts the writer down when the read side ends (flow sends fail fast, socket properly closed), and `bye`/`refer`/`reinvite_via_flow` hand the transaction a pool-resolved fallback target so the existing RFC 3263 §4.3 dispatch failover re-sends via the connection pool when the flow is dead. No siphon-ai code change needed for the failover; the keepalive below closes the gap end-to-end.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.45.2"
+version = "0.45.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.45.2"
+version = "0.45.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.45.2"
+version = "0.45.3"
 dependencies = [
  "base64",
  "bytes",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.45.2"
+version = "0.45.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3927,7 +3927,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.45.2"
+version = "0.45.3"
 dependencies = [
  "regex",
  "serde",
@@ -3946,7 +3946,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.45.2"
+version = "0.45.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.45.2"
+version = "0.45.3"
 dependencies = [
  "base64",
  "hmac",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.45.2"
+version = "0.45.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4040,7 +4040,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.45.2"
+version = "0.45.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -4058,7 +4058,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.45.2"
+version = "0.45.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4076,7 +4076,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.45.2"
+version = "0.45.3"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.45.2"
+version = "0.45.3"
 dependencies = [
  "regex",
  "serde",
@@ -4102,7 +4102,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.45.2"
+version = "0.45.3"
 dependencies = [
  "schemars",
  "serde",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.45.2"
+version = "0.45.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.45.2"
+version = "0.45.3"
 dependencies = [
  "base64",
  "rcgen",
@@ -4157,7 +4157,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.45.2"
+version = "0.45.3"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -4186,7 +4186,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.45.2"
+version = "0.45.3"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.45.2"
+version = "0.45.3"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.45.2.** Production-deployed against real carriers
+**Current release: v0.45.3.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a


### PR DESCRIPTION
Release-prep for **v0.45.3** per RELEASING.md:

- `[workspace.package].version` 0.45.2 → 0.45.3 (+ `Cargo.lock` refresh)
- CHANGELOG: `[Unreleased]` → `## [0.45.3] - 2026-07-28`, fresh empty `[Unreleased]` above
- README current-release marker → v0.45.3

Contents: #381 (siphon-rs #74 pin bump — inbound flow teardown on peer FIN, via-flow → pool failover; new `[sip].tcp_keepalive_interval_secs`).

Verified locally: `check-version-consistency.py` (plain + `--tag v0.45.3`) and `extract-changelog.py 0.45.3` all pass.

After merge: tag `v0.45.3` on the merge commit and push to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mmf3ZdxELyWBAmh3R9ESFV