### PR TITLE
fix(routes): reject unknown keys in route tables (closes #383)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING (config): an unknown key inside `[[route]]`, `[route.match]`, or any `[route.*]` override block is now a startup error instead of being silently ignored** (issue #383). Every section in `crates/config` already carried `#[serde(deny_unknown_fields)]` — its doc comment calls that "the right strictness — it catches typos like `auido_sample_rate`" — but no struct in `crates/routes` did, leaving the dialplan the laxest part of the config. Two ways that bit: a misspelled match key was **dropped**, so a route written as "`from_user` **and** `to`" matched on `from_user` alone and, since routes are first-match-wins, quietly stole calls meant for later routes; and a misspelled override key (`ws_uri` for `ws_url`) was indistinguishable from "not overridden", so the route silently bridged to the global `[bridge].ws_url` — a production misroute with a clean `config OK`. The same shape applied to `[route.media]`/`[route.security]`/`[route.recording]`, where a dropped override silently inherits a *less* restrictive global. Unknown keys now produce the same "unknown field `x`, expected one of …" error the rest of the config gives, which for `to` → `to_user` is self-explaining. Unknown **top-level** tables stay tolerated as before (`RawRouteFile` is deliberately lenient — `load_from_toml` is handed whole config files and picks the routes out), and `[route.match.header]` names are map keys, so arbitrary header names are unaffected. **Upgrade note:** a deployed config carrying a stray key in a route block will now refuse to start; run `siphon-ai --config <file> check` before upgrading — the error names the offending key. The shipped `examples/twilio-trunk/siphon-ai.toml` carried exactly this bug (`register_source = "twilio"` at route level, where it did nothing — and `"twilio"` was the `[[trunk]]` name, not the `"trunk"` literal a UAS-mode call actually carries); it has been corrected.
+
 ## [0.45.3] - 2026-07-28
 
 ### Fixed

--- a/crates/config/tests/shipped_configs.rs
+++ b/crates/config/tests/shipped_configs.rs
@@ -95,7 +95,10 @@ fn every_shipped_daemon_config_parses() {
     // The walk finding nothing would make this test pass silently, so
     // assert it saw the configs we know are published.
     let names: Vec<String> = checked.iter().map(|p| p.display().to_string()).collect();
-    for expected in ["configs/local-dev.toml", "examples/twilio-trunk/siphon-ai.toml"] {
+    for expected in [
+        "configs/local-dev.toml",
+        "examples/twilio-trunk/siphon-ai.toml",
+    ] {
         assert!(
             names.iter().any(|n| n.replace('\\', "/") == expected),
             "{expected} was not discovered; found: {names:?}"

--- a/crates/config/tests/shipped_configs.rs
+++ b/crates/config/tests/shipped_configs.rs
@@ -1,0 +1,104 @@
+//! Guard: every daemon config this repo ships must still parse.
+//!
+//! `examples/twilio-trunk/siphon-ai.toml` sat in the tree carrying
+//! `[[trunk]].sources` long after that key became `peer_addrs`, so the
+//! example a new Twilio user copies produced a daemon that refused to
+//! start — and nothing in CI noticed, because nothing loaded the
+//! configs we publish. See #383/#384.
+//!
+//! Scope is deliberately the **parse** stage: it catches the drift this
+//! missed (renamed keys, removed sections, unknown keys in a route
+//! table) without depending on the machine the test runs on. Full
+//! validation resolves DNS, binds nothing but checks addresses, and
+//! stats files on disk — `examples/homer-stack/siphon-ai-hep.toml`
+//! names `host.docker.internal`, which only resolves inside the
+//! compose network. Those checks belong to `siphon-ai --config X check`,
+//! not to a unit test.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use siphon_ai_config::RawConfig;
+
+/// Repo root, resolved from this crate's manifest directory.
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("repo root resolves from CARGO_MANIFEST_DIR")
+}
+
+/// Collects `*.toml` under `dir`, skipping build and VCS directories.
+///
+/// `tests` is skipped too: a fixture is a pre-substitution template,
+/// not a config we publish. `bins/siphon-ai/tests/fixtures/local-dev.toml`
+/// carries `rtp_port_range = [${TEST_RTP_MIN}, ${TEST_RTP_MAX}]`, which
+/// isn't valid TOML until its own test expands it.
+fn collect_toml(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if path.is_dir() {
+            if matches!(name.as_ref(), "target" | ".git" | "node_modules" | "tests") {
+                continue;
+            }
+            collect_toml(&path, out);
+        } else if path.extension().is_some_and(|ext| ext == "toml") {
+            out.push(path);
+        }
+    }
+}
+
+/// A daemon config is a TOML file with a `[node]` table. That keeps
+/// manifests, `rustfmt.toml`, `pyproject.toml`, the testkit scenario
+/// files and `examples/observability/vector.toml` out without a
+/// hand-maintained skip list — add a new example config and it is
+/// covered the moment it declares `[node]`.
+fn is_daemon_config(text: &str) -> bool {
+    text.lines()
+        .any(|line| line.trim_start().starts_with("[node]"))
+}
+
+#[test]
+fn every_shipped_daemon_config_parses() {
+    let root = repo_root();
+    let mut candidates = Vec::new();
+    collect_toml(&root, &mut candidates);
+    candidates.sort();
+
+    let mut checked = Vec::new();
+    let mut failures = Vec::new();
+    for path in candidates {
+        let Ok(text) = fs::read_to_string(&path) else {
+            continue;
+        };
+        if !is_daemon_config(&text) {
+            continue;
+        }
+        let rel = path.strip_prefix(&root).unwrap_or(&path).to_path_buf();
+        if let Err(e) = toml::from_str::<RawConfig>(&text) {
+            failures.push(format!("{}: {e}", rel.display()));
+        }
+        checked.push(rel);
+    }
+
+    assert!(
+        failures.is_empty(),
+        "shipped config(s) no longer parse:\n{}",
+        failures.join("\n\n")
+    );
+
+    // The walk finding nothing would make this test pass silently, so
+    // assert it saw the configs we know are published.
+    let names: Vec<String> = checked.iter().map(|p| p.display().to_string()).collect();
+    for expected in ["configs/local-dev.toml", "examples/twilio-trunk/siphon-ai.toml"] {
+        assert!(
+            names.iter().any(|n| n.replace('\\', "/") == expected),
+            "{expected} was not discovered; found: {names:?}"
+        );
+    }
+}

--- a/crates/routes/src/raw.rs
+++ b/crates/routes/src/raw.rs
@@ -19,6 +19,11 @@ use serde::Deserialize;
 /// `[[route]]` arrays. The full siphon-ai TOML embeds these via the
 /// `route` key (TOML's array-of-tables syntax). Standalone test
 /// fixtures use this struct directly.
+///
+/// Deliberately *not* `deny_unknown_fields`: [`crate::load_from_toml`]
+/// hands it whole config files and picks the routes out, so every
+/// other top-level table must stay ignorable. Strictness belongs on
+/// the route tables below, where an unknown key is always a typo.
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct RawRouteFile {
     #[serde(default, rename = "route")]
@@ -26,7 +31,13 @@ pub struct RawRouteFile {
 }
 
 /// One `[[route]]` entry.
+///
+/// `deny_unknown_fields` here and on every block below: a route's keys
+/// decide where a call goes, so a silently-dropped typo would widen the
+/// match or quietly fall back to a global override. Same policy the
+/// config crate's sections already carry.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RawRoute {
     pub name: String,
 
@@ -53,6 +64,7 @@ pub struct RawRoute {
 /// block as a Rust regex pattern. The flag is scoped per-route per
 /// CLAUDE.md §4.6 ("`regex = true` is per-route, not per-match-key").
 #[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RawRouteMatch {
     /// Unconditional match. Mutually exclusive with all other keys.
     /// Required on the trailing default route.
@@ -86,6 +98,7 @@ pub struct RawRouteMatch {
 /// inherit from the global `[bridge]` block. The merge happens in
 /// the config crate — routes carries the partial.
 #[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct BridgeOverride {
     pub ws_url: Option<String>,
     pub ws_auth_header: Option<String>,
@@ -132,6 +145,7 @@ pub struct BridgeOverride {
 /// [`crate::CompiledRoute::bridge_tls`] so a bad path fails loud at
 /// startup, not on the first call that matches the route.
 #[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct BridgeTlsOverride {
     /// PEM client certificate chain, leaf first.
     pub client_cert: String,
@@ -144,6 +158,7 @@ pub struct BridgeTlsOverride {
 }
 
 #[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct BargeInOverride {
     pub enabled: Option<bool>,
     pub mode: Option<String>,
@@ -159,6 +174,7 @@ pub struct BargeInOverride {
 
 /// `[route.media]` overrides. Same merge rules as `BridgeOverride`.
 #[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct MediaOverride {
     pub codecs: Option<Vec<String>>,
     pub dtmf: Option<String>,
@@ -183,6 +199,7 @@ pub struct MediaOverride {
 /// security-policy types; the config crate validates it and the accept
 /// path parses it against the global default.
 #[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct SecurityOverride {
     /// `[route.security].min_attestation` — per-route override of the
     /// global `[security].min_attestation` gate. `None` inherits; any of
@@ -197,6 +214,7 @@ pub struct SecurityOverride {
 /// stays free of a dependency on the recording types; the config crate
 /// validates it and the accept path resolves it against the global.
 #[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct RecordingOverride {
     /// `[route.recording].mode` — per-route override of the global
     /// `[recording].mode`. `None` inherits; `"off"` / `"always"` /

--- a/crates/routes/tests/unknown_keys.rs
+++ b/crates/routes/tests/unknown_keys.rs
@@ -1,0 +1,139 @@
+//! A key the dialplan schema doesn't define is a typo, and a typo in a
+//! route is never harmless: dropped silently it either widens the match
+//! (routes are first-match-wins, so an over-broad route steals calls
+//! meant for later ones) or leaves an override unset, which is
+//! indistinguishable from "inherit the global". See issue #383.
+
+use siphon_ai_routes::{load_from_toml, LoadError};
+
+/// Every case here must be rejected at parse time, before compilation.
+fn rejected_key(toml: &str) -> String {
+    match load_from_toml(toml) {
+        Err(LoadError::Toml(e)) => e.to_string(),
+        Err(other) => panic!("expected a TOML parse error, got {other:?}"),
+        Ok(_) => panic!("unknown key was accepted:\n{toml}"),
+    }
+}
+
+#[test]
+fn misspelled_match_key_is_rejected_not_dropped() {
+    // `to` reads right — it is what the SIP header is called — but the
+    // schema key is `to_user`. Dropped, this route would match on
+    // `from_user` alone: broader than written.
+    rejected_key(
+        r#"
+        [[route]]
+        name = "narrow"
+        [route.match]
+        from_user = "+13125551234"
+        to = "+13125559999"
+        "#,
+    );
+}
+
+#[test]
+fn misspelled_bridge_override_is_rejected_not_silently_inherited() {
+    // `ws_uri` vs `ws_url`. Dropped, the route bridges to the global
+    // `[bridge].ws_url` with no warning — a production misroute.
+    let err = rejected_key(
+        r#"
+        [[route]]
+        name = "bot"
+        [route.match]
+        any = true
+        [route.bridge]
+        ws_uri = "ws://127.0.0.1:8081/"
+        "#,
+    );
+    assert!(err.contains("ws_uri"), "error should name the key: {err}");
+}
+
+#[test]
+fn unknown_key_on_the_route_itself_is_rejected() {
+    // `register_source` is a `[route.match]` key; at route level it did
+    // nothing. The shipped twilio-trunk example carried exactly this.
+    rejected_key(
+        r#"
+        [[route]]
+        name = "trunk_inbound"
+        register_source = "trunk"
+        [route.match]
+        any = true
+        "#,
+    );
+}
+
+#[test]
+fn unknown_keys_in_the_remaining_override_blocks_are_rejected() {
+    let blocks = [
+        ("route.media", "codecs_list = [\"pcmu\"]"),
+        ("route.security", "min_attest = \"B\""),
+        ("route.recording", "modes = \"always\""),
+        ("route.bridge.barge_in", "debounce = 200"),
+    ];
+    for (block, key) in blocks {
+        rejected_key(&format!(
+            r#"
+            [[route]]
+            name = "r"
+            [route.match]
+            any = true
+            [{block}]
+            {key}
+            "#
+        ));
+    }
+}
+
+#[test]
+fn known_keys_still_parse() {
+    // The guard against over-tightening: a route using a key from every
+    // block must still load — including `[route.match.header]`, whose
+    // *names* are map keys and must stay unrestricted.
+    let toml = r#"
+        [[route]]
+        name = "full"
+        [route.match]
+        to_user = "5000"
+        [route.match.header]
+        X-Tenant = "acme"
+        [route.bridge]
+        ws_url = "ws://127.0.0.1:8081/"
+        [route.bridge.barge_in]
+        debounce_ms = 200
+        [route.media]
+        codecs = ["pcmu"]
+        [route.security]
+        min_attestation = "B"
+        [route.recording]
+        mode = "always"
+
+        [[route]]
+        name = "fallback"
+        [route.match]
+        any = true
+    "#;
+    let set = load_from_toml(toml).expect("known keys must still load");
+    assert!(set.has_default());
+}
+
+#[test]
+fn non_route_tables_are_still_ignored() {
+    // `load_from_toml` is handed whole config files and picks the routes
+    // out, so unknown *top-level* tables must stay tolerated — the
+    // strictness is scoped to the route tables themselves.
+    let toml = r#"
+        [node]
+        id = "siphon-ai-local"
+
+        [sip]
+        listen = "127.0.0.1:5070"
+
+        [[route]]
+        name = "fallback"
+        [route.match]
+        any = true
+    "#;
+    let set = load_from_toml(toml).expect("top-level tables stay ignorable");
+    assert!(set.has_default());
+}

--- a/docs/DIALPLAN.md
+++ b/docs/DIALPLAN.md
@@ -85,6 +85,11 @@ These rules are CLAUDE.md §4.6 cardinal — don't try to bend them:
    keys, duplicate route names, missing register references — all
    fail loud at startup, not on the first call that would have hit
    them.
+6. **Unknown keys are errors, not comments.** A key this document
+   doesn't define is a typo, and every route table rejects it by
+   name (``unknown field `to`, expected one of ...``). Header
+   *names* under `[route.match.header]` are exempt — they're your
+   data, not schema.
 
 ---
 
@@ -373,6 +378,16 @@ ws_url = "wss://shared.example.com/sip-bridge"
   or unquoted dotted keys (`header.X-Customer-Id = "..."`).
 - **Duplicate route names.** Names are how observability
   correlates calls; collisions are a hard error at load time.
+- **`to` / `from` instead of `to_user` / `from_user`.** The bare
+  header names aren't match keys. They used to be silently
+  dropped, which made the route match on whatever keys were left —
+  broader than written, and first-match-wins meant it could swallow
+  calls intended for a later route. They're now rejected by name.
+- **A typo'd override key.** `ws_uri` for `ws_url` in
+  `[route.bridge]` used to look exactly like "not overridden", so
+  the route quietly used the global `[bridge].ws_url`. Also now
+  rejected — but it's worth re-reading §3 rule 3: an override you
+  *don't* set always inherits the global, silently and by design.
 
 ---
 

--- a/examples/twilio-trunk/siphon-ai.toml
+++ b/examples/twilio-trunk/siphon-ai.toml
@@ -48,13 +48,13 @@ http_listen = "127.0.0.1:9091"
 # internet who learns your public IP can send you INVITEs and get
 # bridged to your WS server.
 #
-# The `sources` list below uses RFC-5737 documentation ranges as
+# The `peer_addrs` list below uses RFC-5737 documentation ranges as
 # placeholders. Replace with the actual Twilio signalling IPs for
 # the regions you accept calls from — see Twilio's "SIP signaling
 # IP addresses" page (linked from docs/INTEGRATIONS_TWILIO.md).
 [[trunk]]
 name = "twilio"
-sources = [
+peer_addrs = [
   "192.0.2.0/24",   # placeholder — replace with Twilio NA Virginia
   "198.51.100.0/24", # placeholder — replace with Twilio Ireland
 ]
@@ -62,9 +62,11 @@ sources = [
 # Single default route — every accepted INVITE bridges to the
 # bridge ws_url above. For multi-tenant fan-out, replace `any =
 # true` with `to_user` / `request_uri` / custom-header matches
-# (see docs/DIALPLAN.md).
+# (see docs/DIALPLAN.md). To scope a route to unregistered trunk
+# arrivals instead, drop `any` and match `register_source =
+# "trunk"` inside `[route.match]` — `"trunk"` is the literal every
+# UAS-mode call carries, not the `[[trunk]]` name above.
 [[route]]
 name = "twilio_inbound"
-register_source = "twilio"
 [route.match]
 any = true


### PR DESCRIPTION
Closes #383.

Adds `#[serde(deny_unknown_fields)]` to the eight route tables in `crates/routes/src/raw.rs`, so a key the dialplan schema doesn't define is an error naming the key instead of a silent drop.

### Why

`crates/config` already has this on every section, and its doc comment states the policy: *"Unknown fields within known sections still surface as parse errors, which is the right strictness — it catches typos like `auido_sample_rate`."* `crates/routes` never implemented it, which left the one block whose keys decide **where a call goes** as the laxest part of the config.

Two failure modes, both silent:

- **A misspelled match key widens the route.** `to` reads right (it's what the SIP header is called) but the key is `to_user`. Dropped, a route written as "`from_user` **and** `to`" matches on `from_user` alone — and since routes are first-match-wins, it swallows calls meant for later routes.
- **A misspelled override key falls back to the global.** `ws_uri` for `ws_url` is indistinguishable from "not overridden", so the route bridges to the global `[bridge].ws_url` with a clean `config OK` and no log line. Same shape for `[route.media]` / `[route.security]` / `[route.recording]`, where a dropped override silently inherits a *less* restrictive global — the `[route.security]` case means an intended per-route attestation floor never applies.

Only a route whose **sole** key was misspelled failed, and then the message named the wrong problem (`has an empty match block`), sending you looking for a missing block rather than the typo in front of you.

### Scope

`RawRouteFile` deliberately stays lenient — `load_from_toml` is handed whole config files and picks the routes out, so unknown *top-level* tables must remain ignorable. Header **names** under `[route.match.header]` are map keys, so arbitrary names are unaffected. Both are covered by tests.

### The example config was carrying the bug

`examples/twilio-trunk/siphon-ai.toml` had `register_source = "twilio"` at `[[route]]` level, where it did nothing — and `"twilio"` was the `[[trunk]]` name, not the `"trunk"` literal a UAS-mode call actually carries, so it would never have matched even in the right place. Removed, with a comment showing the correct form.

While verifying that file I found it **doesn't load at all**, on a key the config crate already rejects: `sources` (renamed to `peer_addrs` at some point). Anyone following that example got a daemon that refuses to start. Fixed here too, since it is the same class of drift and strictness is what surfaced it.

**A guard is now included** (second commit). Nothing in CI loaded the configs we publish, which is why a broken example went unnoticed. `crates/config/tests/shipped_configs.rs` walks the repo and parses every `*.toml` that has a `[node]` table — discovery by content rather than a hand-maintained list, so manifests, `rustfmt.toml`, `pyproject.toml`, the testkit scenarios and `examples/observability/vector.toml` stay out and a new example is covered the moment it declares `[node]`. It selects the 7 configs under `configs/`, `docker/`, `examples/` and `bins/siphon-ai/pkg/`, and asserts two known ones were seen so an empty walk can't pass silently.

Two deliberate limits, both documented in the test: `tests` directories are skipped, because a fixture is a pre-substitution template (`bins/siphon-ai/tests/fixtures/local-dev.toml` has `rtp_port_range = [${TEST_RTP_MIN}, ${TEST_RTP_MAX}]`, not valid TOML until its own test expands it); and the scope is the **parse** stage, which is where this class of drift lands and where the strictness above applies. Full validation resolves DNS and stats files on disk — the homer-stack example names `host.docker.internal`, which only resolves inside the compose network — so that stays the job of `siphon-ai --config X check`.

### Testing

New `crates/routes/tests/unknown_keys.rs`: the realistic `to` and `ws_uri` typos, an unknown key on the route itself (the exact shape the example carried), unknown keys in each remaining override block, plus two guards against over-tightening — a route using a key from every block still loads, and unknown top-level tables stay ignored.

Verified against the released binary that all tracked configs still load (`configs/*`, `docker/local-dev.toml`, `bins/siphon-ai/pkg/config.toml`, and the corrected example), and swept the whole repo — including TOML fixtures inside Rust raw-string literals — for stray keys in route tables; the only hits left are this PR's deliberate negative fixtures.

### Compatibility

**Breaking for a deployed config carrying a stray key in a route block** — it now refuses to start rather than running with the key ignored. `siphon-ai --config <file> check` names the offending key. Called out under `## [Unreleased] / ### Changed` in the CHANGELOG with an upgrade note; may deserve a release-note callout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWxXx4u6SPw4nvjCmdvNT1
