### PR TITLE
fix(sip): bump siphon-rs to 065c2c6 — confirmed dialogs keep their route set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A confirmed dialog's route set no longer changes after dialog creation — teardown BYE after hold/resume on a re-dialed connection is answered immediately instead of timing out** (fixed upstream by [siphon-rs#82](https://github.com/thevoiceguy/siphon-rs/pull/82), pin bumped `376d0e9a5c5e` → `065c2c65a0f7`). `Dialog::update_from_response` refreshed the remote target on a 2xx — correct, RFC 3261 §12.2.1.2 — but **also** overwrote the dialog's route set from the response's `Record-Route`, which §12.1 fixes at dialog creation. Invisible when the response returns over the original connection (same `Record-Route` echoes back), it bit on the 0.45.3/0.46.0 idle-close fallback path: a 2xx returned over a connection *we* re-dialed carries Twilio's transaction-scoped `twnat=sip:<ip>:<port>` NAT hint in `Record-Route`; adopting it as dialog state sent the subsequent BYE to a target only valid for the dead connection — `408` after 32 s, teardown stalled, and the CDR's `ended_at` inflated by the same 30 s (billing-grade). Upstream now recomputes the route set only in the one case RFC 3261 §13.2.2.4 requires it (a 2xx confirming an *early* dialog); in-dialog responses never touch it. Wire-isolated upstream on live Twilio Secure Trunking (hold → resume → BYE now `200` in ~40 ms on a re-dialed connection). Pin bump only — no siphon-ai code change.
+
 ## [0.46.0] - 2026-07-28
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3595,7 +3595,7 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 [[package]]
 name = "sip-auth"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=376d0e9a5c5e#376d0e9a5c5e2a29e7c67234327e8a55d3d4e876"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7#065c2c65a0f71273079b7157f644f7b045f6bb65"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3618,7 +3618,7 @@ dependencies = [
 [[package]]
 name = "sip-core"
 version = "0.7.6"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=376d0e9a5c5e#376d0e9a5c5e2a29e7c67234327e8a55d3d4e876"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7#065c2c65a0f71273079b7157f644f7b045f6bb65"
 dependencies = [
  "bytes",
  "httpdate",
@@ -3631,7 +3631,7 @@ dependencies = [
 [[package]]
 name = "sip-dialog"
 version = "0.3.3"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=376d0e9a5c5e#376d0e9a5c5e2a29e7c67234327e8a55d3d4e876"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7#065c2c65a0f71273079b7157f644f7b045f6bb65"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3649,7 +3649,7 @@ dependencies = [
 [[package]]
 name = "sip-dns"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=376d0e9a5c5e#376d0e9a5c5e2a29e7c67234327e8a55d3d4e876"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7#065c2c65a0f71273079b7157f644f7b045f6bb65"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3663,7 +3663,7 @@ dependencies = [
 [[package]]
 name = "sip-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=376d0e9a5c5e#376d0e9a5c5e2a29e7c67234327e8a55d3d4e876"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7#065c2c65a0f71273079b7157f644f7b045f6bb65"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -3674,7 +3674,7 @@ dependencies = [
 [[package]]
 name = "sip-identity"
 version = "0.1.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=376d0e9a5c5e#376d0e9a5c5e2a29e7c67234327e8a55d3d4e876"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7#065c2c65a0f71273079b7157f644f7b045f6bb65"
 dependencies = [
  "base64",
  "ring",
@@ -3687,7 +3687,7 @@ dependencies = [
 [[package]]
 name = "sip-observe"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=376d0e9a5c5e#376d0e9a5c5e2a29e7c67234327e8a55d3d4e876"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7#065c2c65a0f71273079b7157f644f7b045f6bb65"
 dependencies = [
  "once_cell",
  "tracing",
@@ -3696,7 +3696,7 @@ dependencies = [
 [[package]]
 name = "sip-parse"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=376d0e9a5c5e#376d0e9a5c5e2a29e7c67234327e8a55d3d4e876"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7#065c2c65a0f71273079b7157f644f7b045f6bb65"
 dependencies = [
  "bytes",
  "httpdate",
@@ -3710,7 +3710,7 @@ dependencies = [
 [[package]]
 name = "sip-ratelimit"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=376d0e9a5c5e#376d0e9a5c5e2a29e7c67234327e8a55d3d4e876"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7#065c2c65a0f71273079b7157f644f7b045f6bb65"
 dependencies = [
  "dashmap 5.5.3",
  "parking_lot",
@@ -3730,7 +3730,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=376d0e9a5c5e#376d0e9a5c5e2a29e7c67234327e8a55d3d4e876"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7#065c2c65a0f71273079b7157f644f7b045f6bb65"
 dependencies = [
  "nom 7.1.3",
  "smol_str",
@@ -3739,7 +3739,7 @@ dependencies = [
 [[package]]
 name = "sip-transaction"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=376d0e9a5c5e#376d0e9a5c5e2a29e7c67234327e8a55d3d4e876"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7#065c2c65a0f71273079b7157f644f7b045f6bb65"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3758,7 +3758,7 @@ dependencies = [
 [[package]]
 name = "sip-transport"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=376d0e9a5c5e#376d0e9a5c5e2a29e7c67234327e8a55d3d4e876"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7#065c2c65a0f71273079b7157f644f7b045f6bb65"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3778,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "sip-uac"
 version = "0.4.2"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=376d0e9a5c5e#376d0e9a5c5e2a29e7c67234327e8a55d3d4e876"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7#065c2c65a0f71273079b7157f644f7b045f6bb65"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3791,7 +3791,7 @@ dependencies = [
  "sip-dialog",
  "sip-dns",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=376d0e9a5c5e)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -3803,7 +3803,7 @@ dependencies = [
 [[package]]
 name = "sip-uas"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=376d0e9a5c5e#376d0e9a5c5e2a29e7c67234327e8a55d3d4e876"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7#065c2c65a0f71273079b7157f644f7b045f6bb65"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3813,7 +3813,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=376d0e9a5c5e)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -3966,7 +3966,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=376d0e9a5c5e)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7)",
  "sip-transaction",
  "sip-uac",
  "sip-uas",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,24 +146,24 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 #  `6fd432270bb8` = #67 dialog_manager share, siphon-ai #324;
 #  `fcaff011f9c6` = #65 invite_with_from, siphon-ai #316;
 #  `3a4fc312ade3` = #64 TLS-SNI-is-hostname, siphon-ai #312.)
-sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "376d0e9a5c5e" }
-sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "376d0e9a5c5e" }
-sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "376d0e9a5c5e", features = ["tls"] }
-sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "376d0e9a5c5e" }
-sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "376d0e9a5c5e" }
-sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "376d0e9a5c5e" }
-sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "376d0e9a5c5e" }
-sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "376d0e9a5c5e" }
-sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "376d0e9a5c5e" }
+sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "065c2c65a0f7" }
+sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "065c2c65a0f7" }
+sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "065c2c65a0f7", features = ["tls"] }
+sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "065c2c65a0f7" }
+sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "065c2c65a0f7" }
+sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "065c2c65a0f7" }
+sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "065c2c65a0f7" }
+sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "065c2c65a0f7" }
+sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "065c2c65a0f7" }
 # sip-sdp — the SAME sip-sdp sip-uac's SdpAnswerGenerator trait speaks
 # (distinct from forge-media's pinned sip-sdp). Used by the outbound
 # delayed-offer answer generator to hand the UAC a SessionDescription it
 # accepts. Must stay on the same siphon-rs rev as the rest below.
-sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "376d0e9a5c5e" }
-sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "376d0e9a5c5e" }
+sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "065c2c65a0f7" }
+sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "065c2c65a0f7" }
 # sip-identity — STIR/SHAKEN Identity-header parsing + PASSporT verification
 # (ES256 + X.509 chain validation). Consumed by the stir-shaken verifier crate.
-sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "376d0e9a5c5e" }
+sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "065c2c65a0f7" }
 
 # forge-media — RTP / codecs / SDP / DTMF / engine.
 #


### PR DESCRIPTION
Picks up [siphon-rs#82](https://github.com/thevoiceguy/siphon-rs/pull/82) (closes siphon-rs#81):

`Dialog::update_from_response` refreshed the remote target on a 2xx — correct per RFC 3261 §12.2.1.2 — but **also** overwrote the dialog's route set from the response's `Record-Route`, which §12.1 fixes at dialog creation. The overwrite was invisible when responses return over the original connection (the same `Record-Route` echoes back). It bit on the idle-close fallback path shipped in 0.45.3/0.46.0: a 2xx returned over a connection **we** re-dialed carries Twilio's transaction-scoped `twnat=sip:<ip>:<port>` NAT hint in `Record-Route`; adopting it as dialog state sent the teardown BYE to a target only valid for the dead connection:

```
hold   → 200 OK
resume → 200 OK
BYE    → 408 Request Timeout, ~32 s later
```

Teardown stalled and the CDR's `ended_at` inflated by the same ~30 s — billing-grade. Upstream now recomputes the route set only in the one case RFC 3261 §13.2.2.4 requires (a 2xx confirming an *early* dialog — the RFC 2543-peer compat path); in-dialog responses never touch it. Wire-isolated upstream on live Twilio Secure Trunking: BYE now `200` in ~40 ms on a re-dialed connection.

**Pin bump only** (`376d0e9a5c5e` → `065c2c65a0f7`) — no siphon-ai code change. CHANGELOG entry included under `[Unreleased]`.

## Testing
- Full workspace suite: 1061 passed, 0 failed
- `cargo clippy --workspace --all-targets` clean
- All 38 SIPp scenarios pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PoUeFDdZSL3d6DU3it6yxW