### PR TITLE
chore(release): 0.46.1 — confirmed dialogs keep their route set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.46.1] - 2026-07-28
+
 ### Fixed
 
 - **A confirmed dialog's route set no longer changes after dialog creation — teardown BYE after hold/resume on a re-dialed connection is answered immediately instead of timing out** (fixed upstream by [siphon-rs#82](https://github.com/thevoiceguy/siphon-rs/pull/82), pin bumped `376d0e9a5c5e` → `065c2c65a0f7`). `Dialog::update_from_response` refreshed the remote target on a 2xx — correct, RFC 3261 §12.2.1.2 — but **also** overwrote the dialog's route set from the response's `Record-Route`, which §12.1 fixes at dialog creation. Invisible when the response returns over the original connection (same `Record-Route` echoes back), it bit on the 0.45.3/0.46.0 idle-close fallback path: a 2xx returned over a connection *we* re-dialed carries Twilio's transaction-scoped `twnat=sip:<ip>:<port>` NAT hint in `Record-Route`; adopting it as dialog state sent the subsequent BYE to a target only valid for the dead connection — `408` after 32 s, teardown stalled, and the CDR's `ended_at` inflated by the same 30 s (billing-grade). Upstream now recomputes the route set only in the one case RFC 3261 §13.2.2.4 requires it (a 2xx confirming an *early* dialog); in-dialog responses never touch it. Wire-isolated upstream on live Twilio Secure Trunking (hold → resume → BYE now `200` in ~40 ms on a re-dialed connection). Pin bump only — no siphon-ai code change.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "base64",
  "bytes",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3927,7 +3927,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "regex",
  "serde",
@@ -3946,7 +3946,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "base64",
  "hmac",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4040,7 +4040,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4058,7 +4058,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4076,7 +4076,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "regex",
  "serde",
@@ -4102,7 +4102,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "schemars",
  "serde",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "base64",
  "rcgen",
@@ -4157,7 +4157,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -4186,7 +4186,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.46.0"
+version = "0.46.1"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.46.0.** Production-deployed against real carriers
+**Current release: v0.46.1.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a


### PR DESCRIPTION
Release-prep for **v0.46.1**, per RELEASING.md:

- `[workspace.package].version` 0.46.0 → 0.46.1 (+ Cargo.lock refresh)
- CHANGELOG: `[Unreleased]` → `[0.46.1] - 2026-07-28` (entry landed with #387)
- README current-release marker updated

Single fix in this dot release: **#387** — siphon-rs pin `376d0e9` → `065c2c6` (siphon-rs#82): a confirmed dialog's route set no longer gets overwritten from a 2xx's `Record-Route`, so the teardown BYE after hold/resume on a re-dialed connection is answered in ~40 ms instead of drawing a `408` after ~32 s and inflating the CDR.

`check-version-consistency.py` (plain + `--tag v0.46.1`) and `extract-changelog.py 0.46.1` pass locally.

After merge: tag `v0.46.1` on the release commit and push to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PoUeFDdZSL3d6DU3it6yxW