### PR TITLE
fix(reload): report spool-downgraded sink changes in `restart_required` (closes #390)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Sink changes downgraded to restart-required because their durable spool is active are now reported in the `config_reload` audit event's `restart_required` field and the summarizing reload warning** (issue #390). All three sink arms (`[webhooks]`, `[cdr]`, `[audit]`) logged their own specific journal warning but never added the section to the reload's `restart_required` list, so the machine-readable audit trail claimed a plain `"applied"` while deliveries kept going to the old target until a restart — and since a repeat SIGHUP with an unchanged file short-circuits as `no_change`, that one journal line was the only trace a restart was owed. The sections now surface as `"[webhooks] delivery"` / `"[cdr] delivery"` / `"[audit] delivery"` — distinct from the existing `"[audit]"` entry, which means "audit was disabled at startup and enabling it needs the process-global facade installed". Verified live on 0.46.1: an `[audit.webhook].url` edit under an active spool produced a bare-`applied` audit event while probe events and the drained spool kept POSTing to the old url. Sink fingerprints still advance only on a successful swap, so reverting a downgraded edit converges silently with no restart debt (covered by new tests).
+
 ## [0.46.1] - 2026-07-28
 
 ### Fixed

--- a/bins/siphon-ai/src/reload.rs
+++ b/bins/siphon-ai/src/reload.rs
@@ -453,8 +453,12 @@ pub(crate) struct ReloadState {
 /// outbound gateway set (when outbound is enabled and its `limits` are
 /// unchanged). Mutates `state` in place — advancing a fingerprint only for
 /// a section it actually applied (see [`ReloadState`]) — and returns the
-/// restart-required sections that changed (for the warning). Split out
-/// from the SIGHUP loop so it's unit-testable without signals.
+/// restart-required sections: restart-only sections that changed, plus
+/// sink changes downgraded because their durable spool is active (#390).
+/// The returned vec feeds the summarizing warn AND the `config_reload`
+/// audit event's `restart_required` field — omitting a section here makes
+/// the audit trail claim "applied" for a change that didn't take effect.
+/// Split out from the SIGHUP loop so it's unit-testable without signals.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn apply_reload(
     new: Config,
@@ -519,7 +523,8 @@ pub(crate) async fn apply_reload(
     ) {
         SinkReload::Unchanged => {}
         SinkReload::RestartRequired => {
-            warn!("SIGHUP: [webhooks] changed but its durable spool is active; webhook delivery changes require a restart (not hot-applied)")
+            warn!("SIGHUP: [webhooks] changed but its durable spool is active; webhook delivery changes require a restart (not hot-applied)");
+            restart_required.push("[webhooks] delivery");
         }
         SinkReload::Swap => match crate::runtime::build_webhook_sink(webhooks) {
             Ok(sink) => {
@@ -535,7 +540,8 @@ pub(crate) async fn apply_reload(
     match decide_sink_reload(new_cdr_fp != state.cdr_fp, state.cdr_spool || new_cdr_spool) {
         SinkReload::Unchanged => {}
         SinkReload::RestartRequired => {
-            warn!("SIGHUP: [cdr] changed but its durable spool is active; CDR delivery changes require a restart (not hot-applied)")
+            warn!("SIGHUP: [cdr] changed but its durable spool is active; CDR delivery changes require a restart (not hot-applied)");
+            restart_required.push("[cdr] delivery");
         }
         SinkReload::Swap => match crate::runtime::build_cdr_sink(cdr, hep).await {
             Ok(sink) => {
@@ -562,7 +568,8 @@ pub(crate) async fn apply_reload(
             ) {
                 SinkReload::Unchanged => {}
                 SinkReload::RestartRequired => {
-                    warn!("SIGHUP: [audit] changed but its durable spool is active; audit delivery changes require a restart (not hot-applied)")
+                    warn!("SIGHUP: [audit] changed but its durable spool is active; audit delivery changes require a restart (not hot-applied)");
+                    restart_required.push("[audit] delivery");
                 }
                 SinkReload::Swap => {
                     // `build_audit_sink` requires `enabled = true`; when the
@@ -758,6 +765,97 @@ any = true
         audit_swap
             .emit(AuditEvent::invite_rejected("1.2.3.4:5060", "rate_limited"))
             .await;
+    }
+
+    // #390: a sink change that is downgraded because its durable spool is
+    // active must still be REPORTED as restart-required — the vec feeds
+    // the summarizing warn and the `config_reload` audit event, which
+    // otherwise claims a plain "applied" while the change silently didn't
+    // take effect. One test per sink; each also pins that the sink's
+    // fingerprint baseline does NOT advance (the change was not applied,
+    // so reverting the edit must converge without a restart).
+    #[tokio::test]
+    async fn webhook_change_with_active_spool_is_reported_restart_required() {
+        let with_spool = format!(
+            "{BASE}\n[webhooks]\nenabled = true\nurl = \"http://127.0.0.1:1/hook\"\nspool_dir = \"/spool\"\n"
+        );
+        let route_swap = ArcSwap::from_pointee(cfg(&with_spool).routes);
+        let (wh, cd) = null_sinks();
+        let mut st = state(&cfg(&with_spool));
+        let old_fp = st.webhook_fp.clone();
+
+        let new = cfg(&with_spool.replace("/hook", "/hook2"));
+        let rr = apply_reload(new, &route_swap, &wh, &cd, None, None, None, &mut st).await;
+
+        assert!(
+            rr.contains(&"[webhooks] delivery"),
+            "spool-downgraded [webhooks] change must be reported: {rr:?}"
+        );
+        assert_eq!(
+            st.webhook_fp, old_fp,
+            "baseline must not advance past an unapplied change"
+        );
+    }
+
+    #[tokio::test]
+    async fn cdr_change_with_active_spool_is_reported_restart_required() {
+        let with_spool = format!(
+            "{BASE}\n[cdr]\nenabled = true\n[cdr.webhook]\nenabled = true\nurl = \"http://127.0.0.1:1/cdr\"\nspool_dir = \"/spool\"\n"
+        );
+        let route_swap = ArcSwap::from_pointee(cfg(&with_spool).routes);
+        let (wh, cd) = null_sinks();
+        let mut st = state(&cfg(&with_spool));
+        let old_fp = st.cdr_fp.clone();
+
+        let new = cfg(&with_spool.replace("/cdr", "/cdr2"));
+        let rr = apply_reload(new, &route_swap, &wh, &cd, None, None, None, &mut st).await;
+
+        assert!(
+            rr.contains(&"[cdr] delivery"),
+            "spool-downgraded [cdr] change must be reported: {rr:?}"
+        );
+        assert_eq!(
+            st.cdr_fp, old_fp,
+            "baseline must not advance past an unapplied change"
+        );
+    }
+
+    #[tokio::test]
+    async fn audit_change_with_active_spool_is_reported_restart_required() {
+        // Audit enabled at startup (swap present) — the exact live shape
+        // from #390: a url edit under an active spool reported as plain
+        // "applied" in the audit trail.
+        let with_spool = format!(
+            "{BASE}\n[audit]\nenabled = true\n[audit.webhook]\nenabled = true\nurl = \"http://127.0.0.1:1/audit\"\nspool_dir = \"/spool\"\n"
+        );
+        let route_swap = ArcSwap::from_pointee(cfg(&with_spool).routes);
+        let (wh, cd) = null_sinks();
+        let mut st = state(&cfg(&with_spool));
+        let old_fp = st.audit_fp.clone();
+        let audit_swap =
+            SwappableAuditSink::new(Arc::new(siphon_ai_audit::NullSink) as AuditSinkHandle);
+
+        let new = cfg(&with_spool.replace("/audit", "/audit2"));
+        let rr = apply_reload(
+            new,
+            &route_swap,
+            &wh,
+            &cd,
+            Some(&audit_swap),
+            None,
+            None,
+            &mut st,
+        )
+        .await;
+
+        assert!(
+            rr.contains(&"[audit] delivery"),
+            "spool-downgraded [audit] change must be reported: {rr:?}"
+        );
+        assert_eq!(
+            st.audit_fp, old_fp,
+            "baseline must not advance past an unapplied change"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #390.

## What

When a SIGHUP changes a `[webhooks]` / `[cdr]` / `[audit]` sink whose durable `spool_dir` is configured, the change is (correctly, per DEPLOY.md) downgraded to restart-required — but the section never joined the reload's `restart_required` vector. Consequences, live-verified on the 0.46.1 test box:

- the `config_reload` **audit event** reported bare `{"result":"applied"}` with no `restart_required` field, while deliveries kept going to the old target until a restart;
- the summarizing `warn!(sections = …)` didn't fire (only the arm's own journal warn did);
- a repeat SIGHUP with the unchanged file short-circuits on `text == last_text` → `no_change` (deliberately unaudited), so that single journal line was the operator's only trace a restart was owed.

## Fix

Each of the three `SinkReload::RestartRequired` arms now pushes its section onto `restart_required` — `"[webhooks] delivery"`, `"[cdr] delivery"`, `"[audit] delivery"`. The `delivery` suffix keeps them distinct from the existing `"[audit]"` entry, which means "audit was disabled at startup; enabling it needs the process-global facade". No behavioral change to what is or isn't applied — this is purely surfacing the existing downgrade through the existing warn + audit plumbing.

Also tightened the `apply_reload` doc comment to say the returned vec feeds the audit event, so the next arm added here doesn't repeat the omission.

## Tests

Three new tests (one per sink) through the existing `apply_reload` test harness, each asserting:
1. a sink change under an active spool is reported in the returned `restart_required`;
2. the sink's fingerprint baseline does **not** advance — pinning the (nice, live-verified) property that reverting a downgraded edit converges silently with no restart debt.

The audit-sink test models the exact live repro from #390 (`[audit.webhook].url` edit, swap present, spool configured).

## Not in scope

The `no_change` short-circuit still means restart-required sections are only re-reported when the file changes again (#390's "aggravating interaction"). Left as a design decision — with this fix the audit trail records the downgrade correctly at the moment it happens, which is the load-bearing half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EocNuuJKfjEoSnScNPvG95