### PR TITLE
docs(protocol): `ts_ms` is wall-clock epoch ms, not monotonic-since-start

### DIFF
--- a/crates/bridge/src/protocol.rs
+++ b/crates/bridge/src/protocol.rs
@@ -71,7 +71,8 @@ pub enum BridgeOut {
     SpeechStarted {
         call_id: CallId,
         seq: Seq,
-        /// Milliseconds since `start` was sent (monotonic, NOT wall-clock).
+        /// Wall-clock Unix-epoch milliseconds of the transition (NOT an
+        /// offset from `start`).
         ts_ms: u64,
         /// `true` when this event armed a pause-mode barge-in
         /// arbitration (0.32.0, `[bridge.barge_in].mode = "pause"`):
@@ -93,6 +94,8 @@ pub enum BridgeOut {
     SpeechStopped {
         call_id: CallId,
         seq: Seq,
+        /// Wall-clock Unix-epoch milliseconds of the transition (NOT an
+        /// offset from `start`).
         ts_ms: u64,
         duration_ms: u64,
     },

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -239,12 +239,15 @@ are the same VAD signals that drive barge-in — see `[bridge.barge_in]` in
 `docs/CONFIG.md`.)
 
 ```json
-{ "type": "speech_started", "call_id": "...", "seq": 42, "ts_ms": 1234 }
-{ "type": "speech_stopped", "call_id": "...", "seq": 67, "ts_ms": 1890, "duration_ms": 656 }
+{ "type": "speech_started", "call_id": "...", "seq": 42, "ts_ms": 1785331555126 }
+{ "type": "speech_stopped", "call_id": "...", "seq": 67, "ts_ms": 1785331555782, "duration_ms": 656 }
 ```
 
-`ts_ms` is monotonic milliseconds since `start` was sent (NOT wall-clock);
+`ts_ms` is the wall-clock Unix-epoch milliseconds of the transition (NOT an
+offset from `start` — every daemon version has stamped epoch here);
 `speech_stopped` also carries `duration_ms` (the length of the speech run).
+To place an event on the media timeline, subtract the wall-clock time at
+which you received `start`, or diff consecutive events.
 
 The barge-in **mode** doesn't change *whether* these are sent, only what
 SiphonAI does alongside a `speech_started`: `auto_clear` (the default) also
@@ -263,7 +266,7 @@ arbitration**: SiphonAI instantly pauses playout (same one-frame reaction as
 extra fields:
 
 ```json
-{ "type": "speech_started", "call_id": "...", "seq": 42, "ts_ms": 1234,
+{ "type": "speech_started", "call_id": "...", "seq": 42, "ts_ms": 1785331555126,
   "decision_pending": true, "decision_deadline_ms": 500 }
 ```
 

--- a/schemas/siphon-ai.v1.json
+++ b/schemas/siphon-ai.v1.json
@@ -524,7 +524,7 @@
               "type": "integer"
             },
             "ts_ms": {
-              "description": "Milliseconds since `start` was sent (monotonic, NOT wall-clock).",
+              "description": "Wall-clock Unix-epoch milliseconds of the transition (NOT an\noffset from `start`).",
               "format": "uint64",
               "minimum": 0,
               "type": "integer"
@@ -559,6 +559,7 @@
               "type": "integer"
             },
             "ts_ms": {
+              "description": "Wall-clock Unix-epoch milliseconds of the transition (NOT an\noffset from `start`).",
               "format": "uint64",
               "minimum": 0,
               "type": "integer"

--- a/sdks/python/src/siphon_ai_server/events.py
+++ b/sdks/python/src/siphon_ai_server/events.py
@@ -120,6 +120,7 @@ class SpeechStarted:
     type = "speech_started"
     call_id: str
     seq: int
+    # Wall-clock Unix-epoch milliseconds of the transition.
     ts_ms: int
     # True when this event armed a pause-mode barge-in arbitration
     # (0.32.0): playout is paused with its tail retained, and the daemon
@@ -147,6 +148,7 @@ class SpeechStopped:
     type = "speech_stopped"
     call_id: str
     seq: int
+    # Wall-clock Unix-epoch milliseconds of the transition.
     ts_ms: int
     duration_ms: int
 

--- a/sdks/typescript/src/events.ts
+++ b/sdks/typescript/src/events.ts
@@ -56,6 +56,7 @@ export interface Start extends Base {
 
 export interface SpeechStarted extends Base {
   type: "speech_started";
+  /** Wall-clock Unix-epoch milliseconds of the transition. */
   ts_ms: number;
   /**
    * `true` when this event armed a pause-mode barge-in arbitration
@@ -83,6 +84,7 @@ export interface BargeInResolved extends Base {
 
 export interface SpeechStopped extends Base {
   type: "speech_stopped";
+  /** Wall-clock Unix-epoch milliseconds of the transition. */
   ts_ms: number;
   duration_ms: number;
 }


### PR DESCRIPTION
Closes #389 via **Option A** (fix the doc): every daemon version since the field shipped (c1aaf74, 0.43.0-era) has stamped wall-clock Unix-epoch milliseconds; only the PROTOCOL.md prose (bdb7dd1) ever claimed monotonic-since-`start`. Epoch values are self-identifying (13 digits), so no consumer can plausibly have built on the documented offset semantics — correcting the doc is the non-breaking direction. Option B (changing the code) would silently change wire semantics of a shipped v1 field.

## Changes
- `docs/PROTOCOL.md` §3.2: `ts_ms` documented as wall-clock Unix-epoch ms; example values updated from offset-looking `1234`/`1890` to realistic epoch values; added a note on deriving media-timeline offsets.
- `crates/bridge/src/protocol.rs`: fixed the `SpeechStarted.ts_ms` doc comment (it repeated the false monotonic claim) and added the same doc to `SpeechStopped.ts_ms`.
- `schemas/siphon-ai.v1.json`: descriptions synced. **Hand-edited** — no Rust toolchain on this box to run `gen_schema`; the CI schema-diff job should confirm it matches (revert the schema hunk and regenerate if it doesn't).
- SDKs (py + ts): one-line epoch clarification on both `ts_ms` fields (previously undocumented either way, so nothing to un-say).

No wire, type, or behavior changes; protocol version unchanged (per #389's analysis this is a doc correction, not a semantics change).

If offset-from-`start` semantics are wanted for media-timeline alignment (likely the original intent), that should be a **new additive field** (e.g. `offset_ms`) — happy to file a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jc9xxB6p9YgTq3GafCwGMU