### PR TITLE
docs(protocol): speech events have no enable flag — fix stale bridge.vad doc comment

### DIFF
--- a/crates/bridge/src/protocol.rs
+++ b/crates/bridge/src/protocol.rs
@@ -66,8 +66,9 @@ pub enum BridgeOut {
     /// audio format both directions will use for the lifetime of the call.
     Start(StartMsg),
 
-    /// VAD detected the caller starting to speak. Emitted only when
-    /// `bridge.vad = true`.
+    /// VAD detected the caller starting to speak. Always emitted —
+    /// there is no enable flag; `[media].vad` selects the detection
+    /// backend only.
     SpeechStarted {
         call_id: CallId,
         seq: Seq,

--- a/schemas/siphon-ai.v1.json
+++ b/schemas/siphon-ai.v1.json
@@ -500,7 +500,7 @@
           "type": "object"
         },
         {
-          "description": "VAD detected the caller starting to speak. Emitted only when\n`bridge.vad = true`.",
+          "description": "VAD detected the caller starting to speak. Always emitted —\nthere is no enable flag; `[media].vad` selects the detection\nbackend only.",
           "properties": {
             "call_id": {
               "$ref": "#/$defs/CallId"


### PR DESCRIPTION
The `BridgeOut::SpeechStarted` doc comment (and thus the generated schema description) claimed the event is "emitted only when `bridge.vad = true`". That flag doesn't exist — `[media].vad` is a backend *selector* (`energy`/`neural`, 0.37.0, always-on either way; `compile_vad_backend` has no off value), and PROTOCOL.md §3.2 correctly documents the events as always emitted with no enable flag. Live behavior on the 0.46.1 test box matches PROTOCOL.md on both the energy and neural legs.

Doc-comment + schema-description only; no wire, type, or behavior change. Schema hunk hand-synced (no toolchain on this box) — the CI `gen_schema` diff job verifies, same as #392.

Spotted while fixing #389 (noted in #392 as out-of-scope drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jc9xxB6p9YgTq3GafCwGMU