### PR TITLE
chore(release): 0.47.0 — offset_ms on speech events, spool-downgrade reload reporting, protocol doc truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.47.0] - 2026-07-29
+
 ### Added
 
 - **`offset_ms` on `speech_started` / `speech_stopped` — monotonic milliseconds between `start` being sent and the VAD transition** (issue #394). `ts_ms` carries wall-clock epoch milliseconds (#389/#392), so placing a speech event on the media timeline meant subtracting wall-clock values across two hosts — exposed to clock skew, WS transit jitter on `start`, and NTP steps. The daemon now also stamps the transition against its own monotonic clock, anchored to the instant `start` was written to the socket (the same instant already used as the CDR `first_audio_out_ms` epoch). The stamp is taken when the transition comes off the detector — before any barge-in debounce or pause hold — so a held `speech_started` keeps its true timeline position; a transition detected before `start` hit the wire saturates to `0`. Additive within protocol v1 (optional field, no version bump), absent from older daemons; documented in PROTOCOL.md §3.2, typed in both server SDKs.
@@ -14,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Sink changes downgraded to restart-required because their durable spool is active are now reported in the `config_reload` audit event's `restart_required` field and the summarizing reload warning** (issue #390). All three sink arms (`[webhooks]`, `[cdr]`, `[audit]`) logged their own specific journal warning but never added the section to the reload's `restart_required` list, so the machine-readable audit trail claimed a plain `"applied"` while deliveries kept going to the old target until a restart — and since a repeat SIGHUP with an unchanged file short-circuits as `no_change`, that one journal line was the only trace a restart was owed. The sections now surface as `"[webhooks] delivery"` / `"[cdr] delivery"` / `"[audit] delivery"` — distinct from the existing `"[audit]"` entry, which means "audit was disabled at startup and enabling it needs the process-global facade installed". Verified live on 0.46.1: an `[audit.webhook].url` edit under an active spool produced a bare-`applied` audit event while probe events and the drained spool kept POSTing to the old url. Sink fingerprints still advance only on a successful swap, so reverting a downgraded edit converges silently with no restart debt (covered by new tests).
+
+### Documentation
+
+- **PROTOCOL.md §3.2 now states that `ts_ms` on speech events is wall-clock Unix-epoch milliseconds, not a monotonic offset from `start`** (issue #389) — the ambiguity that motivated `offset_ms` above. Doc-comment and schema descriptions were corrected in the same pass.
+- **The `speech_started` doc comment and schema description no longer claim the event is gated on a nonexistent `bridge.vad = true` flag** — speech events are always emitted; `[media].vad` selects the detection backend only.
 
 ## [0.46.1] - 2026-07-28
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.46.1"
+version = "0.47.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.46.1"
+version = "0.47.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.46.1"
+version = "0.47.0"
 dependencies = [
  "base64",
  "bytes",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.46.1"
+version = "0.47.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3927,7 +3927,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.46.1"
+version = "0.47.0"
 dependencies = [
  "regex",
  "serde",
@@ -3946,7 +3946,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.46.1"
+version = "0.47.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.46.1"
+version = "0.47.0"
 dependencies = [
  "base64",
  "hmac",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.46.1"
+version = "0.47.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4040,7 +4040,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.46.1"
+version = "0.47.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4058,7 +4058,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.46.1"
+version = "0.47.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4076,7 +4076,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.46.1"
+version = "0.47.0"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.46.1"
+version = "0.47.0"
 dependencies = [
  "regex",
  "serde",
@@ -4102,7 +4102,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.46.1"
+version = "0.47.0"
 dependencies = [
  "schemars",
  "serde",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.46.1"
+version = "0.47.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.46.1"
+version = "0.47.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -4157,7 +4157,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.46.1"
+version = "0.47.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -4186,7 +4186,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.46.1"
+version = "0.47.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.46.1"
+version = "0.47.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.46.1.** Production-deployed against real carriers
+**Current release: v0.47.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a


### PR DESCRIPTION
Release-prep for **v0.47.0**, per RELEASING.md:

- `[workspace.package].version` 0.46.1 → 0.47.0 (+ Cargo.lock refresh)
- CHANGELOG: `[Unreleased]` → `[0.47.0] - 2026-07-29`, plus a `### Documentation` section for #392/#393 (the `[Unreleased]` entries for #395/#391 landed with their PRs)
- README current-release marker updated

## What ships in 0.47.0

- **#395** — `offset_ms` on `speech_started`/`speech_stopped`: monotonic ms since `start` was sent, stamped at the VAD transition (before debounce/pause holds). Additive within protocol v1; PROTOCOL.md + schema + both SDKs in lockstep.
- **#391** — spool-downgraded `[webhooks]`/`[cdr]`/`[audit]` sink changes now reported in the `config_reload` audit event's `restart_required` (they previously claimed a bare `applied` while delivery kept going to the old target).
- **#392/#393** — protocol doc truth: `ts_ms` is wall-clock epoch ms, and speech events carry no `bridge.vad` enable gate.

Minor bump for the new protocol surface. siphon-rs pin unchanged (`065c2c6`, current upstream HEAD).

All four PRs were re-reviewed post-merge this session: hot-path clean (monotonic stamp is `Copy`, conversion on the per-event WS path), legacy wire shapes byte-stable, reload tests pin fingerprint non-advance.

`check-version-consistency.py` (plain + `--tag v0.47.0`) and `extract-changelog.py 0.47.0` pass locally.

After merge: tag `v0.47.0` on the release commit and push to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PoUeFDdZSL3d6DU3it6yxW