### PR TITLE
feat(protocol): extend `offset_ms` to `dtmf`, `silence_detected`, `dead_air_detected`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`offset_ms` extended to `dtmf`, `silence_detected`, and `dead_air_detected`** (completes issue #394 — 0.47.0 added it to the speech events). Same semantics and anchor: monotonic milliseconds between `start` being written to the socket and the event's trigger — the digit's *end* detection for `dtmf`, the detector poll that crossed the threshold for the idle pair (so the idle events' offset carries the same up-to-500 ms poll quantization their `duration_ms` already has). Stamped at detection, saturating to `0` for triggers that predate `start` on the wire. Additive within protocol v1; absent from older daemons; documented in PROTOCOL.md §3.4/§3.6/§3.7, typed in both server SDKs.
+
 ## [0.47.0] - 2026-07-29
 
 ### Added

--- a/crates/bridge/src/conn.rs
+++ b/crates/bridge/src/conn.rs
@@ -176,6 +176,10 @@ pub enum OutgoingEvent {
         digit: char,
         duration_ms: u32,
         method: DtmfMethod,
+        /// Monotonic stamp of the digit's end detection (0.48.0); the
+        /// conn turns it into the wire `offset_ms`, as for the speech
+        /// events.
+        at: std::time::Instant,
     },
     Mark {
         name: String,
@@ -209,6 +213,9 @@ pub enum OutgoingEvent {
     /// only after a speech-then-silence cycle.
     SilenceDetected {
         duration_ms: u64,
+        /// Monotonic stamp of the detector poll that crossed the
+        /// threshold (0.48.0) → wire `offset_ms`.
+        at: std::time::Instant,
     },
     /// No audio in EITHER direction (no caller VAD speech AND no
     /// outbound playout from the WS server) for at least
@@ -218,6 +225,9 @@ pub enum OutgoingEvent {
     /// producing audio.
     DeadAirDetected {
         duration_ms: u64,
+        /// Monotonic stamp of the detector poll that crossed the
+        /// threshold (0.48.0) → wire `offset_ms`.
+        at: std::time::Instant,
     },
     /// Periodic snapshot of RTP / RTCP quality, emitted every
     /// `[bridge].rtp_stats_interval_ms` (default 5 s). Fields are
@@ -909,12 +919,14 @@ fn build_bridge_out(
             digit,
             duration_ms,
             method,
+            at,
         } => BridgeOut::Dtmf {
             call_id,
             seq,
             digit,
             duration_ms,
             method,
+            offset_ms: Some(at.saturating_duration_since(start_sent).as_millis() as u64),
         },
         OutgoingEvent::Mark { name } => BridgeOut::Mark { call_id, seq, name },
         OutgoingEvent::Hold { direction } => BridgeOut::Hold {
@@ -930,15 +942,17 @@ fn build_bridge_out(
             seq,
             outcome,
         },
-        OutgoingEvent::SilenceDetected { duration_ms } => BridgeOut::SilenceDetected {
+        OutgoingEvent::SilenceDetected { duration_ms, at } => BridgeOut::SilenceDetected {
             call_id,
             seq,
             duration_ms,
+            offset_ms: Some(at.saturating_duration_since(start_sent).as_millis() as u64),
         },
-        OutgoingEvent::DeadAirDetected { duration_ms } => BridgeOut::DeadAirDetected {
+        OutgoingEvent::DeadAirDetected { duration_ms, at } => BridgeOut::DeadAirDetected {
             call_id,
             seq,
             duration_ms,
+            offset_ms: Some(at.saturating_duration_since(start_sent).as_millis() as u64),
         },
         OutgoingEvent::RtpStats {
             jitter_ms,
@@ -1071,6 +1085,7 @@ mod tests {
                 digit: '5',
                 duration_ms: 120,
                 method: DtmfMethod::Rfc2833,
+                at: std::time::Instant::now(),
             },
             CallId::new("c"),
             7,
@@ -1140,6 +1155,24 @@ mod tests {
             out,
             BridgeOut::SpeechStopped {
                 offset_ms: Some(0),
+                ..
+            }
+        ));
+
+        // The 0.48.0 additions ride the same anchor.
+        let out = build_bridge_out(
+            OutgoingEvent::SilenceDetected {
+                duration_ms: 3000,
+                at: start_sent + Duration::from_millis(41_200),
+            },
+            CallId::new("c"),
+            9,
+            start_sent,
+        );
+        assert!(matches!(
+            out,
+            BridgeOut::SilenceDetected {
+                offset_ms: Some(41_200),
                 ..
             }
         ));

--- a/crates/bridge/src/protocol.rs
+++ b/crates/bridge/src/protocol.rs
@@ -144,6 +144,12 @@ pub enum BridgeOut {
         call_id: CallId,
         seq: Seq,
         duration_ms: u64,
+        /// Monotonic milliseconds between `start` being sent and the
+        /// detector poll that crossed the threshold (0.48.0); see the
+        /// speech events' `offset_ms`. Always present from daemons
+        /// that know the field; absent from older ones.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        offset_ms: Option<u64>,
     },
 
     /// No audio observed in EITHER direction (no caller VAD speech
@@ -156,6 +162,12 @@ pub enum BridgeOut {
         call_id: CallId,
         seq: Seq,
         duration_ms: u64,
+        /// Monotonic milliseconds between `start` being sent and the
+        /// detector poll that crossed the threshold (0.48.0); see the
+        /// speech events' `offset_ms`. Always present from daemons
+        /// that know the field; absent from older ones.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        offset_ms: Option<u64>,
     },
 
     /// Periodic snapshot of RTP / RTCP quality, emitted every
@@ -265,6 +277,12 @@ pub enum BridgeOut {
         digit: char,
         duration_ms: u32,
         method: DtmfMethod,
+        /// Monotonic milliseconds between `start` being sent and the
+        /// digit's end being detected (0.48.0); see the speech events'
+        /// `offset_ms`. Always present from daemons that know the
+        /// field; absent from older ones.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        offset_ms: Option<u64>,
     },
 
     /// Acknowledgement of a server-initiated [`BridgeIn::Mark`]: the audio
@@ -1077,6 +1095,39 @@ mod tests {
             msg,
             BridgeOut::SpeechStopped {
                 offset_ms: Some(13136),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn bridge_out_idle_and_dtmf_offset_ms() {
+        // 0.48.0 additive field; the legacy shapes (tests below) must
+        // stay byte-stable — offset_ms is skip_serializing_if.
+        let raw = r#"{ "type": "silence_detected", "call_id": "c", "seq": 12, "duration_ms": 3000, "offset_ms": 41200 }"#;
+        let msg: BridgeOut = assert_round_trip(raw);
+        assert!(matches!(
+            msg,
+            BridgeOut::SilenceDetected {
+                offset_ms: Some(41200),
+                ..
+            }
+        ));
+        let raw = r#"{ "type": "dead_air_detected", "call_id": "c", "seq": 13, "duration_ms": 10000, "offset_ms": 55700 }"#;
+        let msg: BridgeOut = assert_round_trip(raw);
+        assert!(matches!(
+            msg,
+            BridgeOut::DeadAirDetected {
+                offset_ms: Some(55700),
+                ..
+            }
+        ));
+        let raw = r#"{ "type": "dtmf", "call_id": "c", "seq": 88, "digit": "5", "duration_ms": 120, "method": "rfc2833", "offset_ms": 9040 }"#;
+        let msg: BridgeOut = assert_round_trip(raw);
+        assert!(matches!(
+            msg,
+            BridgeOut::Dtmf {
+                offset_ms: Some(9040),
                 ..
             }
         ));

--- a/crates/bridge/tests/connection.rs
+++ b/crates/bridge/tests/connection.rs
@@ -525,6 +525,7 @@ async fn outgoing_control_events_get_seq_stamped_in_order() {
             digit: '1',
             duration_ms: 100,
             method: DtmfMethod::Rfc2833,
+            at: std::time::Instant::now(),
         })
         .await
         .unwrap();

--- a/crates/media-glue/src/tap.rs
+++ b/crates/media-glue/src/tap.rs
@@ -2338,11 +2338,17 @@ impl MediaTap {
                         let out = match ev {
                             IdleEvent::SilenceDetected { duration_ms } => {
                                 metrics::counter!("siphon_ai_silence_events_total").increment(1);
-                                OutgoingEvent::SilenceDetected { duration_ms }
+                                OutgoingEvent::SilenceDetected {
+                                    duration_ms,
+                                    at: now,
+                                }
                             }
                             IdleEvent::DeadAirDetected { duration_ms } => {
                                 metrics::counter!("siphon_ai_dead_air_events_total").increment(1);
-                                OutgoingEvent::DeadAirDetected { duration_ms }
+                                OutgoingEvent::DeadAirDetected {
+                                    duration_ms,
+                                    at: now,
+                                }
                             }
                         };
                         if let Err(e) = events_tx.try_send(out) {
@@ -2837,6 +2843,7 @@ fn derive_outgoing_event(call_id: &CallId, event: ForgeEvent) -> Option<Outgoing
             // emit the press so the WS server isn't left guessing.
             duration_ms: duration_ms.unwrap_or(0),
             method: map_dtmf_method(method),
+            at: Instant::now(),
         }),
         ForgeEvent::SpeechStarted {
             call_id: ev_call,

--- a/crates/media-glue/tests/tap.rs
+++ b/crates/media-glue/tests/tap.rs
@@ -444,6 +444,7 @@ async fn dtmf_end_event_emits_outgoing_event() {
             digit,
             duration_ms,
             method,
+            ..
         } => {
             assert_eq!(digit, '5');
             assert_eq!(duration_ms, 120);

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -314,11 +314,14 @@ returns to `sendrecv`.
 ### 3.4 `dtmf` — caller pressed a key
 
 ```json
-{ "type": "dtmf", "call_id": "...", "seq": 88, "digit": "5", "duration_ms": 120, "method": "rfc2833" }
+{ "type": "dtmf", "call_id": "...", "seq": 88, "digit": "5", "duration_ms": 120, "method": "rfc2833", "offset_ms": 9040 }
 ```
 
 `digit` is one of `0-9 * # A B C D`.
 `method` is `"rfc2833"` or `"inband"` — depending on detection source.
+`offset_ms` (0.48.0) is monotonic milliseconds between `start` being sent
+and the digit's **end** being detected — same semantics and caveats as the
+speech events' `offset_ms` (§3.2). Absent from older daemons.
 
 ### 3.5 `mark` — playback marker fired
 
@@ -333,7 +336,7 @@ been fully played out into the call.
 ### 3.6 `silence_detected` — caller has been silent
 
 ```json
-{ "type": "silence_detected", "call_id": "...", "seq": 102, "duration_ms": 3000 }
+{ "type": "silence_detected", "call_id": "...", "seq": 102, "duration_ms": 3000, "offset_ms": 41200 }
 ```
 
 Fired when the caller has produced no VAD speech for at least
@@ -342,6 +345,10 @@ override; `0` disables the event). The `duration_ms` reports actual
 elapsed time at fire, which may exceed the threshold by up to one
 poll cadence (500 ms). The event fires **once per silence stretch** —
 the next `silence_detected` only after a speech → silence cycle.
+`offset_ms` (0.48.0) is monotonic milliseconds between `start` being
+sent and the detector poll that crossed the threshold — same semantics
+as the speech events' `offset_ms` (§3.2), same up-to-500 ms poll
+quantization as `duration_ms`. Absent from older daemons.
 
 Typical use: prompt the caller ("are you still there?") or escalate
 to a human after a configurable wait.
@@ -349,8 +356,10 @@ to a human after a configurable wait.
 ### 3.7 `dead_air_detected` — no audio in either direction
 
 ```json
-{ "type": "dead_air_detected", "call_id": "...", "seq": 103, "duration_ms": 10000 }
+{ "type": "dead_air_detected", "call_id": "...", "seq": 103, "duration_ms": 10000, "offset_ms": 55700 }
 ```
+
+`offset_ms` (0.48.0): as on `silence_detected`.
 
 Fired when **neither** caller VAD speech **nor** outbound playout from
 the WS server has been observed for at least

--- a/schemas/siphon-ai.v1.json
+++ b/schemas/siphon-ai.v1.json
@@ -658,6 +658,15 @@
               "minimum": 0,
               "type": "integer"
             },
+            "offset_ms": {
+              "description": "Monotonic milliseconds between `start` being sent and the\ndetector poll that crossed the threshold (0.48.0); see the\nspeech events' `offset_ms`. Always present from daemons\nthat know the field; absent from older ones.",
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
             "seq": {
               "format": "uint64",
               "minimum": 0,
@@ -686,6 +695,15 @@
               "format": "uint64",
               "minimum": 0,
               "type": "integer"
+            },
+            "offset_ms": {
+              "description": "Monotonic milliseconds between `start` being sent and the\ndetector poll that crossed the threshold (0.48.0); see the\nspeech events' `offset_ms`. Always present from daemons\nthat know the field; absent from older ones.",
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "seq": {
               "format": "uint64",
@@ -849,6 +867,15 @@
             },
             "method": {
               "$ref": "#/$defs/DtmfMethod"
+            },
+            "offset_ms": {
+              "description": "Monotonic milliseconds between `start` being sent and the\ndigit's end being detected (0.48.0); see the speech events'\n`offset_ms`. Always present from daemons that know the\nfield; absent from older ones.",
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "seq": {
               "format": "uint64",

--- a/sdks/python/src/siphon_ai_server/events.py
+++ b/sdks/python/src/siphon_ai_server/events.py
@@ -187,6 +187,10 @@ class SilenceDetected:
     call_id: str
     seq: int
     duration_ms: int
+    # Monotonic milliseconds between `start` being sent and the detector
+    # poll that crossed the threshold (0.48.0); see the speech events'
+    # offset_ms. None from older daemons.
+    offset_ms: int | None = None
 
 
 @dataclass(frozen=True)
@@ -195,6 +199,10 @@ class DeadAirDetected:
     call_id: str
     seq: int
     duration_ms: int
+    # Monotonic milliseconds between `start` being sent and the detector
+    # poll that crossed the threshold (0.48.0); see the speech events'
+    # offset_ms. None from older daemons.
+    offset_ms: int | None = None
 
 
 @dataclass(frozen=True)
@@ -240,6 +248,10 @@ class Dtmf:
     digit: str
     duration_ms: int
     method: str
+    # Monotonic milliseconds between `start` being sent and the digit's
+    # end being detected (0.48.0); see the speech events' offset_ms.
+    # None from older daemons.
+    offset_ms: int | None = None
 
 
 @dataclass(frozen=True)

--- a/sdks/typescript/src/events.ts
+++ b/sdks/typescript/src/events.ts
@@ -115,11 +115,23 @@ export interface FarEndResume extends Base {
 export interface SilenceDetected extends Base {
   type: "silence_detected";
   duration_ms: number;
+  /**
+   * Monotonic milliseconds between `start` being sent and the detector
+   * poll that crossed the threshold (0.48.0); see the speech events'
+   * `offset_ms`. Absent from older daemons.
+   */
+  offset_ms?: number;
 }
 
 export interface DeadAirDetected extends Base {
   type: "dead_air_detected";
   duration_ms: number;
+  /**
+   * Monotonic milliseconds between `start` being sent and the detector
+   * poll that crossed the threshold (0.48.0); see the speech events'
+   * `offset_ms`. Absent from older daemons.
+   */
+  offset_ms?: number;
 }
 
 export interface RtpStats extends Base {
@@ -166,6 +178,12 @@ export interface Dtmf extends Base {
   digit: string;
   duration_ms: number;
   method: "rfc2833" | "inband";
+  /**
+   * Monotonic milliseconds between `start` being sent and the digit's
+   * end being detected (0.48.0); see the speech events' `offset_ms`.
+   * Absent from older daemons.
+   */
+  offset_ms?: number;
 }
 
 /** Playout-position echo of a `mark` the server sent. */


### PR DESCRIPTION
Completes the deferred half of #394: the remaining timeline-relevant daemon→server events get the same monotonic `offset_ms` the speech events gained in 0.47.0 (#395), with the same anchor (the `start`-sent `Instant` shared with the CDR `first_audio_out_ms` epoch), the same additive `Option`/`skip_serializing_if` wire shape, and the same saturate-to-0 for triggers that predate `start` on the wire.

## Per-event stamp moments

- **`dtmf`** — the digit's **End** detection, stamped in the tap's `derive_outgoing_event` (same site as the speech events).
- **`silence_detected` / `dead_air_detected`** — the idle-detector poll that crossed the threshold, reusing the `Instant` the poll already takes. Their offset therefore carries the same up-to-500 ms poll quantization their `duration_ms` already has — PROTOCOL.md says so explicitly rather than implying frame-level precision.

## Changes

- `crates/bridge/src/protocol.rs` — wire fields + round-trip test (new shapes; legacy shapes stay byte-stable)
- `crates/bridge/src/conn.rs` — `at: Instant` on the three `OutgoingEvent` variants; `build_bridge_out` stamps; offset-math test extended
- `crates/media-glue/src/tap.rs` — stamps at the two emission sites
- PROTOCOL.md §3.4/§3.6/§3.7, schema, both SDKs, CHANGELOG (Unreleased/Added)

## Caveats

- **Schema hunks hand-edited** (no Rust toolchain on this box); CI's `gen_schema` diff is the verifier — 4th time using this technique (#392/#393/#395 all confirmed exact).
- Docs cite **0.48.0** — adjust if the next release gets a different number.
- With this, every timestamped BridgeOut event that maps to a media-timeline moment carries `offset_ms`; `rtp_stats`/`mark`/acks are excluded deliberately (periodic snapshots and command echoes, not timeline moments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jc9xxB6p9YgTq3GafCwGMU