### PR TITLE
chore(release): 0.47.1 — offset_ms on dtmf, silence_detected, dead_air_detected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.47.1] - 2026-07-29
+
 ### Added
 
 - **`offset_ms` extended to `dtmf`, `silence_detected`, and `dead_air_detected`** (completes issue #394 — 0.47.0 added it to the speech events). Same semantics and anchor: monotonic milliseconds between `start` being written to the socket and the event's trigger — the digit's *end* detection for `dtmf`, the detector poll that crossed the threshold for the idle pair (so the idle events' offset carries the same up-to-500 ms poll quantization their `duration_ms` already has). Stamped at detection, saturating to `0` for triggers that predate `start` on the wire. Additive within protocol v1; absent from older daemons; documented in PROTOCOL.md §3.4/§3.6/§3.7, typed in both server SDKs.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.47.0"
+version = "0.47.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.47.0"
+version = "0.47.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.47.0"
+version = "0.47.1"
 dependencies = [
  "base64",
  "bytes",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.47.0"
+version = "0.47.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3927,7 +3927,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.47.0"
+version = "0.47.1"
 dependencies = [
  "regex",
  "serde",
@@ -3946,7 +3946,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.47.0"
+version = "0.47.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.47.0"
+version = "0.47.1"
 dependencies = [
  "base64",
  "hmac",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.47.0"
+version = "0.47.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4040,7 +4040,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.47.0"
+version = "0.47.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4058,7 +4058,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.47.0"
+version = "0.47.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4076,7 +4076,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.47.0"
+version = "0.47.1"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.47.0"
+version = "0.47.1"
 dependencies = [
  "regex",
  "serde",
@@ -4102,7 +4102,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.47.0"
+version = "0.47.1"
 dependencies = [
  "schemars",
  "serde",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.47.0"
+version = "0.47.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.47.0"
+version = "0.47.1"
 dependencies = [
  "base64",
  "rcgen",
@@ -4157,7 +4157,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.47.0"
+version = "0.47.1"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -4186,7 +4186,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.47.0"
+version = "0.47.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.47.0"
+version = "0.47.1"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.47.0.** Production-deployed against real carriers
+**Current release: v0.47.1.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a

--- a/crates/bridge/src/conn.rs
+++ b/crates/bridge/src/conn.rs
@@ -176,7 +176,7 @@ pub enum OutgoingEvent {
         digit: char,
         duration_ms: u32,
         method: DtmfMethod,
-        /// Monotonic stamp of the digit's end detection (0.48.0); the
+        /// Monotonic stamp of the digit's end detection (0.47.1); the
         /// conn turns it into the wire `offset_ms`, as for the speech
         /// events.
         at: std::time::Instant,
@@ -214,7 +214,7 @@ pub enum OutgoingEvent {
     SilenceDetected {
         duration_ms: u64,
         /// Monotonic stamp of the detector poll that crossed the
-        /// threshold (0.48.0) → wire `offset_ms`.
+        /// threshold (0.47.1) → wire `offset_ms`.
         at: std::time::Instant,
     },
     /// No audio in EITHER direction (no caller VAD speech AND no
@@ -226,7 +226,7 @@ pub enum OutgoingEvent {
     DeadAirDetected {
         duration_ms: u64,
         /// Monotonic stamp of the detector poll that crossed the
-        /// threshold (0.48.0) → wire `offset_ms`.
+        /// threshold (0.47.1) → wire `offset_ms`.
         at: std::time::Instant,
     },
     /// Periodic snapshot of RTP / RTCP quality, emitted every
@@ -1159,7 +1159,7 @@ mod tests {
             }
         ));
 
-        // The 0.48.0 additions ride the same anchor.
+        // The 0.47.1 additions ride the same anchor.
         let out = build_bridge_out(
             OutgoingEvent::SilenceDetected {
                 duration_ms: 3000,

--- a/crates/bridge/src/protocol.rs
+++ b/crates/bridge/src/protocol.rs
@@ -145,7 +145,7 @@ pub enum BridgeOut {
         seq: Seq,
         duration_ms: u64,
         /// Monotonic milliseconds between `start` being sent and the
-        /// detector poll that crossed the threshold (0.48.0); see the
+        /// detector poll that crossed the threshold (0.47.1); see the
         /// speech events' `offset_ms`. Always present from daemons
         /// that know the field; absent from older ones.
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -163,7 +163,7 @@ pub enum BridgeOut {
         seq: Seq,
         duration_ms: u64,
         /// Monotonic milliseconds between `start` being sent and the
-        /// detector poll that crossed the threshold (0.48.0); see the
+        /// detector poll that crossed the threshold (0.47.1); see the
         /// speech events' `offset_ms`. Always present from daemons
         /// that know the field; absent from older ones.
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -278,7 +278,7 @@ pub enum BridgeOut {
         duration_ms: u32,
         method: DtmfMethod,
         /// Monotonic milliseconds between `start` being sent and the
-        /// digit's end being detected (0.48.0); see the speech events'
+        /// digit's end being detected (0.47.1); see the speech events'
         /// `offset_ms`. Always present from daemons that know the
         /// field; absent from older ones.
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1102,7 +1102,7 @@ mod tests {
 
     #[test]
     fn bridge_out_idle_and_dtmf_offset_ms() {
-        // 0.48.0 additive field; the legacy shapes (tests below) must
+        // 0.47.1 additive field; the legacy shapes (tests below) must
         // stay byte-stable — offset_ms is skip_serializing_if.
         let raw = r#"{ "type": "silence_detected", "call_id": "c", "seq": 12, "duration_ms": 3000, "offset_ms": 41200 }"#;
         let msg: BridgeOut = assert_round_trip(raw);

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -319,7 +319,7 @@ returns to `sendrecv`.
 
 `digit` is one of `0-9 * # A B C D`.
 `method` is `"rfc2833"` or `"inband"` — depending on detection source.
-`offset_ms` (0.48.0) is monotonic milliseconds between `start` being sent
+`offset_ms` (0.47.1) is monotonic milliseconds between `start` being sent
 and the digit's **end** being detected — same semantics and caveats as the
 speech events' `offset_ms` (§3.2). Absent from older daemons.
 
@@ -345,7 +345,7 @@ override; `0` disables the event). The `duration_ms` reports actual
 elapsed time at fire, which may exceed the threshold by up to one
 poll cadence (500 ms). The event fires **once per silence stretch** —
 the next `silence_detected` only after a speech → silence cycle.
-`offset_ms` (0.48.0) is monotonic milliseconds between `start` being
+`offset_ms` (0.47.1) is monotonic milliseconds between `start` being
 sent and the detector poll that crossed the threshold — same semantics
 as the speech events' `offset_ms` (§3.2), same up-to-500 ms poll
 quantization as `duration_ms`. Absent from older daemons.
@@ -359,7 +359,7 @@ to a human after a configurable wait.
 { "type": "dead_air_detected", "call_id": "...", "seq": 103, "duration_ms": 10000, "offset_ms": 55700 }
 ```
 
-`offset_ms` (0.48.0): as on `silence_detected`.
+`offset_ms` (0.47.1): as on `silence_detected`.
 
 Fired when **neither** caller VAD speech **nor** outbound playout from
 the WS server has been observed for at least

--- a/schemas/siphon-ai.v1.json
+++ b/schemas/siphon-ai.v1.json
@@ -659,7 +659,7 @@
               "type": "integer"
             },
             "offset_ms": {
-              "description": "Monotonic milliseconds between `start` being sent and the\ndetector poll that crossed the threshold (0.48.0); see the\nspeech events' `offset_ms`. Always present from daemons\nthat know the field; absent from older ones.",
+              "description": "Monotonic milliseconds between `start` being sent and the\ndetector poll that crossed the threshold (0.47.1); see the\nspeech events' `offset_ms`. Always present from daemons\nthat know the field; absent from older ones.",
               "format": "uint64",
               "minimum": 0,
               "type": [
@@ -697,7 +697,7 @@
               "type": "integer"
             },
             "offset_ms": {
-              "description": "Monotonic milliseconds between `start` being sent and the\ndetector poll that crossed the threshold (0.48.0); see the\nspeech events' `offset_ms`. Always present from daemons\nthat know the field; absent from older ones.",
+              "description": "Monotonic milliseconds between `start` being sent and the\ndetector poll that crossed the threshold (0.47.1); see the\nspeech events' `offset_ms`. Always present from daemons\nthat know the field; absent from older ones.",
               "format": "uint64",
               "minimum": 0,
               "type": [
@@ -869,7 +869,7 @@
               "$ref": "#/$defs/DtmfMethod"
             },
             "offset_ms": {
-              "description": "Monotonic milliseconds between `start` being sent and the\ndigit's end being detected (0.48.0); see the speech events'\n`offset_ms`. Always present from daemons that know the\nfield; absent from older ones.",
+              "description": "Monotonic milliseconds between `start` being sent and the\ndigit's end being detected (0.47.1); see the speech events'\n`offset_ms`. Always present from daemons that know the\nfield; absent from older ones.",
               "format": "uint64",
               "minimum": 0,
               "type": [

--- a/sdks/python/src/siphon_ai_server/events.py
+++ b/sdks/python/src/siphon_ai_server/events.py
@@ -188,7 +188,7 @@ class SilenceDetected:
     seq: int
     duration_ms: int
     # Monotonic milliseconds between `start` being sent and the detector
-    # poll that crossed the threshold (0.48.0); see the speech events'
+    # poll that crossed the threshold (0.47.1); see the speech events'
     # offset_ms. None from older daemons.
     offset_ms: int | None = None
 
@@ -200,7 +200,7 @@ class DeadAirDetected:
     seq: int
     duration_ms: int
     # Monotonic milliseconds between `start` being sent and the detector
-    # poll that crossed the threshold (0.48.0); see the speech events'
+    # poll that crossed the threshold (0.47.1); see the speech events'
     # offset_ms. None from older daemons.
     offset_ms: int | None = None
 
@@ -249,7 +249,7 @@ class Dtmf:
     duration_ms: int
     method: str
     # Monotonic milliseconds between `start` being sent and the digit's
-    # end being detected (0.48.0); see the speech events' offset_ms.
+    # end being detected (0.47.1); see the speech events' offset_ms.
     # None from older daemons.
     offset_ms: int | None = None
 

--- a/sdks/typescript/src/events.ts
+++ b/sdks/typescript/src/events.ts
@@ -117,7 +117,7 @@ export interface SilenceDetected extends Base {
   duration_ms: number;
   /**
    * Monotonic milliseconds between `start` being sent and the detector
-   * poll that crossed the threshold (0.48.0); see the speech events'
+   * poll that crossed the threshold (0.47.1); see the speech events'
    * `offset_ms`. Absent from older daemons.
    */
   offset_ms?: number;
@@ -128,7 +128,7 @@ export interface DeadAirDetected extends Base {
   duration_ms: number;
   /**
    * Monotonic milliseconds between `start` being sent and the detector
-   * poll that crossed the threshold (0.48.0); see the speech events'
+   * poll that crossed the threshold (0.47.1); see the speech events'
    * `offset_ms`. Absent from older daemons.
    */
   offset_ms?: number;
@@ -180,7 +180,7 @@ export interface Dtmf extends Base {
   method: "rfc2833" | "inband";
   /**
    * Monotonic milliseconds between `start` being sent and the digit's
-   * end being detected (0.48.0); see the speech events' `offset_ms`.
+   * end being detected (0.47.1); see the speech events' `offset_ms`.
    * Absent from older daemons.
    */
   offset_ms?: number;


### PR DESCRIPTION
Release-prep for **v0.47.1**, per RELEASING.md:

- `[workspace.package].version` 0.47.0 → 0.47.1 (+ Cargo.lock refresh)
- CHANGELOG: `[Unreleased]` → `[0.47.1] - 2026-07-29` (entry landed with #397)
- README current-release marker updated
- **Version-reference sweep:** #397 was authored assuming the next release would be 0.48.0 and stamped that into doc comments, PROTOCOL.md §3.4/§3.6/§3.7, the schema descriptions, and both SDKs. This ships as a dot release, so those references are renamed to 0.47.1 and the schema regenerated with `gen_schema` (CI diffs it).

Single change in this dot release: **#397** — `offset_ms` extended to `dtmf`, `silence_detected`, and `dead_air_detected`, completing #394's monotonic timeline across all timeline-relevant events. Additive within protocol v1.

Reviewed post-merge: same stamp-at-detection pattern as #395, `start`-write anchor shared with the CDR epoch, saturating pre-`start`, legacy shapes byte-stable.

Local: bridge + media-glue suites (264 tests) pass; `check-version-consistency.py` (plain + `--tag v0.47.1`) and `extract-changelog.py 0.47.1` pass.

After merge: tag `v0.47.1` on the release commit and push to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PoUeFDdZSL3d6DU3it6yxW