### PR TITLE
fix(media-glue): anchor silence at speech END; gate idle events while the caller is speaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`silence_detected` no longer fires mid-utterance, and the silence stretch is measured from the caller's last speech *end*, not its onset** (issue #399). The idle detector anchored its silence timer at `speech_started` and never checked whether speech was still active, so any caller utterance longer than `silence_threshold_ms` (default 3 s — routine in real speech) emitted `silence_detected` while the caller was still talking, and the once-per-stretch suppression flag then swallowed the event for the *real* silence that followed — exactly inverted behavior. Short utterances fired early, with `duration_ms` inflated by the utterance's own length. The detector now tracks speech-active state (fed from every forge-vad transition, including debounce-suppressed provisional pairs, so a suppressed pair can't wedge the gate), holds both idle events while the caller is speaking, and anchors silence *and* dead-air at speech end — which also fixes the latent sibling: an utterance longer than `dead_air_threshold_ms` would have fired `dead_air_detected` mid-audio. `duration_ms` now reports the true silence length, matching what PROTOCOL.md §3.6/§3.7 always promised; speechless-call behavior (measured from call start) is unchanged. Live-found on 0.47.1: the new `offset_ms` field made the wrong anchor arithmetically visible on the wire (`silence.offset_ms − duration_ms == speech_started.offset_ms`, three-for-three).
+
 ## [0.47.1] - 2026-07-29
 
 ### Added

--- a/crates/media-glue/src/idle.rs
+++ b/crates/media-glue/src/idle.rs
@@ -39,7 +39,15 @@ pub enum IdleEvent {
 pub struct IdleDetector {
     silence_threshold: Option<Duration>,
     dead_air_threshold: Option<Duration>,
-    last_speech_started: Instant,
+    /// True between `note_speech_started` and `note_speech_stopped`:
+    /// the caller is mid-utterance, so neither idle event may fire
+    /// (#399 — measuring "silence" from the utterance's *onset* made
+    /// any utterance longer than the threshold emit `silence_detected`
+    /// while the caller was still talking).
+    speech_active: bool,
+    /// When the caller last **stopped** speaking (call start before
+    /// any speech) — the anchor actual silence is measured from.
+    last_speech_ended: Instant,
     last_any_audio: Instant,
     /// True once we've emitted `SilenceDetected` for the current
     /// silence stretch; cleared on the next `note_speech_started`.
@@ -57,7 +65,8 @@ impl IdleDetector {
         Self {
             silence_threshold,
             dead_air_threshold,
-            last_speech_started: now,
+            speech_active: false,
+            last_speech_ended: now,
             last_any_audio: now,
             silence_fired: false,
         }
@@ -69,13 +78,25 @@ impl IdleDetector {
         self.silence_threshold.is_some() || self.dead_air_threshold.is_some()
     }
 
-    /// VAD reported the caller started speaking. Resets both
-    /// timers — caller is no longer silent and there's audio
-    /// activity on the call.
+    /// VAD reported the caller started speaking. Marks speech active
+    /// (gating both idle events until the matching
+    /// [`Self::note_speech_stopped`]), notes the audio activity, and
+    /// re-arms the once-per-stretch silence suppression.
     pub fn note_speech_started(&mut self, now: Instant) {
-        self.last_speech_started = now;
+        self.speech_active = true;
         self.last_any_audio = now;
         self.silence_fired = false;
+    }
+
+    /// VAD reported the caller stopped speaking. Silence is measured
+    /// from THIS moment (#399), and caller audio was flowing until it,
+    /// so the dead-air anchor moves too. Safe on a stop without a
+    /// matching start (forge emits one at call setup): both anchors
+    /// just move forward.
+    pub fn note_speech_stopped(&mut self, now: Instant) {
+        self.speech_active = false;
+        self.last_speech_ended = now;
+        self.last_any_audio = now;
     }
 
     /// The WS server pushed audio toward the caller. Resets ONLY
@@ -90,9 +111,15 @@ impl IdleDetector {
     pub fn poll(&mut self, now: Instant) -> Vec<IdleEvent> {
         let mut out = Vec::new();
 
+        // Mid-utterance: the caller is neither silent nor is the call
+        // dead — audio is arriving right now (#399).
+        if self.speech_active {
+            return out;
+        }
+
         if let Some(threshold) = self.silence_threshold {
             if !self.silence_fired {
-                let elapsed = now.saturating_duration_since(self.last_speech_started);
+                let elapsed = now.saturating_duration_since(self.last_speech_ended);
                 if elapsed >= threshold {
                     out.push(IdleEvent::SilenceDetected {
                         duration_ms: elapsed.as_millis() as u64,
@@ -163,12 +190,66 @@ mod tests {
         let now = Instant::now();
         let mut d = IdleDetector::new(Some(ms(3000)), None, now);
         let _ = d.poll(now + ms(3100));
-        // Speech resets the suppression flag.
+        // A speech cycle resets the suppression flag; the next stretch
+        // is measured from the cycle's END.
         d.note_speech_started(now + ms(5000));
-        assert!(d.poll(now + ms(6000)).is_empty());
-        let events = d.poll(now + ms(8500));
+        d.note_speech_stopped(now + ms(5500));
+        assert!(d.poll(now + ms(8499)).is_empty());
+        let events = d.poll(now + ms(8501));
         assert_eq!(events.len(), 1);
-        assert!(matches!(events[0], IdleEvent::SilenceDetected { .. }));
+        assert!(matches!(
+            events[0],
+            IdleEvent::SilenceDetected { duration_ms } if duration_ms == 3001
+        ));
+    }
+
+    #[test]
+    fn no_idle_events_while_speech_is_active() {
+        // #399 regression: a caller utterance LONGER than the
+        // thresholds must not fire either event mid-utterance, and the
+        // following silence stretch must (a) still fire and (b) be
+        // measured from the utterance's END, not its onset.
+        let now = Instant::now();
+        let mut d = IdleDetector::new(Some(ms(3000)), Some(ms(10000)), now);
+        d.note_speech_started(now + ms(1000));
+        // 14s into the utterance: old code had fired silence at +4s
+        // and dead-air at +11s.
+        assert!(d.poll(now + ms(4500)).is_empty());
+        assert!(d.poll(now + ms(15000)).is_empty());
+        d.note_speech_stopped(now + ms(16000));
+        // Silence counts from the END (16s), not the onset (1s).
+        assert!(d.poll(now + ms(18999)).is_empty());
+        let events = d.poll(now + ms(19001));
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            IdleEvent::SilenceDetected { duration_ms } if duration_ms == 3001
+        ));
+        // Dead-air likewise: caller audio flowed until 16s.
+        assert!(d.poll(now + ms(25999)).is_empty());
+        let events = d.poll(now + ms(26001));
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            IdleEvent::DeadAirDetected { duration_ms } if duration_ms == 10001
+        ));
+    }
+
+    #[test]
+    fn stop_without_start_re_anchors_both_timers() {
+        // forge emits a zero-length SpeechStopped at call setup; a
+        // stop with no active speech must not wedge anything — both
+        // anchors simply move forward.
+        let now = Instant::now();
+        let mut d = IdleDetector::new(Some(ms(3000)), None, now);
+        d.note_speech_stopped(now + ms(500));
+        assert!(d.poll(now + ms(3499)).is_empty());
+        let events = d.poll(now + ms(3501));
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            IdleEvent::SilenceDetected { duration_ms } if duration_ms == 3001
+        ));
     }
 
     #[test]
@@ -209,10 +290,11 @@ mod tests {
         let now = Instant::now();
         let mut d = IdleDetector::new(Some(ms(3000)), Some(ms(10000)), now);
         d.note_speech_started(now + ms(8000));
-        // After speech, neither event should fire until thresholds
-        // elapse from the new anchor.
+        d.note_speech_stopped(now + ms(8100));
+        // After the speech cycle, neither event fires until its
+        // threshold elapses from the cycle's end.
         assert!(d.poll(now + ms(10000)).is_empty());
-        let events = d.poll(now + ms(11001));
+        let events = d.poll(now + ms(11101));
         assert_eq!(events.len(), 1);
         assert!(matches!(events[0], IdleEvent::SilenceDetected { .. }));
     }

--- a/crates/media-glue/src/tap.rs
+++ b/crates/media-glue/src/tap.rs
@@ -604,9 +604,11 @@ pub struct MediaTap {
     muted: bool,
     /// Timer-based derivation of `silence_detected` / `dead_air_detected`
     /// events. Polled on a 500 ms tick in `run()` when at least one
-    /// threshold is configured; receives `note_speech_started` on
-    /// every forge-vad speech-started, and `note_ws_audio` on every
-    /// playout byte arriving from the WS server. Initialized with
+    /// threshold is configured; receives `note_speech_started` /
+    /// `note_speech_stopped` on every forge-vad transition (wire
+    /// suppression notwithstanding — VAD truth, #399), and
+    /// `note_ws_audio` on every playout byte arriving from the WS
+    /// server. Initialized with
     /// both thresholds `None` (disabled); the acceptor calls
     /// [`Self::with_idle_thresholds`] before `run()` to install the
     /// resolved per-call values.
@@ -1646,6 +1648,18 @@ impl MediaTap {
                                 // a fresh event.
                                 if matches!(out, OutgoingEvent::SpeechStarted { .. }) {
                                     self.idle_detector.note_speech_started(Instant::now());
+                                }
+                                // …and on every SpeechStopped, at the
+                                // same altitude — BEFORE the debounce
+                                // cancel below can `continue` past
+                                // forwarding. The idle detector tracks
+                                // VAD truth, not wire truth: a
+                                // suppressed provisional pair must
+                                // still clear `speech_active`, or the
+                                // idle events stay gated forever
+                                // (#399).
+                                if matches!(out, OutgoingEvent::SpeechStopped { .. }) {
+                                    self.idle_detector.note_speech_stopped(Instant::now());
                                 }
                                 // Barge-in reaction beyond forwarding the
                                 // event. `auto_clear` drops pending


### PR DESCRIPTION
Closes #399.

## What was wrong

`IdleDetector` measured the silence stretch from `last_speech_started` and `poll()` never checked whether speech was still active. Live-proven consequences (see #399 for the wire captures): `silence_detected` emitted mid-utterance for any utterance ≥ threshold, the real post-utterance silence then suppressed by the once-per-stretch flag, and short utterances fired early with `duration_ms` inflated by the utterance's own length. The dead-air arm had the same latent defect (`last_any_audio` only bumped at speech *start*).

## The fix

- `speech_active` state: set by `note_speech_started`, cleared by the new `note_speech_stopped(now)`, which anchors `last_speech_ended = now` and bumps `last_any_audio` (caller audio was flowing until that moment — fixes the dead-air sibling in the same stroke).
- `poll()` returns empty while speech is active — a talking caller is neither silent nor dead air.
- Silence measured from `last_speech_ended`; speechless calls keep today's from-call-start behavior (live-verified correct: first fire at `offset 2999 / duration 3003`).
- **Tap wiring subtlety**: the stop hook sits at the same altitude as the existing start hook — *before* the debounce-cancel path that `continue`s without forwarding — because the start hook already fires for provisional (later-suppressed) pairs. The detector tracks VAD truth, not wire truth; hooking the forwarded event instead would leave `speech_active` stuck `true` after a suppressed pair, permanently gating both events. A stop without a start (forge emits one at call setup) just moves the anchors forward.

## Tests

New: mid-utterance non-firing for both events across their thresholds + end-anchored `duration_ms` exactness (the #399 regression), stop-without-start setup case. Updated: the two existing tests that (unwittingly) encoded onset-anchoring now model a full start/stop cycle. All other cases (speechless call, ws-audio refresh, re-fire cadence, suppression) unchanged and still pass by inspection — CI confirms.

No wire, schema, config, or SDK changes — `duration_ms` semantics now match what PROTOCOL.md §3.6/§3.7 always documented. No toolchain on this box; CI runs the tests.

After merge + release I'll re-run the 0.47.1 live scenario on the box: a 4 s synth-speech run must produce `speech_started → speech_stopped → silence_detected` (in that order), with `silence.offset_ms − duration_ms == speech_stopped.offset_ms`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jc9xxB6p9YgTq3GafCwGMU