### PR TITLE
chore(release): 0.47.2 — silence anchored at speech end, idle events gated while speech is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.47.2] - 2026-07-29
+
 ### Fixed
 
 - **`silence_detected` no longer fires mid-utterance, and the silence stretch is measured from the caller's last speech *end*, not its onset** (issue #399). The idle detector anchored its silence timer at `speech_started` and never checked whether speech was still active, so any caller utterance longer than `silence_threshold_ms` (default 3 s — routine in real speech) emitted `silence_detected` while the caller was still talking, and the once-per-stretch suppression flag then swallowed the event for the *real* silence that followed — exactly inverted behavior. Short utterances fired early, with `duration_ms` inflated by the utterance's own length. The detector now tracks speech-active state (fed from every forge-vad transition, including debounce-suppressed provisional pairs, so a suppressed pair can't wedge the gate), holds both idle events while the caller is speaking, and anchors silence *and* dead-air at speech end — which also fixes the latent sibling: an utterance longer than `dead_air_threshold_ms` would have fired `dead_air_detected` mid-audio. `duration_ms` now reports the true silence length, matching what PROTOCOL.md §3.6/§3.7 always promised; speechless-call behavior (measured from call start) is unchanged. Live-found on 0.47.1: the new `offset_ms` field made the wrong anchor arithmetically visible on the wire (`silence.offset_ms − duration_ms == speech_started.offset_ms`, three-for-three).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "base64",
  "bytes",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3927,7 +3927,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "regex",
  "serde",
@@ -3946,7 +3946,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "base64",
  "hmac",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4040,7 +4040,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -4058,7 +4058,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4076,7 +4076,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "regex",
  "serde",
@@ -4102,7 +4102,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "schemars",
  "serde",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "base64",
  "rcgen",
@@ -4157,7 +4157,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -4186,7 +4186,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.47.1"
+version = "0.47.2"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.47.1.** Production-deployed against real carriers
+**Current release: v0.47.2.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a


### PR DESCRIPTION
Release-prep for **v0.47.2**, per RELEASING.md:

- `[workspace.package].version` 0.47.1 → 0.47.2 (+ Cargo.lock refresh)
- CHANGELOG: `[Unreleased]` → `[0.47.2] - 2026-07-29` (entry landed with #400)
- README current-release marker updated

Single fix in this dot release: **#400** (closes #399) — the idle detector anchored its silence timer at `speech_started` and never gated on active speech, so any utterance longer than `silence_threshold_ms` fired `silence_detected` mid-utterance and the once-per-stretch suppression then swallowed the real event — exactly inverted. Also fixes the latent dead-air sibling. Silence and dead-air now anchor at speech **end**, and both idle events hold while the caller is speaking. Live-found on 0.47.1 via the new `offset_ms` arithmetic.

Reviewed post-merge: speech-active gate fed from every forge-vad transition (including debounce-suppressed pairs, so a suppressed pair can't wedge the gate); regression tests pin the mid-utterance hold and the end-anchored `duration_ms`; speechless-call behavior unchanged.

Local: media-glue suite (147 tests) passes; `check-version-consistency.py` (plain + `--tag v0.47.2`) and `extract-changelog.py 0.47.2` pass. Main CI fully green on the #400 merge commit before this was cut.

After merge: tag `v0.47.2` on the release commit and push to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PoUeFDdZSL3d6DU3it6yxW