### PR TITLE
chore(deps): siphon-rs 065c2c6 -> 74b903b, forge-media 003b5e1 -> aeae479 (INVITE auth retry + one-m-line-per-type negotiator)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Outbound calls through a digest-authenticated gateway no longer fail instantly as `rejected`** (siphon-rs #83, fixed upstream in siphon-rs #86; pin bump). The UAC never auto-retried an INVITE on a 401/407 challenge — the flag existed but was dead code on the INVITE path — so a perfectly credentialed call through FreeSWITCH/Asterisk-style PBXes that digest-challenge INVITE surfaced the challenge as a terminal rejection ~1 ms after dial (`outbound_failed{cause:"rejected"}`). IP-ACL trunks (e.g. Twilio) masked it. The UAC now builds the authenticated re-INVITE (same Call-ID, CSeq+1, fresh branch) transparently, honoring `max_auth_retries`. `CallHandle::invite_request()` became async upstream (the live attempt is replaced on retry); the one call site adapted.
+- **An offer carrying secure and plaintext audio alternatives (e.g. stock FreeSWITCH late negotiation offering `RTP/SAVP` + `RTP/AVP` on one port) no longer gets both m-lines accepted on the same local port** (siphon-rs #84, fixed upstream in siphon-rs #85; reaches the media path via forge-media #100's submodule bump). Both alternatives were accepted in the answer — indistinguishable on the wire, one encrypted and one not — so the dialog established and then no media flowed in either direction for the life of the call (siphon-ai #406 §2's root). The negotiator now accepts the first acceptable alternative per media type and rejects the rest with port 0, per RFC 3264 §6. The remaining siphon-ai-side hardening for delayed-offer alternatives (SRTP policy gate over the m-line *set*, patching the *selected* m-line) is tracked in #406.
+
 ## [0.47.2] - 2026-07-29
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "forge-codecs"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=003b5e1be563#003b5e1be563094a231a6272972acf84bcac6ec9"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=aeae479b391d#aeae479b391ddd2e73b9962e55623f72192fb5fd"
 dependencies = [
  "audiopus",
  "ezk-g722",
@@ -1022,7 +1022,7 @@ dependencies = [
 [[package]]
 name = "forge-core"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=003b5e1be563#003b5e1be563094a231a6272972acf84bcac6ec9"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=aeae479b391d#aeae479b391ddd2e73b9962e55623f72192fb5fd"
 dependencies = [
  "chrono",
  "serde",
@@ -1037,7 +1037,7 @@ dependencies = [
 [[package]]
 name = "forge-dtmf"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=003b5e1be563#003b5e1be563094a231a6272972acf84bcac6ec9"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=aeae479b391d#aeae479b391ddd2e73b9962e55623f72192fb5fd"
 dependencies = [
  "chrono",
  "forge-core",
@@ -1049,7 +1049,7 @@ dependencies = [
 [[package]]
 name = "forge-engine"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=003b5e1be563#003b5e1be563094a231a6272972acf84bcac6ec9"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=aeae479b391d#aeae479b391ddd2e73b9962e55623f72192fb5fd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1079,7 +1079,7 @@ dependencies = [
 [[package]]
 name = "forge-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=003b5e1be563#003b5e1be563094a231a6272972acf84bcac6ec9"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=aeae479b391d#aeae479b391ddd2e73b9962e55623f72192fb5fd"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -1092,7 +1092,7 @@ dependencies = [
 [[package]]
 name = "forge-injection"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=003b5e1be563#003b5e1be563094a231a6272972acf84bcac6ec9"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=aeae479b391d#aeae479b391ddd2e73b9962e55623f72192fb5fd"
 dependencies = [
  "forge-core",
  "rubato",
@@ -1105,7 +1105,7 @@ dependencies = [
 [[package]]
 name = "forge-mixer"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=003b5e1be563#003b5e1be563094a231a6272972acf84bcac6ec9"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=aeae479b391d#aeae479b391ddd2e73b9962e55623f72192fb5fd"
 dependencies = [
  "bytes",
  "dashmap 6.2.1",
@@ -1119,7 +1119,7 @@ dependencies = [
 [[package]]
 name = "forge-recorder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=003b5e1be563#003b5e1be563094a231a6272972acf84bcac6ec9"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=aeae479b391d#aeae479b391ddd2e73b9962e55623f72192fb5fd"
 dependencies = [
  "bytes",
  "forge-core",
@@ -1133,7 +1133,7 @@ dependencies = [
 [[package]]
 name = "forge-resampler"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=003b5e1be563#003b5e1be563094a231a6272972acf84bcac6ec9"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=aeae479b391d#aeae479b391ddd2e73b9962e55623f72192fb5fd"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -1142,7 +1142,7 @@ dependencies = [
 [[package]]
 name = "forge-rtp"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=003b5e1be563#003b5e1be563094a231a6272972acf84bcac6ec9"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=aeae479b391d#aeae479b391ddd2e73b9962e55623f72192fb5fd"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm 0.11.0",
@@ -1167,14 +1167,14 @@ dependencies = [
 [[package]]
 name = "forge-sdp"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=003b5e1be563#003b5e1be563094a231a6272972acf84bcac6ec9"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=aeae479b391d#aeae479b391ddd2e73b9962e55623f72192fb5fd"
 dependencies = [
  "base64",
  "chrono",
  "forge-core",
  "forge-rtp",
  "rand 0.10.1",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=003b5e1be563)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=aeae479b391d)",
  "smol_str",
  "thiserror 2.0.18",
 ]
@@ -1182,7 +1182,7 @@ dependencies = [
 [[package]]
 name = "forge-transcoder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=003b5e1be563#003b5e1be563094a231a6272972acf84bcac6ec9"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=aeae479b391d#aeae479b391ddd2e73b9962e55623f72192fb5fd"
 dependencies = [
  "bytes",
  "forge-codecs",
@@ -1195,7 +1195,7 @@ dependencies = [
 [[package]]
 name = "forge-vad"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=003b5e1be563#003b5e1be563094a231a6272972acf84bcac6ec9"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=aeae479b391d#aeae479b391ddd2e73b9962e55623f72192fb5fd"
 dependencies = [
  "thiserror 2.0.18",
  "tract-onnx",
@@ -3595,7 +3595,7 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 [[package]]
 name = "sip-auth"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7#065c2c65a0f71273079b7157f644f7b045f6bb65"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=74b903b9afe7#74b903b9afe742a5975ef593b9099c3f1968777a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3618,7 +3618,7 @@ dependencies = [
 [[package]]
 name = "sip-core"
 version = "0.7.6"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7#065c2c65a0f71273079b7157f644f7b045f6bb65"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=74b903b9afe7#74b903b9afe742a5975ef593b9099c3f1968777a"
 dependencies = [
  "bytes",
  "httpdate",
@@ -3631,7 +3631,7 @@ dependencies = [
 [[package]]
 name = "sip-dialog"
 version = "0.3.3"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7#065c2c65a0f71273079b7157f644f7b045f6bb65"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=74b903b9afe7#74b903b9afe742a5975ef593b9099c3f1968777a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3649,7 +3649,7 @@ dependencies = [
 [[package]]
 name = "sip-dns"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7#065c2c65a0f71273079b7157f644f7b045f6bb65"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=74b903b9afe7#74b903b9afe742a5975ef593b9099c3f1968777a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3663,7 +3663,7 @@ dependencies = [
 [[package]]
 name = "sip-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7#065c2c65a0f71273079b7157f644f7b045f6bb65"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=74b903b9afe7#74b903b9afe742a5975ef593b9099c3f1968777a"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -3674,7 +3674,7 @@ dependencies = [
 [[package]]
 name = "sip-identity"
 version = "0.1.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7#065c2c65a0f71273079b7157f644f7b045f6bb65"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=74b903b9afe7#74b903b9afe742a5975ef593b9099c3f1968777a"
 dependencies = [
  "base64",
  "ring",
@@ -3687,7 +3687,7 @@ dependencies = [
 [[package]]
 name = "sip-observe"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7#065c2c65a0f71273079b7157f644f7b045f6bb65"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=74b903b9afe7#74b903b9afe742a5975ef593b9099c3f1968777a"
 dependencies = [
  "once_cell",
  "tracing",
@@ -3696,7 +3696,7 @@ dependencies = [
 [[package]]
 name = "sip-parse"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7#065c2c65a0f71273079b7157f644f7b045f6bb65"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=74b903b9afe7#74b903b9afe742a5975ef593b9099c3f1968777a"
 dependencies = [
  "bytes",
  "httpdate",
@@ -3710,7 +3710,7 @@ dependencies = [
 [[package]]
 name = "sip-ratelimit"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7#065c2c65a0f71273079b7157f644f7b045f6bb65"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=74b903b9afe7#74b903b9afe742a5975ef593b9099c3f1968777a"
 dependencies = [
  "dashmap 5.5.3",
  "parking_lot",
@@ -3721,7 +3721,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=003b5e1be563#003b5e1be563094a231a6272972acf84bcac6ec9"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=74b903b9afe7#74b903b9afe742a5975ef593b9099c3f1968777a"
 dependencies = [
  "nom 7.1.3",
  "smol_str",
@@ -3730,7 +3730,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7#065c2c65a0f71273079b7157f644f7b045f6bb65"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=aeae479b391d#aeae479b391ddd2e73b9962e55623f72192fb5fd"
 dependencies = [
  "nom 7.1.3",
  "smol_str",
@@ -3739,7 +3739,7 @@ dependencies = [
 [[package]]
 name = "sip-transaction"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7#065c2c65a0f71273079b7157f644f7b045f6bb65"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=74b903b9afe7#74b903b9afe742a5975ef593b9099c3f1968777a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3758,7 +3758,7 @@ dependencies = [
 [[package]]
 name = "sip-transport"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7#065c2c65a0f71273079b7157f644f7b045f6bb65"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=74b903b9afe7#74b903b9afe742a5975ef593b9099c3f1968777a"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3778,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "sip-uac"
 version = "0.4.2"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7#065c2c65a0f71273079b7157f644f7b045f6bb65"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=74b903b9afe7#74b903b9afe742a5975ef593b9099c3f1968777a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3791,7 +3791,7 @@ dependencies = [
  "sip-dialog",
  "sip-dns",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=74b903b9afe7)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -3803,7 +3803,7 @@ dependencies = [
 [[package]]
 name = "sip-uas"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7#065c2c65a0f71273079b7157f644f7b045f6bb65"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=74b903b9afe7#74b903b9afe742a5975ef593b9099c3f1968777a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3813,7 +3813,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=74b903b9afe7)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -3966,7 +3966,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=065c2c65a0f7)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=74b903b9afe7)",
  "sip-transaction",
  "sip-uac",
  "sip-uas",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,40 +130,45 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 # main branch and replace the rev hashes here (see CLAUDE.md §7.5).
 
 # siphon-rs — RFC 3261 SIP stack.
-# Bumped 2026-07-28 `ead16f9bf9b7` → `4e7d5d7d0bd7` = siphon-rs #74: inbound
-# TCP/TLS flows tear down properly on peer FIN (was: permanent CLOSE-WAIT +
-# leaked fd, and every in-dialog request on the leg — hold re-INVITE, REFER,
-# the teardown BYE — died at Timer B after a carrier idle-closed the
-# connection, ~2 min on Twilio Secure Trunking). Flow sends now fail fast and
-# bye/refer/reinvite_via_flow fail over to the connection pool via RFC 3263
-# §4.3 dispatch. Also adds opt-in set_stream_keepalive_interval (CRLF
-# keepalive on established inbound sessions) — wired to the new
-# [sip].tcp_keepalive_interval_secs.
-# (Prior: `ead16f9bf9b7` = #72 per-request From tag, RFC 3261 §8.1.1.3;
+# Bumped 2026-07-30 `065c2c65a0f7` → `74b903b9afe7` = siphon-rs #85 + #86.
+# #85: negotiate_answer accepts only ONE m-line per media type — an offer
+# carrying RTP/SAVP and RTP/AVP audio alternatives on one port (stock
+# FreeSWITCH late negotiation) previously got BOTH accepted on the same
+# local port, and media died in both directions (siphon-ai #406 root).
+# #86: IntegratedUAC auto-retries INVITE on 401/407 digest challenges —
+# InviteTransactionUser.auto_retry_auth was dead code, so outbound calls
+# through a digest-authenticated gateway (FreeSWITCH/Asterisk PBXes)
+# surfaced the challenge as a terminal rejection ~1 ms after dial
+# (siphon-rs #83); outbound.rs's classify_failure comment ("401/407 are
+# auto-retried by the UAC") is now actually true.
+# (Prior: `065c2c65a0f7` = #82 route set fixed after dialog creation,
+#  #79 tls_server_name, #80 RFC 5626 ping, #78 UAS route-set order;
+#  `4e7d5d7d0bd7` = #74 flow teardown on peer FIN + failover;
+#  `ead16f9bf9b7` = #72 per-request From tag, RFC 3261 §8.1.1.3;
 #  `5c7cf20beb50` = #70 TLS pool cross-SNI reuse, siphon-ai #342 outbound;
 #  `fbdf132a11d6` = #69 in-dialog BYE route set, siphon-ai #342 inbound;
 #  `50866b1599a7` = #68 pool SIP HEP, siphon-ai #341;
 #  `6fd432270bb8` = #67 dialog_manager share, siphon-ai #324;
 #  `fcaff011f9c6` = #65 invite_with_from, siphon-ai #316;
 #  `3a4fc312ade3` = #64 TLS-SNI-is-hostname, siphon-ai #312.)
-sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "065c2c65a0f7" }
-sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "065c2c65a0f7" }
-sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "065c2c65a0f7", features = ["tls"] }
-sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "065c2c65a0f7" }
-sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "065c2c65a0f7" }
-sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "065c2c65a0f7" }
-sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "065c2c65a0f7" }
-sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "065c2c65a0f7" }
-sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "065c2c65a0f7" }
+sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "74b903b9afe7" }
+sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "74b903b9afe7" }
+sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "74b903b9afe7", features = ["tls"] }
+sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "74b903b9afe7" }
+sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "74b903b9afe7" }
+sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "74b903b9afe7" }
+sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "74b903b9afe7" }
+sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "74b903b9afe7" }
+sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "74b903b9afe7" }
 # sip-sdp — the SAME sip-sdp sip-uac's SdpAnswerGenerator trait speaks
 # (distinct from forge-media's pinned sip-sdp). Used by the outbound
 # delayed-offer answer generator to hand the UAC a SessionDescription it
 # accepts. Must stay on the same siphon-rs rev as the rest below.
-sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "065c2c65a0f7" }
-sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "065c2c65a0f7" }
+sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "74b903b9afe7" }
+sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "74b903b9afe7" }
 # sip-identity — STIR/SHAKEN Identity-header parsing + PASSporT verification
 # (ES256 + X.509 chain validation). Consumed by the stir-shaken verifier crate.
-sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "065c2c65a0f7" }
+sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "74b903b9afe7" }
 
 # forge-media — RTP / codecs / SDP / DTMF / engine.
 #
@@ -173,8 +178,14 @@ sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "065
 # AI logic belongs in the WS server, never here. See CLAUDE.md §4.1 and the
 # upstream gate at https://github.com/thevoiceguy/forge-media/pull/39.
 #
-# forge-media is pinned to a `main` rev. Bumped 2026-07-25 to 003b5e1be563
-# = forge-media #98: per-SSRC SRTCP replay windows (RFC 3711 §3.4). The
+# forge-media is pinned to a `main` rev. Bumped 2026-07-30 to aeae479b391d
+# = forge-media #100: external/siphon-rs submodule f3454c7 → 74b903b, which
+# is how siphon-rs #85 (negotiate_answer accepts one m-line per media type)
+# reaches forge-sdp — the negotiator siphon-ai's media path actually runs.
+# The outbound delayed-offer fixes (siphon-ai #406) depend on this behavior.
+#
+# Prior pin 003b5e1be563 = forge-media #98: per-SSRC SRTCP replay windows
+# (RFC 3711 §3.4). The
 # receive context kept ONE replay window keyed only by SRTCP index, so when
 # the inbound RTCP SSRC changed mid-call (Twilio: ringback/early-media →
 # answered stream) the new SSRC's fresh low indices were rejected as
@@ -206,20 +217,20 @@ sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "065
 # comment for the current rev.) Prior forge pins: forge 1c996ae5fb4f = #86
 # neural VAD; forge 3c59b5f6e464 = #82-#85 dependency migrations; forge
 # 5fa76fb38675 = #81.
-forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "003b5e1be563" }
-forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "003b5e1be563" }
-forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "003b5e1be563", default-features = false, features = ["g722", "dtls", "opus", "neural-vad"] }
-forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "003b5e1be563" }
-forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "003b5e1be563" }
-forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "003b5e1be563" }
-forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "003b5e1be563" }
-forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "003b5e1be563" }
+forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "aeae479b391d" }
+forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "aeae479b391d" }
+forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "aeae479b391d", default-features = false, features = ["g722", "dtls", "opus", "neural-vad"] }
+forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "aeae479b391d" }
+forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "aeae479b391d" }
+forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "aeae479b391d" }
+forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "aeae479b391d" }
+forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "aeae479b391d" }
 # Conference rooms (0.7.0): forge-mixer is the per-room AudioMixer;
 # forge-injection provides ToneGenerator (join/leave tones now, MOH
 # for park later). Deliberately NOT forge-conference — its DTMF
 # IVR/PIN/host-control layer is unused per DEV_PLAN_0.7.0.md §9.4.
-forge-mixer     = { git = "https://github.com/thevoiceguy/forge-media", rev = "003b5e1be563" }
-forge-injection = { git = "https://github.com/thevoiceguy/forge-media", rev = "003b5e1be563" }
+forge-mixer     = { git = "https://github.com/thevoiceguy/forge-media", rev = "aeae479b391d" }
+forge-injection = { git = "https://github.com/thevoiceguy/forge-media", rev = "aeae479b391d" }
 
 # hep-rs — HEP3 codec, transport, HepSink trait. Owned by the same
 # author as siphon-rs and forge-media; lives in its own repo.

--- a/crates/core/src/outbound.rs
+++ b/crates/core/src/outbound.rs
@@ -510,8 +510,13 @@ impl OutboundOriginator {
         //     BEFORE awaiting the final response. The peer cannot 2xx until
         //     it receives the INVITE we just sent, so the generator (which
         //     fires on that 2xx) can't run before this registration.
+        // `invite_request()` is async as of siphon-rs #86 (the live
+        // attempt is replaced on a 401/407 auth retry); the Call-ID is
+        // stable across retries, so reading it from whichever attempt
+        // is live is correct.
         let sip_call_id = handle
             .invite_request()
+            .await
             .headers()
             .get_smol("Call-ID")
             .map(|s| s.to_string())


### PR DESCRIPTION
Pin bump picking up the two upstream fixes that siphon-ai #406's fixes depend on, plus the outbound digest-auth fix:

- **siphon-rs #86** (fixes thevoiceguy/siphon-rs#83): `IntegratedUAC` auto-retries INVITE on 401/407. Outbound calls through digest-authenticated gateways (FreeSWITCH/Asterisk) previously failed instantly as `rejected`. `CallHandle::invite_request()` became async upstream — adapted the single call site in `crates/core/src/outbound.rs` (Call-ID is stable across auth retries, so delayed-offer registry keying is unchanged).
- **siphon-rs #85** (fixes thevoiceguy/siphon-rs#84): `negotiate_answer` accepts only one m-line per media type — first acceptable alternative wins, the rest are rejected with port 0 per RFC 3264 §6. Reaches `forge-sdp` (the negotiator the media path actually runs) via **forge-media #100**'s `external/siphon-rs` submodule bump, hence the coordinated forge pin.

The siphon-ai-side work on top of this behavior (SRTP gate over the m-line *set*, patching the *selected* m-line, outbound delayed-offer metric, FS doc prereqs) lands separately for #406.

## Verification

- `cargo test --workspace` — 57 targets, 0 failures
- all 38 SIPp scenarios green (`test-harness/sipp-scenarios/run-all.sh`)
- `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpAx1iyY567DicG4ZCgZUw