### PR TITLE
chore(release): 0.48.0 — FreeSWITCH interop chain, hold survives the RTP watchdog, registration routing precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.48.0] - 2026-07-30
+
 ### Added
 
 - **`siphon_ai_outbound_delayed_offer_total{result=…}`** (issue #406 §3) — the outbound delayed-offer path (offerless INVITE we sent; peer offers in its 2xx, we answer in the ACK) previously emitted no delayed-offer metric at all: every increment of `siphon_ai_delayed_offer_total` was on the *inbound* path. Results: `answered`, `srtp_policy` (the gateway's `srtp` mode refused every offered audio alternative), `srtp_setup` (selected secure alternative failed to negotiate/install), `invalid_remote_media`, `missing_sdp_offer`. Both live failure modes in #406 would have been one-line diagnoses with it. Documented in `docs/DEPLOY.md`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.47.2"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.47.2"
+version = "0.48.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.47.2"
+version = "0.48.0"
 dependencies = [
  "base64",
  "bytes",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.47.2"
+version = "0.48.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3927,7 +3927,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.47.2"
+version = "0.48.0"
 dependencies = [
  "regex",
  "serde",
@@ -3946,7 +3946,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.47.2"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.47.2"
+version = "0.48.0"
 dependencies = [
  "base64",
  "hmac",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.47.2"
+version = "0.48.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4040,7 +4040,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.47.2"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4058,7 +4058,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.47.2"
+version = "0.48.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4076,7 +4076,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.47.2"
+version = "0.48.0"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.47.2"
+version = "0.48.0"
 dependencies = [
  "regex",
  "serde",
@@ -4102,7 +4102,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.47.2"
+version = "0.48.0"
 dependencies = [
  "schemars",
  "serde",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.47.2"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.47.2"
+version = "0.48.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -4157,7 +4157,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.47.2"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -4186,7 +4186,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.47.2"
+version = "0.48.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.47.2"
+version = "0.48.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.47.2.** Production-deployed against real carriers
+**Current release: v0.48.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a


### PR DESCRIPTION
Release-prep per RELEASING.md: version bump 0.47.2 → 0.48.0 (workspace `Cargo.toml` + lockfile), `## [Unreleased]` → `## [0.48.0] - 2026-07-30` with a fresh empty Unreleased above, README current-release marker.

Verified locally:
- `python3 scripts/check-version-consistency.py` ✓
- `python3 scripts/check-version-consistency.py --tag v0.48.0` ✓
- `python3 scripts/extract-changelog.py 0.48.0` ✓ (notes present)

Ships: #402, #403, #404, #405, #406, plus the siphon-rs 74b903b / forge-media aeae479 pin bumps (INVITE digest auto-retry closing siphon-rs #83, one-m-line-per-type negotiator closing siphon-rs #84).

Minor bump rationale: new metric (`siphon_ai_outbound_delayed_offer_total`) plus deliberate behavior changes (registration>trunk attribution precedence, hold-in-conference rejection).

Tag `v0.48.0` follows after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpAx1iyY567DicG4ZCgZUw