### PR TITLE
chore(release): 0.48.1 — outbound delayed-offer legs carry media

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.48.1] - 2026-07-31
+
 ### Fixed
 
 - **Outbound delayed-offer calls now carry media** (issue #414). The path's forge session was never transitioned `Initializing → Active` — `DelayedOfferAnswerer::generate_answer` answers via `accept_inbound`, which allocates/negotiates/attaches but deliberately does not activate, and unlike the inbound early-offer path nothing downstream compensated with an explicit `start_session`. The call looked healthy at every other layer (200 OK → ACK with a valid answer, WS `start` delivered, `result="answered"` counted) while zero RTP flowed in either direction, since the forwarding task was never spawned. Present since the feature's introduction (0.9.0, #191), masked until 0.48.0 by the #406 SDP-negotiation failures that killed these calls earlier. The generator now activates the session after DTLS/SDES key install and before the answer rides out in the ACK — the peer only learns our RTP address from the ACK, so the session is Active before the first packet can arrive; a new `result="media_activate"` label on `siphon_ai_outbound_delayed_offer_total` counts the (previously impossible-to-see) activation failure, and a regression test pins `SessionState::Active` on this path, mirroring the one that already pinned it for `apply_answer`. Also fixed while there: the generator's post-`accept_inbound` SRTP failure arms (DTLS/SDES post-processing, `enable_dtls`) now roll the session back instead of leaking it and its port pair, and `apply_answer`'s activation comment no longer claims to cover this path — the mis-statement that kept the gap invisible.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "base64",
  "bytes",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3927,7 +3927,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "regex",
  "serde",
@@ -3946,7 +3946,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "base64",
  "hmac",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4040,7 +4040,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4058,7 +4058,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4076,7 +4076,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "regex",
  "serde",
@@ -4102,7 +4102,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "schemars",
  "serde",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "base64",
  "rcgen",
@@ -4157,7 +4157,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -4186,7 +4186,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.48.0"
+version = "0.48.1"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.48.0.** Production-deployed against real carriers
+**Current release: v0.48.1.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged, and upgrading the daemon is a


### PR DESCRIPTION
Release-prep commit for **v0.48.1** per RELEASING.md: workspace version bump (+ refreshed `Cargo.lock`), `## [Unreleased]` → `## [0.48.1] - 2026-07-31` with a fresh empty Unreleased above, README current-release marker.

Contents: #414 / PR #415 only — outbound delayed-offer legs never activated their forge session (no RTP in either direction despite a healthy-looking call), plus the latent session/port-pair leak on the generator's SRTP failure arms.

Preflight verified locally:
- `check-version-consistency.py` ✓ (and `--tag v0.48.1` ✓)
- `extract-changelog.py 0.48.1` ✓

Tag `v0.48.1` goes on the merge commit once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxgUhfF5vNNvJrvr74qKV6