### PR TITLE
chore(telemetry,media-glue): register the #417 tx-suppression counter description; fix an overclaiming comment

### DIFF
--- a/crates/media-glue/src/tap.rs
+++ b/crates/media-glue/src/tap.rs
@@ -115,7 +115,9 @@ const FORGE_LEAD_FRAMES: usize = 5;
 /// our send — we answered a peer hold with `recvonly`/`inactive`
 /// (#417). Counts 20 ms frames across every push site (WS playout,
 /// barge-in re-queue, room mix, parked MOH / announcements); outbound
-/// DTMF drops log but don't count (not a frame).
+/// DTMF drops log but don't count (not a frame). Literal must match
+/// `siphon-ai-telemetry::metrics` (same pattern as the room metrics
+/// in `room.rs`), where the Prometheus description is registered.
 const PEER_HOLD_TX_SUPPRESSED_TOTAL: &str = "siphon_ai_peer_hold_tx_suppressed_frames_total";
 
 /// One entry in the tap-owned outbound queue (#365/#366). Audio frames
@@ -2638,16 +2640,19 @@ impl MediaTap {
                 // per 20 ms into the caller leg. Active in either state;
                 // both share the same MohSource-driven tick.
                 _ = moh_tick.tick(), if parked.is_some() || held.is_some() || announcing.is_some() => {
-                    // #417: a parked call (or one mid-announcement) can
-                    // be peer-held underneath — skip the whole tick
-                    // while our send is forbidden. MOH is a loop, so
-                    // skipping pauses it harmlessly; an announcement
-                    // deliberately STALLS rather than plays into a deaf
-                    // leg — it exists to be heard (recording-consent),
-                    // so it resumes where it left off when the peer
-                    // does. (Bot-hold can't coexist with a peer hold —
-                    // the no-stacking rejection — so `held` never
-                    // races this.)
+                    // #417: a parked, bot-held, or mid-announcement
+                    // call can be peer-held underneath — skip the
+                    // whole tick while our send is forbidden. MOH is a
+                    // loop, so skipping pauses it harmlessly; an
+                    // announcement deliberately STALLS rather than
+                    // plays into a deaf leg — it exists to be heard
+                    // (recording-consent), so it resumes where it left
+                    // off when the peer does. (The no-stacking
+                    // rejection blocks a bot-hold *request* while
+                    // peer-held, but not the reverse order — a peer
+                    // re-INVITE arriving during a bot-hold lands here,
+                    // and stalling the bot-hold's MOH is exactly the
+                    // recvonly-compliant behavior.)
                     if self.tx_gate_active() {
                         self.note_tx_suppressed();
                         continue;

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -169,6 +169,18 @@ pub const DELAYED_OFFER_TOTAL: &str = "siphon_ai_delayed_offer_total";
 /// Literal must match the call sites in `siphon-ai-core::outbound`.
 pub const OUTBOUND_DELAYED_OFFER_TOTAL: &str = "siphon_ai_outbound_delayed_offer_total";
 
+/// Caller-leg 20 ms frames dropped because the negotiated direction
+/// forbade our send — we answered a peer hold with `recvonly` /
+/// `inactive` (RFC 3264 §6.1, #417). Counts every suppressed push
+/// site (WS playout, barge-in re-queues, the room mix, parked MOH and
+/// announcements); a sustained rate means the WS server keeps
+/// streaming through peer holds instead of pausing on the §3.3 `hold`
+/// event — harmless but wasted bandwidth. No labels. Literal must
+/// match the const in `siphon-ai-media-glue::tap` (same pattern as
+/// the room metrics above it in that crate).
+pub const PEER_HOLD_TX_SUPPRESSED_FRAMES_TOTAL: &str =
+    "siphon_ai_peer_hold_tx_suppressed_frames_total";
+
 /// REFER transfers attempted (0.6.1; back-fills blind-transfer
 /// counting, which previously had no metric). Labeled by `mode`
 /// (`blind` / `attended`) and `result`: `accepted` (202, call torn
@@ -524,6 +536,10 @@ pub fn register_descriptions() {
     describe_counter!(
         ROOM_FRAMES_DROPPED_TOTAL,
         "20 ms frames a conference room dropped instead of blocking, by stage (input, sink) and side (sip, ws)."
+    );
+    describe_counter!(
+        PEER_HOLD_TX_SUPPRESSED_FRAMES_TOTAL,
+        "Caller-leg 20 ms frames dropped because the answered direction (recvonly/inactive, peer hold) forbade our send (#417)."
     );
     describe_counter!(PARKS_TOTAL, "Calls parked, by result (ok, rejected).");
     describe_counter!(


### PR DESCRIPTION
Post-merge review follow-ups for #418 (review otherwise clean — the gate logic, RFC 3264 asymmetry, room-routing placement, drop-not-buffer stance, and recording-fork coherence all verified, and the new test passes locally):

1. **`siphon_ai_peer_hold_tx_suppressed_frames_total` had no telemetry-side registration** — every other media-glue-local metric literal (the room metrics) has a matching `pub const` + `describe_counter!` in `siphon-ai-telemetry::metrics`; without it the counter ships with no `# HELP` line. Added, with literal-must-match cross-references on both sides.
2. **MOH-tick gate comment overclaimed**: it said bot-hold can't coexist with a peer hold via the no-stacking rejection — but that rejection only blocks a bot-hold *request* while already peer-held; the reverse order (peer re-INVITE during a bot-hold) is reachable and lands on this gate, where stalling the bot-hold's MOH is exactly the `recvonly`-compliant behavior. Code was right; comment now is too.

No behavior change. Full workspace suite (57 targets) green; clippy `-D warnings`, fmt.

0.48.2 release-prep follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpAx1iyY567DicG4ZCgZUw