### PR TITLE
chore(release): 0.48.3 — srtp=preferred offers RTP/AVP + a=crypto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.48.3] - 2026-08-03
+
 ### Fixed
 
 - **`srtp = "preferred"` now offers `RTP/AVP` + `a=crypto` instead of `RTP/SAVP`** (issue #422). RFC 3264 answers echo the offered transport profile, so an `RTP/SAVP` offer gives a compliant plaintext-only peer no legal way to answer — it must reject the stream — which made "preferred" behave as "required, against peers polite enough to violate the RFC." Live shape: a FreeSWITCH `originate loopback/9000` makes its gateway leg send an offerless INVITE, our delayed-offer 200 OK offered SAVP, and FS (no SRTP on that leg) correctly gave up — ACK then BYE with `cause=500 "Internal media error"` — while the same peer on the early-offer path (where we merely mirror its `RTP/AVP`) worked fine. The generated SDES offer now follows the policy: `required` keeps `RTP/SAVP` (encryption non-negotiable, unchanged); `preferred` offers plain `RTP/AVP` carrying `a=crypto` — the long-standing optional-SRTP convention — so capable peers answer with their own key and both sides encrypt, and everyone else answers plaintext and proceeds in the clear. The answer path already keyed off the crypto attribute rather than the transport profile, so both outcomes flow through the existing install/downgrade logic; new tests pin the offer shape per mode and both answer outcomes (AVP+crypto → keys installed + `start.srtp.profile`; plaintext → clean downgrade, no profile claimed). Applies to both users of the shared offer builder: outbound origination (`[[gateway]].srtp`) and the inbound delayed-offer 200 OK (`[media].srtp` / route override). Documented in CONFIG.md (`[media].srtp_offer`, `[[gateway]].srtp`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "base64",
  "bytes",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3927,7 +3927,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "regex",
  "serde",
@@ -3946,7 +3946,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "base64",
  "hmac",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4040,7 +4040,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -4058,7 +4058,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4076,7 +4076,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "regex",
  "serde",
@@ -4102,7 +4102,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "schemars",
  "serde",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "base64",
  "rcgen",
@@ -4157,7 +4157,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -4186,7 +4186,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.48.2"
+version = "0.48.3"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.48.2.** Production-deployed against real carriers
+**Current release: v0.48.3.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged. Daemon upgrades are near-drop-in


### PR DESCRIPTION
Release-prep for **0.48.3** per RELEASING.md: workspace version bump (+ Cargo.lock), CHANGELOG `[Unreleased]` → `[0.48.3] - 2026-08-03` with a fresh empty `[Unreleased]` above, README current-release marker.

Sole change since 0.48.2 is #423 (closes #422): `srtp = "preferred"` now generates an `RTP/AVP` + `a=crypto` SDES offer — the optional-SRTP convention a compliant plaintext-only peer can answer — instead of `RTP/SAVP`, which forced such peers to reject the stream (FreeSWITCH offerless-INVITE legs died with an instant post-ACK BYE `cause=500`). `required` keeps `RTP/SAVP`. Covers both consumers of the shared offer builder: outbound origination (`[[gateway]].srtp`) and the inbound delayed-offer 200 OK. #423 pre-stamped 0.48.3 in a doc comment — matches this release, no renumbering needed.

Verified locally: `check-version-consistency.py` (plain + `--tag v0.48.3`), `extract-changelog.py 0.48.3`, `cargo test -p siphon-ai-media-glue` green.

After merge: tag `v0.48.3` on the merge commit and push to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2i3tRMKzRetrctWFXtPnV