### PR TITLE
chore(release): 0.48.4 — delayed-offer pending window honors BYE and body-less ACK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.48.4] - 2026-08-04
+
 ### Fixed
 
 - **A BYE or body-less ACK during the delayed-offer pending window now ends the call immediately** (issue #425). Between our 200-with-offer and the peer's ACK answer, an inbound delayed-offer call has a confirmed dialog but no controller yet — and both teardown signals fell into that gap: the routing handler dropped ACKs without a body before the acceptor could see them, and `dispatch_bye` consulted only the controller registry, so the peer's BYE got its RFC-mandated 200 while the parked call sat — forge session and ports held — until the Timer-H watchdog expired 32 s later and wrote a CDR claiming `ack_timeout` with a 32 s duration for a call the peer had ended in milliseconds (live shape: FreeSWITCH's gateway leg failing its own media setup sends exactly this empty-ACK + BYE pair 2 ms after our 200). Now every in-dialog ACK reaches the acceptor — a body-less one on a held dialog is the peer failing to answer our offer (RFC 3261 §13.2.2.4) and reaps the call as `missing_sdp_answer`, the outcome that was documented in the metric description and CDR schema since 0.9.5 but that no code path ever emitted — and the daemon installs the acceptor as the dialog terminator, so a BYE that misses the controller registry also checks the pending window and reaps the call with the ordinary `caller_hangup` cause and its real duration (CANCEL deliberately does not: RFC 3261 §9.2, no effect after a final response). `siphon_ai_delayed_offer_total` gains the `caller_hangup` result label; documented in DEPLOY.md.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.48.3"
+version = "0.48.4"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.48.3"
+version = "0.48.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.48.3"
+version = "0.48.4"
 dependencies = [
  "base64",
  "bytes",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.48.3"
+version = "0.48.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3927,7 +3927,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.48.3"
+version = "0.48.4"
 dependencies = [
  "regex",
  "serde",
@@ -3946,7 +3946,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.48.3"
+version = "0.48.4"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.48.3"
+version = "0.48.4"
 dependencies = [
  "base64",
  "hmac",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.48.3"
+version = "0.48.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4040,7 +4040,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.48.3"
+version = "0.48.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -4058,7 +4058,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.48.3"
+version = "0.48.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4076,7 +4076,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.48.3"
+version = "0.48.4"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.48.3"
+version = "0.48.4"
 dependencies = [
  "regex",
  "serde",
@@ -4102,7 +4102,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.48.3"
+version = "0.48.4"
 dependencies = [
  "schemars",
  "serde",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.48.3"
+version = "0.48.4"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.48.3"
+version = "0.48.4"
 dependencies = [
  "base64",
  "rcgen",
@@ -4157,7 +4157,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.48.3"
+version = "0.48.4"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -4186,7 +4186,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.48.3"
+version = "0.48.4"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.48.3"
+version = "0.48.4"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.48.3.** Production-deployed against real carriers
+**Current release: v0.48.4.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged. Daemon upgrades are near-drop-in


### PR DESCRIPTION
Release-prep for **0.48.4** per RELEASING.md: workspace version bump (+ Cargo.lock), CHANGELOG `[Unreleased]` → `[0.48.4] - 2026-08-04` with a fresh empty `[Unreleased]` above, README current-release marker.

Two merges since 0.48.3:

- **#426** (closes #425) — a peer BYE or body-less ACK between our delayed-offer 200-with-offer and the ACK answer now reaps the parked call immediately (`caller_hangup` / `missing_sdp_answer` CDR with the real duration) instead of holding the forge session and ports for the full 32 s Timer-H window and mis-reporting `ack_timeout`. No CDR schema version bump needed — `caller_hangup` is an existing variant; `siphon_ai_delayed_offer_total` gains the `caller_hangup` result label (documented in DEPLOY.md).
- **#427** — docs only: FreeSWITCH interop caveats from the #422 live verification (stock FS 488s the crypto-in-AVP `preferred` offer as callee → use `required`/`off` toward FS; a `bypass_media` leg can never answer a delayed offer).

Verified locally: `check-version-consistency.py` (plain + `--tag v0.48.4`), `extract-changelog.py 0.48.4`, `cargo test -p siphon-ai-core -p siphon-ai-sip-glue` green (includes the new #425 pending-window tests). Note: the #426 push run on main shows `cancelled` only because #427's push superseded it seconds later — the green run at the main tip includes both merges.

After merge: tag `v0.48.4` on the merge commit and push to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2i3tRMKzRetrctWFXtPnV