### PR TITLE
chore(deps): bump forge-media aeae479b391d -> b4f8df5c8f09

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,6 +530,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,6 +751,18 @@ dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1010,7 +1028,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "forge-codecs"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=aeae479b391d#aeae479b391ddd2e73b9962e55623f72192fb5fd"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=b4f8df5c8f09#b4f8df5c8f09dedcc86f39a700304b1c19a6f167"
 dependencies = [
  "audiopus",
  "ezk-g722",
@@ -1022,7 +1040,7 @@ dependencies = [
 [[package]]
 name = "forge-core"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=aeae479b391d#aeae479b391ddd2e73b9962e55623f72192fb5fd"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=b4f8df5c8f09#b4f8df5c8f09dedcc86f39a700304b1c19a6f167"
 dependencies = [
  "chrono",
  "serde",
@@ -1037,7 +1055,7 @@ dependencies = [
 [[package]]
 name = "forge-dtmf"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=aeae479b391d#aeae479b391ddd2e73b9962e55623f72192fb5fd"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=b4f8df5c8f09#b4f8df5c8f09dedcc86f39a700304b1c19a6f167"
 dependencies = [
  "chrono",
  "forge-core",
@@ -1049,7 +1067,7 @@ dependencies = [
 [[package]]
 name = "forge-engine"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=aeae479b391d#aeae479b391ddd2e73b9962e55623f72192fb5fd"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=b4f8df5c8f09#b4f8df5c8f09dedcc86f39a700304b1c19a6f167"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1079,7 +1097,7 @@ dependencies = [
 [[package]]
 name = "forge-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=aeae479b391d#aeae479b391ddd2e73b9962e55623f72192fb5fd"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=b4f8df5c8f09#b4f8df5c8f09dedcc86f39a700304b1c19a6f167"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -1092,7 +1110,7 @@ dependencies = [
 [[package]]
 name = "forge-injection"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=aeae479b391d#aeae479b391ddd2e73b9962e55623f72192fb5fd"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=b4f8df5c8f09#b4f8df5c8f09dedcc86f39a700304b1c19a6f167"
 dependencies = [
  "forge-core",
  "rubato",
@@ -1105,7 +1123,7 @@ dependencies = [
 [[package]]
 name = "forge-mixer"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=aeae479b391d#aeae479b391ddd2e73b9962e55623f72192fb5fd"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=b4f8df5c8f09#b4f8df5c8f09dedcc86f39a700304b1c19a6f167"
 dependencies = [
  "bytes",
  "dashmap 6.2.1",
@@ -1119,7 +1137,7 @@ dependencies = [
 [[package]]
 name = "forge-recorder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=aeae479b391d#aeae479b391ddd2e73b9962e55623f72192fb5fd"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=b4f8df5c8f09#b4f8df5c8f09dedcc86f39a700304b1c19a6f167"
 dependencies = [
  "bytes",
  "forge-core",
@@ -1133,7 +1151,7 @@ dependencies = [
 [[package]]
 name = "forge-resampler"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=aeae479b391d#aeae479b391ddd2e73b9962e55623f72192fb5fd"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=b4f8df5c8f09#b4f8df5c8f09dedcc86f39a700304b1c19a6f167"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -1142,21 +1160,21 @@ dependencies = [
 [[package]]
 name = "forge-rtp"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=aeae479b391d#aeae479b391ddd2e73b9962e55623f72192fb5fd"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=b4f8df5c8f09#b4f8df5c8f09dedcc86f39a700304b1c19a6f167"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm 0.11.0",
  "bytes",
  "foreign-types",
  "forge-core",
- "hmac",
+ "hmac 0.13.0",
  "libc",
  "metrics",
  "openssl",
  "openssl-sys",
  "rand 0.10.1",
- "sha1",
- "sha2",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "socket2 0.6.3",
  "subtle",
  "thiserror 2.0.18",
@@ -1167,14 +1185,14 @@ dependencies = [
 [[package]]
 name = "forge-sdp"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=aeae479b391d#aeae479b391ddd2e73b9962e55623f72192fb5fd"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=b4f8df5c8f09#b4f8df5c8f09dedcc86f39a700304b1c19a6f167"
 dependencies = [
  "base64",
  "chrono",
  "forge-core",
  "forge-rtp",
  "rand 0.10.1",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=aeae479b391d)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=b4f8df5c8f09)",
  "smol_str",
  "thiserror 2.0.18",
 ]
@@ -1182,7 +1200,7 @@ dependencies = [
 [[package]]
 name = "forge-transcoder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=aeae479b391d#aeae479b391ddd2e73b9962e55623f72192fb5fd"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=b4f8df5c8f09#b4f8df5c8f09dedcc86f39a700304b1c19a6f167"
 dependencies = [
  "bytes",
  "forge-codecs",
@@ -1195,7 +1213,7 @@ dependencies = [
 [[package]]
 name = "forge-vad"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=aeae479b391d#aeae479b391ddd2e73b9962e55623f72192fb5fd"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=b4f8df5c8f09#b4f8df5c8f09dedcc86f39a700304b1c19a6f167"
 dependencies = [
  "thiserror 2.0.18",
  "tract-onnx",
@@ -1576,7 +1594,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3531,7 +3558,18 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3542,7 +3580,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3604,7 +3653,7 @@ dependencies = [
  "hex",
  "md5",
  "rand 0.10.1",
- "sha2",
+ "sha2 0.10.9",
  "sip-core",
  "sip-parse",
  "sip-ratelimit",
@@ -3721,7 +3770,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=aeae479b391d#aeae479b391ddd2e73b9962e55623f72192fb5fd"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=b4f8df5c8f09#b4f8df5c8f09dedcc86f39a700304b1c19a6f167"
 dependencies = [
  "nom 7.1.3",
  "smol_str",
@@ -3785,7 +3834,7 @@ dependencies = [
  "bytes",
  "hex",
  "rand 0.10.1",
- "sha1",
+ "sha1 0.10.6",
  "sip-auth",
  "sip-core",
  "sip-dialog",
@@ -3899,7 +3948,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "siphon-ai-security",
  "thiserror 1.0.69",
  "tokio",
@@ -3995,7 +4044,7 @@ name = "siphon-ai-http"
 version = "0.48.5"
 dependencies = [
  "base64",
- "hmac",
+ "hmac 0.12.1",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -4003,7 +4052,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -4121,7 +4170,7 @@ dependencies = [
  "chrono",
  "metrics",
  "parking_lot",
- "sha2",
+ "sha2 0.10.9",
  "sip-auth",
  "sip-core",
  "sip-dialog",
@@ -4172,7 +4221,7 @@ dependencies = [
  "opentelemetry_sdk",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sip-hep",
  "siphon-ai-audit",
  "subtle",
@@ -5198,7 +5247,7 @@ dependencies = [
  "rand 0.8.6",
  "rustls",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 1.0.69",
  "utf-8",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,7 +178,21 @@ sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "dae
 # AI logic belongs in the WS server, never here. See CLAUDE.md §4.1 and the
 # upstream gate at https://github.com/thevoiceguy/forge-media/pull/39.
 #
-# forge-media is pinned to a `main` rev. Bumped 2026-07-30 to aeae479b391d
+# forge-media is pinned to a `main` rev. Bumped 2026-08-07 to b4f8df5c8f09
+# = forge-media #102 + #104 + #105 (plus dependabot bumps #88/#89/#91/#99).
+# #102: every facade metric family gets describe_*! HELP text and every
+# histogram explicit buckets (forge's sibling of siphon-ai #432); six
+# forge-api metrics were renamed to gain the forge_ prefix — forge-api is
+# not a crate we consume, and no siphon-ai dashboard/doc referenced the old
+# names. #104: sha1 0.11 / hmac 0.13 / sha2 0.11 (digest 0.11 move) — we
+# still ship hmac 0.12 / sha2 0.10 for our own use, so those now build as
+# duplicate versions; harmless, dedupe when we do our own digest move.
+# #105: forge_rtcp_sender_{packets,bytes}_total now count SR deltas per
+# SSRC instead of summing running totals. `metrics` facade stays 0.24 on
+# both sides (must move in lockstep with our exporter — see v0.31.1 note).
+# external/siphon-rs submodule unchanged (74b903b).
+#
+# Prior pin: bumped 2026-07-30 to aeae479b391d
 # = forge-media #100: external/siphon-rs submodule f3454c7 → 74b903b, which
 # is how siphon-rs #85 (negotiate_answer accepts one m-line per media type)
 # reaches forge-sdp — the negotiator siphon-ai's media path actually runs.
@@ -217,20 +231,20 @@ sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "dae
 # comment for the current rev.) Prior forge pins: forge 1c996ae5fb4f = #86
 # neural VAD; forge 3c59b5f6e464 = #82-#85 dependency migrations; forge
 # 5fa76fb38675 = #81.
-forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "aeae479b391d" }
-forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "aeae479b391d" }
-forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "aeae479b391d", default-features = false, features = ["g722", "dtls", "opus", "neural-vad"] }
-forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "aeae479b391d" }
-forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "aeae479b391d" }
-forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "aeae479b391d" }
-forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "aeae479b391d" }
-forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "aeae479b391d" }
+forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "b4f8df5c8f09" }
+forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "b4f8df5c8f09" }
+forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "b4f8df5c8f09", default-features = false, features = ["g722", "dtls", "opus", "neural-vad"] }
+forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "b4f8df5c8f09" }
+forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "b4f8df5c8f09" }
+forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "b4f8df5c8f09" }
+forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "b4f8df5c8f09" }
+forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "b4f8df5c8f09" }
 # Conference rooms (0.7.0): forge-mixer is the per-room AudioMixer;
 # forge-injection provides ToneGenerator (join/leave tones now, MOH
 # for park later). Deliberately NOT forge-conference — its DTMF
 # IVR/PIN/host-control layer is unused per DEV_PLAN_0.7.0.md §9.4.
-forge-mixer     = { git = "https://github.com/thevoiceguy/forge-media", rev = "aeae479b391d" }
-forge-injection = { git = "https://github.com/thevoiceguy/forge-media", rev = "aeae479b391d" }
+forge-mixer     = { git = "https://github.com/thevoiceguy/forge-media", rev = "b4f8df5c8f09" }
+forge-injection = { git = "https://github.com/thevoiceguy/forge-media", rev = "b4f8df5c8f09" }
 
 # hep-rs — HEP3 codec, transport, HepSink trait. Owned by the same
 # author as siphon-rs and forge-media; lives in its own repo.


### PR DESCRIPTION
## What

Bumps the forge-media pin `aeae479b391d` → `b4f8df5c8f09` (7 commits): forge-media #102, #104, #105, plus dependabot bumps #88/#89/#91/#99. siphon-rs (`daee496e1a17`) and hep-rs (`91e689b`, via Cargo.lock) were checked and are already at their latest upstream commits — no changes there.

- **forge #102** — every facade metric family gets `describe_*!` HELP text and every histogram explicit buckets (forge's sibling of siphon-ai #432). Six forge-api metrics were renamed to gain the `forge_` prefix; forge-api is not a crate we consume, and a repo-wide grep confirmed no siphon-ai code/doc/dashboard references the old names.
- **forge #104** — coordinated digest-0.11 move (sha1 0.11 / hmac 0.13 / sha2 0.11). We still ship hmac 0.12 / sha2 0.10 for our own use, so those now build as duplicate versions — harmless; dedupe when we do our own digest move.
- **forge #105** — `forge_rtcp_sender_{packets,bytes}_total` now count SR deltas per SSRC instead of summing running totals (the follow-up flagged in #102's review notes).

## Compatibility checks

- `metrics` facade is 0.24 on both sides — the exporter/facade lockstep (v0.31.1 lesson) is preserved.
- forge's `external/siphon-rs` submodule is unchanged (74b903b).
- Cargo.lock diff is exactly the 14 forge crates plus the new digest-family duplicates — nothing else moved.
- Pin-history comment in `Cargo.toml` updated per convention.

## Testing

- `cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo test --workspace`: 57 suites, 0 failures (includes telemetry HEP tests)
- SIPp integration suite: all 38 scenarios pass (delayed-offer/SRTP/DTLS, opus, barge-in, transfers, graceful drain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015M9CS2B7ayexXCQuB2YXCt