### PR TITLE
chore(release): 0.48.6 — forge-media bump: metric HELP/buckets + per-SSRC RTCP sender counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.48.6] - 2026-08-07
+
+### Changed
+
+- **forge-media bumped `aeae479b391d` → `b4f8df5c8f09`** (PR #435 — forge-media [#102](https://github.com/thevoiceguy/forge-media/pull/102), [#104](https://github.com/thevoiceguy/forge-media/pull/104), [#105](https://github.com/thevoiceguy/forge-media/pull/105), plus dependabot bumps #88/#89/#91/#99). Two of these are visible on this daemon's own `/metrics`, since the embedded forge crates' `forge_*` families export through our recorder: forge #102 gives every forge facade metric a `# HELP` line and every forge histogram explicit buckets (forge's sibling of our #431/#432 sweep — `forge_vad_neural_inference_seconds` previously rendered as an unaggregatable summary), and forge #105 makes `forge_rtcp_sender_{packets,bytes}_total` count per-SSRC deltas from received sender reports instead of summing running totals, so they now grow linearly as wire counts do rather than superlinearly. forge #102 also renamed six unprefixed forge-api metrics — forge-api is not a crate SiphonAI consumes, and nothing here referenced the old names. forge #104 moves forge to the digest-0.11 stack (sha1 0.11 / hmac 0.13 / sha2 0.11); SiphonAI's own hmac 0.12 / sha2 0.10 now build alongside as duplicate versions — harmless, to be deduped with our own digest move. The `metrics` facade stays 0.24 on both sides (exporter lockstep preserved), and forge's `external/siphon-rs` submodule is unchanged. siphon-rs (`daee496e1a17`) and hep-rs (`91e689b`) were audited in the same pass and were already at their latest upstream commits. No SiphonAI behavior change; full workspace tests plus all 38 SIPp integration scenarios pass on the new pin.
+
 ## [0.48.5] - 2026-08-05
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.48.5"
+version = "0.48.6"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3921,7 +3921,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.48.5"
+version = "0.48.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3937,7 +3937,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.48.5"
+version = "0.48.6"
 dependencies = [
  "base64",
  "bytes",
@@ -3959,7 +3959,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.48.5"
+version = "0.48.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3976,7 +3976,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.48.5"
+version = "0.48.6"
 dependencies = [
  "regex",
  "serde",
@@ -3995,7 +3995,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.48.5"
+version = "0.48.6"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4041,7 +4041,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.48.5"
+version = "0.48.6"
 dependencies = [
  "base64",
  "hmac 0.12.1",
@@ -4064,7 +4064,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.48.5"
+version = "0.48.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.48.5"
+version = "0.48.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -4107,7 +4107,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.48.5"
+version = "0.48.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4125,7 +4125,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.48.5"
+version = "0.48.6"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.48.5"
+version = "0.48.6"
 dependencies = [
  "regex",
  "serde",
@@ -4151,7 +4151,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.48.5"
+version = "0.48.6"
 dependencies = [
  "schemars",
  "serde",
@@ -4161,7 +4161,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.48.5"
+version = "0.48.6"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4188,7 +4188,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.48.5"
+version = "0.48.6"
 dependencies = [
  "base64",
  "rcgen",
@@ -4206,7 +4206,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.48.5"
+version = "0.48.6"
 dependencies = [
  "anyhow",
  "forge-hep",
@@ -4235,7 +4235,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.48.5"
+version = "0.48.6"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.48.5"
+version = "0.48.6"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.48.5.** Production-deployed against real carriers
+**Current release: v0.48.6.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged. Daemon upgrades are near-drop-in


### PR DESCRIPTION
Release-prep for **v0.48.6** — a deps-only patch release carrying #435 (forge-media `aeae479b391d` → `b4f8df5c8f09`).

Per RELEASING.md:
- `[workspace.package].version` 0.48.5 → 0.48.6 (+ `Cargo.lock` refresh)
- `CHANGELOG.md`: new dated `[0.48.6]` section (the #435 bump landed without an entry, so it's written here), fresh empty `[Unreleased]` above
- `README.md` current-release marker → v0.48.6

Verified locally: `check-version-consistency.py` (plain and `--tag v0.48.6`) and `extract-changelog.py 0.48.6` all pass.

After merge: tag `v0.48.6` on the merge commit and push to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015M9CS2B7ayexXCQuB2YXCt