### PR TITLE
fix(telemetry): apply forge-engine suggested buckets so forge histograms render buckets, not summaries (#437)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The forge histograms actually render buckets now** (issue #437). The 0.48.6 note below claimed the forge-media bump gave "every forge histogram explicit buckets"; that was wrong for this daemon's own `/metrics` — a 0.48.6 instance still rendered `forge_vad_neural_inference_seconds` as a Prometheus summary (quantiles), unaggregatable across instances. `describe_*!` HELP text travels through the `metrics` facade to whatever recorder is installed, but bucket registration is **exporter-side**: forge-media #102 could only export suggested-bucket consts, and `prometheus_builder()` never applied them. It now registers forge-engine's exported buckets for the only two forge histogram families the consumed forge crates emit — `forge_vad_neural_inference_seconds` and `forge_transcoding_duration_seconds` (the conference/webrtc/sdp histograms live in forge-conference and forge-api, which SiphonAI deliberately doesn't consume) — referencing the upstream consts directly so name and buckets track the pin by construction, with a rendered-output test alongside the #431 suite. DEPLOY.md's forge row now points at forge-media's `docs/METRICS.md` and names the two bucketed families.
+
 ## [0.48.6] - 2026-08-07
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4209,6 +4209,7 @@ name = "siphon-ai-telemetry"
 version = "0.48.6"
 dependencies = [
  "anyhow",
+ "forge-engine",
  "forge-hep",
  "hep-rs",
  "http-body-util",

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -42,6 +42,12 @@ tokio-rustls.workspace                = true
 hep-rs       = { workspace = true }
 sip-hep      = { workspace = true }
 forge-hep    = { workspace = true }
+# Only for the exported metric-name/bucket consts in
+# `forge_engine::metrics` (#437): the embedded forge crates emit through
+# our recorder, and their histograms need exporter-side bucket
+# registration in `prometheus_builder()`. Already in the build graph at
+# the same pin/features via core and media-glue — no new compilation.
+forge-engine = { workspace = true }
 opentelemetry = "0.32.0"
 opentelemetry_sdk = { version = "0.32.1", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.32.0", default-features = false, features = ["grpc-tonic", "trace"] }

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -565,6 +565,26 @@ pub fn prometheus_builder() -> Result<PrometheusBuilder, InitError> {
                 &RTP_MOS_ESTIMATE_BUCKETS,
             )
         })
+        // The embedded forge crates emit through this same recorder, and
+        // bucket registration is exporter-side — forge can only *suggest*
+        // buckets by exporting consts (forge-media #102). Without these
+        // two matchers the forge histograms fall back to summaries
+        // (quantiles), unaggregatable across instances (#437). These are
+        // the only histogram families the forge crates we consume emit;
+        // referencing forge-engine's consts keeps name and buckets in
+        // lockstep with the pin by construction.
+        .and_then(|b| {
+            b.set_buckets_for_metric(
+                Matcher::Full(forge_engine::metrics::M_VAD_NEURAL_INFERENCE.to_string()),
+                &forge_engine::metrics::VAD_NEURAL_INFERENCE_SECONDS_BUCKETS,
+            )
+        })
+        .and_then(|b| {
+            b.set_buckets_for_metric(
+                Matcher::Full(forge_engine::metrics::M_TRANSCODING_DURATION.to_string()),
+                &forge_engine::metrics::TRANSCODING_DURATION_SECONDS_BUCKETS,
+            )
+        })
         .map_err(|e| InitError::Install(e.to_string()))
 }
 
@@ -1206,6 +1226,31 @@ mod tests {
         for &name in ALL_HISTOGRAMS {
             let out = with_recorder(|| {
                 histogram!(name).record(1.0);
+            });
+            assert!(
+                out.contains(&format!("{name}_bucket")),
+                "{name} has no buckets registered in prometheus_builder():\n{out}"
+            );
+            assert!(
+                !out.contains(&format!("{name}{{quantile")),
+                "{name} rendered as a summary:\n{out}"
+            );
+        }
+    }
+
+    #[test]
+    fn forge_histograms_render_with_buckets_not_summaries() {
+        // Same promise as above, for the forge families that emit
+        // through our recorder (#437): forge-media #102 exports
+        // suggested buckets, but only prometheus_builder() can apply
+        // them. Kept out of ALL_HISTOGRAMS — that list is pinned to the
+        // `siphon_ai_` namespace by the source-scan test.
+        for &name in &[
+            forge_engine::metrics::M_VAD_NEURAL_INFERENCE,
+            forge_engine::metrics::M_TRANSCODING_DURATION,
+        ] {
+            let out = with_recorder(|| {
+                histogram!(name).record(0.001);
             });
             assert!(
                 out.contains(&format!("{name}_bucket")),

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1161,7 +1161,9 @@ on the metrics crate's defaults (CLAUDE.md §7.4) — and every metric below
 carries a `# HELP` line on the endpoint. Both are enforced by tests over the
 full metric list in `crates/telemetry/src/metrics.rs`, so a metric can't ship
 undescribed or unbucketed (issue #431, which found eleven of the former and
-four of the latter).
+four of the latter). This covers the embedded forge crates' histograms too:
+bucket registration is exporter-side, so forge-engine's suggested buckets are
+applied (and test-enforced) in our `prometheus_builder()` (issue #437).
 
 > **Dashboards & alerts as code (0.21.0).** You don't have to author these
 > from scratch: [`examples/observability/`](../examples/observability/) ships
@@ -1233,7 +1235,7 @@ four of the latter).
 | `siphon_ai_draining`                    | gauge     | —                                     | `1` while the daemon is draining for shutdown (0.17.0, `[shutdown]`), `0` otherwise. Set the instant a SIGTERM/SIGINT drain begins — new INVITEs are then `503`'d and `/ready` reports not-ready. A scraper that catches `1` knows the pod is going away. |
 | `siphon_ai_drain_seconds`               | histogram | —                                     | How long the shutdown drain took (0.17.0): drain start → registry empty or the `[shutdown].drain_timeout_secs` deadline. Observed once per process lifetime, so only a scrape catching the dying pod (or a push gateway) sees it. Buckets 0.1 s – 120 s. A value near the timeout means calls didn't finish in the window. |
 | `siphon_ai_calls_drain_forced_total`    | counter   | —                                     | Calls force-terminated (BYE + WS hangup) at the drain deadline (0.17.0) — they were still active when `[shutdown].drain_timeout_secs` elapsed. `0` after a clean rolling deploy; non-zero means the drain window was too short for the call mix. Also appear on `siphon_ai_calls_total{cause="drain_forced"}` and per-call on the CDR. |
-| `forge_rtcp_*`                          | various   | per-call (forge-side)                 | RTP/RTCP quality. See forge-media's own metric inventory. |
+| `forge_*`                               | various   | per-call (forge-side)                 | Media internals from the embedded forge crates, exported through this daemon's recorder. See forge-media's `docs/METRICS.md` for the inventory. The two forge histograms this daemon can emit — `forge_vad_neural_inference_seconds` (`vad = "neural"` routes) and `forge_transcoding_duration_seconds` — render with forge-engine's suggested buckets, applied by our exporter (#437); every other reachable forge family is a counter or gauge. |
 | `heplify_*`                             | various   | from the HEP collector                | Only visible if you scrape heplify too. |
 
 The §11.8 ten-questions audit in `docs/OPERATIONS.md` shows how to use


### PR DESCRIPTION
Closes #437.

## What

`prometheus_builder()` now applies forge-engine's exported suggested buckets for the only two forge histogram families the consumed forge crates emit:

- `forge_vad_neural_inference_seconds` — `VAD_NEURAL_INFERENCE_SECONDS_BUCKETS` (0.5 ms – 100 ms)
- `forge_transcoding_duration_seconds` — `TRANSCODING_DURATION_SECONDS_BUCKETS` (0.1 ms – 20 ms)

Both referenced as `forge_engine::metrics::` consts (names *and* arrays), so a forge rename or bucket change tracks the pin by construction instead of silently drifting. The conference/webrtc/sdp histograms live in forge-conference and forge-api, which siphon-ai deliberately doesn't consume (DEV_PLAN_0.7.0 §9.4) — swept every consumed forge crate at pin `b4f8df5c8f09` for `histogram!` emissions to confirm the list is exactly these two.

## Why

Live 0.48.6 scrape after a 14 s call on a `vad = "neural"` route (issue #437):

```
# TYPE forge_vad_neural_inference_seconds summary
forge_vad_neural_inference_seconds{quantile="0.5"} 0.0005729569185330446
...
```

Still a summary — quantiles, unaggregatable across instances — because `describe_*!` HELP travels through the `metrics` facade but **bucket registration is exporter-side**; forge-media #102 could only export suggestions, and only the embedding consumer's `PrometheusBuilder` can apply them. Same failure mode #431 fixed for our four `rtp_*` histograms.

## Changes

- `crates/telemetry/src/metrics.rs` — two `set_buckets_for_metric(Matcher::Full(...))` calls + `forge_histograms_render_with_buckets_not_summaries` test (record → render → assert `_bucket{`, refuse `quantile=`). Forge names stay **out** of `ALL_HISTOGRAMS`: the source-scan test pins that list to the `siphon_ai_` namespace.
- `crates/telemetry/Cargo.toml` — `forge-engine` dep for the consts; already in the build graph at the same pin/features via core and media-glue, no new compilation. `Cargo.lock` gains the edge.
- `docs/DEPLOY.md` — forge row now points at forge-media's `docs/METRICS.md` inventory and names the two bucketed families; the §Metrics buckets-everywhere claim extended to cover them.
- `CHANGELOG.md` — Unreleased entry correcting the 0.48.6 note's "every forge histogram explicit buckets" claim.

## Verification plan (post-release)

Same second-instance-lab recipe that found this: 14 s `rtp_call_uac.py` call on a `vad = "neural"` route, then assert `forge_vad_neural_inference_seconds_bucket{le="0.001"}` lines on the scrape and zero `quantile=` lines. 0.48.5 and 0.48.6 baselines are banked for comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMFJ3y4L2hoqRgaHzvM4wW
