### PR TITLE
chore(release): 0.48.7 — forge histograms render buckets, not summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.48.7] - 2026-08-07
+
 ### Fixed
 
 - **The forge histograms actually render buckets now** (issue #437). The 0.48.6 note below claimed the forge-media bump gave "every forge histogram explicit buckets"; that was wrong for this daemon's own `/metrics` — a 0.48.6 instance still rendered `forge_vad_neural_inference_seconds` as a Prometheus summary (quantiles), unaggregatable across instances. `describe_*!` HELP text travels through the `metrics` facade to whatever recorder is installed, but bucket registration is **exporter-side**: forge-media #102 could only export suggested-bucket consts, and `prometheus_builder()` never applied them. It now registers forge-engine's exported buckets for the only two forge histogram families the consumed forge crates emit — `forge_vad_neural_inference_seconds` and `forge_transcoding_duration_seconds` (the conference/webrtc/sdp histograms live in forge-conference and forge-api, which SiphonAI deliberately doesn't consume) — referencing the upstream consts directly so name and buckets track the pin by construction, with a rendered-output test alongside the #431 suite. DEPLOY.md's forge row now points at forge-media's `docs/METRICS.md` and names the two bucketed families.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.48.6"
+version = "0.48.7"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3921,7 +3921,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.48.6"
+version = "0.48.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3937,7 +3937,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.48.6"
+version = "0.48.7"
 dependencies = [
  "base64",
  "bytes",
@@ -3959,7 +3959,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.48.6"
+version = "0.48.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3976,7 +3976,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.48.6"
+version = "0.48.7"
 dependencies = [
  "regex",
  "serde",
@@ -3995,7 +3995,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.48.6"
+version = "0.48.7"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4041,7 +4041,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.48.6"
+version = "0.48.7"
 dependencies = [
  "base64",
  "hmac 0.12.1",
@@ -4064,7 +4064,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.48.6"
+version = "0.48.7"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.48.6"
+version = "0.48.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -4107,7 +4107,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.48.6"
+version = "0.48.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4125,7 +4125,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.48.6"
+version = "0.48.7"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.48.6"
+version = "0.48.7"
 dependencies = [
  "regex",
  "serde",
@@ -4151,7 +4151,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.48.6"
+version = "0.48.7"
 dependencies = [
  "schemars",
  "serde",
@@ -4161,7 +4161,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.48.6"
+version = "0.48.7"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4188,7 +4188,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.48.6"
+version = "0.48.7"
 dependencies = [
  "base64",
  "rcgen",
@@ -4206,7 +4206,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.48.6"
+version = "0.48.7"
 dependencies = [
  "anyhow",
  "forge-engine",
@@ -4236,7 +4236,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.48.6"
+version = "0.48.7"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.48.6"
+version = "0.48.7"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.48.6.** Production-deployed against real carriers
+**Current release: v0.48.7.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged. Daemon upgrades are near-drop-in


### PR DESCRIPTION
Release-prep for **v0.48.7** — single-fix patch release carrying #438 (issue #437: `prometheus_builder()` now registers forge-engine's exported suggested buckets, so `forge_vad_neural_inference_seconds` and `forge_transcoding_duration_seconds` render as aggregatable histograms instead of summaries).

Per RELEASING.md:
- `[workspace.package].version` 0.48.6 → 0.48.7 (+ `Cargo.lock` refresh)
- `CHANGELOG.md`: `[Unreleased]` (which already carried #438's entry) renamed to dated `[0.48.7]`, fresh empty `[Unreleased]` above
- `README.md` current-release marker → v0.48.7

Verified locally: `check-version-consistency.py` (plain and `--tag v0.48.7`) and `extract-changelog.py 0.48.7` all pass.

After merge: tag `v0.48.7` on the merge commit and push to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015M9CS2B7ayexXCQuB2YXCt