### PR TITLE
chore(release): 0.48.8 — CDR v8: recording_result + consent fail-close on the record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.48.8] - 2026-08-08
+
 ### Fixed
 
 - **A recording that fail-closes on its consent announcement now says so on the CDR** (issue #440). `[recording.announcement]` is a fail-closed control: if the prompt can't play, the call doesn't record. That part worked on the mainline path (edge caveats found by post-merge review are tracked in #444/#445/#446). What didn't was the record of it — `docs/CONFIG.md` promised the call "shows up as `consent.announced = false`" and the code comment beside the fail-close said the same, but the consent block was gated on the two things that hadn't happened (an announcement having played, or the server having reported consent), so it was omitted entirely. A call whose consent prompt failed serialized identically to a call recording was never turned on for, which is exactly the distinction a recording-consent audit needs; the only trace was a WARN line. The block is now stamped `{ announced: false, announcement_ms: 0 }` whenever an announcement was configured and couldn't be played. The path also incremented **no metric at all** — the recording never finished because it never started — so a bad prompt file pushed to a fleet would silently stop it recording with nothing to alert on; `siphon_ai_recordings_total` gains a `result="blocked"` value, deliberately distinct from `failed` so a bad prompt and a bad disk stay separately alertable.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.48.7"
+version = "0.48.8"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3921,7 +3921,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.48.7"
+version = "0.48.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3937,7 +3937,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.48.7"
+version = "0.48.8"
 dependencies = [
  "base64",
  "bytes",
@@ -3959,7 +3959,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.48.7"
+version = "0.48.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3976,7 +3976,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.48.7"
+version = "0.48.8"
 dependencies = [
  "regex",
  "serde",
@@ -3995,7 +3995,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.48.7"
+version = "0.48.8"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4041,7 +4041,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.48.7"
+version = "0.48.8"
 dependencies = [
  "base64",
  "hmac 0.12.1",
@@ -4064,7 +4064,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.48.7"
+version = "0.48.8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.48.7"
+version = "0.48.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -4107,7 +4107,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.48.7"
+version = "0.48.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4125,7 +4125,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.48.7"
+version = "0.48.8"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.48.7"
+version = "0.48.8"
 dependencies = [
  "regex",
  "serde",
@@ -4151,7 +4151,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.48.7"
+version = "0.48.8"
 dependencies = [
  "schemars",
  "serde",
@@ -4161,7 +4161,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.48.7"
+version = "0.48.8"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4188,7 +4188,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.48.7"
+version = "0.48.8"
 dependencies = [
  "base64",
  "rcgen",
@@ -4206,7 +4206,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.48.7"
+version = "0.48.8"
 dependencies = [
  "anyhow",
  "forge-engine",
@@ -4236,7 +4236,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.48.7"
+version = "0.48.8"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.48.7"
+version = "0.48.8"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.48.7.** Production-deployed against real carriers
+**Current release: v0.48.8.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged. Daemon upgrades are near-drop-in


### PR DESCRIPTION
Release-prep for **v0.48.8**, carrying #442/#443 (issues #440/#441 — consent fail-close stamped on the CDR, `recordings_total` gains `blocked`, `recording_result` lands with CDR schema **v8** / 50th CSV column) and #448 (post-merge review doc + HELP fixes).

Post-merge review of the round was run before this cut: textual findings fixed in #448; behavioral edge findings tracked as #444/#445/#446/#447 for the next release (none are regressions — mainline paths ship correct).

Per RELEASING.md:
- `[workspace.package].version` 0.48.7 → 0.48.8 (+ `Cargo.lock` refresh)
- `CHANGELOG.md`: `[Unreleased]` renamed to dated `[0.48.8]`, fresh empty `[Unreleased]` above
- `README.md` current-release marker → v0.48.8

Verified locally: `check-version-consistency.py` (plain and `--tag v0.48.8`) and `extract-changelog.py 0.48.8` all pass; full workspace suite green on the merged round.

**Upgrade note (from the CHANGELOG):** a CSV CDR ingestor asserting exactly 49 columns must be updated before deploying this release; JSON consumers tolerant of unknown fields need nothing.

After merge: tag `v0.48.8` on the merge commit and push to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015M9CS2B7ayexXCQuB2YXCt