### PR TITLE
chore(release): 0.48.10 — consent cut-short fails closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.48.10] - 2026-08-08
+
 ### Fixed
 
 - **A consent announcement cut short by a hold or park now fails closed** (issue #445). Since 0.26.0, a `Park`/`Hold` arriving mid-prompt resolved the announcement with its partial play time, and the controller treated any completion as consent: `RecControl::Start` fired, audio was captured, and the CDR affirmatively stamped `consent { announced: true }` with the partial duration — possibly the incoherent `announced: true, announcement_ms: 0` when the cut landed inside the first 20 ms tick (an announce arriving while already held was "skipped" the same way). Reachable in production shapes: the `on_ws_failure` auto-park (the WS connects in parallel with the prompt), an early server `hold`, or an operator park landing during the announcement. A partially heard prompt is not consent — maintainer policy call on the issue's three options was **fail-closed**: capture does not start, `consent { announced: false }` is stamped, and the outcome follows the 0.48.9 rules — `recording_result = "blocked"` when the call was actually going to record (`mode = "always"`, or an on-demand `start_recording`), the #446 deferred escalation otherwise. The WARN log carries the partial `played_ms`. Operational corollary, now documented in RECORDING.md: a bot that holds or parks callers immediately after answer will fail-close its own recordings — let the prompt finish first. Wire shape: `AnnounceEnd::CutShort` (0.48.9) was built as the seam for exactly this decision; no protocol or schema change.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.48.9"
+version = "0.48.10"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3921,7 +3921,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.48.9"
+version = "0.48.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3937,7 +3937,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.48.9"
+version = "0.48.10"
 dependencies = [
  "base64",
  "bytes",
@@ -3959,7 +3959,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.48.9"
+version = "0.48.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3976,7 +3976,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.48.9"
+version = "0.48.10"
 dependencies = [
  "regex",
  "serde",
@@ -3995,7 +3995,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.48.9"
+version = "0.48.10"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4041,7 +4041,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.48.9"
+version = "0.48.10"
 dependencies = [
  "base64",
  "hmac 0.12.1",
@@ -4064,7 +4064,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.48.9"
+version = "0.48.10"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.48.9"
+version = "0.48.10"
 dependencies = [
  "anyhow",
  "clap",
@@ -4107,7 +4107,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.48.9"
+version = "0.48.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4125,7 +4125,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.48.9"
+version = "0.48.10"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.48.9"
+version = "0.48.10"
 dependencies = [
  "regex",
  "serde",
@@ -4151,7 +4151,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.48.9"
+version = "0.48.10"
 dependencies = [
  "schemars",
  "serde",
@@ -4161,7 +4161,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.48.9"
+version = "0.48.10"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4188,7 +4188,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.48.9"
+version = "0.48.10"
 dependencies = [
  "base64",
  "rcgen",
@@ -4206,7 +4206,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.48.9"
+version = "0.48.10"
 dependencies = [
  "anyhow",
  "forge-engine",
@@ -4236,7 +4236,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.48.9"
+version = "0.48.10"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.48.9"
+version = "0.48.10"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.48.9.** Production-deployed against real carriers
+**Current release: v0.48.10.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged. Daemon upgrades are near-drop-in


### PR DESCRIPTION
Release-prep for **v0.48.10**, carrying #452 (closes #445 — fail-closed policy on consent announcements cut short by hold/park). This closes out the last open finding from the 0.48.8 post-merge review.

Per RELEASING.md:
- `[workspace.package].version` 0.48.9 → 0.48.10 (+ `Cargo.lock` refresh)
- `CHANGELOG.md`: `[Unreleased]` renamed to dated `[0.48.10]`, fresh empty `[Unreleased]` above
- `README.md` current-release marker → v0.48.10

Verified locally: `check-version-consistency.py` (plain and `--tag v0.48.10`) and `extract-changelog.py 0.48.10` pass; #452 shipped with 57 green suites + all 38 SIPp scenarios.

No protocol or CDR schema change.

After merge: tag `v0.48.10` on the merge commit and push to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015M9CS2B7ayexXCQuB2YXCt