### PR TITLE
fix(core): 491-glare backoff picks the RFC 3261 §14.1 band by call direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The 491-glare backoff for hold/resume re-INVITEs now follows RFC 3261 §14.1's role split** (issue #454). Both call directions retried after a fixed 250 ms, which sits inside the *non-owner's* 0–2 s band — correct for inbound legs (SiphonAI doesn't own the Call-ID there, verified live on 0.48.10), wrong for outbound legs, where SiphonAI **is** the Call-ID owner and the RFC prescribes 2.1–4.0 s. The two bands are disjoint on purpose — after a collision one side is guaranteed to re-offer first, so the glare cannot repeat — and on the outbound path that guarantee was forfeited: a peer retrying fast could collide a second time and spend the once-only retry, failing the hold (`hold_failed`; the call stays in its prior media state, so the blast radius was one unheld call — low severity, but the collision-avoidance guarantee is the whole point of the scheme). The backoff is now chosen from the role's band — outbound 2.1–4.0 s, inbound 0–2 s — and **randomised within it**, also per the RFC: the previous fixed value meant two SiphonAI instances glaring at each other would retry in permanent lockstep. Jitter comes from std's OS-seeded `RandomState` (no new dependency; desynchronisation is all §14.1's randomness buys). A unit test pins both bands, their disjointness, and that the value actually varies. The functional test plan's HOLD-04 row, which expected 2.1–4.0 s unconditionally, now states the per-role bands.
+
 ## [0.48.10] - 2026-08-08
 
 ### Fixed

--- a/crates/core/src/call.rs
+++ b/crates/core/src/call.rs
@@ -63,7 +63,7 @@ use std::time::{Duration, Instant};
 
 use siphon_ai_bridge::{
     connect_and_run, connect_and_run_with_ready, BridgeChannels, BridgeConfig, BridgeError,
-    BridgeIn, CallId, DisconnectReason, ErrorCode, OutgoingEvent, StartMsg, StopReason,
+    BridgeIn, CallId, Direction, DisconnectReason, ErrorCode, OutgoingEvent, StartMsg, StopReason,
 };
 use siphon_ai_media_glue::{
     AnnounceEnd, AnnounceSource, MediaTap, MediaTapError, MohSource, QualityReport, QualitySummary,
@@ -942,6 +942,11 @@ impl CallController {
             ws_failure_prompt,
         } = cfg;
 
+        // The call's direction picks the RFC 3261 §14.1 glare-backoff
+        // band for hold/resume re-INVITEs (#454); captured before
+        // `start` is consumed by the bridge plumbing below.
+        let call_direction = start.direction;
+
         // W3C trace propagation (0.23.0): render this `run` span — the
         // call's trace root — as `traceparent`/`tracestate` and stamp it
         // onto `start`; the bridge sends it as upgrade headers and the
@@ -1273,8 +1278,9 @@ impl CallController {
         let mut held_since: Option<Instant> = None;
         // Re-INVITE glare backoff (RFC 3261 §14.1): if the peer sends
         // its own re-INVITE at the same moment, our offer draws a 491 —
-        // we wait this long, then retry once.
-        const HOLD_GLARE_BACKOFF: Duration = Duration::from_millis(250);
+        // we wait a role-dependent random interval (see
+        // `glare_backoff`), then retry once. Sampled fresh at each
+        // hold/resume command site (#454).
         // How long to wait for the tap to acknowledge a Hold command
         // (#403 — it refuses when the call is in a conference room).
         // The tap answers from its select loop, so this is effectively
@@ -1593,7 +1599,7 @@ impl CallController {
                                         match drive_hold_reinvite(
                                             hctx,
                                             &hctx.hold_offer_sdp,
-                                            HOLD_GLARE_BACKOFF,
+                                            glare_backoff(call_direction),
                                         )
                                         .await
                                         {
@@ -1638,7 +1644,7 @@ impl CallController {
                                 match drive_hold_reinvite(
                                     hctx,
                                     &hctx.resume_offer_sdp,
-                                    HOLD_GLARE_BACKOFF,
+                                    glare_backoff(call_direction),
                                 )
                                 .await
                                 {
@@ -3008,6 +3014,33 @@ async fn run_transfer_inner(
     }
 }
 
+/// RFC 3261 §14.1 backoff for a re-INVITE that drew a 491, split by
+/// role exactly as the RFC prescribes (#454): the **owner of the
+/// Call-ID** — our outbound legs, which originated the dialog — retries
+/// in 2.1–4.0 s; the non-owner — inbound legs — in 0–2 s. The bands are
+/// disjoint on purpose: after a collision one side is guaranteed to
+/// retry before the other can re-offer, so the glare cannot repeat and
+/// spend the once-only retry in [`drive_hold_reinvite`]. The value is
+/// randomised within the band, also per the RFC — a fixed value would
+/// put two glaring SiphonAI instances in permanent lockstep.
+///
+/// Jitter source: std's `RandomState`, seeded from OS entropy per
+/// process — dependency-free, and desynchronisation is all §14.1's
+/// randomness buys (nothing secret rides on it).
+fn glare_backoff(direction: Direction) -> Duration {
+    use std::hash::{BuildHasher, Hasher};
+    let jitter = std::collections::hash_map::RandomState::new()
+        .build_hasher()
+        .finish();
+    let (base_ms, span_ms) = match direction {
+        // Call-ID owner: 2.1–4.0 s.
+        Direction::Outbound => (2_100, 1_900),
+        // Not the owner: 0–2 s.
+        Direction::Inbound => (0, 2_000),
+    };
+    Duration::from_millis(base_ms + jitter % span_ms)
+}
+
 /// Drive one bot-initiated hold/resume re-INVITE with `offer_sdp` (our
 /// cached media with the direction flipped — `a=sendonly` to hold,
 /// `a=sendrecv` to resume), reusing the inbound TCP/TLS connection when
@@ -3247,6 +3280,37 @@ mod recording_outcome_tests {
         assert!(!c.announced);
         assert_eq!(c.announcement_ms, 0);
         assert_eq!(c.server, None);
+    }
+
+    /// #454: the 491-glare backoff follows RFC 3261 §14.1's role split —
+    /// the Call-ID owner (outbound legs) retries in 2.1–4.0 s, the
+    /// non-owner (inbound) in 0–2 s. The bands must stay disjoint (that
+    /// is the RFC's collision-avoidance guarantee: one side always
+    /// re-offers first) and the value must actually vary (a fixed value
+    /// would put two glaring instances in lockstep).
+    #[test]
+    fn glare_backoff_bands_follow_rfc3261_roles() {
+        let mut inbound_seen = std::collections::HashSet::new();
+        let mut outbound_seen = std::collections::HashSet::new();
+        for _ in 0..64 {
+            let inbound = glare_backoff(Direction::Inbound).as_millis() as u64;
+            let outbound = glare_backoff(Direction::Outbound).as_millis() as u64;
+            assert!(inbound < 2_000, "non-owner band is 0–2 s, got {inbound} ms");
+            assert!(
+                (2_100..4_000).contains(&outbound),
+                "owner band is 2.1–4.0 s, got {outbound} ms"
+            );
+            assert!(
+                inbound < outbound,
+                "bands must be disjoint — the owner always backs off longer"
+            );
+            inbound_seen.insert(inbound);
+            outbound_seen.insert(outbound);
+        }
+        assert!(
+            inbound_seen.len() > 1 && outbound_seen.len() > 1,
+            "backoff must be randomised within the band, not fixed"
+        );
     }
 
     /// A played announcement stamps its measured duration.

--- a/test-harness/FUNCTIONAL_TEST_PLAN.md
+++ b/test-harness/FUNCTIONAL_TEST_PLAN.md
@@ -215,7 +215,7 @@ Much of this is testable **offline** via `siphon-ai route-test` (no call). Match
 | HOLD-01 | `hold`/`resume` (bot-initiated) | 🔵 | `held`/`resumed` after re-INVITE 2xx; MOH to caller; `holds_total{ok}`; CDR `hold{count,total_ms}` |
 | HOLD-02 | double-hold / resume-not-held | 🔵 | idempotent no-op, call survives |
 | HOLD-03 | hold while in conference / peer-held | 🔵 | rejected `hold_failed`, no stacking |
-| HOLD-04 | 491 glare | 🟣 | backoff 2.1–4.0s, retry once, else `hold_failed` stays sendrecv |
+| HOLD-04 | 491 glare | 🟣 | backoff randomised per RFC 3261 §14.1 role (#454): inbound (not Call-ID owner) 0–2 s, outbound (owner) 2.1–4.0 s; retry once, else `hold_failed` stays sendrecv |
 | HOLD-05 | peer-initiated hold | 🔵 | `BridgeOut::hold{direction}` / `resume` (distinct from `held`/`resumed`) |
 
 ### 3.5 Park / retrieve — **P1**, 🔵 (needs inbound + a WS endpoint; no 2nd phone)


### PR DESCRIPTION
Closes #454.

## What

`drive_hold_reinvite`'s glare backoff was a fixed `HOLD_GLARE_BACKOFF = 250ms` passed from both the hold and resume arms regardless of call direction. Per the issue's analysis: correct for inbound legs (SiphonAI is not the Call-ID owner → 0–2 s band, verified live on 0.48.10), wrong for outbound legs, where SiphonAI owns the Call-ID and RFC 3261 §14.1 prescribes 2.1–4.0 s — the disjoint bands being exactly what guarantees a glare can't repeat and spend the once-only retry.

The constant is replaced by `glare_backoff(direction)`, sampled fresh at each hold/resume command site:

- **outbound** (Call-ID owner) → 2.1–4.0 s
- **inbound** (non-owner) → 0–2 s
- **randomised within the band**, per the RFC — the fixed value also meant two SiphonAI instances glaring at each other would retry in permanent lockstep.

`run()` destructures `self` before the select loop, so the direction is captured (`Copy`) right after destructuring, before `start` is consumed by the bridge plumbing.

## No new dependency

Jitter comes from std's `RandomState` (OS-seeded per process, fresh per instance). `rand` is only in the tree transitively, and §14.1's randomness buys desynchronisation, not secrecy — so no dep addition (CLAUDE.md small-dep-tree rule).

## Tests / docs

- New unit test pins both bands, their disjointness (owner always backs off longer), and that values actually vary.
- `FUNCTIONAL_TEST_PLAN.md` HOLD-04 now states the per-role bands (the row expected 2.1–4.0 s unconditionally — wrong for the inbound case it was tested against; the issue noted this correction and it wasn't yet in the repo).
- CHANGELOG entry under Unreleased.
- 57 test suites, clippy `-D warnings`, fmt, and all 38 SIPp scenarios (incl. `reinvite_hold_resume`) pass. The outbound-glare case itself remains unreproduced in the lab, as the issue documents — the unit test on the band selection is the honest coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015M9CS2B7ayexXCQuB2YXCt