### PR TITLE
chore(release): 0.48.13 — dialogs are reclaimed when calls end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.48.13] - 2026-08-10
+
 ### Fixed
 
 - **Finished calls no longer leave their SIP dialog in the shared store forever** (issue #458). `sip-uas` inserts one confirmed dialog per accepted INVITE and siphon-ai never removed it, so `DialogManager` grew for the life of the process — the per-call RSS growth reported against 0.48.10. **The memory was the smaller half of the problem:** `sip-dialog` caps the store at `MAX_CONFIRMED_DIALOGS = 10_000` and `sip-uas` discards the resulting `insert` error (`let _ = ...`), so a daemon past ten thousand cumulative calls silently stops tracking new dialogs altogether — and in-dialog requests (BYE, re-INVITE, the post-REFER NOTIFY, transfer) resolve through exactly that store. At 10k calls/day that is a one-day fuse on a busy node, and nothing in the daemon reported it. Located with a `dhat` heap profile diffing a 100-call run against an 800-call run at constant concurrency: `DialogManager::insert` ← `sip_uas::accept_invite_with_session_timer` ← `BridgingAcceptor::on_matched`, ~976 B/call, with the retained dialog's contact URI and two transaction-metrics `String`s never freed alongside it. Ruled out on the way: metrics cardinality (series count flat at 60 across 4,000 calls), the call registry (empty after every batch), multi-arena glibc fragmentation (`MALLOC_ARENA_MAX=2` was marginally *worse*), untrimmed heap (aggressive `MALLOC_TRIM_THRESHOLD_` changed nothing), and the transaction map (genuinely bounded — it evicts oldest at `max_server_transactions`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3873,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.48.12"
+version = "0.48.13"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3922,7 +3922,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.48.12"
+version = "0.48.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3938,7 +3938,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.48.12"
+version = "0.48.13"
 dependencies = [
  "base64",
  "bytes",
@@ -3960,7 +3960,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.48.12"
+version = "0.48.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3977,7 +3977,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.48.12"
+version = "0.48.13"
 dependencies = [
  "regex",
  "serde",
@@ -3996,7 +3996,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.48.12"
+version = "0.48.13"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4042,7 +4042,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.48.12"
+version = "0.48.13"
 dependencies = [
  "base64",
  "hmac 0.12.1",
@@ -4065,7 +4065,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.48.12"
+version = "0.48.13"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.48.12"
+version = "0.48.13"
 dependencies = [
  "anyhow",
  "clap",
@@ -4108,7 +4108,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.48.12"
+version = "0.48.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4126,7 +4126,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.48.12"
+version = "0.48.13"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4140,7 +4140,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.48.12"
+version = "0.48.13"
 dependencies = [
  "regex",
  "serde",
@@ -4152,7 +4152,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.48.12"
+version = "0.48.13"
 dependencies = [
  "schemars",
  "serde",
@@ -4162,7 +4162,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.48.12"
+version = "0.48.13"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4189,7 +4189,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.48.12"
+version = "0.48.13"
 dependencies = [
  "base64",
  "rcgen",
@@ -4207,7 +4207,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.48.12"
+version = "0.48.13"
 dependencies = [
  "anyhow",
  "forge-engine",
@@ -4238,7 +4238,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.48.12"
+version = "0.48.13"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.48.12"
+version = "0.48.13"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.48.12.** Production-deployed against real carriers
+**Current release: v0.48.13.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged. Daemon upgrades are near-drop-in


### PR DESCRIPTION
Version bump only — `Cargo.toml`, `README.md`, `CHANGELOG.md` dated heading, `Cargo.lock`
workspace versions. No code changes; #470 already merged.

| | |
|---|---|
| #458 | finished calls' SIP dialogs are reclaimed from the shared `DialogManager` instead of accumulating for the life of the process; new `siphon_ai_dialogs_active` gauge |

## Read this if you run long-lived daemons

The memory growth was the smaller half of #458. `sip-dialog` caps the store at 10,000 confirmed
dialogs and `sip-uas` discards the `insert` error, so a daemon past ten thousand cumulative calls
**silently stopped tracking new dialogs** — and BYE, re-INVITE, the post-REFER NOTIFY and
transfer all resolve through that store.

Any node that has served more than ~10k calls since its last restart is in that state until it is
restarted onto this release.

Removal is deferred by a 32 s grace window (SIP Timer H/J) so a retransmitted BYE still matches —
in-dialog behaviour is unchanged.

**After upgrading, watch `siphon_ai_dialogs_active`:** it should track `calls_active`, lagging by
the grace window, and settle rather than climb.

Drop-in otherwise: WS protocol stays `version: "1"`, CDR schema stays v8, no config changes.

Tag `v0.48.13` goes on the merge commit and triggers the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)