### PR TITLE
docs(load): publish 0.48.13 tier-1 results; RSS is not a soak criterion

### DIFF
--- a/test-harness/load/LOAD_TEST_PLAN.md
+++ b/test-harness/load/LOAD_TEST_PLAN.md
@@ -205,10 +205,18 @@ Three separate questions. Run them in this order.
 
 ### 6.1 Sustained soak — 60 min at 80% of the knee
 
-**Pass:** RSS flat within ±10 MB after a 5-minute warm-up; fd count flat;
-thread count flat; zero unexplained call terminations
+**Pass:** fd count flat; thread count flat; `dialogs_active` returns to 0
+after the grace window; zero unexplained call terminations
 (`calls_total{cause}` should show only your own teardowns); quality SLOs
 from §4 still met at minute 59.
+
+**RSS is deliberately not a criterion here** — put it through §6.3 instead.
+A soak is the *worst* place to judge memory: growth arrives in bursts
+(measured: flat for eight minutes, then +4 MB in sixty seconds, then flat
+again, with no correlate in CPU or load), so whether an hour looks flat or
+looks like +37 MB depends on how many bursts happened to land in it. Two
+matched 15-minute runs of identical work differed by 14 MB on nothing but
+timing. Record the RSS curve, then interpret it with §6.3's reuse test.
 
 ### 6.2 Long-call soak — 1 call, 1 hour (`long_call_1h.xml`)
 
@@ -232,28 +240,50 @@ ps -o rss= -p <pid>                 # within ~10% of pre-load idle
 back down is a leak, and it matters more than the peak number.
 
 **RSS is the exception, and "within ~10% of idle" is the wrong test for
-it.** The daemon sizes its buffer pools to the highest concurrency it has
-ever seen and keeps them — the necessary price of allocating nothing in the
-frame loop (CLAUDE.md §4.3). RSS therefore *never* returns to idle after
-load, so that criterion fails on every run that did any work, while a real
-leak hides inside the failure. Measured here: ~0.23 MB per call of
-high-water pool, which is bounded and legitimate.
+it.** Two things keep it high, and neither is a leak. The daemon sizes its
+buffer pools to the highest concurrency it has ever seen and keeps them —
+the necessary price of allocating nothing in the frame loop (CLAUDE.md
+§4.3). On top of that, sustained per-frame churn (~10,000 alloc/free pairs
+per second at 200 calls) ratchets glibc's arenas upward, and glibc does not
+trim them back: measured on 0.48.13, a drained-to-idle daemon held 90.2 MB
+of which 76.7 MB was `RssAnon` in two mmap'd secondary arenas, and it stayed
+there for ten hours. RSS therefore *never* returns to idle after load, so
+that criterion fails on every run that did any work, while a real leak hides
+inside the failure. Measured steady state: **0.38 MB per call** at 200
+concurrent, bounded and reused (test 1 below).
 
-Use these two instead, which separate the pool from an actual leak:
+Use these three instead, which separate the pool from an actual leak:
 
-1. **Repeat the peak step.** Run the same concurrency twice and require RSS
+1. **Re-load the same process** (start here — it is the decisive one). Take a
+   daemon that has already been through a full load and drained to idle, and
+   put an *identical* load through it again. Free-but-untrimmed arena gets
+   handed straight back to the new calls; a leak cannot be, so it must
+   allocate on top. Measured on 0.48.13: a daemon idling at 90.2 MB after
+   200 calls × 60 min absorbed a second 200-call load for **+2.2 MB**, where
+   a fresh daemon needed ~45 MB for the same work. That is a bounded,
+   reused working set — and it is a fifteen-minute test.
+2. **Repeat the peak step.** Run the same concurrency twice and require RSS
    not to grow materially the second time. Pool sizing is already paid;
    growth here is not. Make it thousands of calls, not hundreds — at a few
    KB/call, 250 calls moves RSS ~1.5 MB and is easily dismissed as noise.
-2. **Vary calls independently of concurrency.** Run many short calls at
+3. **Vary calls independently of concurrency.** Run many short calls at
    *low* concurrency (§5's rate steps do this naturally). Any growth there
    cannot be pool sizing, because concurrency never exceeded the existing
    high-water mark. Divide by completed calls to get bytes-per-call.
 
-A per-frame leak is ruled out separately by §6.2/§6.1: a 60-minute soak
-puts tens of millions of frames through a couple of hundred calls, so flat
-RSS across the hour means the hot path is clean whatever the per-call
-figure says.
+**Do not infer the hot path from whether the soak's RSS looked flat.** The
+tempting reading — tens of millions of frames through a couple of hundred
+calls, so flat RSS means a clean frame loop — does not hold in either
+direction. Growth is bursty arena expansion, so a flat hour can hide churn
+and a +37 MB hour can be a daemon whose live set never moved. Test 1 is what
+answers the question.
+
+**Report the plateau, not the warm-up.** Per-call memory keeps climbing for
+roughly *fifty* minutes at a fixed concurrency before it settles: measured
+~0.2 MB/call plus ~5 MB fixed at fifteen minutes, against **0.38 MB/call**
+after an hour at 200 concurrent. Five-minute ramp steps therefore understate
+steady-state memory by about 60%, and that is the number an operator would
+otherwise size on.
 
 ### 6.4 Degradation past the ceiling
 

--- a/test-harness/load/RESULTS-0.48.10.md
+++ b/test-harness/load/RESULTS-0.48.10.md
@@ -4,6 +4,20 @@ Executed against `LOAD_TEST_PLAN.md` on 2026-08-10. Tier 1 only (SIPp on the
 same box, loopback, plaintext) — §10's tier 2 and tier 3 are **not** run, so
 nothing here is a claim about a network, crypto, or a real carrier.
 
+> **Superseded in two places by `RESULTS-0.48.13.md`.** (1) §6.1's "RSS +1.3 MB
+> over the hour" was measured on a process already at 137 MB, whose allocator
+> had free pool enough to absorb an hour of churn invisibly; it is not evidence
+> that memory is flat, and the per-call figures below are warm-up numbers that
+> understate steady state by ~60%. (2) §5's 626 failures at 75 cps do not occur
+> with the pps cap disabled, so the "generator-side, not a bridge limit"
+> attribution is unconfirmed. (3) §7.2's neural-VAD memory figures are wrong and
+> contradict each other — "~6× the per-call memory" below against the "~1.6 vs
+> ~0.79 MB/call" bullet, which is 2×. Both per-call numbers are taken at 25
+> concurrent, where energy's cost is mostly fixed overhead divided by a small
+> N; the real ratio at 200 concurrent is ~8.8× per call. See
+> [#472](https://github.com/thevoiceguy/siphon-ai/issues/472). Everything else
+> here still stands.
+
 ## Environment
 
 | | |

--- a/test-harness/load/RESULTS-0.48.13.md
+++ b/test-harness/load/RESULTS-0.48.13.md
@@ -1,0 +1,219 @@
+# Load & Capacity Results — siphon-ai 0.48.13
+
+Executed against `LOAD_TEST_PLAN.md` on 2026-08-11. Tier 1 only (SIPp on the
+same box, loopback, plaintext) — §10's tier 2 and tier 3 are **not** run, so
+nothing here is a claim about a network, crypto, or a real carrier.
+
+This is a re-run of `RESULTS-0.48.10.md` on the same hardware, in the same
+posture, after four releases (0.48.11 → 0.48.13). Read the two side by side:
+the point of this run is the deltas, and the largest of them is in memory.
+
+## Environment
+
+| | |
+|---|---|
+| Hardware | 4 vCPU, 7.9 GB RAM |
+| OS / kernel | Debian 13, Linux 6.12.95+deb13-amd64 |
+| Version | `siphon-ai 0.48.13` |
+| Posture | G.711 µ-law, recording **off**, HEP **off**, energy VAD, no webhooks, no audit |
+| `[sip].udp_rate_limit_pps` | **0 (disabled)** — see below |
+| `rtp_port_range` | `[41000, 45000]` |
+| Generator | SIPp, same box, real PCMU RTP per call |
+| WS server | Node sink on `127.0.0.1:8767`, discards audio and returns silence |
+
+Second unprivileged instance on `:5070` / metrics `:9191`, alongside an
+untouched production daemon on `:5060`.
+
+**The one deliberate difference from the 0.48.10 run** is
+`udp_rate_limit_pps = 0`. On 0.48.10 that cap was hard-coded at 200/sec and
+engaged in 68 distinct seconds of the §5 rate ramp, silently dropping SIP
+mid-measurement (#459, fixed in 0.48.11 — the cap is now configurable and
+counted). Disabling it is what makes §5 a measurement of the bridge rather
+than of the transport's packet cap. Every phase below ran with it disabled;
+the `stream_rate_limit_fps = 200` line in the startup log is a separate
+limiter that does not apply to UDP.
+
+## Headline
+
+| Metric | Result | vs 0.48.10 |
+|---|---|---|
+| **Sustained concurrent calls** | **≥ 250** — every SLO held; not a measured ceiling | same |
+| **Setup rate** | **≥ 75 cps** at p95 ≤ 0.5 ms, **zero failures** | 626 failures at 75 cps → **0** |
+| CPU at 250 concurrent | 134.5% of one core = **33.6% of 4 vCPU** | 130.4% (noise) |
+| CPU per call | **0.54 %/core**, *falling* with concurrency | identical |
+| Jitter p95 / MOS p50 / loss | **≤ 20 ms** / **> 4.4** / **0** | identical |
+| First audio out (p95) | **19 ms**, flat from 25 to 250 concurrent | identical |
+| 60-min soak at 200 | zero drops, fds/threads immovable, **all 200 torn down on BYE** | teardown anomaly **resolved** |
+| Memory at 200 concurrent | **0.38 MB/call** at steady state (~50 min to reach) | 0.23 MB/call at 5 min — *understated* |
+| Per-completed-call RSS growth | **gone** (#458 fixed) | was 6–10 KB/call |
+| Behaviour past the cap | **503 shed, exact, admitted calls unaffected** | identical |
+
+**250 and 75 cps remain floors, not ceilings.** The ramp ended where the plan
+said to stop, with two-thirds of the CPU idle and quality flat.
+
+## §4 — concurrency ramp (10 cps, 5 min per step)
+
+| Concurrent | Setups | CPU (1 core) | CPU/call | RSS | MOS min/avg | Loss | first_audio p50/p95 |
+|---|---|---|---|---|---|---|---|
+| 25 | 25/25 | 17.3% | 0.69% | 22.5 → 25.8 MB | 4.433 / 4.439 | 0 / 369,462 | 11 / 17 ms |
+| 50 | 50/50 | 32.1% | 0.64% | 28.3 → 31.5 MB | 4.430 / 4.438 | 0 / 738,925 | 11 / 19 ms |
+| 100 | 100/100 | 58.5% | 0.58% | 40.1 → 46.6 MB | 4.430 / 4.437 | 0 / 1,478,070 | 10 / 19 ms |
+| 150 | 150/150 | 87.3% | 0.58% | 53.1 → 62.2 MB | 4.428 / 4.436 | 0 / 2,217,301 | 12 / 19 ms |
+| 200 | 200/200 | 113.9% | 0.57% | 66.8 → 72.1 MB | 4.429 / 4.436 | 0 / 2,956,287 | 13 / 19 ms |
+| **250** | **250/250** | **134.5%** | **0.54%** | 78.2 → 83.9 MB | 4.428 / 4.436 | 0 / 3,695,422 | 12 / 19 ms |
+
+775 calls, **zero failed setups, zero unexplained terminations** — every step
+ended `{'caller_hangup': N}`. **Zero packets lost across 11.4 million
+received.** Per-call CPU falls as concurrency rises, as on 0.48.10.
+
+The RSS column is one daemon across sequential steps, so it is cumulative and
+each step's "first" includes the previous step's high-water. Do not read it as
+per-step cost — §6.3 below measures that properly.
+
+`dialogs_active` (new gauge, 0.48.13) returned to **0** after the ramp. On
+0.48.10 the dialog store only ever grew.
+
+## §5 — arrival rate (concurrency pinned at 125)
+
+| Rate | Calls | Successful | Failed | p95 setup | Admission |
+|---|---|---|---|---|---|
+| 10 cps | 600 | 600 | **0** | ≤ 0.5 ms | never engaged |
+| 25 cps | 1500 | 1500 | **0** | ≤ 0.5 ms | never engaged |
+| 50 cps | 3000 | 3000 | **0** | ≤ 0.5 ms | never engaged |
+| 75 cps | 4500 | 4500 | **0** | ≤ 0.5 ms | never engaged |
+
+9,600 calls, **zero failures at every rate**, and setup latency did not move
+across a 7.5× rate increase.
+
+**This clears the 0.48.10 run's 626 failures at 75 cps.** That run attributed
+them to the generator (SIPp stopping RTP, the watchdog reaping via
+`tap_ended`) and treated 75 cps as the rig's edge. With the pps cap disabled
+they do not occur at all. Two candidate explanations survive — the cap
+dropping SIP was the real cause, or the rig simply had more headroom this run
+— and this data does not separate them. What it does establish is that the
+0.48.10 report's "generator-side, not a bridge limit" attribution is **not
+confirmed**, and 75 cps is clean.
+
+## §6.1 — 60-minute soak at 200 concurrent
+
+| Criterion | Threshold | Result |
+|---|---|---|
+| Call drops during soak | zero | **zero** — 200/200, `sipp_exit=0` |
+| Terminations | your own teardowns only | **200 × `caller_hangup`** |
+| fds / threads flat | — | **612 / 5**, unchanged for the hour (`612 = 12 + 3×200`) |
+| Quality at minute 59 | MOS p50 ≥ 4.0, jitter p95 ≤ 30 ms | **MOS 100% > 4.4; jitter p50 ≤ 10 ms, p95 ≤ 20 ms** |
+| RSS flat after warm-up | ±10 MB | **+36.8 MB (53.0 → 89.8)** — see §6.3 |
+
+Minute-59 quality is measured from the **129,604 samples in the T+5 → T+59
+window alone**, not cumulatively. Zero packets lost and zero out-of-order
+across 179,866 received per call. The daemon logged **nothing at all** between
+the last setup and the first BYE — no warnings, no errors, for the full hour.
+
+**The 0.48.10 run's one unresolved item is resolved.** That soak ended with
+all 200 calls reaped by the inactivity watchdog and late BYEs answered `481`,
+which left §6.1's "only your own teardowns" criterion inconclusive. On 0.48.13
+all 200 tore down on BYE, and the criterion passes outright.
+
+Only the RSS criterion fails, and it fails for a reason that is not a defect
+in the daemon. That is the subject of §6.3.
+
+## §6.3 — what RSS actually does
+
+The soak's +36.8 MB was worth chasing down, because on its face it looks like
+a per-frame leak: concurrency was pinned at 200 for the whole hour with **zero
+call churn**, so nothing that grows can be blamed on completed calls (#458,
+fixed in 0.48.13). Five measurements, all on this hardware:
+
+| Measurement | Daemon | Result |
+|---|---|---|
+| Idle baseline, fresh process | 0.48.13 | **14.9 MB** |
+| 50 calls × 15 min, fresh | 0.48.13 | 30.2 MB (**+2.7 MB** after warm-up) |
+| 200 calls × 15 min, fresh | 0.48.13 | 60.0 MB (**+2.9 MB** after warm-up) |
+| 200 calls × 15 min, fresh | 0.48.10 | 69.0 MB (**+16.9 MB** after warm-up) |
+| 200 calls × 60 min, fresh (the soak) | 0.48.13 | 90.2 MB (**+36.8 MB**) |
+| **200 calls × 15 min into the already-loaded 90.2 MB process** | 0.48.13 | **92.4 MB (+2.2 MB)** |
+
+**It is not a leak.** The last row is the test that settles it. The soak
+daemon sat idle for ten hours at exactly 90.2 MB with zero calls, 12 fds and
+`dialogs_active = 0`. Putting a *complete second load* — another 200 calls,
+another 15 minutes, another ~9 million frames — through that same process
+grew it by **2.2 MB**, where a fresh daemon needs ~45 MB for the identical
+work. Roughly 95% of the retained memory was handed straight back to the new
+calls. The working set is bounded and reused; what RSS is showing is memory
+that is free to the program but never returned to the OS.
+
+The shape confirms it. That 90.2 MB is `RssAnon` 76.7 MB living in two mmap'd
+glibc secondary arenas (45 MB and 20.5 MB regions, nearly fully resident),
+with no `[heap]` segment at all. Growth arrives in **discrete steps** — flat
+for eight minutes, then +4 MB in sixty seconds, then flat again — with no
+correlate in daemon CPU, generator CPU, sink CPU, or system load. That is
+arena expansion under allocation churn, not a live set that grows. The tap's
+outbound queue holds one `Vec<u8>` per frame (`push_audio(bytes: Vec<u8>)`),
+so a 200-call daemon is doing on the order of 10,000 alloc/free pairs per
+second; glibc grows arena headroom to absorb it and does not trim.
+
+Two hypotheses were tested and killed:
+
+- **Metrics scraping.** An idle daemon with zero calls took 1,372 `/metrics`
+  scrapes at 4 Hz: +1.1 MB across the first ~400, then flat. The soak's 240
+  scrapes cannot produce 37 MB.
+- **The new dialog reaper** (0.48.13, #458). It only acts on retirements, and
+  during a pinned-concurrency hold there are none.
+
+### What to budget
+
+Per-call memory is **~0.2 MB/call plus ~5 MB fixed** at 15 minutes — a linear
+fit through the 50-call and 200-call arms — but the steady-state figure after
+an hour at 200 concurrent is **0.38 MB/call**. The 5-minute-per-step figures
+in `RESULTS-0.48.10.md` (~0.23 MB/call) are the *warm-up* number, and they
+understate the plateau by about 60%. Size on the plateau: ~110 MB at 250
+concurrent, which is nothing on any real box — the point is not the magnitude
+but that the smaller number is the one an operator would otherwise quote.
+
+**0.48.13 is strictly better than 0.48.10 here**, which is the opposite of
+what the soak's raw number suggests: matched fresh 15-minute arms at 200
+concurrent grew +2.9 MB against +16.9 MB and finished 9 MB lower. The bursty
+ratcheting is present in both; 0.48.10 simply happened to take one of its
+bursts inside the measurement window and 0.48.13 did not. **The soak's
++36.8 MB against 0.48.10's published +1.3 MB is not a regression** — the
+0.48.10 soak ran on a process already at 137 MB from earlier phases, whose
+allocator had ample free pool to absorb an hour of churn invisibly. Compare
+warm to warm and the numbers agree: +1.3 MB there, +2.2 MB in the reuse row
+above.
+
+### Consequences for the plan
+
+§6.1's "RSS flat within ±10 MB after a 5-minute warm-up" is not a criterion
+this daemon can meet, and failing it means nothing. The warm-up is closer to
+50 minutes than 5, and growth arrives in bursts that a short run may or may
+not catch — the two 15-minute arms above differ by 14 MB on identical work
+purely by which side of a burst they landed. Both §6.1 and §6.3 have been
+rewritten around the reuse test, which is cheap, deterministic, and actually
+distinguishes untrimmed arena from a leak.
+
+## §6.4 — degradation past the cap
+
+`max_concurrent = 250`, offered 375 (150%):
+
+| | |
+|---|---|
+| Admitted | **250** — exactly the cap |
+| Shed with `503` | **125** — exactly the excess, all logged `admission rate limit` |
+| Silently dropped | **0** |
+
+Clean shed at a known cap, identical to 0.48.10.
+
+## Not measured
+
+- **§6.2 long-call soak** (1 call, 1 hour) — not run this pass.
+- **§7.2 feature-cost deltas** — not re-run; the 0.48.10 figures stand
+  (recording +81% CPU, neural VAD +191%, HEP free).
+- **Playout SLO** — still no data source. `outbound_audio_frames_dropped_total`
+  exists in the code but is not exported unless it increments, so "zero
+  dropped" and "not instrumented" are indistinguishable. Unverified, not
+  passed — unchanged from 0.48.10.
+- **A second hour at 200 concurrent.** The plateau is inferred from the soak
+  flattening at 90.1–90.2 MB over its final six minutes, holding that value
+  for ten idle hours, and absorbing a full second load for +2.2 MB. That is
+  strong, but it is not the same as having watched hour two.
+- **Tier 2 / tier 3** — generator on its own box, TLS/SRTP, real carrier.


### PR DESCRIPTION
Tier-1 re-run of `LOAD_TEST_PLAN.md` on 0.48.13, and the memory finding it
turned up. Same box and same posture as the 0.48.10 run, so the two read side
by side. Docs only — no code touched.

## The soak passed, and it closes an old loose end

200/200 calls over the hour, all torn down on BYE, fds and threads immovable
at 612/5, MOS > 4.4 and jitter p95 ≤ 20 ms across the **129,604 samples in the
T+5 → T+59 window alone**, and the daemon logged nothing at all for the hour.

That also resolves the 0.48.10 run's one unresolved item — all 200 calls reaped
by the inactivity watchdog with late BYEs answered `481`, which left §6.1's
"only your own teardowns" criterion inconclusive. It does not recur on the
release that reclaims dialogs, which is what the `MAX_CONFIRMED_DIALOGS`
hypothesis predicted. `dialogs_active` sat at 0 after 400 cumulative calls.

## RSS grew 36.8 MB, and it is not a leak

That was the one failed criterion, and on its face it looks like the worst
kind: concurrency pinned at 200 for the whole hour with **zero call churn**, so
nothing that grows can be blamed on completed calls (#458, fixed here).

The test that settles it is re-loading a drained process. The soak daemon idled
**ten hours at exactly 90.2 MB** with zero calls, then absorbed a *complete
second* 200-call load for **+2.2 MB** — where a fresh daemon needs ~45 MB for
identical work. About 95% of the retained memory went straight back to the new
calls, so the working set is bounded and reused and what RSS reports is
free-but-untrimmed glibc arena (76.7 MB of `RssAnon` in two mmap'd secondary
arenas, no `[heap]`). Growth arrives in discrete bursts — flat eight minutes,
+4 MB in sixty seconds, flat again — with no correlate in daemon, generator,
sink, or system CPU.

**Not a regression, either.** Matched *fresh* 15-minute arms at 200 concurrent:
**+2.9 MB on 0.48.13 against +16.9 MB on 0.48.10**, finishing 9 MB lower. The
soak's +36.8 MB only looks bad against 0.48.10's published +1.3 MB because that
hour ran on a process already at 137 MB, whose allocator had free pool enough to
absorb an hour of churn invisibly. Compare warm to warm and both give ~+2 MB.

Metrics scraping (1,372 scrapes at 4 Hz on an idle daemon → +1.1 MB then flat)
and the new dialog reaper were both tested and excluded.

## So the plan changes, not the daemon

- **§6.1 drops RSS as a criterion.** "Flat within ±10 MB after a 5-minute
  warm-up" was unmeetable and meaningless: the warm-up is closer to 50 minutes,
  and two matched 15-minute runs of identical work differed by 14 MB purely on
  which side of a burst they landed.
- **§6.3 makes re-loading a drained process the first leak test** — it is what
  separates untrimmed arena from a leak, and it is a fifteen-minute test.
- **Both now say to size on the plateau** — 0.38 MB/call at 200 concurrent —
  rather than the 5-minute figure, which understates it by ~60%.

## Also in here

`RESULTS-0.48.10.md` gets a header note for the three conclusions this run
overturns: the soak RSS figure above; §5's 626 failures at 75 cps, which do not
occur with the pps cap disabled (4,500/4,500 clean), so the "generator-side, not
a bridge limit" attribution is **unconfirmed**; and §7.2's neural-VAD memory
figures, which are wrong and self-contradictory (#472).

## Not measured

§6.2 long-call soak, §7.2 re-run (0.48.10 figures stand), the Playout SLO (still
no exported data source), a literal second hour at 200 concurrent, and tier 2/3.
All called out in the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dQMvb5CqFbitwXtmieocS
