### PR TITLE
chore(release): 0.48.15 — a registrar's MWI is absorbed, not refused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.48.15] - 2026-08-12
+
 ### Fixed
 
 - **A registrar's unsolicited MWI no longer reads as a protocol fault** (issue #486). A PBX we register to pushes `NOTIFY Event: message-summary` (RFC 3842) at the account immediately after every successful REGISTER — the default for FreeSWITCH and Asterisk when the account has a mailbox — and SiphonAI answered every one with `489 Bad Event`, because `dispatch_notify` supported exactly one package (`refer`, for post-REFER progress). RFC-defensible in isolation, but it meant `siphon_ai_notify_total{result="bad_event"}` climbed at the registration refresh rate on a perfectly healthy daemon: measured on the production node at **one per minute, ~1,440/day, indefinitely** (100% of NOTIFYs received — 38 of 38 in the sampled window — were this one shape from the registrar). The counter therefore could not distinguish a healthy node from a broken one, and a genuinely unexpected event package landed in the same bucket, invisible. Same defect class as #474 in 0.48.14: there a counter that was always absent, here one that is always climbing.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3873,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.48.14"
+version = "0.48.15"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3922,7 +3922,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.48.14"
+version = "0.48.15"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3938,7 +3938,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.48.14"
+version = "0.48.15"
 dependencies = [
  "base64",
  "bytes",
@@ -3960,7 +3960,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.48.14"
+version = "0.48.15"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3977,7 +3977,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.48.14"
+version = "0.48.15"
 dependencies = [
  "regex",
  "serde",
@@ -3996,7 +3996,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.48.14"
+version = "0.48.15"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4042,7 +4042,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.48.14"
+version = "0.48.15"
 dependencies = [
  "base64",
  "hmac 0.12.1",
@@ -4065,7 +4065,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.48.14"
+version = "0.48.15"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4091,7 +4091,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.48.14"
+version = "0.48.15"
 dependencies = [
  "anyhow",
  "clap",
@@ -4109,7 +4109,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.48.14"
+version = "0.48.15"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4127,7 +4127,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.48.14"
+version = "0.48.15"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4141,7 +4141,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.48.14"
+version = "0.48.15"
 dependencies = [
  "regex",
  "serde",
@@ -4153,7 +4153,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.48.14"
+version = "0.48.15"
 dependencies = [
  "schemars",
  "serde",
@@ -4163,7 +4163,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.48.14"
+version = "0.48.15"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4191,7 +4191,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.48.14"
+version = "0.48.15"
 dependencies = [
  "base64",
  "rcgen",
@@ -4209,7 +4209,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.48.14"
+version = "0.48.15"
 dependencies = [
  "anyhow",
  "forge-engine",
@@ -4240,7 +4240,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.48.14"
+version = "0.48.15"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.48.14"
+version = "0.48.15"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.48.14.** Production-deployed against real carriers
+**Current release: v0.48.15.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged. Daemon upgrades are near-drop-in


### PR DESCRIPTION
Cuts 0.48.15 over the #486 fix merged in #487.

Patch release, drop-in over 0.48.14. Verified rather than assumed: `PROTOCOL_VERSION` still `"1"`, `CDR_VERSION` still `8`, no config-crate or schema diff since 0.48.14.

**Contents:** #486 only — a registrar's unsolicited MWI `NOTIFY` is absorbed with `200 OK` instead of refused `489`, scored under a new `siphon_ai_notify_total{result="ignored"}` label.

**Operator impact.** `bad_event` should now sit at zero and is finally alertable; anyone with a rule keyed on it being non-zero was firing on healthy traffic before this release. The new `ignored` label will track the REGISTER rate one-for-one on a registered node, which is expected. `Allow-Events` still advertises `refer` alone.

**Verification on the release commit:** `cargo test --workspace` 1,150 passed / 0 failed across 57 binaries; `cargo fmt --all --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean; `check-version-consistency.py --tag v0.48.15` and `extract-changelog.py 0.48.15` both resolve.

Same four-file shape as every prior release commit (CHANGELOG heading, Cargo.toml, Cargo.lock, README). After merge I'll tag `v0.48.15`, which drives the deb build.