### PR TITLE
fix(core): log the session-refresh period instead of describing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The outbound session-timer arming log no longer describes a cadence it does not use.** It read *"we refresh at half the interval"*, which #490 made wrong in the same release that shipped it — refreshes run a five-second guard ahead of the half-way point. It now logs `refresh_period_secs`, computed by the same function the loop schedules from, so the line cannot drift from the code again; the prose says "we refresh on that period" and the two branches (we-refresh vs callee-refreshes) are split so only the relevant one carries the field. `docs/CONFIG.md` and `docs/DEPLOY.md` were already corrected in #490 — this was the one place left saying the old thing, and the tense of `reserve_cseq`'s doc comment is fixed with it.
+
 ## [0.48.16] - 2026-08-13
 
 ### Fixed

--- a/crates/core/src/outbound_service.rs
+++ b/crates/core/src/outbound_service.rs
@@ -846,17 +846,30 @@ async fn run_call(
             let expires = std::time::Duration::from_secs(u64::from(negotiated.delta_seconds()));
             timers.arm(dialog_id.clone(), expires, cleanup_handle.clone());
             let we_refresh = negotiated.refresher() == Some(sip_core::RefresherRole::Uac);
-            info!(
-                session_expires_secs = negotiated.delta_seconds(),
-                refresher = ?negotiated.refresher(),
-                we_refresh,
-                "armed RFC 4028 expiry on outbound leg; {}",
-                if we_refresh {
-                    "we refresh at half the interval and this is the backstop if that fails"
-                } else {
-                    "the callee refreshes and the call ends at this deadline if it stops"
-                }
-            );
+            // Log the cadence we will actually use rather than a phrase
+            // describing it: this line claimed "half the interval" for a
+            // release after #490's guard made it `se/2` less five
+            // seconds. A computed field cannot drift from the code that
+            // computes it.
+            if we_refresh {
+                info!(
+                    session_expires_secs = negotiated.delta_seconds(),
+                    refresher = ?negotiated.refresher(),
+                    we_refresh,
+                    refresh_period_secs =
+                        session_refresh_period(negotiated.delta_seconds()).as_secs(),
+                    "armed RFC 4028 expiry on outbound leg; we refresh on that period and this \
+                     is the backstop if that fails"
+                );
+            } else {
+                info!(
+                    session_expires_secs = negotiated.delta_seconds(),
+                    refresher = ?negotiated.refresher(),
+                    we_refresh,
+                    "armed RFC 4028 expiry on outbound leg; the callee refreshes and the call \
+                     ends at this deadline if it stops"
+                );
+            }
             Some((timers.clone(), dialog_id))
         }
         _ => None,

--- a/crates/core/src/transfer.rs
+++ b/crates/core/src/transfer.rs
@@ -112,11 +112,13 @@ impl DialogSource {
     /// the response, so between send and answer the shared dialog still
     /// reads the *pre-request* number, and anything else on this leg
     /// picks it up. The teardown BYE did exactly that: the RFC 4028
-    /// refresh loop ticks at `Session-Expires/2` while the armed expiry
-    /// sits at `Session-Expires`, so on a leg whose refreshes are being
-    /// rejected the tick and the expiry fire together — measured 564 µs
+    /// refresh loop ticked at `Session-Expires/2` while the armed expiry
+    /// sat at `Session-Expires`, so on a leg whose refreshes were being
+    /// rejected the tick and the expiry fired together — measured 564 µs
     /// apart — and the BYE went out carrying the in-flight re-INVITE's
-    /// CSeq. A peer entitled to reject that BYE leaves the leg, and its
+    /// CSeq. (`SESSION_REFRESH_GUARD` has since pulled the ticks clear
+    /// of the deadline; this reservation is what keeps the sequence
+    /// correct whenever two requests do overlap.) A peer entitled to reject that BYE leaves the leg, and its
     /// billing, up at the far end: the leak #480 armed the expiry to
     /// close.
     ///


### PR DESCRIPTION
Follow-up to #491 — drift I introduced there and missed.

The arming line read *"we refresh at half the interval"*. #490 made that false in the same release that shipped it (refreshes run a five-second guard ahead of the half-way point), and `docs/CONFIG.md` + `docs/DEPLOY.md` were corrected while this string was not. On a 90 s timer an operator reading the log expected a refresh at t+45 and got one at t+40.

It now logs **`refresh_period_secs`**, taken from `session_refresh_period` — the same function the loop schedules from — so the line cannot drift from the code that decides it:

```
INFO armed RFC 4028 expiry on outbound leg; we refresh on that period and this is the backstop
     if that fails session_expires_secs=90 refresher=Some(Uac) we_refresh=true refresh_period_secs=40
```

The two branches are split so only the one that refreshes carries the field — an `Option` rendered `Some(40)`, or a `0` standing in for "not applicable", would both be worse than not emitting it.

`reserve_cseq`'s doc comment described the old cadence in the present tense; it moves to the past and points at `SESSION_REFRESH_GUARD` for what stops the collision recurring, leaving the reservation as what keeps the sequence correct whenever two requests *do* overlap.

Verified live on the lab (output above is the real line). `cargo test --workspace` 1,161 passed / 0 failed; fmt, clippy `-D warnings`, `check-doc-links.py`, `check-version-consistency.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuXzTkYKhVaVaSwuYu314J
