### PR TITLE
chore(deps): bump siphon-rs to 9f70b83011f2 — the session refresh reserves its CSeq before sending

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3644,7 +3644,7 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 [[package]]
 name = "sip-auth"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9f5a3bf66f2#b9f5a3bf66f2c64a059e3467bf5eac8c618f4b81"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=9f70b83011f2#9f70b83011f24bfa151df53d835f317389a02b4a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3667,7 +3667,7 @@ dependencies = [
 [[package]]
 name = "sip-core"
 version = "0.7.6"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9f5a3bf66f2#b9f5a3bf66f2c64a059e3467bf5eac8c618f4b81"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=9f70b83011f2#9f70b83011f24bfa151df53d835f317389a02b4a"
 dependencies = [
  "bytes",
  "httpdate",
@@ -3680,7 +3680,7 @@ dependencies = [
 [[package]]
 name = "sip-dialog"
 version = "0.3.3"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9f5a3bf66f2#b9f5a3bf66f2c64a059e3467bf5eac8c618f4b81"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=9f70b83011f2#9f70b83011f24bfa151df53d835f317389a02b4a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3698,7 +3698,7 @@ dependencies = [
 [[package]]
 name = "sip-dns"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9f5a3bf66f2#b9f5a3bf66f2c64a059e3467bf5eac8c618f4b81"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=9f70b83011f2#9f70b83011f24bfa151df53d835f317389a02b4a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3712,7 +3712,7 @@ dependencies = [
 [[package]]
 name = "sip-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9f5a3bf66f2#b9f5a3bf66f2c64a059e3467bf5eac8c618f4b81"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=9f70b83011f2#9f70b83011f24bfa151df53d835f317389a02b4a"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -3723,7 +3723,7 @@ dependencies = [
 [[package]]
 name = "sip-identity"
 version = "0.1.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9f5a3bf66f2#b9f5a3bf66f2c64a059e3467bf5eac8c618f4b81"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=9f70b83011f2#9f70b83011f24bfa151df53d835f317389a02b4a"
 dependencies = [
  "base64",
  "ring",
@@ -3736,7 +3736,7 @@ dependencies = [
 [[package]]
 name = "sip-observe"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9f5a3bf66f2#b9f5a3bf66f2c64a059e3467bf5eac8c618f4b81"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=9f70b83011f2#9f70b83011f24bfa151df53d835f317389a02b4a"
 dependencies = [
  "once_cell",
  "tracing",
@@ -3745,7 +3745,7 @@ dependencies = [
 [[package]]
 name = "sip-parse"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9f5a3bf66f2#b9f5a3bf66f2c64a059e3467bf5eac8c618f4b81"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=9f70b83011f2#9f70b83011f24bfa151df53d835f317389a02b4a"
 dependencies = [
  "bytes",
  "httpdate",
@@ -3759,12 +3759,21 @@ dependencies = [
 [[package]]
 name = "sip-ratelimit"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9f5a3bf66f2#b9f5a3bf66f2c64a059e3467bf5eac8c618f4b81"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=9f70b83011f2#9f70b83011f24bfa151df53d835f317389a02b4a"
 dependencies = [
  "dashmap 5.5.3",
  "parking_lot",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "sip-sdp"
+version = "0.3.0"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=9f70b83011f2#9f70b83011f24bfa151df53d835f317389a02b4a"
+dependencies = [
+ "nom 7.1.3",
+ "smol_str",
 ]
 
 [[package]]
@@ -3777,18 +3786,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "sip-sdp"
-version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9f5a3bf66f2#b9f5a3bf66f2c64a059e3467bf5eac8c618f4b81"
-dependencies = [
- "nom 7.1.3",
- "smol_str",
-]
-
-[[package]]
 name = "sip-transaction"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9f5a3bf66f2#b9f5a3bf66f2c64a059e3467bf5eac8c618f4b81"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=9f70b83011f2#9f70b83011f24bfa151df53d835f317389a02b4a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3807,7 +3807,7 @@ dependencies = [
 [[package]]
 name = "sip-transport"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9f5a3bf66f2#b9f5a3bf66f2c64a059e3467bf5eac8c618f4b81"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=9f70b83011f2#9f70b83011f24bfa151df53d835f317389a02b4a"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3828,7 +3828,7 @@ dependencies = [
 [[package]]
 name = "sip-uac"
 version = "0.4.2"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9f5a3bf66f2#b9f5a3bf66f2c64a059e3467bf5eac8c618f4b81"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=9f70b83011f2#9f70b83011f24bfa151df53d835f317389a02b4a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3841,7 +3841,7 @@ dependencies = [
  "sip-dialog",
  "sip-dns",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=b9f5a3bf66f2)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=9f70b83011f2)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -3853,7 +3853,7 @@ dependencies = [
 [[package]]
 name = "sip-uas"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=b9f5a3bf66f2#b9f5a3bf66f2c64a059e3467bf5eac8c618f4b81"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=9f70b83011f2#9f70b83011f24bfa151df53d835f317389a02b4a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3863,7 +3863,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=b9f5a3bf66f2)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=9f70b83011f2)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -4016,7 +4016,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=b9f5a3bf66f2)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=9f70b83011f2)",
  "sip-transaction",
  "sip-uac",
  "sip-uas",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,22 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 # main branch and replace the rev hashes here (see CLAUDE.md §7.5).
 
 # siphon-rs — RFC 3261 SIP stack.
-# Bumped 2026-08-12 `b71a75f1eacf` → `b9f5a3bf66f2` = siphon-rs #96 (the UAC
+# Bumped 2026-08-13 `b9f5a3bf66f2` → `9f70b83011f2` = siphon-rs #100: the UAC
+# session refresh reserves the CSeq it consumes *before* the request leaves,
+# instead of committing it after the response (siphon-rs #99, filed from this
+# project's #490). Upstream's window was ours: for a whole round trip the
+# shared dialog still read the pre-request number, so an owner request that
+# raced the refresh — a teardown BYE, a hold re-INVITE, a REFER — reused it.
+# `start_session_timer` had documented that as unclosable at that layer, on
+# the reasoning that the alternative was serialising behind the dialog's write
+# lock across a ~32 s round trip; reserving holds it for two clones and an
+# increment instead.
+# Changes nothing on the wire for 0.48.16: nothing here calls
+# `CallHandle::start_session_timer`, and our own legs are already covered by
+# `DialogSource::reserve_cseq` (#491), which does the same thing on the
+# `shared_dialog` upstream never touches. It removes the last reason not to
+# adopt the upstream timer, which is what #484 is now gated on.
+# (Prior: 2026-08-12 `b71a75f1eacf` → `b9f5a3bf66f2` = siphon-rs #96 (the UAC
 # session timer refreshes the caller's own dialog rather than a private clone,
 # siphon-rs #95) + #98 (a doomed refresh loop stops and says so, via a new
 # `CallHandle::session_timer_state()` watch channel, siphon-rs #93).
@@ -138,7 +153,7 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 # `CallHandle::start_session_timer` — our outbound refresh drives
 # `DialogControl` directly (see `core/src/outbound_service.rs`) — so both land
 # as a correctness floor under any future switch to the upstream timer, not as
-# a change to what 0.48.14 does on the wire.
+# a change to what 0.48.14 does on the wire.)
 # (Prior: 2026-08-12 `9ae6ce2cee5a` → `b71a75f1eacf` = siphon-rs #91 (per-source
 #  rate-limit warning throttle, our #90) + #94 (session refresh at se/2, our
 #  #92).)
@@ -172,31 +187,31 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 #  `6fd432270bb8` = #67 dialog_manager share, siphon-ai #324;
 #  `fcaff011f9c6` = #65 invite_with_from, siphon-ai #316;
 #  `3a4fc312ade3` = #64 TLS-SNI-is-hostname, siphon-ai #312.)
-sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9f5a3bf66f2" }
-sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9f5a3bf66f2" }
-sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9f5a3bf66f2", features = ["tls"] }
-sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9f5a3bf66f2" }
-sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9f5a3bf66f2" }
-sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9f5a3bf66f2" }
-sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9f5a3bf66f2" }
-sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9f5a3bf66f2" }
-sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9f5a3bf66f2" }
+sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "9f70b83011f2" }
+sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "9f70b83011f2" }
+sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "9f70b83011f2", features = ["tls"] }
+sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "9f70b83011f2" }
+sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "9f70b83011f2" }
+sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "9f70b83011f2" }
+sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "9f70b83011f2" }
+sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "9f70b83011f2" }
+sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "9f70b83011f2" }
 # sip-sdp — the SAME sip-sdp sip-uac's SdpAnswerGenerator trait speaks
 # (distinct from forge-media's pinned sip-sdp). Used by the outbound
 # delayed-offer answer generator to hand the UAC a SessionDescription it
 # accepts. Must stay on the same siphon-rs rev as the rest below.
-sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9f5a3bf66f2" }
-sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9f5a3bf66f2" }
+sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "9f70b83011f2" }
+sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "9f70b83011f2" }
 # sip-observe — the transport-layer observability seam. We implement its
 # `TransportMetrics` trait in siphon-ai-telemetry and install it with
 # `set_transport_metrics`, which is the only way to see ingress
 # rate-limit drops: the hook is defaulted to a no-op upstream, so an
 # embedder that installs nothing (as we did until 0.48.11) silently gets
 # the `NoopTransportMetrics` fallback (siphon-ai #459).
-sip-observe     = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9f5a3bf66f2" }
+sip-observe     = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "9f70b83011f2" }
 # sip-identity — STIR/SHAKEN Identity-header parsing + PASSporT verification
 # (ES256 + X.509 chain validation). Consumed by the stir-shaken verifier crate.
-sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "b9f5a3bf66f2" }
+sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "9f70b83011f2" }
 
 # forge-media — RTP / codecs / SDP / DTMF / engine.
 #


### PR DESCRIPTION
Picks up [siphon-rs#100](https://github.com/thevoiceguy/siphon-rs/pull/100) (its issue #99), which this project filed from #490.

Upstream's refresh had the window we removed from ours: `refresh_shared_session` cloned the dialog under a read lock, sent, and committed the advance only *after* the response — so for a whole round trip the shared dialog still read the pre-request CSeq, and an owner request racing it (teardown BYE, hold re-INVITE, REFER) reused that number. `start_session_timer` had documented it as unclosable at that layer, on the reasoning that the alternative was serialising behind the dialog's write lock across a ~32 s round trip. Reserving is the third option: hold the lock for two clones and an increment, publish the number before the request leaves.

**Nothing changes on the wire here.** Nothing in this daemon calls `CallHandle::start_session_timer`, and our own outbound legs were already fixed by `DialogSource::reserve_cseq` (#491) on the `shared_dialog` upstream never touches. What the bump buys is removing the last reason not to adopt the upstream timer — the gate #484 now names.

## Verification (CLAUDE.md §7.5)

| | |
|---|---|
| `cargo test --workspace` | **1,161 passed / 0 failed** |
| SIPp signalling regression | **37 of 38** — the documented local baseline; only `barge_in_pause`, which needs a `setcap cap_net_raw+ep` this box doesn't grant and which passes in CI |
| Glue changes | **none** — the fix is internal to `refresh_shared_session`; no signature this daemon calls moved |
| fmt / clippy | clean (`--all-targets -- -D warnings`) |
| HEP-collector-stub tests | **do not exist** — `test-harness/hep-collector-stub/` holds only a `.gitkeep`, as it did at the last two bumps. §7.5 asks for a suite that was never written |

Plus the #490 repro re-run against the bumped build, on the lab that produced the original collision:

```
19:04:47  WARN session refresh rejected … code=500 cseq=Some(2) consecutive=1   (t+40)
          INVITE … CSeq: 3 INVITE                                              (t+80, in flight)
19:05:37  INFO RFC 4028 session expired; tearing down call                     (t+90.0)
          BYE … CSeq: 4 BYE
```

CDR `local_shutdown`, `duration_ms` 90008. Unchanged from 0.48.16, as expected — our reservation, not upstream's, is what covers that path today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuXzTkYKhVaVaSwuYu314J
