### PR TITLE
chore(release): 0.48.18 — an ACK the transaction already absorbed no longer reaches the UAS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.48.18] - 2026-08-14
+
 ### Changed
 
 - **Bumped siphon-rs `9f70b83011f2` → `9ad33983b0e9`** — [siphon-rs#102](https://github.com/thevoiceguy/siphon-rs/pull/102) (its issue #101, filed from this project): `TransactionManager::ack_received` now returns whether it **absorbed** the ACK. It used to return `()` and no-op on a miss, hiding the one distinction RFC 3261 §17.2.1 draws — an ACK for a non-2xx final belongs to the completed INVITE server transaction alone, while an ACK for a 2xx is end-to-end and only the transaction user can handle it. The FSM already knew which was which (`send_final` terminates the server transaction on a 2xx and leaves it `Completed` on a non-2xx, so "matched an entry" is exactly "ACK to a non-2xx") and simply did not say so. Source-compatible and not `#[must_use]`, so the signal is opt-in; this release opts in — see the `Fixed` entry below. Verified per CLAUDE.md §7.5: workspace suite green, SIPp signalling suite re-run, no glue changes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3873,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.48.17"
+version = "0.48.18"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3922,7 +3922,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.48.17"
+version = "0.48.18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3938,7 +3938,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.48.17"
+version = "0.48.18"
 dependencies = [
  "base64",
  "bytes",
@@ -3960,7 +3960,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.48.17"
+version = "0.48.18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3977,7 +3977,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.48.17"
+version = "0.48.18"
 dependencies = [
  "regex",
  "serde",
@@ -3996,7 +3996,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.48.17"
+version = "0.48.18"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4042,7 +4042,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.48.17"
+version = "0.48.18"
 dependencies = [
  "base64",
  "hmac 0.12.1",
@@ -4065,7 +4065,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.48.17"
+version = "0.48.18"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4091,7 +4091,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.48.17"
+version = "0.48.18"
 dependencies = [
  "anyhow",
  "clap",
@@ -4109,7 +4109,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.48.17"
+version = "0.48.18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4127,7 +4127,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.48.17"
+version = "0.48.18"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4141,7 +4141,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.48.17"
+version = "0.48.18"
 dependencies = [
  "regex",
  "serde",
@@ -4153,7 +4153,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.48.17"
+version = "0.48.18"
 dependencies = [
  "schemars",
  "serde",
@@ -4163,7 +4163,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.48.17"
+version = "0.48.18"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4191,7 +4191,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.48.17"
+version = "0.48.18"
 dependencies = [
  "base64",
  "rcgen",
@@ -4209,7 +4209,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.48.17"
+version = "0.48.18"
 dependencies = [
  "anyhow",
  "forge-engine",
@@ -4240,7 +4240,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.48.17"
+version = "0.48.18"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.48.17"
+version = "0.48.18"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.48.17.** Production-deployed against real carriers
+**Current release: v0.48.18.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged. Daemon upgrades are near-drop-in


### PR DESCRIPTION
Patch release, drop-in over 0.48.17: WS protocol stays version `"1"`, CDR schema stays v8, no config changes, no behaviour change on any call.

| | |
|---|---|
| **#500** | The packet pump stops dispatching ACKs the INVITE server transaction has already absorbed. An ACK acknowledging a non-2xx final is hop-by-hop (RFC 3261 §17.2.1); dispatching it reached a dialog lookup that could not match and logged `Received ACK for unknown dialog` once per rejected INVITE. |
| **deps** | siphon-rs `9f70b83011f2` → `9ad33983b0e9` ([siphon-rs#102](https://github.com/thevoiceguy/siphon-rs/pull/102), its issue #101 filed from here) — `TransactionManager::ack_received` now returns whether it absorbed the ACK. That is the signal the pump had been missing. |

## Read this only if you watch the daemon's WARN stream

0.48.17 made `missing_sdp_answer` reachable (#497) by dispatching **every** ACK, because the pump had no way to keep the delayed-offer ACK it needed while dropping the ones it did not. The side effect shipped with it: an ACK acknowledging a non-2xx final — already absorbed by the completed INVITE server transaction — was handed to the UAS anyway, matched no dialog, and logged a `WARN`. On a public listener that is one per scanner INVITE rejected with a `403` and then ACKed: **~0.5/min (~660/day)** on the reference node, against one in the whole preceding week.

- **That `WARN` stops appearing**, and the daemon stops taking a dialog-manager lock and spawning a task for each such packet.
- **Nothing else moves.** No metric, CDR field, protocol message or config key changes.
- **No call ever behaved differently.** `ack_received` was called before dispatch throughout, so absorption and retransmission-timer clearing were untouched the whole time.
- If you built an alert on that log line it will go quiet. It was never actionable.

The fix is the RFC's own layering rather than a log level — `warn!`→`debug!` would have hidden the symptom while still doing the lookup and the spawn.

The delayed-offer path is unchanged and still covered: a 2xx terminates the server transaction as it is sent, so its ACK is never absorbed and still reaches `on_ack`, body or not.

## Checks

`cargo test --workspace` 1,161 / 0 · fmt · clippy `-D warnings` · `check-version-consistency.py` · `check-doc-links.py` · `check-observability-metrics.py` — all clean. SIPp signalling suite **39/40** locally (only `barge_in_pause`, which needs a `setcap` this box does not grant) and green in CI. The new `rejected_invite_ack` phase guards the regression and was verified to fail against the shipped 0.48.17 binary.

After merge: `git tag -a v0.48.18 && git push origin v0.48.18`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Dugo4krkhibhqb6jSfUCV
