### PR TITLE
test(core): check the controller's exit in hold_resume instead of discarding it

### DIFF
--- a/crates/core/tests/hold_resume.rs
+++ b/crates/core/tests/hold_resume.rs
@@ -148,6 +148,18 @@ async fn push_bridge_event_emits_hold_and_resume_on_ws() {
     assert_eq!(resume["type"], "resume");
 
     // 4. Drive cleanup so the controller exits.
+    //
+    // Each layer is checked rather than discarded. `let _ = …` here hid
+    // three distinct failures behind a passing test: a timeout (the
+    // controller ignored `shutdown()`), a `JoinError` (it panicked on
+    // the way out), and an `Err` return (it exited reporting failure).
+    // The assertions above would all still have passed through any of
+    // them, since they only read events the controller had already
+    // emitted. Same idiom as `registry_bye`.
     handle.shutdown();
-    let _ = tokio::time::timeout(Duration::from_secs(3), run).await;
+    tokio::time::timeout(Duration::from_secs(3), run)
+        .await
+        .expect("controller exits after shutdown()")
+        .expect("task didn't panic")
+        .expect("controller returns Ok");
 }


### PR DESCRIPTION
Follow-up to #502, closing the one loose end that PR flagged.

`push_bridge_event_emits_hold_and_resume_on_ws` ended with:

```rust
let _ = tokio::time::timeout(Duration::from_secs(3), run).await;
```

That discarded three distinct failures: a **timeout** (the controller ignored `shutdown()`), a **`JoinError`** (it panicked on the way out), and an **`Err` return** (it exited reporting failure).

None of the assertions above that line would have caught any of them — they only read events the controller had already emitted, so the test's verdict was entirely independent of whether the controller shut down at all.

Now checked at each layer, using the idiom `registry_bye` already uses.

## Demonstrated, not asserted

By commenting out the `handle.shutdown()` the test depends on:

| | result |
|---|---|
| old code, no `shutdown()` | **passes** — and silently burns the full 3 s timeout |
| new code, no `shutdown()` | **FAILS** — `controller exits after shutdown(): Elapsed(())` |
| new code, unmodified | passes in 0.05 s |

The **3.05 s vs 0.05 s** runtime was the visible tell that something was being swallowed.

## Scope

This is a different defect from #502's. There, assertions lived *inside* a spawned handler whose `JoinHandle` was dropped, so they could never fail. Here the assertions were always live — it was the controller's own exit that went unchecked.

The other four test files in this crate were checked and need no change: they spawn assertion-free helpers that report over channels and assert in the test body.

## Checks

`cargo test --workspace` 1,161 / 0 · fmt · clippy `-D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Dugo4krkhibhqb6jSfUCV
