### PR TITLE
chore(deps): bump forge-media to 1d7bbaba0c22 — a port bind that loses a race retries instead of failing the call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Bumped forge-media `b4f8df5c8f09` → `1d7bbaba0c22`** — [forge-media#112](https://github.com/thevoiceguy/forge-media/pull/112) (its issue #111, filed from this project's #504): a port bind that hits `AddrInUse` now **retries the next pair instead of failing the session**. `PortPool` allocates from its own bookkeeping and binds later, so a port it believes free can be held by a socket outside the process — `[media].rtp_port_range` sits inside the kernel's ephemeral range (`net.ipv4.ip_local_port_range`, commonly 32768–60999), and a DNS lookup by anything on the host is enough to take one. Here that surfaced as a `500 Server Internal Error` on an inbound INVITE, measured at **one call in 399** during the 0.48.18 soak. Upstream splits `ForgeError::AddrInUse(SocketAddr)` out of `Network(String)` — so the retry keys off a type rather than message text — and draws up to five pairs, logging a `warn!` with the address each time it steps past one.
+  - **No code change here and nothing to configure.** Nothing in this workspace matches on `ForgeError`, so the new variant is purely additive. Operators get the fix by upgrading.
+  - **The `net.ipv4.ip_local_reserved_ports` guidance in `docs/DEPLOY.md` stays correct and is still worth applying.** This removes the *requirement* to reserve the range, not the value of doing so: a reserved range means the retry never has to fire, and a `warn!` that does fire is still telling you something real about the host. The docs are left as they are for that reason.
+  - Verified per CLAUDE.md §7.5: workspace suite 1,161 passed / 0 failed, fmt, clippy `-D warnings`, all three check scripts, and the SIPp signalling suite re-run. No glue changes.
+
 ## [0.48.18] - 2026-08-14
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,7 +1028,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "forge-codecs"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=b4f8df5c8f09#b4f8df5c8f09dedcc86f39a700304b1c19a6f167"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=1d7bbaba0c22#1d7bbaba0c223d9686c3ae42595c13f2b409a980"
 dependencies = [
  "audiopus",
  "ezk-g722",
@@ -1040,7 +1040,7 @@ dependencies = [
 [[package]]
 name = "forge-core"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=b4f8df5c8f09#b4f8df5c8f09dedcc86f39a700304b1c19a6f167"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=1d7bbaba0c22#1d7bbaba0c223d9686c3ae42595c13f2b409a980"
 dependencies = [
  "chrono",
  "serde",
@@ -1055,7 +1055,7 @@ dependencies = [
 [[package]]
 name = "forge-dtmf"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=b4f8df5c8f09#b4f8df5c8f09dedcc86f39a700304b1c19a6f167"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=1d7bbaba0c22#1d7bbaba0c223d9686c3ae42595c13f2b409a980"
 dependencies = [
  "chrono",
  "forge-core",
@@ -1067,7 +1067,7 @@ dependencies = [
 [[package]]
 name = "forge-engine"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=b4f8df5c8f09#b4f8df5c8f09dedcc86f39a700304b1c19a6f167"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=1d7bbaba0c22#1d7bbaba0c223d9686c3ae42595c13f2b409a980"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1097,7 +1097,7 @@ dependencies = [
 [[package]]
 name = "forge-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=b4f8df5c8f09#b4f8df5c8f09dedcc86f39a700304b1c19a6f167"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=1d7bbaba0c22#1d7bbaba0c223d9686c3ae42595c13f2b409a980"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -1110,7 +1110,7 @@ dependencies = [
 [[package]]
 name = "forge-injection"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=b4f8df5c8f09#b4f8df5c8f09dedcc86f39a700304b1c19a6f167"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=1d7bbaba0c22#1d7bbaba0c223d9686c3ae42595c13f2b409a980"
 dependencies = [
  "forge-core",
  "rubato",
@@ -1123,7 +1123,7 @@ dependencies = [
 [[package]]
 name = "forge-mixer"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=b4f8df5c8f09#b4f8df5c8f09dedcc86f39a700304b1c19a6f167"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=1d7bbaba0c22#1d7bbaba0c223d9686c3ae42595c13f2b409a980"
 dependencies = [
  "bytes",
  "dashmap 6.2.1",
@@ -1137,7 +1137,7 @@ dependencies = [
 [[package]]
 name = "forge-recorder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=b4f8df5c8f09#b4f8df5c8f09dedcc86f39a700304b1c19a6f167"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=1d7bbaba0c22#1d7bbaba0c223d9686c3ae42595c13f2b409a980"
 dependencies = [
  "bytes",
  "forge-core",
@@ -1151,7 +1151,7 @@ dependencies = [
 [[package]]
 name = "forge-resampler"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=b4f8df5c8f09#b4f8df5c8f09dedcc86f39a700304b1c19a6f167"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=1d7bbaba0c22#1d7bbaba0c223d9686c3ae42595c13f2b409a980"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -1160,7 +1160,7 @@ dependencies = [
 [[package]]
 name = "forge-rtp"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=b4f8df5c8f09#b4f8df5c8f09dedcc86f39a700304b1c19a6f167"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=1d7bbaba0c22#1d7bbaba0c223d9686c3ae42595c13f2b409a980"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm 0.11.0",
@@ -1185,14 +1185,14 @@ dependencies = [
 [[package]]
 name = "forge-sdp"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=b4f8df5c8f09#b4f8df5c8f09dedcc86f39a700304b1c19a6f167"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=1d7bbaba0c22#1d7bbaba0c223d9686c3ae42595c13f2b409a980"
 dependencies = [
  "base64",
  "chrono",
  "forge-core",
  "forge-rtp",
  "rand 0.10.1",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=b4f8df5c8f09)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=1d7bbaba0c22)",
  "smol_str",
  "thiserror 2.0.18",
 ]
@@ -1200,7 +1200,7 @@ dependencies = [
 [[package]]
 name = "forge-transcoder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=b4f8df5c8f09#b4f8df5c8f09dedcc86f39a700304b1c19a6f167"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=1d7bbaba0c22#1d7bbaba0c223d9686c3ae42595c13f2b409a980"
 dependencies = [
  "bytes",
  "forge-codecs",
@@ -1213,7 +1213,7 @@ dependencies = [
 [[package]]
 name = "forge-vad"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=b4f8df5c8f09#b4f8df5c8f09dedcc86f39a700304b1c19a6f167"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=1d7bbaba0c22#1d7bbaba0c223d9686c3ae42595c13f2b409a980"
 dependencies = [
  "thiserror 2.0.18",
  "tract-onnx",
@@ -3770,7 +3770,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=9ad33983b0e9#9ad33983b0e9c5d0bd4e94bb89c46038d39b6d16"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=1d7bbaba0c22#1d7bbaba0c223d9686c3ae42595c13f2b409a980"
 dependencies = [
  "nom 7.1.3",
  "smol_str",
@@ -3779,7 +3779,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=b4f8df5c8f09#b4f8df5c8f09dedcc86f39a700304b1c19a6f167"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=9ad33983b0e9#9ad33983b0e9c5d0bd4e94bb89c46038d39b6d16"
 dependencies = [
  "nom 7.1.3",
  "smol_str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -232,7 +232,22 @@ sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "9ad
 # AI logic belongs in the WS server, never here. See CLAUDE.md §4.1 and the
 # upstream gate at https://github.com/thevoiceguy/forge-media/pull/39.
 #
-# forge-media is pinned to a `main` rev. Bumped 2026-08-07 to b4f8df5c8f09
+# forge-media is pinned to a `main` rev. Bumped 2026-08-14 to 1d7bbaba0c22
+# = forge-media #112 (its issue #111, filed from this project's #504): a
+# port bind that hits AddrInUse now retries the next pair instead of
+# failing the session. `PortPool` allocates from its own bookkeeping and
+# binds later, so a port it believes free can be held by a socket outside
+# the process — our `rtp_port_range` sits inside the kernel's ephemeral
+# range, and a DNS lookup by anything on the host is enough to take one.
+# That surfaced here as a `500 Server Internal Error` on an inbound INVITE,
+# measured at one call in 399 during the 0.48.18 soak. Upstream now splits
+# `ForgeError::AddrInUse(SocketAddr)` out of `Network(String)` and draws up
+# to five pairs. **Additive for us**: nothing in this workspace matches on
+# `ForgeError`, so the new variant changes no code here.
+# The `net.ipv4.ip_local_reserved_ports` guidance in docs/DEPLOY.md stays
+# correct and is still worth applying — this removes the *requirement*,
+# not the value, of reserving the range.
+# (Prior: 2026-08-07 to b4f8df5c8f09
 # = forge-media #102 + #104 + #105 (plus dependabot bumps #88/#89/#91/#99).
 # #102: every facade metric family gets describe_*! HELP text and every
 # histogram explicit buckets (forge's sibling of siphon-ai #432); six
@@ -244,7 +259,7 @@ sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "9ad
 # #105: forge_rtcp_sender_{packets,bytes}_total now count SR deltas per
 # SSRC instead of summing running totals. `metrics` facade stays 0.24 on
 # both sides (must move in lockstep with our exporter — see v0.31.1 note).
-# external/siphon-rs submodule unchanged (74b903b).
+# external/siphon-rs submodule unchanged (74b903b).)
 #
 # Prior pin: bumped 2026-07-30 to aeae479b391d
 # = forge-media #100: external/siphon-rs submodule f3454c7 → 74b903b, which
@@ -285,20 +300,20 @@ sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "9ad
 # comment for the current rev.) Prior forge pins: forge 1c996ae5fb4f = #86
 # neural VAD; forge 3c59b5f6e464 = #82-#85 dependency migrations; forge
 # 5fa76fb38675 = #81.
-forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "b4f8df5c8f09" }
-forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "b4f8df5c8f09" }
-forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "b4f8df5c8f09", default-features = false, features = ["g722", "dtls", "opus", "neural-vad"] }
-forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "b4f8df5c8f09" }
-forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "b4f8df5c8f09" }
-forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "b4f8df5c8f09" }
-forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "b4f8df5c8f09" }
-forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "b4f8df5c8f09" }
+forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "1d7bbaba0c22" }
+forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "1d7bbaba0c22" }
+forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "1d7bbaba0c22", default-features = false, features = ["g722", "dtls", "opus", "neural-vad"] }
+forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "1d7bbaba0c22" }
+forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "1d7bbaba0c22" }
+forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "1d7bbaba0c22" }
+forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "1d7bbaba0c22" }
+forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "1d7bbaba0c22" }
 # Conference rooms (0.7.0): forge-mixer is the per-room AudioMixer;
 # forge-injection provides ToneGenerator (join/leave tones now, MOH
 # for park later). Deliberately NOT forge-conference — its DTMF
 # IVR/PIN/host-control layer is unused per DEV_PLAN_0.7.0.md §9.4.
-forge-mixer     = { git = "https://github.com/thevoiceguy/forge-media", rev = "b4f8df5c8f09" }
-forge-injection = { git = "https://github.com/thevoiceguy/forge-media", rev = "b4f8df5c8f09" }
+forge-mixer     = { git = "https://github.com/thevoiceguy/forge-media", rev = "1d7bbaba0c22" }
+forge-injection = { git = "https://github.com/thevoiceguy/forge-media", rev = "1d7bbaba0c22" }
 
 # hep-rs — HEP3 codec, transport, HepSink trait. Owned by the same
 # author as siphon-rs and forge-media; lives in its own repo.


### PR DESCRIPTION
Brings in [forge-media#112](https://github.com/thevoiceguy/forge-media/pull/112) (its issue #111, filed from this project's #504) — the fix that makes the operator's sysctl optional rather than required.

## What upstream changed

`PortPool` allocates from **its own bookkeeping** and binds later, so a port it believes free can be held by a socket outside the process. `[media].rtp_port_range` sits inside the kernel's ephemeral range (`net.ipv4.ip_local_port_range`, commonly 32768–60999), and a DNS lookup by anything on the host is enough to take one. Here that surfaced as a `500 Server Internal Error` on an inbound INVITE — **one call in 399** during the 0.48.18 soak, scaling with the host's ephemeral UDP traffic rather than with call volume.

Upstream now splits `ForgeError::AddrInUse(SocketAddr)` out of `Network(String)` — so the retry keys off a **type** rather than message text — and draws up to five pairs before giving up, logging a `warn!` with the address each time it steps past one.

## What changes here

**Nothing, and nothing to configure.** No code in this workspace matches on `ForgeError`, so the new variant is purely additive. Operators get the fix by upgrading.

**The `net.ipv4.ip_local_reserved_ports` guidance in `docs/DEPLOY.md` is deliberately left in place.** The retry removes the *requirement* to reserve the range, not the value of doing so: a reserved range means the retry never has to fire, and a `warn!` that does fire is still telling an operator something true about their host. Deleting that section would trade a real diagnostic for a false sense that the problem is gone.

## Verified per CLAUDE.md §7.5

| | |
|---|---|
| `cargo test --workspace` | **1,161 passed / 0 failed** |
| fmt · clippy `--all-targets -D warnings` | clean |
| `check-doc-links` · `check-observability-metrics` · `check-version-consistency` | clean |
| SIPp signalling suite | **39/40** — only `barge_in_pause`, which needs a `setcap` this box does not grant and fails identically before the bump; green in CI |
| `Cargo.lock` | the 14 `forge-*` crates and nothing else — no incidental dependency drift |

No glue changes were needed in `media-glue` or elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Dugo4krkhibhqb6jSfUCV
