### PR TITLE
chore(release): 0.48.19 — a call no longer dies because the kernel gave its RTP port to someone else

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.48.19] - 2026-08-14
+
 ### Changed
 
 - **Bumped forge-media `b4f8df5c8f09` → `1d7bbaba0c22`** — [forge-media#112](https://github.com/thevoiceguy/forge-media/pull/112) (its issue #111, filed from this project's #504): a port bind that hits `AddrInUse` now **retries the next pair instead of failing the session**. `PortPool` allocates from its own bookkeeping and binds later, so a port it believes free can be held by a socket outside the process — `[media].rtp_port_range` sits inside the kernel's ephemeral range (`net.ipv4.ip_local_port_range`, commonly 32768–60999), and a DNS lookup by anything on the host is enough to take one. Here that surfaced as a `500 Server Internal Error` on an inbound INVITE, measured at **one call in 399** during the 0.48.18 soak. Upstream splits `ForgeError::AddrInUse(SocketAddr)` out of `Network(String)` — so the retry keys off a type rather than message text — and draws up to five pairs, logging a `warn!` with the address each time it steps past one.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3873,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.48.18"
+version = "0.48.19"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3922,7 +3922,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.48.18"
+version = "0.48.19"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3938,7 +3938,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.48.18"
+version = "0.48.19"
 dependencies = [
  "base64",
  "bytes",
@@ -3960,7 +3960,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.48.18"
+version = "0.48.19"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3977,7 +3977,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.48.18"
+version = "0.48.19"
 dependencies = [
  "regex",
  "serde",
@@ -3996,7 +3996,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.48.18"
+version = "0.48.19"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4042,7 +4042,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.48.18"
+version = "0.48.19"
 dependencies = [
  "base64",
  "hmac 0.12.1",
@@ -4065,7 +4065,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.48.18"
+version = "0.48.19"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4091,7 +4091,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.48.18"
+version = "0.48.19"
 dependencies = [
  "anyhow",
  "clap",
@@ -4109,7 +4109,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.48.18"
+version = "0.48.19"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4127,7 +4127,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.48.18"
+version = "0.48.19"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4141,7 +4141,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.48.18"
+version = "0.48.19"
 dependencies = [
  "regex",
  "serde",
@@ -4153,7 +4153,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.48.18"
+version = "0.48.19"
 dependencies = [
  "schemars",
  "serde",
@@ -4163,7 +4163,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.48.18"
+version = "0.48.19"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4191,7 +4191,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.48.18"
+version = "0.48.19"
 dependencies = [
  "base64",
  "rcgen",
@@ -4209,7 +4209,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.48.18"
+version = "0.48.19"
 dependencies = [
  "anyhow",
  "forge-engine",
@@ -4240,7 +4240,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.48.18"
+version = "0.48.19"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.48.18"
+version = "0.48.19"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.48.18.** Production-deployed against real carriers
+**Current release: v0.48.19.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged. Daemon upgrades are near-drop-in


### PR DESCRIPTION
Patch release, drop-in over 0.48.18: WS protocol stays version `"1"`, CDR schema stays v8, no config changes — and **no code in this repo changed at all**. The fix arrives entirely through the dependency.

| | |
|---|---|
| **deps** | forge-media → `1d7bbaba0c22` ([forge-media#112](https://github.com/thevoiceguy/forge-media/pull/112), its issue #111, filed from this project's #504): a port bind that hits `AddrInUse` retries the next pair instead of failing the session. |

## Read this if you have ever seen a 500 on an inbound INVITE

`PortPool` allocates from its own bookkeeping and binds later, so a port it believes free can be held by a socket outside the process. `[media].rtp_port_range` sits inside the kernel's ephemeral range (`net.ipv4.ip_local_port_range`, commonly 32768–60999), and **a DNS lookup by anything on the host is enough** to take one. The call that wanted that port was rejected `500 Server Internal Error` with `Failed to bind socket … Address in use`.

Measured at **one call in 399** during the 0.48.18 soak. Rare, silent until it happens, and it scales with the host's ephemeral UDP traffic rather than with call volume — so a busy host drops calls a quiet one never will.

**What changes for you:** those calls now connect. forge draws up to five port pairs before giving up, logging a `warn!` with the address each time it steps past an occupied one. Nothing else moves — no metric, CDR field, protocol message or config key.

**The `net.ipv4.ip_local_reserved_ports` guidance in `docs/DEPLOY.md` stays, deliberately.** This removes the *requirement* to reserve the range, not the value: a reserved range means the retry never has to fire, and a `warn!` that does fire is still telling you something true about the host.

## Checks

`cargo test --workspace` 1,161 / 0 · fmt · clippy `-D warnings` · `check-version-consistency.py` · `check-doc-links.py` · `check-observability-metrics.py` — all clean. SIPp signalling suite ran **39/40** against the bumped dependency in #508 (only `barge_in_pause`, which needs a `setcap` this box does not grant; green in CI).

After merge: `git tag -a v0.48.19 && git push origin v0.48.19`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Dugo4krkhibhqb6jSfUCV
