### PR TITLE
docs(load): publish the 0.48.19 port-bind A/B — 7 failures became 1, and that one is the retry cap

### DIFF
--- a/test-harness/load/LOAD_TEST_PLAN.md
+++ b/test-harness/load/LOAD_TEST_PLAN.md
@@ -57,6 +57,14 @@ sudo sysctl -w net.ipv4.ip_local_reserved_ports=41000-45000   # = rtp_port_range
 See issue #504 and `docs/DEPLOY.md`. A run without this is still valid for
 everything except a clean zero-failure claim, so record it if you skip it.
 
+**From 0.48.19 a single lost bind no longer fails the call** — forge draws up
+to five pairs, logging `RTP port is held outside the pool; drawing another
+pair` each time it steps past one, so the `500` above needs *five consecutive*
+collisions. Reserve the range anyway: it means the retry never fires, and a
+`warn!` that does fire is telling you something real about the host. Against a
+pool with half its pairs held, 0.48.18 lost 7 calls in 20 and 0.48.19 lost 1 —
+see `RESULTS-0.48.19.md`.
+
 ### 1.2 Admission control will rate-limit the whole test
 
 SIPp drives every call from **one source IP**, so `[sip.admission]`'s

--- a/test-harness/load/README.md
+++ b/test-harness/load/README.md
@@ -131,7 +131,7 @@ A "passing" run is boring. Common failure modes and where they show:
 | RSS grows linearly over an hour          | A per-call allocation isn't being freed. | `dhat` or `heaptrack` against a shorter run. |
 | Audio quality degrades after N minutes    | Jitter buffer drift or codec encoder state leak. | `forge_rtcp_jitter_ms` histogram. |
 | Burst hits a `503 Service Unavailable`    | Port pool exhausted before old calls released. | `[media].rtp_port_range` size; ensure post-call `stop_session` is winning. |
-| Burst hits a `500 Server Internal Error`  | Usually **not** forge. Check the daemon log for `Failed to bind socket … Address in use`: the RTP range overlaps `net.ipv4.ip_local_port_range` and the kernel gave the port to another socket (issue #504, `LOAD_TEST_PLAN.md` §1.1 — reserve the range and re-run). Only if the error is something else is this the `start_session` failure path PR #19 fixed. | Daemon log. |
+| Burst hits a `500 Server Internal Error`  | Usually **not** forge. Check the daemon log for `Failed to bind socket … Address in use`: the RTP range overlaps `net.ipv4.ip_local_port_range` and the kernel gave the port to another socket (issue #504, `LOAD_TEST_PLAN.md` §1.1 — reserve the range and re-run). On 0.48.19+ that takes **five consecutive** collisions, preceded by `RTP port is held outside the pool` warnings — one collision is retried past. Only if the error is something else is this the `start_session` failure path PR #19 fixed. | Daemon log. |
 | `siphon_ai_hep_packets_dropped_total` rises | HEP queue too small for the call rate. | Bump `[hep].queue_capacity`. |
 
 ## Why this isn't in CI

--- a/test-harness/load/RESULTS-0.48.19.md
+++ b/test-harness/load/RESULTS-0.48.19.md
@@ -1,0 +1,145 @@
+# Load results — 0.48.19 (RTP port bind retry, #504 / forge-media#112)
+
+Run 2026-08-15 01:47 UTC. This is **not** a `LOAD_TEST_PLAN.md` phase — it is
+a targeted A/B regression test for the one change in 0.48.19, using a
+deliberately hostile port pool. The §4 ramp, §5 arrival-rate ceiling and
+§6 soak were **not** re-run: 0.48.19 changes port allocation on the setup
+path and nothing in media or steady state, so the 0.48.18 figures stand.
+
+## What it tests
+
+The 0.48.18 soak lost one call in 399 to a `500` when the kernel handed an
+RTP port to some other socket before the daemon bound it (§1.1, issue #504).
+0.48.19 bumps forge-media to `1d7bbaba0c22`, which retries the next pair on
+`AddrInUse` instead of failing the session, drawing up to **five** pairs.
+
+Waiting for a 1-in-399 event to reappear proves nothing in a 20-call run, so
+`squat.py` manufactures the collision: it binds the **even (RTP) port of
+every other pair** in the range, holding **25 of 50 pairs**, the way an
+ephemeral socket does. That makes ~50 % of the pool's draws collide instead
+of ~0.25 %.
+
+## Environment
+
+| | |
+|---|---|
+| Hardware | 4 vCPU, 7.9 GB RAM |
+| OS / kernel | Debian 13, Linux 6.12.95+deb13-amd64 |
+| Versions | `siphon-ai 0.48.18` sha256 `ecbc5e128…` vs `0.48.19` sha256 `6b7340df4…` |
+| Provenance | both extracted from their shipped `.deb` with `dpkg-deb -x` (no sudo); the 0.48.19 binary is **byte-identical to production's `/usr/bin/siphon-ai`** |
+| Posture | G.711 µ-law, recording off, HEP off, no webhooks, no audit |
+| `rtp_port_range` | `[41000, 41100]` — 50 pairs, deliberately **outside** the reserved 40000–40500, so the squatter can work |
+| Squatter | `squat.py 41000 41100 --fraction 0.5` → *holding 25 of 50 RTP ports (50 %)* |
+| Generator | SIPp, `basic_call_then_bye.xml`, `-m 20 -r 2 -l 4`, same box |
+| WS server | `examples/echo-ws-server-python` on `127.0.0.1:8090` |
+
+Second unprivileged instance on `:5070` / metrics `:9191`, alongside an
+untouched production daemon on `:5060`. Both versions ran back-to-back
+against the same squatter, the same generator invocation and the same
+config file.
+
+## Headline
+
+| | 0.48.18 | 0.48.19 |
+|---|---|---|
+| Successful calls | 13 / 20 | **19 / 20** |
+| Failed calls | 7 | **1** |
+| `rejecting INVITE … Address in use` | **7** | **1** |
+| `RTP port is held outside the pool; drawing another pair` | 0 (no such path) | **26** |
+| Distinct `accept_inbound` spans | **13** | **20** |
+
+The span count is the structural half of the result, and it is worth more
+than the pass rate. On 0.48.18, thirteen calls entered `accept_inbound` —
+exactly the thirteen that succeeded; the other seven died before session
+setup got that far. On 0.48.19 **all twenty** entered it, and nineteen came
+out the other side. The retry is happening inside session setup, not in the
+generator and not by luck.
+
+The failures land on squatted ports and nowhere else. 0.48.18's seven bind
+failures hit 41044, 41080 ×2, 41084 ×2, 41092, 41096 — all even, all in the
+held set.
+
+The rejection's *shape* changed too, which is the visible half of upstream
+splitting `ForgeError::AddrInUse(SocketAddr)` out of `Network(String)`:
+
+| 0.48.18 | `Network error: Failed to bind socket to 0.0.0.0:41096: Address in use (os error 98)` |
+|---|---|
+| **0.48.19** | `Address already in use: 0.0.0.0:41044` |
+
+The retry keys off that type rather than message text, and the surviving
+rejection still names the port — which is what makes a squatter identifiable
+from the log at all.
+
+## The one remaining failure is the retry cap, not a defect
+
+```
+WARN … forge_engine::session: RTP port is held outside the pool;
+  drawing another pair addr=0.0.0.0:41096 attempt=4 max_attempts=5
+WARN … acceptor: rejecting INVITE error=forge session error:
+  Address already in use: 0.0.0.0:41044 code=500
+```
+
+Retries needed, per call:
+
+| Retries | 1 | 2 | 3 | 4 | 5 (exhausted) |
+|---|---|---|---|---|---|
+| Calls | 5 | 1 | 2 | 2 | **1** |
+
+Eleven of twenty calls hit at least one squatted draw — against ten expected
+at a 50 % squat rate — and 26 collisions across 46 total draws is 57 %, so
+the squatter did what it claims. Ten of those eleven recovered.
+
+One call burned all five draws. At p = 0.5 per draw that is 0.5⁵ = **3.1 %
+per call**, i.e. 0.6 expected failures in 20, and a **47 % chance of seeing
+at least one** in a run this size. Observing exactly one is the cap behaving
+as designed against an absurd collision rate, not a residual bug.
+
+At the rate actually measured in the field — 1 in 399 draws, p ≈ 0.0025 —
+exhausting five consecutive draws is p⁵ ≈ **10⁻¹³ per call**. The cap is
+unreachable in practice and does not warrant an upstream issue. It is
+hardcoded at five upstream; there is no knob for it in `[media]`, and this
+result gives no reason to want one.
+
+## Verdict
+
+The fix works, in the only way that matters here: a call that would have
+died on the first lost bind now steps past it. Failures fell 7 → 1 and the
+`Address in use` rejections that motivated #504 fell to a single case that
+is explained by the retry limit and quantified above.
+
+**The `net.ipv4.ip_local_reserved_ports` guidance in §1.1 and `docs/DEPLOY.md`
+is still worth applying**, and the CHANGELOG says so too. This removes the
+*requirement* to reserve the range, not the value: reserving it means the
+retry never fires, and a `warn!` that does fire is telling you something real
+about the host.
+
+## Not measured
+
+- **No soak, no ramp, no arrival-rate run.** One 20-call sequence at 2 cps on
+  loopback with PCMU. 0.48.13/0.48.18 figures stand for §4, §5 and §6.
+- **The retry's cost under load is unmeasured.** Each retry is a bind attempt
+  on the setup path; at 50 % squat it fired 26 times across 20 calls with no
+  observable effect at this rate, but nothing here bounds its cost at 200
+  concurrent calls. Setup latency was not instrumented in this run.
+- **Only proven at a 50 % collision rate.** The natural rate is ~0.25 %; the
+  behaviour in between is interpolated from the per-draw model above, not
+  measured.
+- **The squatter is not the field mechanism.** It holds ports for the whole
+  run; a real ephemeral squatter holds one transiently. That makes this
+  strictly harder than reality for the allocator, which is the point, but it
+  does not reproduce a port freed mid-retry.
+
+## Timeline note
+
+The run completed at 01:47:42 UTC and 0.48.19 was deployed to production at
+01:49:55 UTC, on these numbers. The harness shell never printed its summary
+line — it stayed open on a backgrounded WS server — so the figures were read
+off the raw logs then, and off the same logs again on 2026-08-17 when this was
+written up. Nothing was re-run; every figure above comes from the original
+01:47 artefacts, and the two readings agree.
+
+**Production cannot demonstrate this fix.** `ip_local_reserved_ports` on the
+production node covers its whole `rtp_port_range`, so the retry never fires
+there and a quiet journal proves nothing about it. The squatted lab A/B is the
+only honest evidence, which is why it ran against the shipped artefacts rather
+than a dev build.

--- a/test-harness/load/squat.py
+++ b/test-harness/load/squat.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Hold half the RTP pairs in a range, the way an ephemeral socket does.
+
+Reproduces siphon-ai#504 deliberately instead of waiting for the 1-in-399
+chance: bind the RTP (even) port of every other pair, so roughly half of
+the pool's draws collide. On 0.48.18 that fails calls outright; on 0.48.19
+forge steps past to another pair (up to five draws).
+
+Point `[media].rtp_port_range` at a range OUTSIDE any
+net.ipv4.ip_local_reserved_ports reservation, or there is nothing to squat.
+Results of the 0.48.18-vs-0.48.19 A/B run: RESULTS-0.48.19.md.
+
+Usage: squat.py <min_port> <max_port> [--fraction 0.5]
+Prints how many it holds, then sleeps until killed.
+"""
+import socket
+import sys
+import time
+
+lo, hi = int(sys.argv[1]), int(sys.argv[2])
+frac = 0.5
+if "--fraction" in sys.argv:
+    frac = float(sys.argv[sys.argv.index("--fraction") + 1])
+
+held = []
+# Pairs are (even, even+1). Take the even port of every Nth pair.
+step = int(round(2 / frac)) if frac > 0 else 2
+if step % 2:
+    step += 1
+for p in range(lo, hi, step):
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.bind(("0.0.0.0", p))
+        held.append(s)
+    except OSError:
+        s.close()
+
+total_pairs = len(range(lo, hi, 2))
+print(f"holding {len(held)} of {total_pairs} RTP ports in {lo}-{hi} "
+      f"({100 * len(held) / total_pairs:.0f}%)", flush=True)
+while True:
+    time.sleep(3600)


### PR DESCRIPTION
0.48.19 was a pure dependency release (forge-media `1d7bbaba0c22`, #508/#509: a
port bind hitting `AddrInUse` retries the next pair instead of failing the
call). The A/B that justified shipping it ran against the **shipped** binaries
and the production deploy went out on its numbers — but it was never published
next to `RESULTS-0.48.10/13/18`. The figures lived only in the run's raw logs,
in a scratchpad. This writes them up from those same artifacts; **nothing was
re-run**.

## Method

Waiting for the field rate (1 collision in 399 calls, #504) proves nothing in a
20-call run, so `squat.py` manufactures it: bind the even/RTP port of every
other pair, holding **25 of 50 pairs**, so ~50% of the pool's draws collide.
`rtp_port_range` was deliberately set to `[41000, 41100]` — outside the node's
reserved `40000-40500` — or there would be nothing to squat.

## Result

| | 0.48.18 | 0.48.19 |
|---|---|---|
| Successful calls | 13 / 20 | **19 / 20** |
| `rejecting INVITE … Address in use` | 7 | **1** |
| `RTP port is held outside the pool; drawing another pair` | 0 (no such path) | **26** |
| Distinct `accept_inbound` spans | **13** | **20** |

The span count is worth more than the pass rate: on 0.48.18 exactly thirteen
calls entered `accept_inbound` — its thirteen successes — while on 0.48.19 all
twenty entered it and nineteen came out. The retry is in session setup, not in
the generator and not luck.

The one remaining failure exhausted all five draws. At p=0.5 that is 3.1% per
call, i.e. 0.6 expected in 20 and a **47% chance of seeing at least one** in a
run this size — the cap behaving as designed against an absurd collision rate.
At the field rate the same cap is ~1e-13 per call, so **no upstream issue is
warranted** and no knob is wanted.

## Also in here

- **`squat.py` moves into `test-harness/load/`.** The doc's method is not
  reproducible while the tool exists only in a scratchpad.
- **`LOAD_TEST_PLAN.md` §1.1 and the README failure row are corrected.** Both
  still described a lost bind as fatal; from 0.48.19 it takes *five consecutive*
  collisions. Both still tell you to reserve the range — this removes the
  requirement, not the value, which is the line the CHANGELOG already takes.

## What this does not establish

Recorded in the doc rather than left implied: no soak, no ramp, no
arrival-rate run (0.48.13/0.48.18 figures stand for §4/§5/§6); the retry's cost
on the setup path is uninstrumented at 200 concurrent; the behaviour between a
50% and a 0.25% collision rate is modelled, not measured; and the squatter
holds ports for the whole run, so it never reproduces a port freed mid-retry.

**Production cannot demonstrate this fix** — `ip_local_reserved_ports` covers
its whole RTP range, so the retry never fires there and a quiet journal proves
nothing about it. The squatted lab A/B is the only honest evidence.

Docs and one test-harness script only; no crate code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNXkU45xPHgomcDkSs5GuN