### PR TITLE
docs(load): publish tier 2 — FreeSWITCH generator, TLS+SRTP, and netem

### DIFF
--- a/test-harness/load/LOAD_TEST_PLAN.md
+++ b/test-harness/load/LOAD_TEST_PLAN.md
@@ -57,6 +57,14 @@ sudo sysctl -w net.ipv4.ip_local_reserved_ports=41000-45000   # = rtp_port_range
 See issue #504 and `docs/DEPLOY.md`. A run without this is still valid for
 everything except a clean zero-failure claim, so record it if you skip it.
 
+**From 0.48.19 a single lost bind no longer fails the call** — forge draws up
+to five pairs, logging `RTP port is held outside the pool; drawing another
+pair` each time it steps past one, so the `500` above needs *five consecutive*
+collisions. Reserve the range anyway: it means the retry never fires, and a
+`warn!` that does fire is telling you something real about the host. Against a
+pool with half its pairs held, 0.48.18 lost 7 calls in 20 and 0.48.19 lost 1 —
+see `RESULTS-0.48.19.md`.
+
 ### 1.2 Admission control will rate-limit the whole test
 
 SIPp drives every call from **one source IP**, so `[sip.admission]`'s

--- a/test-harness/load/LOAD_TEST_PLAN.md
+++ b/test-harness/load/LOAD_TEST_PLAN.md
@@ -439,6 +439,22 @@ us the first time someone hits the wall and reports it as a bug.
   available to it; say so rather than reporting zero drops.
 - **Re-sample a gauge before calling it stale.** Sampling in the same breath
   as the event that clears it produces phantom leaks.
+- **`ps -o %cpu` is a lifetime average, not an instantaneous rate.** It made a
+  flat 50-call run look like it was ramping (18 → 24 → 26%), and it is
+  meaningless for a generator process that has been up for hours. Measure with
+  `/proc/<pid>/stat` fields 14+15 delta over a fixed window. `bc` may not be
+  installed on a stock box — do the arithmetic in `awk`.
+- **Forcing SIGTERM during the daemon's 30 s drain orphans the calls** — no BYE,
+  no CDR, and the far end holds its channels up until *its* media timeout. Wait
+  the drain out, or hang up from the generator first.
+- **Bound the calls, don't rely on a closing `hupall`.** Originating with
+  `execute_on_answer='sched_hangup +<hold> NORMAL_CLEARING'` makes every call
+  end on its own schedule, so a run that loses its driving session still
+  terminates. Tier 2 (§10.2) uses this throughout.
+- **Arm a detached auto-removal alongside `netem`.** It impairs your own ssh to
+  the box; a dropped session must not strand the qdisc.
+- **`fs_cli -x "show channels count"` prints a leading blank line** — `head -1`
+  silently yields nothing. Use `tail -1`.
 
 ---
 
@@ -489,6 +505,15 @@ the constraint. Record the generator box's CPU in every row. If it is above
 ~70% while the daemon under test is below it, the run is void.
 
 ### 10.2 Tier 2 — FreeSWITCH as the load generator
+
+> **Run 2026-08-17 — see `RESULTS-tier2.md`, rig in `tier2/`.** All three phases
+> (plaintext ramp, TLS+SRTP, `netem`) are done at 50/100/200 concurrent. Two
+> things below need correcting in light of it: the daemon side needs
+> `[media].srtp = "required"` — stock FreeSWITCH `488`s the `"preferred"`
+> `RTP/AVP` + `a=crypto` shape — and FreeSWITCH's stock `max-sessions` /
+> `sessions-per-second` already cover 200 at 10 cps, so the raise below is only
+> needed past ~500 (~400 with crypto, where FS's own CPU starts to threaten
+> §10.1).
 
 This is the highest-value addition and it costs nothing but a second VM.
 FreeSWITCH is a real SIP stack, so unlike a SIPp scenario it exercises

--- a/test-harness/load/README.md
+++ b/test-harness/load/README.md
@@ -131,7 +131,7 @@ A "passing" run is boring. Common failure modes and where they show:
 | RSS grows linearly over an hour          | A per-call allocation isn't being freed. | `dhat` or `heaptrack` against a shorter run. |
 | Audio quality degrades after N minutes    | Jitter buffer drift or codec encoder state leak. | `forge_rtcp_jitter_ms` histogram. |
 | Burst hits a `503 Service Unavailable`    | Port pool exhausted before old calls released. | `[media].rtp_port_range` size; ensure post-call `stop_session` is winning. |
-| Burst hits a `500 Server Internal Error`  | Usually **not** forge. Check the daemon log for `Failed to bind socket … Address in use`: the RTP range overlaps `net.ipv4.ip_local_port_range` and the kernel gave the port to another socket (issue #504, `LOAD_TEST_PLAN.md` §1.1 — reserve the range and re-run). Only if the error is something else is this the `start_session` failure path PR #19 fixed. | Daemon log. |
+| Burst hits a `500 Server Internal Error`  | Usually **not** forge. Check the daemon log for `Failed to bind socket … Address in use`: the RTP range overlaps `net.ipv4.ip_local_port_range` and the kernel gave the port to another socket (issue #504, `LOAD_TEST_PLAN.md` §1.1 — reserve the range and re-run). On 0.48.19+ that takes **five consecutive** collisions, preceded by `RTP port is held outside the pool` warnings — one collision is retried past. Only if the error is something else is this the `start_session` failure path PR #19 fixed. | Daemon log. |
 | `siphon_ai_hep_packets_dropped_total` rises | HEP queue too small for the call rate. | Bump `[hep].queue_capacity`. |
 
 ## Why this isn't in CI

--- a/test-harness/load/README.md
+++ b/test-harness/load/README.md
@@ -28,6 +28,15 @@ the burst's signalling-only calls at the one-minute mark.
 > (admission control, the inactivity watchdog, and the WS server's own
 > ceiling) that will otherwise invalidate a run.
 
+## What else is in here
+
+| | |
+|---|---|
+| `RESULTS-*.md` | published runs — `0.48.10`, `0.48.13`, `0.48.18`, `0.48.19` (RTP port-bind A/B), and `tier2` |
+| `tier2/` | the two-box FreeSWITCH rig behind `RESULTS-tier2.md` (§10.2) — generator scripts, phase drivers, lab configs |
+| `paced_sink.mjs` | the WS sink the §6.1 and tier-2 numbers were measured through. **Use this, not a `setInterval`-paced sink** — see §8's first trap |
+| `squat.py` | holds RTP ports the way an ephemeral socket does, to reproduce #504 on demand |
+
 ## Prerequisites
 
 ```sh

--- a/test-harness/load/RESULTS-0.48.19.md
+++ b/test-harness/load/RESULTS-0.48.19.md
@@ -1,0 +1,145 @@
+# Load results — 0.48.19 (RTP port bind retry, #504 / forge-media#112)
+
+Run 2026-08-15 01:47 UTC. This is **not** a `LOAD_TEST_PLAN.md` phase — it is
+a targeted A/B regression test for the one change in 0.48.19, using a
+deliberately hostile port pool. The §4 ramp, §5 arrival-rate ceiling and
+§6 soak were **not** re-run: 0.48.19 changes port allocation on the setup
+path and nothing in media or steady state, so the 0.48.18 figures stand.
+
+## What it tests
+
+The 0.48.18 soak lost one call in 399 to a `500` when the kernel handed an
+RTP port to some other socket before the daemon bound it (§1.1, issue #504).
+0.48.19 bumps forge-media to `1d7bbaba0c22`, which retries the next pair on
+`AddrInUse` instead of failing the session, drawing up to **five** pairs.
+
+Waiting for a 1-in-399 event to reappear proves nothing in a 20-call run, so
+`squat.py` manufactures the collision: it binds the **even (RTP) port of
+every other pair** in the range, holding **25 of 50 pairs**, the way an
+ephemeral socket does. That makes ~50 % of the pool's draws collide instead
+of ~0.25 %.
+
+## Environment
+
+| | |
+|---|---|
+| Hardware | 4 vCPU, 7.9 GB RAM |
+| OS / kernel | Debian 13, Linux 6.12.95+deb13-amd64 |
+| Versions | `siphon-ai 0.48.18` sha256 `ecbc5e128…` vs `0.48.19` sha256 `6b7340df4…` |
+| Provenance | both extracted from their shipped `.deb` with `dpkg-deb -x` (no sudo); the 0.48.19 binary is **byte-identical to production's `/usr/bin/siphon-ai`** |
+| Posture | G.711 µ-law, recording off, HEP off, no webhooks, no audit |
+| `rtp_port_range` | `[41000, 41100]` — 50 pairs, deliberately **outside** the reserved 40000–40500, so the squatter can work |
+| Squatter | `squat.py 41000 41100 --fraction 0.5` → *holding 25 of 50 RTP ports (50 %)* |
+| Generator | SIPp, `basic_call_then_bye.xml`, `-m 20 -r 2 -l 4`, same box |
+| WS server | `examples/echo-ws-server-python` on `127.0.0.1:8090` |
+
+Second unprivileged instance on `:5070` / metrics `:9191`, alongside an
+untouched production daemon on `:5060`. Both versions ran back-to-back
+against the same squatter, the same generator invocation and the same
+config file.
+
+## Headline
+
+| | 0.48.18 | 0.48.19 |
+|---|---|---|
+| Successful calls | 13 / 20 | **19 / 20** |
+| Failed calls | 7 | **1** |
+| `rejecting INVITE … Address in use` | **7** | **1** |
+| `RTP port is held outside the pool; drawing another pair` | 0 (no such path) | **26** |
+| Distinct `accept_inbound` spans | **13** | **20** |
+
+The span count is the structural half of the result, and it is worth more
+than the pass rate. On 0.48.18, thirteen calls entered `accept_inbound` —
+exactly the thirteen that succeeded; the other seven died before session
+setup got that far. On 0.48.19 **all twenty** entered it, and nineteen came
+out the other side. The retry is happening inside session setup, not in the
+generator and not by luck.
+
+The failures land on squatted ports and nowhere else. 0.48.18's seven bind
+failures hit 41044, 41080 ×2, 41084 ×2, 41092, 41096 — all even, all in the
+held set.
+
+The rejection's *shape* changed too, which is the visible half of upstream
+splitting `ForgeError::AddrInUse(SocketAddr)` out of `Network(String)`:
+
+| 0.48.18 | `Network error: Failed to bind socket to 0.0.0.0:41096: Address in use (os error 98)` |
+|---|---|
+| **0.48.19** | `Address already in use: 0.0.0.0:41044` |
+
+The retry keys off that type rather than message text, and the surviving
+rejection still names the port — which is what makes a squatter identifiable
+from the log at all.
+
+## The one remaining failure is the retry cap, not a defect
+
+```
+WARN … forge_engine::session: RTP port is held outside the pool;
+  drawing another pair addr=0.0.0.0:41096 attempt=4 max_attempts=5
+WARN … acceptor: rejecting INVITE error=forge session error:
+  Address already in use: 0.0.0.0:41044 code=500
+```
+
+Retries needed, per call:
+
+| Retries | 1 | 2 | 3 | 4 | 5 (exhausted) |
+|---|---|---|---|---|---|
+| Calls | 5 | 1 | 2 | 2 | **1** |
+
+Eleven of twenty calls hit at least one squatted draw — against ten expected
+at a 50 % squat rate — and 26 collisions across 46 total draws is 57 %, so
+the squatter did what it claims. Ten of those eleven recovered.
+
+One call burned all five draws. At p = 0.5 per draw that is 0.5⁵ = **3.1 %
+per call**, i.e. 0.6 expected failures in 20, and a **47 % chance of seeing
+at least one** in a run this size. Observing exactly one is the cap behaving
+as designed against an absurd collision rate, not a residual bug.
+
+At the rate actually measured in the field — 1 in 399 draws, p ≈ 0.0025 —
+exhausting five consecutive draws is p⁵ ≈ **10⁻¹³ per call**. The cap is
+unreachable in practice and does not warrant an upstream issue. It is
+hardcoded at five upstream; there is no knob for it in `[media]`, and this
+result gives no reason to want one.
+
+## Verdict
+
+The fix works, in the only way that matters here: a call that would have
+died on the first lost bind now steps past it. Failures fell 7 → 1 and the
+`Address in use` rejections that motivated #504 fell to a single case that
+is explained by the retry limit and quantified above.
+
+**The `net.ipv4.ip_local_reserved_ports` guidance in §1.1 and `docs/DEPLOY.md`
+is still worth applying**, and the CHANGELOG says so too. This removes the
+*requirement* to reserve the range, not the value: reserving it means the
+retry never fires, and a `warn!` that does fire is telling you something real
+about the host.
+
+## Not measured
+
+- **No soak, no ramp, no arrival-rate run.** One 20-call sequence at 2 cps on
+  loopback with PCMU. 0.48.13/0.48.18 figures stand for §4, §5 and §6.
+- **The retry's cost under load is unmeasured.** Each retry is a bind attempt
+  on the setup path; at 50 % squat it fired 26 times across 20 calls with no
+  observable effect at this rate, but nothing here bounds its cost at 200
+  concurrent calls. Setup latency was not instrumented in this run.
+- **Only proven at a 50 % collision rate.** The natural rate is ~0.25 %; the
+  behaviour in between is interpolated from the per-draw model above, not
+  measured.
+- **The squatter is not the field mechanism.** It holds ports for the whole
+  run; a real ephemeral squatter holds one transiently. That makes this
+  strictly harder than reality for the allocator, which is the point, but it
+  does not reproduce a port freed mid-retry.
+
+## Timeline note
+
+The run completed at 01:47:42 UTC and 0.48.19 was deployed to production at
+01:49:55 UTC, on these numbers. The harness shell never printed its summary
+line — it stayed open on a backgrounded WS server — so the figures were read
+off the raw logs then, and off the same logs again on 2026-08-17 when this was
+written up. Nothing was re-run; every figure above comes from the original
+01:47 artefacts, and the two readings agree.
+
+**Production cannot demonstrate this fix.** `ip_local_reserved_ports` on the
+production node covers its whole `rtp_port_range`, so the retry never fires
+there and a quiet journal proves nothing about it. The squatted lab A/B is the
+only honest evidence, which is why it ran against the shipped artefacts rather
+than a dev build.

--- a/test-harness/load/RESULTS-tier2.md
+++ b/test-harness/load/RESULTS-tier2.md
@@ -1,0 +1,218 @@
+# Tier 2 results — FreeSWITCH generator, separate box, TLS + SRTP, netem
+
+Run 2026-08-17 against the **shipped 0.48.19 `.deb` binary** (sha256
+`6b7340df4…`, byte-identical to the one the reference node runs), driven by a
+real FreeSWITCH on a second host.
+
+Scope: `LOAD_TEST_PLAN.md` **§10.2** in three phases — a plaintext concurrency
+ramp over the network, the same ramp over SIP/TLS with SRTP, and a quality pass
+under `netem` impairment. **1,100 calls, zero failures, and not one log line
+above `INFO` from either daemon across the whole session.**
+
+This is the tier that §9 says must exist before quoting a secure-trunk number.
+It does not replace tier 1: §§4–6 remain the source for the knee, the soak and
+the leak audit.
+
+## Environment
+
+| | Box A — under test | Box B — generator |
+|---|---|---|
+| Hardware | 4 vCPU, 7.9 GB | 4 vCPU, 7.9 GB |
+| OS | Debian 13, Linux 6.12.95 | Debian 12 |
+| Software | `siphon-ai 0.48.19` (shipped deb) on `:5070` udp / `:5071` tls | FreeSWITCH 1.11.0 `mod_sofia`, external profile |
+| RTT | **0.27 ms** — same datacenter | |
+
+Posture on Box A is copied from the tier-1 soak config so any delta is
+attributable to the generator, the network and the crypto rather than to
+posture drift: G.711 µ-law, recording **off**, HEP **off**, energy VAD, no
+webhooks, no audit, `udp_rate_limit_pps = 0`, `rtp_port_range = [41000, 45000]`.
+
+**WS sink:** `paced_sink.mjs` on Box A `:8767` — the monotonic-origin sink, not
+`ws_sink.mjs` (§8's pacing trap). It held **50.000 Hz across 252,002 ticks** for
+the entire session, so §1.4's "prove the sink is not the constraint" is
+satisfied throughout.
+
+**Generator shape.** Calls are originated with
+`execute_on_answer='sched_hangup +<hold> NORMAL_CLEARING'`, so **every call
+terminates on its own schedule** rather than depending on a closing `hupall`.
+A run that loses its driving session still ends itself. Mean measured duration
+was 299,8xx ms against a 300,000 ms target in every step.
+
+A third box for the WS sink was not available, so the sink runs on Box A. Its
+cost is inside the daemon-box figures below and is not separated out.
+
+---
+
+## Phase 1 — concurrency ramp, plaintext, over the network
+
+5 minutes per step, three CPU samples per step, `/proc/<pid>/stat` deltas over
+fixed windows (**not** `ps %cpu`, which is a lifetime average — see Traps).
+
+| Concurrency | Daemon %of one core | CPU/call | FreeSWITCH %of one core | RSS | fds | threads |
+|---|---|---|---|---|---|---|
+| 50 | 35.7 | 0.713 % | 12.8 | 35 MB | 162 | 5 |
+| 100 | 65.5 | 0.655 % | 29.8 | 51 MB | 312 | 5 |
+| 200 | **129.9** (32.5 % of the box) | **0.650 %** | 54.5 | 70 MB | 612 | 5 |
+
+**The network and a real SIP stack cost +23 % CPU per call.** Tier 1 measured
+**0.53 %/call at the same 200 concurrent** (`RESULTS-0.48.18.md`) with SIPp on
+loopback; this run measures **0.650 %/call**. That is the number §9 forbids
+quoting without measuring.
+
+**No knee at 200 over the network.** Per-call cost is flat-to-improving as
+concurrency rises (0.713 → 0.655 → 0.650) — fixed overhead amortising, not
+saturation. The ceiling remains the port range, as §1.1 says.
+
+Three independent checks say the two tiers measured the same system:
+
+- **File descriptors are exactly `12 + 3N` at every step**, and **612 at 200
+  concurrent is the identical number tier 1 published**.
+- **Threads pinned at 5** throughout, as in every tier-1 run.
+- **RTP arrived at rate**: 2,670,523 packets during the 200-call step against
+  ~2.5 M expected for the sampled window at 50 fps — the calls carried media,
+  they were not merely signalled up.
+
+`siphon_ai_outbound_audio_frames_dropped_total` was **0** at every step, so the
+§4 Playout SLO is asserted here rather than skipped (it was unassertable before
+0.48.18 — #474).
+
+---
+
+## Phase 2 — SIP/TLS + SRTP
+
+Identical ramp over `;transport=tls` with `rtp_secure_media=mandatory:AES_CM_128_HMAC_SHA1_80`
+and `[media].srtp = "required"` on the daemon.
+
+> `"required"`, not `"preferred"`: stock FreeSWITCH rejects the preferred-mode
+> `RTP/AVP` + `a=crypto` offer outright (`488`). Both `docs/CONFIG.md` and
+> `docs/FREESWITCH_INTEGRATION.md` say so; this run is the confirmation that
+> `required` is the workable mode toward FS.
+
+| Concurrency | Daemon: plain → TLS+SRTP | CPU/call | FreeSWITCH: plain → TLS+SRTP | fds | RSS |
+|---|---|---|---|---|---|
+| 50 | 35.7 → 38.4 (+7.6 %) | 0.767 % | 12.8 → 23.5 | 164 | 39 MB |
+| 100 | 65.5 → 71.7 (+9.4 %) | 0.717 % | 29.8 → 47.8 | 314 | 63 MB |
+| 200 | 129.9 → **132.6** | **0.663 %** | 54.5 → **102.9** | 614 | 79 MB |
+
+**Coverage is proven, not assumed.**
+`forge_srtp_packets_decrypted_total` = **5,248,192** =
+`forge_rtp_packets_received_total`. Every received packet was decrypted, so no
+call quietly negotiated its way back to plaintext — the failure mode that would
+have made this phase meaningless.
+
+**Crypto is cheap for SiphonAI and expensive for FreeSWITCH.** The daemon pays
+under 10 %, and at 200 concurrent **the difference is inside the sample spread**
+— 128.6 / 140.5 / 128.8 against 127.5 / 132.6 / 129.7, medians that actually
+cross. Do not quote "+2.1 % at 200" as a measured cost; the honest claim is
+"under 10 %, and not separable from noise at 200". FreeSWITCH, doing the same
+crypto on the same media, rose **60–89 %**.
+
+The asymmetry is structural rather than surprising: AES-CM-128 over 20 ms G.711
+frames is small next to the per-frame work the daemon already does (jitter
+buffer, WS framing, VAD), and **TLS is signalling-only** — one connection whose
+handshake amortises across the run, which is why file descriptors moved just
+612 → 614. RSS rose ~10 MB at 200 for the SRTP contexts.
+
+---
+
+## Phase 3 — quality under `netem`
+
+Two back-to-back 200-call TLS+SRTP runs. Quality is read as **histogram deltas**
+around each run, so the 700 calls already in the counters cannot flatter the
+result.
+
+```sh
+tc qdisc replace dev eth0 root netem delay 20ms 5ms loss 0.5%   # Box B egress
+```
+
+| | clean LAN | netem 20 ms ±5 ms, 0.5 % loss |
+|---|---|---|
+| Jitter mean | 0.44 ms | **3.35 ms** |
+| Jitter p50 / p95 / p99 | ≤1 / ≤1 / ≤2 ms | ≤5 / ≤5 / ≤5 ms |
+| Jitter distribution | ≤1 ms 96.4 % | ≤5 ms 98.2 % |
+| MOS mean | 4.441 | 4.418 |
+| MOS below 4.4 | 0 % | 0.6 % |
+| CDR `rx_packets_lost` | **0.0** (max 0 over 200 calls) | **73.2** mean (53–93) |
+| CDR `rx_packets_received` | 14,780.0 | 14,705.4 |
+| Worst call `mos_estimate_min` | 4.436 | 4.339 |
+
+**The result here is not the MOS number — it is that the telemetry is
+trustworthy.** The daemon measured **0.495 % loss against 0.5 % injected**
+(73.2 of 14,778.6 offered), and reported **exactly zero** loss on all 200 clean
+calls. A counter that reports both the impairment you caused and the absence of
+one you did not is what §10.2 set out to establish.
+
+Two readings to guard against:
+
+- **MOS moved only −0.023, which is not "impairment had no effect."** G.711 at
+  0.5 % loss and 5 ms jitter genuinely is still good audio. The loss and jitter
+  counters are where the effect is visible, and they moved sharply.
+- **The 20 ms delay correctly did *not* move the jitter histogram.** RFC 3550
+  interarrival jitter responds to the ±5 ms variation, not to constant latency,
+  which is why ~3.3 ms appears rather than ~20 ms. That is a consistency check
+  passing. Latency must be measured as RTT or `sdp_negotiate_seconds`, not here.
+
+**Impairment was one-directional.** It sat on Box B's egress — the
+caller→SiphonAI path, which is exactly what `siphon_ai_rtp_rx_jitter_ms`
+measures. The return path was clean, so nothing here characterises the daemon's
+*transmit* behaviour under loss.
+
+---
+
+## The claim this earns
+
+Filling in §10.4's template for tiers 1 and 2 (tier 3 is not run):
+
+```
+200 concurrent calls on 4 vCPU at 0.53 % CPU/call
+  (SIPp loopback, G.711, plaintext, no recording).
+Validated from a separate FreeSWITCH box at 200 concurrent:
+  +23 % CPU per call for the network and a real stack (0.650 %/call),
+  TLS + SRTP under 10 % on top and not separable from noise at 200 (0.663 %/call).
+Under 20 ms ±5 ms jitter and 0.5 % loss: MOS 4.42, jitter p95 5 ms,
+  and loss reported to within 1 % relative of the injected rate.
+RTP port range caps concurrency at range/2 — size it for your target.
+```
+
+## Not measured
+
+- **No soak at tier 2.** Each step is three 10-second CPU samples inside a
+  5-minute hold. This establishes per-call cost and linearity; it says nothing
+  about hour-scale behaviour. §6.1/§6.3 remain tier-1-only.
+- **A real network.** 0.27 ms between the boxes means this is a real NIC, a real
+  kernel path and a real stack — but *not* a WAN. Every impairment figure here
+  is synthetic, applied one hop away.
+- **Latency.** No RTT or setup-latency measurement was taken; the netem delay is
+  invisible to the metric this phase captured.
+- **Transmit-side impairment**, per phase 3's one-directional note.
+- **Past 200 concurrent.** Also note the generator's own headroom narrowed
+  sharply under crypto: FreeSWITCH at 200 TLS calls sits at 102.9 % of one core
+  (25.7 % of its box). Comfortable now, but a ~400-call TLS run would start
+  making Box B the constraint, and would first need §10.2's
+  `max-sessions` / `sessions-per-second` raise — which this run did **not**
+  need, since the FS defaults (1000 / 30) already cover 200 at 10 cps.
+- **Tier 3** — a live carrier. Unchanged from §10.3: ticket it first.
+- **§11's human reference call**, which is the natural next step now that tier 2
+  can stage the load.
+
+## Reproducing
+
+The rig is in `tier2/` — `ramp.sh` and `ramp-tls.sh` (Box B), the phase drivers
+and the two lab configs (Box A). See `tier2/README.md`; the setup that is easy
+to get wrong (FS TLS enablement, the cert, `srtp = "required"`) is written down
+there.
+
+## Traps found (also folded into §8)
+
+- **`ps -o %cpu` is a lifetime average, not an instantaneous rate.** It made a
+  flat 50-call run look like it was ramping (18 → 24 → 26 %) and is meaningless
+  for a FreeSWITCH process that has been up for hours. Use `/proc/<pid>/stat`
+  fields 14+15 over a fixed window.
+- **`bc` is not installed on either box.** Do the arithmetic in `awk`.
+- **`fs_cli -x "show channels count"` prints a leading blank line** — `head -1`
+  silently yields nothing. Use `tail -1`.
+- **Forcing SIGTERM during the daemon's 30 s drain orphans calls** — no BYE, no
+  CDR, and channels stay up on the generator until FS's media timeout. Wait the
+  drain out.
+- **Always arm a detached auto-removal alongside `netem`.** It impairs your own
+  ssh to the box; a lost session must not strand the qdisc.

--- a/test-harness/load/paced_sink.mjs
+++ b/test-harness/load/paced_sink.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+// ws_sink.mjs paces with setInterval(20), which in Node fires at >=20 ms and
+// so under-runs realtime. That is invisible for CPU/RSS work but it lands
+// directly on any tx-rate or clock-drift measurement (LOAD_TEST_PLAN §6.2),
+// because the daemon can only play out what it is fed. This sink corrects
+// against a monotonic origin instead, the same way the UAC's send loop does.
+import { createRequire } from "node:module";
+const require = createRequire(process.env.SINK_REQUIRE_BASE ?? "/opt/siphon-ai-src/examples/deepgram-llm-bot-node/node_modules/");
+const { WebSocketServer } = require("ws");
+const PORT = Number(process.argv[2] || 8769);
+const SILENCE = Buffer.alloc(320);
+const conns = new Set();
+let tx = 0, rx = 0;
+const wss = new WebSocketServer({ host: "127.0.0.1", port: PORT, handleProtocols: () => "siphon-ai.v1" });
+wss.on("connection", (ws) => {
+  conns.add(ws);
+  ws.on("message", (d, isBin) => { if (isBin) rx++; });
+  ws.on("close", () => conns.delete(ws));
+  ws.on("error", () => conns.delete(ws));
+});
+const t0 = process.hrtime.bigint();
+let n = 0;
+function tick() {
+  for (const ws of conns) { if (ws.readyState === 1 && ws.bufferedAmount <= 3200) { ws.send(SILENCE); tx++; } }
+  n++;
+  const targetMs = n * 20;
+  const elapsedMs = Number(process.hrtime.bigint() - t0) / 1e6;
+  setTimeout(tick, Math.max(0, targetMs - elapsedMs));
+}
+setTimeout(tick, 20);
+setInterval(() => {
+  const el = Number(process.hrtime.bigint() - t0) / 1e9;
+  console.log(JSON.stringify({ conns: conns.size, ticks: n, tick_hz: +(n / el).toFixed(3), tx, rx }));
+}, 30000);
+wss.on("listening", () => console.log(`paced_sink on 127.0.0.1:${PORT}`));

--- a/test-harness/load/squat.py
+++ b/test-harness/load/squat.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Hold half the RTP pairs in a range, the way an ephemeral socket does.
+
+Reproduces siphon-ai#504 deliberately instead of waiting for the 1-in-399
+chance: bind the RTP (even) port of every other pair, so roughly half of
+the pool's draws collide. On 0.48.18 that fails calls outright; on 0.48.19
+forge steps past to another pair (up to five draws).
+
+Point `[media].rtp_port_range` at a range OUTSIDE any
+net.ipv4.ip_local_reserved_ports reservation, or there is nothing to squat.
+Results of the 0.48.18-vs-0.48.19 A/B run: RESULTS-0.48.19.md.
+
+Usage: squat.py <min_port> <max_port> [--fraction 0.5]
+Prints how many it holds, then sleeps until killed.
+"""
+import socket
+import sys
+import time
+
+lo, hi = int(sys.argv[1]), int(sys.argv[2])
+frac = 0.5
+if "--fraction" in sys.argv:
+    frac = float(sys.argv[sys.argv.index("--fraction") + 1])
+
+held = []
+# Pairs are (even, even+1). Take the even port of every Nth pair.
+step = int(round(2 / frac)) if frac > 0 else 2
+if step % 2:
+    step += 1
+for p in range(lo, hi, step):
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.bind(("0.0.0.0", p))
+        held.append(s)
+    except OSError:
+        s.close()
+
+total_pairs = len(range(lo, hi, 2))
+print(f"holding {len(held)} of {total_pairs} RTP ports in {lo}-{hi} "
+      f"({100 * len(held) / total_pairs:.0f}%)", flush=True)
+while True:
+    time.sleep(3600)

--- a/test-harness/load/tier2/README.md
+++ b/test-harness/load/tier2/README.md
@@ -1,0 +1,122 @@
+# Tier 2 rig — FreeSWITCH generator on a separate box
+
+Everything needed to reproduce `../RESULTS-tier2.md` (`LOAD_TEST_PLAN.md` §10.2).
+Two hosts: **Box A** runs the daemon under test, **Box B** runs FreeSWITCH as the
+generator. §10.1 is the whole point — the generator must not live on the box
+under test, and must be proven not to be the constraint.
+
+```
+Box B  FreeSWITCH ──SIP + RTP over the NIC──► Box A  siphon-ai  ──WS──► paced_sink.mjs
+```
+
+## Files
+
+| | where it runs | what it is |
+|---|---|---|
+| `ramp.sh` | Box B | originate N calls at C cps, plaintext |
+| `ramp-tls.sh` | Box B | same over `;transport=tls` with SRTP mandatory |
+| `phase1.sh` | Box A | 50/100/200 ramp, 5 min per step, plaintext |
+| `phase2.sh` | Box A | same ramp, TLS + SRTP |
+| `phase3.sh` | Box A | clean vs `netem`-impaired quality runs |
+| `tier2-lab.toml.example` | Box A | daemon config, plaintext |
+| `tier2-tls.toml.example` | Box A | daemon config, TLS listener + `srtp = "required"` |
+
+The phase drivers require `SP` — a working directory for logs, CDRs and metric
+snapshots:
+
+```sh
+export SP=/var/tmp/tier2 && mkdir -p $SP
+```
+
+Replace `/PATH/TO/WORKDIR` in the `.toml.example` files with the same directory,
+and put the daemon's pid in `$SP/lab.pid`. The drivers assume metrics on
+`127.0.0.1:9191` and the WS sink on `127.0.0.1:8767`.
+
+## Setup that is easy to get wrong
+
+**The sink.** Use `../paced_sink.mjs`, not `ws_sink.mjs` — the latter paces with
+`setInterval(20)`, which under-runs realtime and lands directly on any tx-rate or
+clock-drift measurement (§8). Check its reported `tick_hz` is 50.00 before
+trusting a run. It needs the `ws` module; point `SINK_REQUIRE_BASE` at a
+`node_modules` that has it.
+
+**`[node].public_address` is required** once `[sip].listen` binds `0.0.0.0` — the
+SDP answer's `c=` line cannot be `0.0.0.0`, and the validator refuses to start
+without it.
+
+**Size the RTP range for the target**, per §1.1: `2 × concurrency` plus teardown
+headroom. The examples use `[41000, 45000]` for up to 1000 calls.
+
+**Restrict the listener.** Both boxes here have public IPs and `:5060` already
+sees scanner INVITEs, so the configs carry a `[[trunk]]` allowlist naming Box B.
+
+### TLS + SRTP (phase 2)
+
+**On Box A** — `srtp = "required"`, **not** `"preferred"`. Stock FreeSWITCH
+rejects the preferred-mode `RTP/AVP` + `a=crypto` offer with a `488`
+(`docs/CONFIG.md`, `docs/FREESWITCH_INTEGRATION.md`). If the production
+`privkey.pem` is not readable by the account running the test, generate a lab
+cert — FreeSWITCH's default `tls-verify-policy` is `none`, so self-signed is
+accepted:
+
+```sh
+openssl ecparam -genkey -name prime256v1 -out lab-key.pem
+openssl req -new -x509 -key lab-key.pem -out lab-cert.pem -days 30 \
+  -subj "/CN=sip-lab.example" -addext "subjectAltName=IP:<BOX_A_IP>"
+```
+
+**On Box B** — the stock external profile ships `external_ssl_enable=false` and
+binds udp/tcp only. Set it true in `vars.xml`, and create `agent.pem` (only
+`dtls-srtp.pem` and `wss.pem` ship), or the profile will not offer TLS:
+
+```sh
+openssl req -x509 -newkey rsa:2048 -nodes -days 30 -subj "/CN=fs-lab.local" \
+  -keyout k.pem -out c.pem && cat k.pem c.pem > /etc/freeswitch/tls/agent.pem
+cp c.pem /etc/freeswitch/tls/cafile.pem
+chown freeswitch:freeswitch /etc/freeswitch/tls/{agent,cafile}.pem
+fs_cli -x "reloadxml" && fs_cli -x "sofia profile external restart"
+fs_cli -x "sofia status profile external" | grep TLS-BIND-URL   # expect :5081
+```
+
+Confirm SRTP actually covered every call rather than assuming it:
+`forge_srtp_packets_decrypted_total` should equal
+`forge_rtp_packets_received_total`.
+
+### FreeSWITCH limits
+
+The stock `max-sessions 1000` / `sessions-per-second 30` already cover 200
+concurrent at 10 cps, so §10.2's raise to 3000/200 is only needed past ~500 —
+or past ~400 with crypto, where FreeSWITCH's own CPU starts to threaten §10.1.
+
+## Calls end themselves
+
+`ramp.sh` sets `execute_on_answer='sched_hangup +<hold> NORMAL_CLEARING'` on
+every originate, so a run terminates on its own schedule instead of depending on
+a closing `hupall`. If the driving session dies, the calls still end. Keep this
+property in anything derived from these scripts — it is what makes an unattended
+ramp safe.
+
+## Measuring
+
+Use `/proc/<pid>/stat` fields 14+15 over a fixed window. **`ps -o %cpu` is a
+lifetime average**, not an instantaneous rate: it makes a flat run look like it
+is ramping, and is meaningless for a long-lived FreeSWITCH process. `bc` may not
+be installed — the drivers do their arithmetic in `awk`.
+
+Sample the generator's CPU in every row too. If Box B is above ~70 % while the
+daemon is below it, **the run is void** (§10.1).
+
+## netem
+
+`phase3.sh` applies impairment to **Box B's egress only** — the
+caller→SiphonAI direction, which is what `siphon_ai_rtp_rx_jitter_ms` measures.
+The return path stays clean; say so when publishing.
+
+It also arms a detached auto-removal:
+
+```sh
+setsid nohup bash -c 'sleep 1800; tc qdisc del dev eth0 root' >/dev/null 2>&1 &
+```
+
+Keep that. `netem` impairs your own ssh to the box, so a dropped session must
+not strand the qdisc.

--- a/test-harness/load/tier2/phase1.sh
+++ b/test-harness/load/tier2/phase1.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Tier-2 phase 1: concurrency ramp, plaintext, generator on Box B.
+# Mirrors LOAD_TEST_PLAN.md §4 (5 min per step) so the numbers are comparable
+# to the tier-1 figures in RESULTS-0.48.13.md.
+set -u
+SP=${SP:?set SP to a working directory}
+B=root@194.195.208.34
+HOLD=300
+CPS=10
+M=http://127.0.0.1:9191/metrics
+D=$(cat $SP/lab.pid)
+HZ=$(getconf CLK_TCK)
+NCPU=$(nproc)
+
+met() { curl -s --max-time 4 $M | grep -oP "^$1 \K[0-9.]+" | head -1; }
+
+# Instantaneous CPU% of one core for a local pid, over $2 seconds.
+cpu_local() {
+  local p=$1 w=$2 u1 s1 u2 s2 t1 t2
+  read u1 s1 <<<$(awk '{print $14, $15}' /proc/$p/stat); t1=$(date +%s%N)
+  sleep $w
+  read u2 s2 <<<$(awk '{print $14, $15}' /proc/$p/stat); t2=$(date +%s%N)
+  awk -v a=$u1 -v b=$s1 -v c=$u2 -v d=$s2 -v t1=$t1 -v t2=$t2 -v hz=$HZ \
+    'BEGIN{printf "%.1f", 100*((c+d)-(a+b))/hz/((t2-t1)/1e9)}'
+}
+
+# Same for freeswitch on Box B.
+cpu_remote() {
+  ssh -o BatchMode=yes -o ConnectTimeout=10 $B "bash -s" <<REMOTE
+P=\$(pgrep -x freeswitch | head -1)
+read u1 s1 <<<\$(awk '{print \$14, \$15}' /proc/\$P/stat); t1=\$(date +%s%N)
+sleep $1
+read u2 s2 <<<\$(awk '{print \$14, \$15}' /proc/\$P/stat); t2=\$(date +%s%N)
+awk -v a=\$u1 -v b=\$s1 -v c=\$u2 -v d=\$s2 -v t1=\$t1 -v t2=\$t2 -v hz=\$(getconf CLK_TCK) \
+  'BEGIN{printf "%.1f", 100*((c+d)-(a+b))/hz/((t2-t1)/1e9)}'
+REMOTE
+}
+
+echo "=== tier-2 phase 1 started $(date -u +%FT%TZ) ==="
+for CONC in 50 100 200; do
+  echo ""
+  echo "########## STEP: $CONC concurrent ##########"
+  : > $SP/cdr.jsonl                      # fresh CDR file per step
+  WARN0=$(grep -cE ' WARN | ERROR ' $SP/daemon-cal.log || true)
+  RTP0=$(met forge_rtp_packets_received_total)
+
+  ssh -o BatchMode=yes -o ConnectTimeout=10 $B "/root/ramp.sh $CONC $CPS $HOLD" >/dev/null 2>&1
+  echo "originated $CONC at $CPS cps, hold ${HOLD}s — settling 60s"
+  sleep 60
+
+  # Steady-state window: three samples across the hold.
+  for s in 1 2 3; do
+    ACT=$(met siphon_ai_calls_active)
+    ACPU=$(cpu_local $D 10)
+    BCPU=$(cpu_remote 10)
+    RSS=$(awk '/VmRSS/{print $2}' /proc/$D/status)
+    FDS=$(ls /proc/$D/fd 2>/dev/null | wc -l)
+    THR=$(awk '/Threads/{print $2}' /proc/$D/status)
+    echo "  sample$s active=$ACT  A_cpu=${ACPU}%core  B_cpu=${BCPU}%core  rss=$((RSS/1024))MB  fds=$FDS  threads=$THR"
+    awk -v c="$ACPU" -v a="$ACT" 'BEGIN{if(a>0) printf "           cpu/call=%.3f%%  (%.1f%% of box)\n", c/a, c/'"$NCPU"'}'
+    sleep 45
+  done
+
+  DROP=$(met siphon_ai_outbound_audio_frames_dropped_total)
+  RTP1=$(met forge_rtp_packets_received_total)
+  echo "  playout drops=${DROP:-unset}   rtp_pkts_this_step=$(awk -v a=${RTP0:-0} -v b=${RTP1:-0} 'BEGIN{print b-a}')"
+
+  echo "  waiting for self-hangup + drain..."
+  for i in $(seq 1 40); do
+    A=$(met siphon_ai_calls_active); [ "${A:-1}" = "0" ] && break; sleep 15
+  done
+  sleep 10
+  N=$(wc -l < $SP/cdr.jsonl)
+  echo "  drained: calls_active=$(met siphon_ai_calls_active)  cdrs=$N"
+  python3 - <<PY
+import json,collections
+c=collections.Counter(); d=[]
+for l in open("$SP/cdr.jsonl"):
+    r=json.loads(l); c[r.get("termination",{}).get("cause")]+=1; d.append(r.get("duration_ms",0))
+if d: print("  causes=%s  duration_ms min=%d max=%d mean=%d"%(dict(c),min(d),max(d),sum(d)/len(d)))
+PY
+  WARN1=$(grep -cE ' WARN | ERROR ' $SP/daemon-cal.log || true)
+  echo "  WARN/ERROR added this step: $((WARN1-WARN0))"
+  cp $SP/cdr.jsonl $SP/cdr-$CONC.jsonl
+  sleep 20
+done
+echo ""
+echo "=== tier-2 phase 1 finished $(date -u +%FT%TZ) ==="

--- a/test-harness/load/tier2/phase2.sh
+++ b/test-harness/load/tier2/phase2.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Tier-2 phase 2: concurrency ramp over SIP/TLS with SRTP, generator on Box B.
+# Mirrors LOAD_TEST_PLAN.md §4 (5 min per step) so the numbers are comparable
+# to the tier-1 figures in RESULTS-0.48.13.md.
+set -u
+SP=${SP:?set SP to a working directory}
+B=root@194.195.208.34
+HOLD=300
+CPS=10
+M=http://127.0.0.1:9191/metrics
+D=$(cat $SP/lab.pid)
+HZ=$(getconf CLK_TCK)
+NCPU=$(nproc)
+
+met() { curl -s --max-time 4 $M | grep -oP "^$1 \K[0-9.]+" | head -1; }
+
+# Instantaneous CPU% of one core for a local pid, over $2 seconds.
+cpu_local() {
+  local p=$1 w=$2 u1 s1 u2 s2 t1 t2
+  read u1 s1 <<<$(awk '{print $14, $15}' /proc/$p/stat); t1=$(date +%s%N)
+  sleep $w
+  read u2 s2 <<<$(awk '{print $14, $15}' /proc/$p/stat); t2=$(date +%s%N)
+  awk -v a=$u1 -v b=$s1 -v c=$u2 -v d=$s2 -v t1=$t1 -v t2=$t2 -v hz=$HZ \
+    'BEGIN{printf "%.1f", 100*((c+d)-(a+b))/hz/((t2-t1)/1e9)}'
+}
+
+# Same for freeswitch on Box B.
+cpu_remote() {
+  ssh -o BatchMode=yes -o ConnectTimeout=10 $B "bash -s" <<REMOTE
+P=\$(pgrep -x freeswitch | head -1)
+read u1 s1 <<<\$(awk '{print \$14, \$15}' /proc/\$P/stat); t1=\$(date +%s%N)
+sleep $1
+read u2 s2 <<<\$(awk '{print \$14, \$15}' /proc/\$P/stat); t2=\$(date +%s%N)
+awk -v a=\$u1 -v b=\$s1 -v c=\$u2 -v d=\$s2 -v t1=\$t1 -v t2=\$t2 -v hz=\$(getconf CLK_TCK) \
+  'BEGIN{printf "%.1f", 100*((c+d)-(a+b))/hz/((t2-t1)/1e9)}'
+REMOTE
+}
+
+echo "=== tier-2 phase 2 TLS+SRTP started $(date -u +%FT%TZ) ==="
+for CONC in 50 100 200; do
+  echo ""
+  echo "########## STEP: $CONC concurrent ##########"
+  : > $SP/cdr-tls.jsonl                      # fresh CDR file per step
+  WARN0=$(grep -cE ' WARN | ERROR ' $SP/daemon-tls.log || true)
+  RTP0=$(met forge_rtp_packets_received_total)
+
+  ssh -o BatchMode=yes -o ConnectTimeout=10 $B "/root/ramp-tls.sh $CONC $CPS $HOLD" >/dev/null 2>&1
+  echo "originated $CONC at $CPS cps, hold ${HOLD}s — settling 60s"
+  sleep 60
+
+  # Steady-state window: three samples across the hold.
+  for s in 1 2 3; do
+    ACT=$(met siphon_ai_calls_active)
+    ACPU=$(cpu_local $D 10)
+    BCPU=$(cpu_remote 10)
+    RSS=$(awk '/VmRSS/{print $2}' /proc/$D/status)
+    FDS=$(ls /proc/$D/fd 2>/dev/null | wc -l)
+    THR=$(awk '/Threads/{print $2}' /proc/$D/status)
+    echo "  sample$s active=$ACT  A_cpu=${ACPU}%core  B_cpu=${BCPU}%core  rss=$((RSS/1024))MB  fds=$FDS  threads=$THR"
+    awk -v c="$ACPU" -v a="$ACT" 'BEGIN{if(a>0) printf "           cpu/call=%.3f%%  (%.1f%% of box)\n", c/a, c/'"$NCPU"'}'
+    sleep 45
+  done
+
+  DROP=$(met siphon_ai_outbound_audio_frames_dropped_total)
+  RTP1=$(met forge_rtp_packets_received_total)
+  echo "  playout drops=${DROP:-unset}   rtp_pkts_this_step=$(awk -v a=${RTP0:-0} -v b=${RTP1:-0} 'BEGIN{print b-a}')"
+
+  echo "  waiting for self-hangup + drain..."
+  for i in $(seq 1 40); do
+    A=$(met siphon_ai_calls_active); [ "${A:-1}" = "0" ] && break; sleep 15
+  done
+  sleep 10
+  N=$(wc -l < $SP/cdr-tls.jsonl)
+  echo "  drained: calls_active=$(met siphon_ai_calls_active)  cdrs=$N"
+  python3 - <<PY
+import json,collections
+c=collections.Counter(); d=[]
+for l in open("$SP/cdr-tls.jsonl"):
+    r=json.loads(l); c[r.get("termination",{}).get("cause")]+=1; d.append(r.get("duration_ms",0))
+if d: print("  causes=%s  duration_ms min=%d max=%d mean=%d"%(dict(c),min(d),max(d),sum(d)/len(d)))
+PY
+  WARN1=$(grep -cE ' WARN | ERROR ' $SP/daemon-tls.log || true)
+  echo "  WARN/ERROR added this step: $((WARN1-WARN0))"
+  cp $SP/cdr-tls.jsonl $SP/cdr-tls-$CONC.jsonl
+  sleep 20
+done
+echo ""
+echo "=== tier-2 phase 2 TLS+SRTP finished $(date -u +%FT%TZ) ==="

--- a/test-harness/load/tier2/phase3.sh
+++ b/test-harness/load/tier2/phase3.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Tier-2 phase 3: quality under netem impairment (LOAD_TEST_PLAN.md §10.2).
+#
+# Two 200-call TLS+SRTP runs, back to back: one clean, one with 20ms±5ms delay
+# and 0.5% loss applied to Box B's egress. Quality is read as histogram DELTAS
+# around each run, so the 700 calls already in the daemon's counters cannot
+# flatter the result.
+#
+# Impairment is on B's egress only, i.e. the caller->SiphonAI direction — which
+# is exactly the stream siphon_ai_rtp_rx_jitter_ms measures. The return path is
+# unimpaired; that asymmetry is deliberate and belongs in the write-up.
+set -u
+SP=${SP:?set SP to a working directory}
+B=root@194.195.208.34
+M=http://127.0.0.1:9191/metrics
+CONC=200; CPS=10; HOLD=300
+
+snap() { curl -s --max-time 5 $M | grep -E '^siphon_ai_rtp_(rx_jitter_ms|mos_estimate)_(bucket|count|sum)' > "$1"; }
+
+run_one() {                       # $1=label  $2=pre file  $3=post file
+  : > $SP/cdr-tls.jsonl
+  snap "$2"
+  ssh -o BatchMode=yes -o ConnectTimeout=10 $B "/root/ramp-tls.sh $CONC $CPS $HOLD" >/dev/null 2>&1
+  echo "  [$1] originated $CONC, settling then holding"
+  sleep 280
+  snap "$3"
+  echo "  [$1] quality window captured; draining"
+  for i in $(seq 1 40); do
+    A=$(curl -s --max-time 4 $M | grep -oP '^siphon_ai_calls_active \K[0-9]+')
+    [ "${A:-1}" = "0" ] && break; sleep 15
+  done
+  sleep 10
+  echo "  [$1] drained: cdrs=$(wc -l < $SP/cdr-tls.jsonl) active=$(curl -s --max-time 4 $M | grep -oP '^siphon_ai_calls_active \K[0-9]+')"
+  cp $SP/cdr-tls.jsonl $SP/cdr-$1.jsonl
+}
+
+echo "=== tier-2 phase 3 (netem) started $(date -u +%FT%TZ) ==="
+
+echo "--- RUN A: clean LAN, 200 concurrent TLS+SRTP ---"
+run_one clean $SP/q-clean-pre.txt $SP/q-clean-post.txt
+
+echo "--- applying netem on Box B egress: 20ms +/-5ms, 0.5% loss ---"
+ssh -o BatchMode=yes -o ConnectTimeout=10 $B \
+  "tc qdisc replace dev eth0 root netem delay 20ms 5ms loss 0.5%; \
+   setsid nohup bash -c 'sleep 1800; tc qdisc del dev eth0 root' >/dev/null 2>&1 & \
+   sleep 1; tc qdisc show dev eth0 | head -2"
+echo "  (a detached 30-min auto-removal is armed, so impairment self-clears if this session dies)"
+
+echo "--- RUN B: impaired, 200 concurrent TLS+SRTP ---"
+run_one impaired $SP/q-imp-pre.txt $SP/q-imp-post.txt
+
+echo "--- removing netem ---"
+ssh -o BatchMode=yes -o ConnectTimeout=10 $B \
+  "tc qdisc del dev eth0 root 2>/dev/null; tc qdisc show dev eth0 | head -2"
+
+echo "=== tier-2 phase 3 finished $(date -u +%FT%TZ) ==="

--- a/test-harness/load/tier2/ramp-tls.sh
+++ b/test-harness/load/tier2/ramp-tls.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Tier-2 phase 2: same ramp as ramp.sh but over SIP/TLS with SRTP mandatory.
+# srtp=required on the daemon side per docs/CONFIG.md — stock FreeSWITCH 488s
+# the "preferred" AVP+a=crypto shape, so required is the only workable mode here.
+CONC=${1:-50}; CPS=${2:-10}; HOLD=${3:-300}
+TARGET="sip:9001@139.177.205.140:5071;transport=tls"
+MEDIA=/usr/share/freeswitch/sounds/music/8000/suite-espanola-op-47-leyenda.wav
+DELAY=$(python3 -c "print(1/$CPS)")
+for i in $(seq 1 "$CONC"); do
+  fs_cli -x "bgapi originate {ignore_early_media=true,absolute_codec_string=PCMU,\
+rtp_secure_media=mandatory:AES_CM_128_HMAC_SHA1_80,origination_caller_id_number=1000,\
+execute_on_answer='sched_hangup +$HOLD NORMAL_CLEARING'}sofia/external/$TARGET \
+&endless_playback($MEDIA)" >/dev/null
+  sleep "$DELAY"
+done
+echo "originated $CONC TLS+SRTP calls at $CPS cps, hold ${HOLD}s"

--- a/test-harness/load/tier2/ramp.sh
+++ b/test-harness/load/tier2/ramp.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Tier-2 ramp generator (LOAD_TEST_PLAN.md §10.2), with one deliberate change:
+# every call carries sched_hangup, so it terminates on its own schedule instead
+# of depending on a global `hupall` at the end. If the driving session dies
+# mid-run the calls still end by themselves.
+#   ramp.sh <concurrency> <cps> <hold_seconds>
+CONC=${1:-50}; CPS=${2:-10}; HOLD=${3:-180}
+TARGET="sip:9001@139.177.205.140:5070"
+MEDIA=/usr/share/freeswitch/sounds/music/8000/suite-espanola-op-47-leyenda.wav
+DELAY=$(python3 -c "print(1/$CPS)")
+for i in $(seq 1 "$CONC"); do
+  fs_cli -x "bgapi originate {ignore_early_media=true,absolute_codec_string=PCMU,\
+origination_caller_id_number=1000,execute_on_answer='sched_hangup +$HOLD NORMAL_CLEARING'}\
+sofia/external/$TARGET &endless_playback($MEDIA)" >/dev/null
+  sleep "$DELAY"
+done
+echo "originated $CONC calls at $CPS cps, each self-hanging after ${HOLD}s"

--- a/test-harness/load/tier2/tier2-lab.toml.example
+++ b/test-harness/load/tier2/tier2-lab.toml.example
@@ -1,0 +1,60 @@
+# Tier 2 (LOAD_TEST_PLAN.md §10.2) — generator is FreeSWITCH on Box B
+# (194.195.208.34), daemon under test is the SHIPPED 0.48.19 deb binary here
+# on Box A (139.177.205.140).
+#
+# Posture is deliberately IDENTICAL to the tier-1 lab config (soak18/lab.toml,
+# which produced the published 0.48.18 §6.1 numbers): G.711, recording off,
+# HEP off, energy VAD, no webhooks/audit, udp_rate_limit_pps = 0. The only
+# things tier 2 changes are the generator, the network and (in phase 2) the
+# crypto — so any delta is attributable to those and not to posture drift.
+[node]
+id = "siphon-tier2-lab"
+# Required once [sip].listen is unspecified: the SDP answer's c= line cannot
+# be 0.0.0.0, and Box B must be told where to send RTP.
+public_address = "139.177.205.140"
+
+[sip]
+# 0.0.0.0, not 127.0.0.1: the INVITEs arrive over the NIC from Box B.
+listen             = "0.0.0.0:5070"
+transports         = ["udp"]
+user_agent         = "SiphonAI/tier2-lab"
+# Matches tier 1 (see RESULTS-0.48.13 §Environment / #459): admission control
+# off, so §5-style numbers measure the bridge and not the transport cap.
+udp_rate_limit_pps = 0
+
+# This listener is on a public IP and :5060 already sees scanner INVITEs, so
+# the allowlist is not optional here — only Box B may originate.
+[[trunk]]
+name       = "fs-load"
+peer_addrs = ["194.195.208.34"]
+
+[media]
+codecs                  = ["pcmu", "pcma"]
+dtmf                    = "rfc2833"
+# Same range as the tier-1 run for comparability. NOT covered by
+# /etc/sysctl.d/60-siphon-ai-rtp.conf (which reserves 40000-40500), so a
+# kernel-issued ephemeral port can still collide here — on 0.48.19 that is
+# retried rather than fatal (#504 / RESULTS-0.48.19.md). Any
+# "held outside the pool" warning during a run belongs in the write-up.
+rtp_port_range          = [41000, 45000]
+inactivity_timeout_secs = 60
+
+[bridge]
+ws_url                = "ws://127.0.0.1:8767/"
+ws_connect_timeout_ms = 3000
+
+[observability]
+enabled     = true
+http_listen = "127.0.0.1:9191"
+
+[cdr]
+enabled = true
+
+[cdr.file]
+enabled = true
+path    = "/PATH/TO/WORKDIR/cdr.jsonl"
+
+[[route]]
+name = "default"
+[route.match]
+any = true

--- a/test-harness/load/tier2/tier2-tls.toml.example
+++ b/test-harness/load/tier2/tier2-tls.toml.example
@@ -1,0 +1,66 @@
+# Tier 2 (LOAD_TEST_PLAN.md §10.2) — generator is FreeSWITCH on Box B
+# (194.195.208.34), daemon under test is the SHIPPED 0.48.19 deb binary here
+# on Box A (139.177.205.140).
+#
+# Posture is deliberately IDENTICAL to the tier-1 lab config (soak18/lab.toml,
+# which produced the published 0.48.18 §6.1 numbers): G.711, recording off,
+# HEP off, energy VAD, no webhooks/audit, udp_rate_limit_pps = 0. The only
+# things tier 2 changes are the generator, the network and (in phase 2) the
+# crypto — so any delta is attributable to those and not to posture drift.
+[node]
+id = "siphon-tier2-tls"
+# Required once [sip].listen is unspecified: the SDP answer's c= line cannot
+# be 0.0.0.0, and Box B must be told where to send RTP.
+public_address = "139.177.205.140"
+
+[sip]
+# 0.0.0.0, not 127.0.0.1: the INVITEs arrive over the NIC from Box B.
+listen             = "0.0.0.0:5070"
+transports         = ["udp", "tls"]
+user_agent         = "SiphonAI/tier2-lab"
+# Matches tier 1 (see RESULTS-0.48.13 §Environment / #459): admission control
+# off, so §5-style numbers measure the bridge and not the transport cap.
+udp_rate_limit_pps = 0
+
+# This listener is on a public IP and :5060 already sees scanner INVITEs, so
+# the allowlist is not optional here — only Box B may originate.
+[sip.tls]
+listen = "0.0.0.0:5071"
+cert   = "/PATH/TO/WORKDIR/lab-cert.pem"
+key    = "/PATH/TO/WORKDIR/lab-key.pem"
+
+[[trunk]]
+name       = "fs-load"
+peer_addrs = ["194.195.208.34"]
+
+[media]
+codecs                  = ["pcmu", "pcma"]
+dtmf                    = "rfc2833"
+# Same range as the tier-1 run for comparability. NOT covered by
+# /etc/sysctl.d/60-siphon-ai-rtp.conf (which reserves 40000-40500), so a
+# kernel-issued ephemeral port can still collide here — on 0.48.19 that is
+# retried rather than fatal (#504 / RESULTS-0.48.19.md). Any
+# "held outside the pool" warning during a run belongs in the write-up.
+rtp_port_range          = [41000, 45000]
+srtp                    = "required"
+inactivity_timeout_secs = 60
+
+[bridge]
+ws_url                = "ws://127.0.0.1:8767/"
+ws_connect_timeout_ms = 3000
+
+[observability]
+enabled     = true
+http_listen = "127.0.0.1:9191"
+
+[cdr]
+enabled = true
+
+[cdr.file]
+enabled = true
+path    = "/PATH/TO/WORKDIR/cdr-tls.jsonl"
+
+[[route]]
+name = "default"
+[route.match]
+any = true


### PR DESCRIPTION
`LOAD_TEST_PLAN.md` has described tier 2 since it was written and nothing had
ever run it, so §9's *"don't quote a secure-trunk number until it's run"* had no
number behind it. This runs all three phases against the **shipped 0.48.19 deb**
(sha256 `6b7340df4…`, byte-identical to the reference node's binary), driven by
**FreeSWITCH 1.11.0 on a second host** 0.27 ms away.

**1,100 calls, zero failures, and not one log line above `INFO`** from either
daemon across the whole session.

## Phase 1 — plaintext, over the NIC

| conc | daemon %of one core | CPU/call | FreeSWITCH | fds |
|---|---|---|---|---|
| 50 | 35.7 | 0.713% | 12.8 | 162 |
| 100 | 65.5 | 0.655% | 29.8 | 312 |
| 200 | **129.9** | **0.650%** | 54.5 | 612 |

**The network and a real SIP stack cost +23% CPU per call** — 0.650%/call
against tier 1's 0.53%/call at the same 200 concurrent on SIPp loopback. Per-call
cost is flat-to-improving across the ramp, so there is still no knee at 200; the
port range remains the ceiling.

Three checks say both tiers measured the same system: fds land on exactly
`12 + 3N` (**612 at 200 — the identical number tier 1 published**), threads stay
at 5, and the RTP count matches theory for the sampled window.

## Phase 2 — TLS + SRTP

| conc | daemon: plain → TLS+SRTP | CPU/call | FreeSWITCH: plain → TLS+SRTP |
|---|---|---|---|
| 50 | 35.7 → 38.4 | 0.767% | 12.8 → 23.5 |
| 100 | 65.5 → 71.7 | 0.717% | 29.8 → 47.8 |
| 200 | 129.9 → **132.6** | **0.663%** | 54.5 → **102.9** |

**Crypto is cheap for SiphonAI and expensive for FreeSWITCH.** The daemon pays
under 10%, and at 200 concurrent the difference is *inside the sample spread* —
the medians cross — so the doc explicitly **refuses to quote "+2.1%" as a
measured cost**. FreeSWITCH, doing the same crypto on the same media, rose
60–89%. TLS is signalling-only, which is why fds moved just 612 → 614.

Coverage is proven rather than assumed: `forge_srtp_packets_decrypted_total`
**equals** `forge_rtp_packets_received_total` (5,248,192), so no call quietly
fell back to plaintext — the failure mode that would have made the phase
meaningless.

## Phase 3 — netem

| | clean LAN | 20 ms ±5 ms, 0.5% loss |
|---|---|---|
| jitter mean | 0.44 ms | **3.35 ms** |
| MOS mean | 4.441 | 4.418 |
| CDR `rx_packets_lost` | **0.0** (max 0 / 200 calls) | **73.2** (53–93) |

Meant to produce an impaired MOS; produced something more useful — **evidence
the telemetry can be trusted.** Against 0.5% injected loss the CDRs report
**0.495%**, and **exactly zero** across 200 clean calls.

Two readings are guarded against in the text rather than left to the reader:
MOS moving only −0.023 is **not** "impairment had no effect" (G.711 at 0.5% loss
genuinely is still good audio — the loss and jitter counters are where the effect
is), and the 20 ms delay correctly **not** moving RFC 3550 interarrival jitter is
a consistency check *passing*, since that metric responds to variation and not to
constant latency.

## Also in here

- **`tier2/`** — the rig, so the method is reproducible rather than described:
  generator scripts, phase drivers (`SP` parameterised), lab configs, and a
  README covering the setup that is easy to get wrong (FS ships
  `external_ssl_enable=false` and no `agent.pem`; the daemon needs
  `srtp = "required"`).
- **`paced_sink.mjs`** into the harness — the published §6.1 numbers already
  depended on it while it existed only in a scratchpad. It held **50.000 Hz
  across 252,002 ticks** here, satisfying §1.4.
- **Five traps folded into §8**, including that `ps -o %cpu` is a lifetime
  average which made a flat 50-call run look like it was ramping.
- **§10.2 corrected on two points this run disproved**: `srtp` must be
  `"required"` toward FreeSWITCH (it `488`s the `"preferred"` AVP+crypto shape),
  and FS's stock session limits already cover 200 at 10 cps, so the documented
  3000/200 raise is only needed past ~500.

## What it does not establish

Recorded in the doc rather than implied: no soak at tier 2 (three 10-second CPU
samples inside each 5-minute hold); 0.27 ms between boxes means a real NIC but
**not** a real network, so every impairment figure is synthetic; no latency
measurement; impairment was one-directional (Box B egress, the direction the RX
metrics measure); and nothing past 200 — where FreeSWITCH's crypto cost (102.9%
of one core) would start making the *generator* the constraint.

> **Merge order:** based on `main`, but the README's file table mentions
> `RESULTS-0.48.19.md` and `squat.py`, which arrive with #510. Both are prose
> mentions, not links, so nothing breaks either way — merging #510 first just
> makes the table true on arrival.

Docs and test-harness scripts only; no crate code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNXkU45xPHgomcDkSs5GuN