### PR TITLE
feat(sightglass): multi-node TUI scaffold + shared admin wire types (PR 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`sightglass`: a terminal operator console for one or more siphon-ai nodes** (DESIGN_SIGHTGLASS.md, PR 1 of 6). A new `bins/sightglass` binary (crate `siphon-ai-sightglass`, ratatui) that fans out to each configured node's `[admin]` listener and renders a tabbed live view — **overview** (fleet health grid + active-call sparkline), **trunks** (registration state across nodes), **calls** (fleet-unified table with both id namespaces and direction, plus a per-focused-call quality pane fed by `GET /admin/v1/calls/:id/stats` with a client-side MOS trend). Multi-node is first-class from this first cut: every record is keyed `(node, id)`, one staggered poller set per node, a down node degrades to its own dimmed row without stalling the rest, and the Node column auto-hides on single-node fleets. Fleet config is `~/.config/sightglass/config.toml` (`[[node]]` name/url/token_file/ca) or `--target` for an ad-hoc single node; `--read-only` and `--ascii` flags per the design note. Read-only in this PR — operator actions (hangup/park/retrieve/originate, node-named confirm modals, per-node RBAC-aware keybinds) are PR 2. The daemon binary is untouched: ratatui/crossterm live only in the new crate.
+
+- **`crates/admin-api-types`: the admin API's request/response wire shapes as a shared crate**. The `/admin/v1/*` JSON shapes (`AdminCallRow`, `RegistrationRow`, `ConferenceRow`, `ParkedRow`, `DrainStatus`, the list envelopes, and the POST bodies) moved out of `siphon-ai-telemetry` into a serde-only crate consumed by both the daemon (serializer) and sightglass (deserializer), so the two cannot drift. Wire-preserving by construction: telemetry re-exports the same names at the same paths, the handlers serialize the same JSON byte-for-byte (all 79 existing admin dispatch tests pass unchanged), and new wire snapshot tests in the crate pin the exact JSON as the contract. One internal type change: `AdminCallRow.direction` is `String` rather than `&'static str` (identical on the wire; required for the deserialize direction).
+
 ## [0.48.19] - 2026-08-14
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ For the full design rationale, see `docs/DEV_PLAN.md`.
 siphon-ai/
 ├── Cargo.toml                    # workspace root
 ├── crates/
+│   ├── admin-api-types/          # Admin API wire shapes (shared: daemon serializes, sightglass deserializes)
 │   ├── core/                     # CallController, state machine, glue
 │   ├── bridge/                   # WS client + protocol types + audio bridging
 │   ├── sip-glue/                 # Adapter: siphon-rs events → core
@@ -56,6 +57,7 @@ siphon-ai/
 │   ├── protocol-testkit/         # siphon-ai-testkit: WS protocol conformance harness
 │   └── telemetry/                # tracing + metrics + HEP wiring + admin/health endpoints
 ├── bins/
+│   ├── sightglass/               # Terminal operator console (crate: siphon-ai-sightglass; docs/design/DESIGN_SIGHTGLASS.md)
 │   └── siphon-ai/                # The daemon binary
 ├── sdks/
 │   ├── python/                   # Server SDK (siphon-ai-server on PyPI-style layout)
@@ -99,6 +101,8 @@ siphon-ai/
 | New HEP chunk emission | `crates/telemetry/src/hep.rs` (uses `hep-rs` crate) |
 | New metric | `crates/telemetry/src/metrics.rs` + document in `docs/DEPLOY.md` |
 | New admin endpoint | `crates/telemetry/src/admin.rs` + document in `docs/DEPLOY.md` |
+| Admin API request/response shape | `crates/admin-api-types/` (wire snapshot tests lock the JSON; sightglass parses these) |
+| Sightglass TUI feature | `bins/sightglass/` — per the PR plan in `docs/design/DESIGN_SIGHTGLASS.md` |
 | New CLI flag | `bins/siphon-ai/src/main.rs` |
 | Integration test against a real SIP scenario | `test-harness/sipp-scenarios/` |
 | Test that needs a HEP collector | `test-harness/hep-collector-stub/` |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -389,6 +389,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,7 +504,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -527,6 +542,20 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -635,6 +664,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.11.1",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,6 +744,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,7 +827,7 @@ checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -773,7 +861,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1300,7 +1388,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1468,6 +1556,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -1854,6 +1944,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1887,6 +1983,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1902,6 +2007,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf84e73fa6f27f299dec58e13223cf70db80da872eb921d4f6138342a0eabc8"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1953,6 +2071,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1993,7 +2120,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2012,7 +2139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2110,6 +2237,12 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -2146,6 +2279,15 @@ dependencies = [
  "scoped-tls",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -2295,6 +2437,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -2512,7 +2655,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2635,6 +2778,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pastey"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2673,7 +2822,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2768,7 +2917,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2806,10 +2955,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3027,6 +3176,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.11.1",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3109,7 +3279,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3287,6 +3457,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3294,7 +3477,7 @@ dependencies = [
  "bitflags 2.11.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -3431,7 +3614,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3502,7 +3685,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3513,7 +3696,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3608,6 +3791,27 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -3921,6 +4125,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphon-ai-admin-api-types"
+version = "0.48.19"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "siphon-ai-audit"
 version = "0.48.19"
 dependencies = [
@@ -4162,6 +4374,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphon-ai-sightglass"
+version = "0.48.19"
+dependencies = [
+ "anyhow",
+ "clap",
+ "ratatui",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "siphon-ai-admin-api-types",
+ "tokio",
+ "toml",
+]
+
+[[package]]
 name = "siphon-ai-sip-glue"
 version = "0.48.19"
 dependencies = [
@@ -4228,6 +4455,7 @@ dependencies = [
  "sha2 0.10.9",
  "sip-hep",
  "sip-observe",
+ "siphon-ai-admin-api-types",
  "siphon-ai-audit",
  "subtle",
  "thiserror 1.0.69",
@@ -4317,6 +4545,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4337,6 +4571,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "subtle"
@@ -4551,6 +4807,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4567,7 +4834,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4617,7 +4884,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -4647,7 +4914,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4658,7 +4925,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4739,7 +5006,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4949,7 +5216,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5063,7 +5330,7 @@ dependencies = [
  "dyn-hash",
  "half",
  "inventory",
- "itertools",
+ "itertools 0.14.0",
  "lazy_static",
  "libm",
  "maplit",
@@ -5282,6 +5549,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5480,7 +5776,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -5636,7 +5932,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5647,7 +5943,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5812,7 +6108,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -5828,7 +6124,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -5883,7 +6179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -5914,7 +6210,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5935,7 +6231,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5955,7 +6251,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5976,7 +6272,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6009,7 +6305,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,9 @@
 [workspace]
 resolver = "2"
 members = [
+    "bins/sightglass",
     "bins/siphon-ai",
+    "crates/admin-api-types",
     "crates/audit",
     "crates/bridge",
     "crates/cdr",
@@ -31,6 +33,7 @@ homepage = "https://github.com/thevoiceguy/siphon-ai"
 
 [workspace.dependencies]
 # Internal crates (used by bins/siphon-ai and cross-crate)
+siphon-ai-admin-api-types = { path = "crates/admin-api-types" }
 siphon-ai-audit       = { path = "crates/audit" }
 siphon-ai-bridge      = { path = "crates/bridge" }
 siphon-ai-cdr         = { path = "crates/cdr" }
@@ -115,6 +118,11 @@ regex = "1"
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
+
+# Sightglass TUI (bins/sightglass ONLY — the daemon never links these;
+# DESIGN_SIGHTGLASS.md §9). crossterm comes via ratatui's re-export so
+# the two can't version-skew.
+ratatui = "0.29"
 
 # Utilities
 parking_lot = "0.12"

--- a/bins/sightglass/Cargo.toml
+++ b/bins/sightglass/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name        = "siphon-ai-sightglass"
+description = "Sightglass: terminal operator console for one or more siphon-ai nodes."
+version.workspace      = true
+edition.workspace      = true
+rust-version.workspace = true
+license.workspace      = true
+authors.workspace      = true
+repository.workspace   = true
+
+[[bin]]
+name = "sightglass"
+path = "src/main.rs"
+
+[dependencies]
+anyhow.workspace     = true
+clap.workspace       = true
+ratatui.workspace    = true
+reqwest.workspace    = true
+serde.workspace      = true
+serde_json.workspace = true
+tokio.workspace      = true
+toml.workspace       = true
+siphon-ai-admin-api-types.workspace = true

--- a/bins/sightglass/src/client.rs
+++ b/bins/sightglass/src/client.rs
@@ -1,0 +1,90 @@
+//! Per-node admin API client.
+//!
+//! One [`AdminClient`] per configured node, built once at startup.
+//! Every method returns `Result<T, String>` — the error string is
+//! operator-facing (it lands in the node's health row), so it favors
+//! "connect error: …" over debug dumps.
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use serde::de::DeserializeOwned;
+use siphon_ai_admin_api_types::{CallsResponse, DrainStatus, ErrorBody, RegistrationsResponse};
+
+use crate::config::Node;
+
+pub struct AdminClient {
+    http: reqwest::Client,
+    base: String,
+    token: Option<String>,
+}
+
+impl AdminClient {
+    pub fn new(node: &Node) -> Result<Self> {
+        let mut builder = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(3))
+            .timeout(Duration::from_secs(5));
+        if let Some(pem) = &node.ca_pem {
+            let cert = reqwest::Certificate::from_pem(pem)
+                .with_context(|| format!("node {:?}: CA bundle is not valid PEM", node.name))?;
+            builder = builder.add_root_certificate(cert);
+        }
+        Ok(Self {
+            http: builder
+                .build()
+                .with_context(|| format!("node {:?}: building HTTP client", node.name))?,
+            base: node.url.clone(),
+            token: node.token.clone(),
+        })
+    }
+
+    pub async fn calls(&self) -> Result<CallsResponse, String> {
+        self.get_json("/admin/v1/calls").await
+    }
+
+    pub async fn registrations(&self) -> Result<RegistrationsResponse, String> {
+        self.get_json("/admin/v1/registrations").await
+    }
+
+    pub async fn drain(&self) -> Result<DrainStatus, String> {
+        self.get_json("/admin/v1/drain").await
+    }
+
+    /// Live quality snapshot for one active call. Kept as a loose
+    /// `Value` until the stats shape joins `admin-api-types`
+    /// (DESIGN_SIGHTGLASS.md §6.4, PR 5).
+    pub async fn call_stats(&self, call_id: &str) -> Result<serde_json::Value, String> {
+        self.get_json(&format!("/admin/v1/calls/{call_id}/stats"))
+            .await
+    }
+
+    async fn get_json<T: DeserializeOwned>(&self, path: &str) -> Result<T, String> {
+        let mut req = self.http.get(format!("{}{}", self.base, path));
+        if let Some(token) = &self.token {
+            req = req.bearer_auth(token);
+        }
+        let resp = req.send().await.map_err(connect_error)?;
+        let status = resp.status();
+        let body = resp.bytes().await.map_err(connect_error)?;
+        if !status.is_success() {
+            // Admin endpoints answer failures with `{"error": …}`;
+            // fall back to the raw status for anything else (an
+            // intercepting proxy, an HTML error page).
+            let detail = serde_json::from_slice::<ErrorBody>(&body)
+                .map(|e| e.error)
+                .unwrap_or_else(|_| status.to_string());
+            return Err(format!("{} {}: {}", status.as_u16(), path, detail));
+        }
+        serde_json::from_slice(&body).map_err(|e| format!("bad response from {path}: {e}"))
+    }
+}
+
+/// Reqwest errors chain the useful part ("connection refused") a few
+/// sources deep; surface the innermost message.
+fn connect_error(e: reqwest::Error) -> String {
+    let mut source: &dyn std::error::Error = &e;
+    while let Some(inner) = source.source() {
+        source = inner;
+    }
+    source.to_string()
+}

--- a/bins/sightglass/src/config.rs
+++ b/bins/sightglass/src/config.rs
@@ -1,0 +1,259 @@
+//! Fleet configuration: which siphon-ai nodes to watch and how.
+//!
+//! Two mutually exclusive sources (DESIGN_SIGHTGLASS.md §8):
+//! a `config.toml` with one `[[node]]` per daemon, or `--target` for
+//! an ad-hoc single-node fleet. Everything is resolved (token files
+//! read, names validated) before the terminal is put into raw mode,
+//! so config errors print as plain CLI errors.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+
+use crate::Cli;
+
+/// On-disk shape of `~/.config/sightglass/config.toml`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FileConfig {
+    /// Per-node poll cadence. Default 1000 (§2: 1 s).
+    poll_interval_ms: Option<u64>,
+    #[serde(default)]
+    node: Vec<FileNode>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FileNode {
+    /// Unique display name — the `NodeId` shown in every Node column
+    /// and confirm modal.
+    name: String,
+    /// Admin listener base URL, e.g. `https://prod-1.example.com:9090`.
+    url: String,
+    /// File holding the admin bearer token for this node.
+    token_file: Option<PathBuf>,
+    /// PEM CA bundle for a privately-signed admin TLS cert.
+    ca: Option<PathBuf>,
+}
+
+/// One fully resolved node: secrets read, url normalized.
+#[derive(Debug, Clone)]
+pub struct Node {
+    pub name: String,
+    /// Base URL without a trailing slash.
+    pub url: String,
+    pub token: Option<String>,
+    /// PEM bytes of a private CA, when configured.
+    pub ca_pem: Option<Vec<u8>>,
+}
+
+/// The resolved fleet the rest of the program runs on.
+#[derive(Debug, Clone)]
+pub struct Fleet {
+    pub poll_interval: Duration,
+    pub nodes: Vec<Node>,
+}
+
+/// Resolve CLI args + config file into a [`Fleet`].
+pub fn load(cli: &Cli) -> Result<Fleet> {
+    if let Some(target) = &cli.target {
+        let token = match &cli.token_file {
+            Some(p) => Some(read_token(p)?),
+            // Env fallback is single-node only (§8) — a fleet config
+            // can't disambiguate which node one env token belongs to.
+            None => std::env::var("SIGHTGLASS_TOKEN")
+                .ok()
+                .map(|t| t.trim().to_string()),
+        };
+        let ca_pem = cli.ca.as_deref().map(read_ca).transpose()?;
+        let url = normalize_url(target)?;
+        return Ok(Fleet {
+            poll_interval: Duration::from_millis(1000),
+            nodes: vec![Node {
+                name: display_name_for(&url),
+                url,
+                token,
+                ca_pem,
+            }],
+        });
+    }
+
+    let path = match &cli.config {
+        Some(p) => p.clone(),
+        None => default_config_path()?,
+    };
+    let raw = std::fs::read_to_string(&path)
+        .with_context(|| format!("reading fleet config {}", path.display()))?;
+    let parsed: FileConfig =
+        toml::from_str(&raw).with_context(|| format!("parsing fleet config {}", path.display()))?;
+    resolve(parsed, path.parent().unwrap_or(Path::new(".")))
+}
+
+fn resolve(cfg: FileConfig, base_dir: &Path) -> Result<Fleet> {
+    if cfg.node.is_empty() {
+        bail!("fleet config has no [[node]] entries (or use --target for an ad-hoc node)");
+    }
+    let mut nodes = Vec::with_capacity(cfg.node.len());
+    for n in &cfg.node {
+        if n.name.trim().is_empty() {
+            bail!("[[node]] with url {:?} has an empty name", n.url);
+        }
+        if nodes.iter().any(|r: &Node| r.name == n.name) {
+            bail!(
+                "duplicate [[node]] name {:?} — names are the NodeId and must be unique",
+                n.name
+            );
+        }
+        let token = n
+            .token_file
+            .as_deref()
+            .map(|p| read_token(&resolve_path(base_dir, p)))
+            .transpose()
+            .with_context(|| format!("node {:?}", n.name))?;
+        let ca_pem =
+            n.ca.as_deref()
+                .map(|p| read_ca(&resolve_path(base_dir, p)))
+                .transpose()
+                .with_context(|| format!("node {:?}", n.name))?;
+        nodes.push(Node {
+            name: n.name.clone(),
+            url: normalize_url(&n.url).with_context(|| format!("node {:?}", n.name))?,
+            token,
+            ca_pem,
+        });
+    }
+    let poll_ms = cfg.poll_interval_ms.unwrap_or(1000);
+    if poll_ms < 100 {
+        bail!("poll_interval_ms {poll_ms} is below the 100ms floor");
+    }
+    Ok(Fleet {
+        poll_interval: Duration::from_millis(poll_ms),
+        nodes,
+    })
+}
+
+/// Token/CA paths in the config resolve relative to the config file's
+/// directory (with `~/` expanded), so a checked-out config dir is
+/// relocatable.
+fn resolve_path(base_dir: &Path, p: &Path) -> PathBuf {
+    if let Ok(rest) = p.strip_prefix("~") {
+        if let Some(home) = std::env::var_os("HOME") {
+            return PathBuf::from(home).join(rest);
+        }
+    }
+    if p.is_absolute() {
+        p.to_path_buf()
+    } else {
+        base_dir.join(p)
+    }
+}
+
+fn read_token(path: &Path) -> Result<String> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("reading token file {}", path.display()))?;
+    let token = raw.trim().to_string();
+    if token.is_empty() {
+        bail!("token file {} is empty", path.display());
+    }
+    Ok(token)
+}
+
+fn read_ca(path: &Path) -> Result<Vec<u8>> {
+    std::fs::read(path).with_context(|| format!("reading CA bundle {}", path.display()))
+}
+
+fn normalize_url(url: &str) -> Result<String> {
+    let url = url.trim().trim_end_matches('/');
+    if !(url.starts_with("http://") || url.starts_with("https://")) {
+        bail!("node url {url:?} must start with http:// or https://");
+    }
+    Ok(url.to_string())
+}
+
+/// Ad-hoc `--target` nodes are named by host[:port] — good enough to
+/// label a one-node fleet.
+fn display_name_for(url: &str) -> String {
+    url.trim_start_matches("http://")
+        .trim_start_matches("https://")
+        .split('/')
+        .next()
+        .unwrap_or(url)
+        .to_string()
+}
+
+fn default_config_path() -> Result<PathBuf> {
+    let home = std::env::var_os("HOME").context("HOME is not set; pass --config or --target")?;
+    Ok(PathBuf::from(home).join(".config/sightglass/config.toml"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(toml_src: &str) -> Result<Fleet> {
+        resolve(toml::from_str(toml_src).unwrap(), Path::new("/tmp"))
+    }
+
+    #[test]
+    fn two_node_fleet_parses() {
+        let fleet = parse(
+            r#"
+            poll_interval_ms = 500
+            [[node]]
+            name = "prod-1"
+            url = "https://prod-1.example.com:9090/"
+            [[node]]
+            name = "prod-2"
+            url = "http://127.0.0.1:9090"
+            "#,
+        )
+        .unwrap();
+        assert_eq!(fleet.poll_interval, Duration::from_millis(500));
+        assert_eq!(fleet.nodes.len(), 2);
+        // trailing slash normalized away
+        assert_eq!(fleet.nodes[0].url, "https://prod-1.example.com:9090");
+    }
+
+    #[test]
+    fn duplicate_node_names_are_rejected() {
+        let err = parse(
+            r#"
+            [[node]]
+            name = "a"
+            url = "http://h1:9090"
+            [[node]]
+            name = "a"
+            url = "http://h2:9090"
+            "#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("duplicate"), "{err}");
+    }
+
+    #[test]
+    fn empty_fleet_and_bad_scheme_are_rejected() {
+        assert!(parse("").is_err());
+        assert!(parse(
+            r#"
+            [[node]]
+            name = "a"
+            url = "ftp://nope"
+            "#
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn target_names_derive_from_host() {
+        assert_eq!(
+            display_name_for("https://prod-1.example.com:9090"),
+            "prod-1.example.com:9090"
+        );
+        assert_eq!(
+            display_name_for("http://127.0.0.1:9090/admin"),
+            "127.0.0.1:9090"
+        );
+    }
+}

--- a/bins/sightglass/src/keys.rs
+++ b/bins/sightglass/src/keys.rs
@@ -1,0 +1,78 @@
+//! Keyboard dispatch: crossterm key events → [`App`] mutations.
+//!
+//! Kept apart from the draw code so the keymap is unit-testable and
+//! the PR-2 action keys (`x`/`p`/`u`/`o`, DESIGN_SIGHTGLASS.md §5)
+//! have one obvious home.
+
+use ratatui::crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers};
+
+use crate::model::{App, Tab};
+
+pub fn handle(app: &mut App, event: &Event) {
+    let Event::Key(key) = event else { return };
+    if key.kind != KeyEventKind::Press {
+        return;
+    }
+    match key.code {
+        KeyCode::Char('q') | KeyCode::Esc => app.should_quit = true,
+        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            app.should_quit = true;
+        }
+        KeyCode::Tab => app.tab = app.tab.next(),
+        KeyCode::BackTab => app.tab = app.tab.prev(),
+        KeyCode::Char('1') => app.tab = Tab::Overview,
+        KeyCode::Char('2') => app.tab = Tab::Trunks,
+        KeyCode::Char('3') => app.tab = Tab::Calls,
+        KeyCode::Char('n') => app.cycle_node_filter(),
+        KeyCode::Char('j') | KeyCode::Down => app.select_next(),
+        KeyCode::Char('k') | KeyCode::Up => app.select_prev(),
+        KeyCode::Char('g') | KeyCode::Home => app.select_first(),
+        KeyCode::Char('G') | KeyCode::End => app.select_last(),
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::crossterm::event::KeyEvent;
+
+    fn press(code: KeyCode) -> Event {
+        Event::Key(KeyEvent::new(code, KeyModifiers::NONE))
+    }
+
+    #[test]
+    fn tab_keys_cycle_and_jump() {
+        let mut app = App::new(vec!["a".into()], false);
+        handle(&mut app, &press(KeyCode::Tab));
+        assert_eq!(app.tab, Tab::Trunks);
+        handle(&mut app, &press(KeyCode::Char('3')));
+        assert_eq!(app.tab, Tab::Calls);
+        handle(&mut app, &press(KeyCode::BackTab));
+        assert_eq!(app.tab, Tab::Trunks);
+    }
+
+    #[test]
+    fn q_and_ctrl_c_quit() {
+        let mut app = App::new(vec!["a".into()], false);
+        handle(&mut app, &press(KeyCode::Char('q')));
+        assert!(app.should_quit);
+
+        let mut app = App::new(vec!["a".into()], false);
+        handle(
+            &mut app,
+            &Event::Key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)),
+        );
+        assert!(app.should_quit);
+    }
+
+    #[test]
+    fn release_events_are_ignored() {
+        use ratatui::crossterm::event::KeyEvent;
+        let mut app = App::new(vec!["a".into()], false);
+        let mut release = KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE);
+        release.kind = KeyEventKind::Release;
+        handle(&mut app, &Event::Key(release));
+        assert!(!app.should_quit);
+    }
+}

--- a/bins/sightglass/src/main.rs
+++ b/bins/sightglass/src/main.rs
@@ -1,0 +1,158 @@
+//! sightglass — terminal operator console for siphon-ai fleets.
+//!
+//! A sight glass is the fitting on a pipe that lets you watch the
+//! fluid moving through it. This is that for one or more running
+//! siphon-ai nodes: a read-and-act client of each node's `[admin]`
+//! HTTP listener, and nothing more — no SIP, no RTP, no daemon
+//! coupling beyond the admin wire types. See DESIGN_SIGHTGLASS.md.
+
+mod client;
+mod config;
+mod keys;
+mod model;
+mod poller;
+mod ui;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use clap::Parser;
+use tokio::sync::{mpsc, watch};
+
+use client::AdminClient;
+use model::{App, Msg, NodeId};
+use ui::Theme;
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "sightglass",
+    version,
+    about = "Terminal operator console for siphon-ai nodes"
+)]
+pub struct Cli {
+    /// Fleet config file (default: ~/.config/sightglass/config.toml).
+    #[arg(long, conflicts_with = "target")]
+    config: Option<std::path::PathBuf>,
+
+    /// Ad-hoc single node: admin listener base URL
+    /// (e.g. https://prod-1.example.com:9090). Token via --token-file
+    /// or $SIGHTGLASS_TOKEN.
+    #[arg(long)]
+    target: Option<String>,
+
+    /// Bearer-token file for --target. (Never a raw token argument —
+    /// argv is visible in `ps`.)
+    #[arg(long, requires = "target")]
+    token_file: Option<std::path::PathBuf>,
+
+    /// PEM CA bundle for --target when the admin TLS cert is
+    /// privately signed.
+    #[arg(long, requires = "target")]
+    ca: Option<std::path::PathBuf>,
+
+    /// Disable every mutating action client-side, regardless of token
+    /// role — for NOC wall screens.
+    #[arg(long)]
+    read_only: bool,
+
+    /// ASCII-only status glyphs (no Unicode dots).
+    #[arg(long)]
+    ascii: bool,
+}
+
+/// Wall-clock redraw cadence when nothing else arrives, and the
+/// sampling cadence for the fleet-history sparkline.
+const TICK: Duration = Duration::from_secs(1);
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+    // Resolve config (and its errors) before raw mode: a bad fleet
+    // file should print like a normal CLI failure, not corrupt a
+    // half-initialized terminal.
+    let fleet = config::load(&cli)?;
+    let clients: Vec<Arc<AdminClient>> = fleet
+        .nodes
+        .iter()
+        .map(|n| AdminClient::new(n).map(Arc::new))
+        .collect::<Result<_>>()?;
+
+    let (tx, rx) = mpsc::channel::<Msg>(64);
+    let (focus_tx, focus_rx) = watch::channel::<Option<(NodeId, String)>>(None);
+    for (id, client) in clients.iter().enumerate() {
+        poller::spawn(
+            id,
+            clients.len(),
+            client.clone(),
+            fleet.poll_interval,
+            tx.clone(),
+            focus_rx.clone(),
+        );
+    }
+    spawn_input_thread(tx.clone());
+
+    let app = App::new(
+        fleet.nodes.iter().map(|n| n.name.clone()).collect(),
+        cli.read_only,
+    );
+    let theme = Theme::new(cli.ascii);
+
+    let mut terminal = ratatui::init();
+    let result = run(&mut terminal, app, &theme, rx, focus_tx).await;
+    ratatui::restore();
+    result
+}
+
+async fn run(
+    terminal: &mut ratatui::DefaultTerminal,
+    mut app: App,
+    theme: &Theme,
+    mut rx: mpsc::Receiver<Msg>,
+    focus_tx: watch::Sender<Option<(NodeId, String)>>,
+) -> Result<()> {
+    let mut tick = tokio::time::interval(TICK);
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        terminal.draw(|f| ui::draw(f, &app, theme))?;
+        tokio::select! {
+            msg = rx.recv() => match msg {
+                Some(Msg::Input(event)) => keys::handle(&mut app, &event),
+                Some(msg) => app.update(msg),
+                None => return Ok(()), // all producers gone
+            },
+            _ = tick.tick() => app.update(Msg::Tick),
+        }
+        // Tell the pollers which call's stats to fetch. send_if_modified
+        // keeps the watch quiet when the focus didn't move.
+        focus_tx.send_if_modified(|current| {
+            let focus = app.focus();
+            if *current == focus {
+                false
+            } else {
+                *current = focus;
+                true
+            }
+        });
+        if app.should_quit {
+            return Ok(());
+        }
+    }
+}
+
+/// Terminal input on a plain thread: `crossterm::event::read` blocks,
+/// which is fine here and keeps the async side purely channel-driven.
+/// The thread ends with the process (the receiver hanging up just
+/// makes it exit on the next event).
+fn spawn_input_thread(tx: mpsc::Sender<Msg>) {
+    std::thread::spawn(move || loop {
+        match ratatui::crossterm::event::read() {
+            Ok(event) => {
+                if tx.blocking_send(Msg::Input(event)).is_err() {
+                    return;
+                }
+            }
+            Err(_) => return,
+        }
+    });
+}

--- a/bins/sightglass/src/model.rs
+++ b/bins/sightglass/src/model.rs
@@ -1,0 +1,442 @@
+//! Application state and the update function.
+//!
+//! Elm-shaped on purpose: pollers and the input thread produce
+//! [`Msg`]s, [`App::update`] folds them into state, `ui::draw`
+//! renders it. Update is pure (no I/O, no clocks), which is what the
+//! multi-node reducer tests below lean on.
+//!
+//! The fleet invariant (DESIGN_SIGHTGLASS.md §2): every record is
+//! keyed by `(node, id)`. A `NodeId` is the node's index into
+//! [`App::nodes`] — stable for the process lifetime because the fleet
+//! is fixed at startup.
+
+use std::collections::VecDeque;
+
+use siphon_ai_admin_api_types::{AdminCallRow, DrainStatus, RegistrationRow};
+
+/// Index into [`App::nodes`]. Display name lives on the node itself.
+pub type NodeId = usize;
+
+/// Samples kept for sparklines (~2 minutes at the 1 s default poll).
+const HISTORY_LEN: usize = 120;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Tab {
+    Overview,
+    Trunks,
+    Calls,
+}
+
+impl Tab {
+    pub const ALL: [Tab; 3] = [Tab::Overview, Tab::Trunks, Tab::Calls];
+
+    pub fn title(self) -> &'static str {
+        match self {
+            Tab::Overview => "overview",
+            Tab::Trunks => "trunks",
+            Tab::Calls => "calls",
+        }
+    }
+
+    fn index(self) -> usize {
+        Self::ALL
+            .iter()
+            .position(|t| *t == self)
+            .expect("tab is in ALL")
+    }
+
+    pub fn next(self) -> Tab {
+        Self::ALL[(self.index() + 1) % Self::ALL.len()]
+    }
+
+    pub fn prev(self) -> Tab {
+        Self::ALL[(self.index() + Self::ALL.len() - 1) % Self::ALL.len()]
+    }
+}
+
+/// Reachability of one node's admin listener. A down node keeps its
+/// last-seen data (rendered dimmed) — §2's "degrade, never break".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NodeHealth {
+    /// No poll has completed yet.
+    Connecting,
+    Up,
+    Down {
+        error: String,
+    },
+}
+
+/// Everything sightglass knows about one node.
+#[derive(Debug)]
+pub struct NodeState {
+    pub name: String,
+    pub health: NodeHealth,
+    pub calls: Vec<AdminCallRow>,
+    pub registrations: Vec<RegistrationRow>,
+    pub drain: Option<DrainStatus>,
+}
+
+impl NodeState {
+    fn new(name: String) -> Self {
+        Self {
+            name,
+            health: NodeHealth::Connecting,
+            calls: Vec::new(),
+            registrations: Vec::new(),
+            drain: None,
+        }
+    }
+}
+
+/// One successful poll round for a node.
+#[derive(Debug)]
+pub struct NodeSnapshot {
+    pub calls: Vec<AdminCallRow>,
+    pub registrations: Vec<RegistrationRow>,
+    pub drain: DrainStatus,
+}
+
+/// Live-stats pane for the focused call: latest snapshot plus
+/// client-side history rings (§2 — the daemon stores no history).
+#[derive(Debug, Default)]
+pub struct StatsPane {
+    /// `(node, call_id)` the pane is showing. Cleared on focus change
+    /// so a new selection never renders the previous call's numbers.
+    pub key: Option<(NodeId, String)>,
+    pub latest: Option<serde_json::Value>,
+    /// MOS ×100 (Sparkline wants u64), newest last.
+    pub mos_hist: VecDeque<u64>,
+    /// Average jitter in ms, newest last.
+    pub jitter_hist: VecDeque<u64>,
+}
+
+#[derive(Debug)]
+pub enum Msg {
+    /// One poll round finished for a node.
+    Snapshot {
+        node: NodeId,
+        result: Result<NodeSnapshot, String>,
+    },
+    /// Stats arrived for the focused call.
+    Stats {
+        node: NodeId,
+        call_id: String,
+        stats: serde_json::Value,
+    },
+    /// 1 s cadence: sample fleet history for the overview sparkline.
+    Tick,
+    /// A terminal event from the input thread. Routed to `keys::handle`
+    /// by the main loop before `update` ever sees it.
+    Input(ratatui::crossterm::event::Event),
+}
+
+pub struct App {
+    pub nodes: Vec<NodeState>,
+    pub tab: Tab,
+    /// `None` = all nodes; `Some(id)` scopes every tab to one node.
+    pub node_filter: Option<NodeId>,
+    /// Selection index into [`App::visible_calls`].
+    pub selected_call: usize,
+    pub stats: StatsPane,
+    /// Fleet-wide active-call totals, one sample per tick, newest last.
+    pub fleet_history: VecDeque<u64>,
+    pub read_only: bool,
+    pub should_quit: bool,
+}
+
+impl App {
+    pub fn new(node_names: Vec<String>, read_only: bool) -> Self {
+        Self {
+            nodes: node_names.into_iter().map(NodeState::new).collect(),
+            tab: Tab::Overview,
+            node_filter: None,
+            selected_call: 0,
+            stats: StatsPane::default(),
+            fleet_history: VecDeque::new(),
+            read_only,
+            should_quit: false,
+        }
+    }
+
+    pub fn update(&mut self, msg: Msg) {
+        match msg {
+            Msg::Snapshot { node, result } => {
+                let Some(n) = self.nodes.get_mut(node) else {
+                    return;
+                };
+                match result {
+                    Ok(snap) => {
+                        n.health = NodeHealth::Up;
+                        n.calls = snap.calls;
+                        n.registrations = snap.registrations;
+                        n.drain = Some(snap.drain);
+                    }
+                    // Keep last-seen data; only the health flips.
+                    Err(error) => n.health = NodeHealth::Down { error },
+                }
+                self.clamp_selection();
+                self.sync_stats_focus();
+            }
+            Msg::Stats {
+                node,
+                call_id,
+                stats,
+            } => {
+                // A stale in-flight fetch can land after the selection
+                // moved — drop anything that isn't the current focus.
+                if self.stats.key.as_ref() != Some(&(node, call_id.clone())) {
+                    return;
+                }
+                push_capped(
+                    &mut self.stats.mos_hist,
+                    extract_scaled(&stats, "mos_estimate_avg", 100.0),
+                );
+                push_capped(
+                    &mut self.stats.jitter_hist,
+                    extract_scaled(&stats, "avg_jitter_ms", 1.0),
+                );
+                self.stats.latest = Some(stats);
+            }
+            Msg::Tick => {
+                let total: u64 = self.nodes.iter().map(|n| n.calls.len() as u64).sum();
+                push_capped(&mut self.fleet_history, Some(total));
+            }
+            // Input is dispatched to `keys::handle` by the main loop.
+            Msg::Input(_) => {}
+        }
+    }
+
+    /// Calls visible under the current node filter, in stable
+    /// (node, listing) order. The selection index points into this.
+    pub fn visible_calls(&self) -> Vec<(NodeId, &AdminCallRow)> {
+        self.nodes
+            .iter()
+            .enumerate()
+            .filter(|(id, _)| self.node_filter.is_none_or(|f| f == *id))
+            .flat_map(|(id, n)| n.calls.iter().map(move |c| (id, c)))
+            .collect()
+    }
+
+    /// The `(node, call_id)` the stats poller should be fetching.
+    pub fn focus(&self) -> Option<(NodeId, String)> {
+        let calls = self.visible_calls();
+        calls
+            .get(self.selected_call)
+            .map(|(id, c)| (*id, c.call_id.clone()))
+    }
+
+    pub fn select_next(&mut self) {
+        self.selected_call = self.selected_call.saturating_add(1);
+        self.clamp_selection();
+        self.sync_stats_focus();
+    }
+
+    pub fn select_prev(&mut self) {
+        self.selected_call = self.selected_call.saturating_sub(1);
+        self.sync_stats_focus();
+    }
+
+    pub fn select_first(&mut self) {
+        self.selected_call = 0;
+        self.sync_stats_focus();
+    }
+
+    pub fn select_last(&mut self) {
+        self.selected_call = self.visible_calls().len().saturating_sub(1);
+        self.sync_stats_focus();
+    }
+
+    /// Cycle the node filter: all → node 0 → node 1 → … → all.
+    pub fn cycle_node_filter(&mut self) {
+        self.node_filter = match self.node_filter {
+            None => Some(0),
+            Some(i) if i + 1 < self.nodes.len() => Some(i + 1),
+            Some(_) => None,
+        };
+        self.clamp_selection();
+        self.sync_stats_focus();
+    }
+
+    fn clamp_selection(&mut self) {
+        let len = self.visible_calls().len();
+        if len == 0 {
+            self.selected_call = 0;
+        } else if self.selected_call >= len {
+            self.selected_call = len - 1;
+        }
+    }
+
+    /// Reset the stats pane whenever the focused `(node, call_id)`
+    /// changed, so histories never mix calls.
+    fn sync_stats_focus(&mut self) {
+        let focus = self.focus();
+        if self.stats.key != focus {
+            self.stats = StatsPane {
+                key: focus,
+                ..StatsPane::default()
+            };
+        }
+    }
+
+    // ─── Fleet rollups for the header/overview ─────────────────────
+
+    pub fn nodes_up(&self) -> usize {
+        self.nodes
+            .iter()
+            .filter(|n| n.health == NodeHealth::Up)
+            .count()
+    }
+
+    pub fn total_calls(&self) -> usize {
+        self.nodes.iter().map(|n| n.calls.len()).sum()
+    }
+}
+
+fn push_capped(hist: &mut VecDeque<u64>, sample: Option<u64>) {
+    let Some(sample) = sample else { return };
+    if hist.len() == HISTORY_LEN {
+        hist.pop_front();
+    }
+    hist.push_back(sample);
+}
+
+/// Pull a numeric field out of the loose stats payload, scaled to an
+/// integer for sparkline use. Absent/unmeasured fields yield `None`.
+fn extract_scaled(stats: &serde_json::Value, key: &str, scale: f64) -> Option<u64> {
+    let v = stats.get(key)?.as_f64()?;
+    if !v.is_finite() || v < 0.0 {
+        return None;
+    }
+    Some((v * scale).round() as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn call(id: &str) -> AdminCallRow {
+        AdminCallRow {
+            call_id: id.to_string(),
+            sip_call_id: format!("{id}@host"),
+            direction: "inbound".to_string(),
+        }
+    }
+
+    fn snapshot(calls: Vec<AdminCallRow>) -> NodeSnapshot {
+        NodeSnapshot {
+            calls,
+            registrations: vec![],
+            drain: DrainStatus {
+                draining: false,
+                active_calls: 0,
+                drain_timeout_secs: 30,
+                remaining_secs: None,
+            },
+        }
+    }
+
+    fn two_node_app() -> App {
+        let mut app = App::new(vec!["prod-1".into(), "prod-2".into()], false);
+        app.update(Msg::Snapshot {
+            node: 0,
+            result: Ok(snapshot(vec![call("a"), call("b")])),
+        });
+        app.update(Msg::Snapshot {
+            node: 1,
+            result: Ok(snapshot(vec![call("a")])), // same call_id as node 0 on purpose
+        });
+        app
+    }
+
+    #[test]
+    fn same_call_id_on_two_nodes_stays_two_rows() {
+        let app = two_node_app();
+        let visible = app.visible_calls();
+        assert_eq!(visible.len(), 3);
+        // The composite key differs even though call_id collides.
+        let keys: Vec<(NodeId, &str)> = visible
+            .iter()
+            .map(|(n, c)| (*n, c.call_id.as_str()))
+            .collect();
+        assert_eq!(keys, vec![(0, "a"), (0, "b"), (1, "a")]);
+    }
+
+    #[test]
+    fn node_filter_scopes_calls_and_cycles_back_to_all() {
+        let mut app = two_node_app();
+        app.cycle_node_filter(); // -> node 0
+        assert_eq!(app.visible_calls().len(), 2);
+        app.cycle_node_filter(); // -> node 1
+        assert_eq!(app.visible_calls().len(), 1);
+        assert_eq!(app.focus(), Some((1, "a".to_string())));
+        app.cycle_node_filter(); // -> all
+        assert_eq!(app.node_filter, None);
+        assert_eq!(app.visible_calls().len(), 3);
+    }
+
+    #[test]
+    fn node_down_keeps_last_seen_data_and_flips_health() {
+        let mut app = two_node_app();
+        app.update(Msg::Snapshot {
+            node: 0,
+            result: Err("connection refused".into()),
+        });
+        assert_eq!(
+            app.nodes[0].health,
+            NodeHealth::Down {
+                error: "connection refused".into()
+            }
+        );
+        // Last-seen calls are still there (rendered dimmed, not gone).
+        assert_eq!(app.nodes[0].calls.len(), 2);
+        assert_eq!(app.nodes_up(), 1);
+    }
+
+    #[test]
+    fn selection_clamps_when_calls_shrink() {
+        let mut app = two_node_app();
+        app.select_last();
+        assert_eq!(app.selected_call, 2);
+        // Node 0's calls end; only node 1's remains.
+        app.update(Msg::Snapshot {
+            node: 0,
+            result: Ok(snapshot(vec![])),
+        });
+        assert_eq!(app.selected_call, 0);
+        assert_eq!(app.focus(), Some((1, "a".to_string())));
+    }
+
+    #[test]
+    fn focus_change_resets_stats_pane() {
+        let mut app = two_node_app();
+        app.select_first();
+        let stats = serde_json::json!({ "mos_estimate_avg": 4.2, "avg_jitter_ms": 11.5 });
+        app.update(Msg::Stats {
+            node: 0,
+            call_id: "a".into(),
+            stats,
+        });
+        assert_eq!(app.stats.mos_hist.back(), Some(&420));
+        assert_eq!(app.stats.jitter_hist.back(), Some(&12));
+        assert!(app.stats.latest.is_some());
+
+        app.select_next(); // focus moved -> pane must reset
+        assert!(app.stats.latest.is_none());
+        assert!(app.stats.mos_hist.is_empty());
+
+        // A stale stats message for the old focus is dropped.
+        app.update(Msg::Stats {
+            node: 0,
+            call_id: "a".into(),
+            stats: serde_json::json!({ "mos_estimate_avg": 1.0 }),
+        });
+        assert!(app.stats.latest.is_none());
+    }
+
+    #[test]
+    fn tick_samples_fleet_total() {
+        let mut app = two_node_app();
+        app.update(Msg::Tick);
+        assert_eq!(app.fleet_history.back(), Some(&3));
+    }
+}

--- a/bins/sightglass/src/poller.rs
+++ b/bins/sightglass/src/poller.rs
@@ -1,0 +1,71 @@
+//! Per-node poll tasks.
+//!
+//! One task per node (DESIGN_SIGHTGLASS.md §2): fetch the three list
+//! endpoints concurrently each interval, plus the focused call's
+//! stats when the focus (a `watch` fed by the UI) points at this
+//! node. Start times are staggered so N nodes don't burst-poll in
+//! phase. A task ends when the UI side of the channel is gone.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::{mpsc, watch};
+
+use crate::client::AdminClient;
+use crate::model::{Msg, NodeId, NodeSnapshot};
+
+pub fn spawn(
+    node: NodeId,
+    node_count: usize,
+    client: Arc<AdminClient>,
+    interval: Duration,
+    tx: mpsc::Sender<Msg>,
+    focus: watch::Receiver<Option<(NodeId, String)>>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        // Spread node start offsets across one interval.
+        tokio::time::sleep(interval * node as u32 / node_count.max(1) as u32).await;
+        let mut tick = tokio::time::interval(interval);
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            tick.tick().await;
+            let (calls, registrations, drain) =
+                tokio::join!(client.calls(), client.registrations(), client.drain());
+            let result = calls
+                .and_then(|c| registrations.map(|r| (c, r)))
+                .and_then(|(c, r)| {
+                    drain.map(|d| NodeSnapshot {
+                        calls: c.calls,
+                        registrations: r.registrations,
+                        drain: d,
+                    })
+                });
+            if tx.send(Msg::Snapshot { node, result }).await.is_err() {
+                return; // UI is gone — shut down.
+            }
+
+            // Focused-call stats: only this node's poller fetches, and
+            // only while the focus points here (§2 — never fanned out).
+            let focused = focus.borrow().clone();
+            if let Some((focus_node, call_id)) = focused {
+                if focus_node == node {
+                    if let Ok(stats) = client.call_stats(&call_id).await {
+                        let send = tx
+                            .send(Msg::Stats {
+                                node,
+                                call_id,
+                                stats,
+                            })
+                            .await;
+                        if send.is_err() {
+                            return;
+                        }
+                    }
+                    // A stats error is not node-down: the call likely
+                    // just ended between the listing and this fetch.
+                    // The next snapshot will drop the row.
+                }
+            }
+        }
+    })
+}

--- a/bins/sightglass/src/ui/calls.rs
+++ b/bins/sightglass/src/ui/calls.rs
@@ -1,0 +1,274 @@
+//! Calls tab: fleet-unified call table + focused-call detail pane.
+//!
+//! The detail pane renders the `GET /admin/v1/calls/:id/stats`
+//! payload (the CDR `quality` shape) plus a client-side MOS
+//! sparkline. Stats fields are read defensively — a young call
+//! legitimately answers with most fields absent.
+
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Sparkline, Table, TableState};
+use ratatui::Frame;
+
+use crate::model::App;
+
+use super::Theme;
+
+pub fn draw(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
+    // Collapse to a vertical stack on narrow terminals (§7).
+    let (table_area, detail_area) = if area.width < 80 {
+        let [t, d] =
+            Layout::vertical([Constraint::Percentage(55), Constraint::Percentage(45)]).areas(area);
+        (t, d)
+    } else {
+        let [t, d] = Layout::horizontal([Constraint::Percentage(58), Constraint::Percentage(42)])
+            .areas(area);
+        (t, d)
+    };
+
+    draw_table(frame, app, theme, table_area);
+    draw_detail(frame, app, theme, detail_area);
+}
+
+fn draw_table(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
+    let multi_node = app.nodes.len() > 1;
+    let visible = app.visible_calls();
+
+    let mut headers = vec!["CALL ID", "SIP CALL ID", "DIR"];
+    if multi_node {
+        headers.insert(0, "NODE");
+    }
+    let header = Row::new(
+        headers
+            .into_iter()
+            .map(|h| Cell::from(Span::styled(h, theme.dim_text()))),
+    );
+
+    let rows = visible.iter().map(|(node, c)| {
+        let mut cells = vec![
+            Cell::from(Span::styled(c.call_id.as_str(), theme.text())),
+            Cell::from(Span::styled(c.sip_call_id.as_str(), theme.dim_text())),
+            Cell::from(Span::styled(c.direction.as_str(), theme.text())),
+        ];
+        if multi_node {
+            cells.insert(
+                0,
+                Cell::from(Span::styled(app.nodes[*node].name.as_str(), theme.text())),
+            );
+        }
+        Row::new(cells)
+    });
+
+    let mut widths = vec![
+        Constraint::Min(18),
+        Constraint::Min(16),
+        Constraint::Length(8),
+    ];
+    if multi_node {
+        widths.insert(0, Constraint::Length(10));
+    }
+
+    let title = format!(" calls ({}) ", visible.len());
+    let table = Table::new(rows, widths)
+        .header(header)
+        .row_highlight_style(theme.selected_row())
+        .block(
+            Block::new()
+                .borders(Borders::ALL)
+                .border_style(theme.dim_text())
+                .title(Span::styled(title, theme.title())),
+        );
+
+    let mut state = TableState::default();
+    if !visible.is_empty() {
+        state.select(Some(app.selected_call.min(visible.len() - 1)));
+    }
+    frame.render_stateful_widget(table, area, &mut state);
+
+    if visible.is_empty() {
+        let inner = Rect {
+            x: area.x + 2,
+            y: area.y + 2,
+            width: area.width.saturating_sub(4),
+            height: 1,
+        };
+        frame.render_widget(
+            Paragraph::new(Span::styled("no active calls", theme.dim_text())),
+            inner,
+        );
+    }
+}
+
+fn draw_detail(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
+    let block = Block::new()
+        .borders(Borders::ALL)
+        .border_style(theme.dim_text())
+        .title(Span::styled(" call detail ", theme.title()));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let Some((node, call_id)) = &app.stats.key else {
+        frame.render_widget(
+            Paragraph::new(Span::styled("no call selected", theme.dim_text())),
+            inner,
+        );
+        return;
+    };
+
+    let [text_area, spark_area] =
+        Layout::vertical([Constraint::Min(0), Constraint::Length(4)]).areas(inner);
+
+    let mut lines = vec![
+        field_line(theme, "call", call_id),
+        field_line(theme, "node", &app.nodes[*node].name),
+    ];
+    match &app.stats.latest {
+        None => lines.push(Line::styled("fetching stats…", theme.dim_text())),
+        Some(stats) => {
+            lines.push(Line::default());
+            push_stat(
+                &mut lines,
+                theme,
+                stats,
+                "mos_estimate_avg",
+                "MOS avg",
+                None,
+            );
+            push_stat(
+                &mut lines,
+                theme,
+                stats,
+                "mos_estimate_min",
+                "MOS min",
+                None,
+            );
+            push_stat(
+                &mut lines,
+                theme,
+                stats,
+                "avg_jitter_ms",
+                "jitter avg",
+                Some("ms"),
+            );
+            push_stat(
+                &mut lines,
+                theme,
+                stats,
+                "max_jitter_ms",
+                "jitter max",
+                Some("ms"),
+            );
+            push_ratio(
+                &mut lines,
+                theme,
+                stats,
+                "avg_packet_loss_ratio",
+                "loss avg",
+            );
+            push_stat(
+                &mut lines,
+                theme,
+                stats,
+                "rx_packets_received",
+                "rx packets",
+                None,
+            );
+            push_stat(&mut lines, theme, stats, "rx_packets_lost", "rx lost", None);
+            push_stat(
+                &mut lines,
+                theme,
+                stats,
+                "tx_packets_sent",
+                "tx packets",
+                None,
+            );
+            push_stat(
+                &mut lines,
+                theme,
+                stats,
+                "first_audio_out_ms",
+                "first audio",
+                Some("ms"),
+            );
+            push_stat(
+                &mut lines,
+                theme,
+                stats,
+                "barge_in_count",
+                "barge-ins",
+                None,
+            );
+            if let Some(ts) = stats.get("sampled_at").and_then(|v| v.as_str()) {
+                lines.push(Line::default());
+                lines.push(field_line(theme, "sampled", ts));
+            }
+        }
+    }
+    frame.render_widget(Paragraph::new(lines), text_area);
+
+    let mos: Vec<u64> = app.stats.mos_hist.iter().copied().collect();
+    let spark = Sparkline::default()
+        .data(&mos)
+        // MOS is 1.0–4.5 (×100 in the ring); a fixed max keeps the
+        // sparkline comparable across calls instead of auto-scaling.
+        .max(450)
+        .style(theme.text().fg(theme.accent))
+        .block(
+            Block::new()
+                .borders(Borders::TOP)
+                .border_style(theme.dim_text())
+                .title(Span::styled(" MOS trend ", theme.dim_text())),
+        );
+    frame.render_widget(spark, spark_area);
+}
+
+fn field_line<'a>(theme: &Theme, label: &'a str, value: &'a str) -> Line<'a> {
+    Line::from(vec![
+        Span::styled(format!("{label:>12}  "), theme.dim_text()),
+        Span::styled(value, theme.text()),
+    ])
+}
+
+fn push_stat(
+    lines: &mut Vec<Line<'_>>,
+    theme: &Theme,
+    stats: &serde_json::Value,
+    key: &str,
+    label: &str,
+    unit: Option<&str>,
+) {
+    let Some(v) = stats.get(key).and_then(|v| v.as_f64()) else {
+        return; // unmeasured fields are omitted, not zeroed
+    };
+    let text = if v.fract() == 0.0 {
+        format!(
+            "{v:.0}{}",
+            unit.map(|u| format!(" {u}")).unwrap_or_default()
+        )
+    } else {
+        format!(
+            "{v:.2}{}",
+            unit.map(|u| format!(" {u}")).unwrap_or_default()
+        )
+    };
+    lines.push(Line::from(vec![
+        Span::styled(format!("{label:>12}  "), theme.dim_text()),
+        Span::styled(text, theme.text()),
+    ]));
+}
+
+fn push_ratio(
+    lines: &mut Vec<Line<'_>>,
+    theme: &Theme,
+    stats: &serde_json::Value,
+    key: &str,
+    label: &str,
+) {
+    let Some(v) = stats.get(key).and_then(|v| v.as_f64()) else {
+        return;
+    };
+    lines.push(Line::from(vec![
+        Span::styled(format!("{label:>12}  "), theme.dim_text()),
+        Span::styled(format!("{:.2}%", v * 100.0), theme.text()),
+    ]));
+}

--- a/bins/sightglass/src/ui/chrome.rs
+++ b/bins/sightglass/src/ui/chrome.rs
@@ -1,0 +1,93 @@
+//! Header, tab bar, footer — the frame around every tab.
+//!
+//! The footer shows only the keybinds valid on the current tab
+//! (DESIGN_SIGHTGLASS.md §7).
+
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::Modifier;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Paragraph, Tabs};
+use ratatui::Frame;
+
+use crate::model::{App, Tab};
+
+use super::Theme;
+
+/// Draw the chrome; returns the body area the active tab renders into.
+pub fn draw(frame: &mut Frame, app: &App, theme: &Theme) -> Rect {
+    let [header, tabs, body, footer] = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Min(0),
+        Constraint::Length(1),
+    ])
+    .areas(frame.area());
+
+    draw_header(frame, app, theme, header);
+    draw_tabs(frame, app, theme, tabs);
+    draw_footer(frame, app, theme, footer);
+    body
+}
+
+fn draw_header(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
+    let sep = Span::styled("  │  ", theme.dim_text());
+    let mut spans = vec![
+        Span::styled(
+            " sightglass ",
+            theme.title().add_modifier(Modifier::REVERSED),
+        ),
+        Span::raw(" "),
+        Span::styled(
+            format!("{}/{} up", app.nodes_up(), app.nodes.len()),
+            theme.text(),
+        ),
+        sep.clone(),
+        Span::styled(format!("{} calls", app.total_calls()), theme.text()),
+    ];
+    if let Some(id) = app.node_filter {
+        spans.push(sep.clone());
+        spans.push(Span::styled(
+            format!("node: {}", app.nodes[id].name),
+            theme.title(),
+        ));
+    }
+    if app.read_only {
+        spans.push(sep);
+        spans.push(Span::styled("read-only", theme.text().fg(theme.warn)));
+    }
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+fn draw_tabs(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
+    let titles = Tab::ALL
+        .iter()
+        .enumerate()
+        .map(|(i, t)| Line::from(format!(" {} {} ", i + 1, t.title())));
+    let selected = Tab::ALL
+        .iter()
+        .position(|t| *t == app.tab)
+        .unwrap_or_default();
+    let tabs = Tabs::new(titles)
+        .select(selected)
+        .style(theme.dim_text())
+        .highlight_style(theme.title().add_modifier(Modifier::UNDERLINED))
+        .divider(Span::styled("│", theme.dim_text()));
+    frame.render_widget(tabs, area);
+}
+
+fn draw_footer(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
+    let mut hints: Vec<(&str, &str)> = vec![("q", "quit"), ("⇥/1-3", "tabs")];
+    if app.nodes.len() > 1 {
+        hints.push(("n", "node filter"));
+    }
+    if app.tab == Tab::Calls {
+        hints.push(("j/k", "select"));
+        hints.push(("g/G", "top/bottom"));
+    }
+    let mut spans = Vec::with_capacity(hints.len() * 3);
+    for (key, what) in hints {
+        spans.push(Span::styled(format!(" {key} "), theme.title()));
+        spans.push(Span::styled(format!("{what}  "), theme.dim_text()));
+    }
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}

--- a/bins/sightglass/src/ui/mod.rs
+++ b/bins/sightglass/src/ui/mod.rs
@@ -1,0 +1,163 @@
+//! Rendering. `draw` is a pure function of `(App, Theme)` — all state
+//! lives in the model, which is what lets the `TestBackend` tests at
+//! the bottom render fixtures without a real terminal.
+
+mod calls;
+mod chrome;
+mod overview;
+pub mod theme;
+mod trunks;
+
+use ratatui::Frame;
+
+use crate::model::{App, Tab};
+pub use theme::Theme;
+
+pub fn draw(frame: &mut Frame, app: &App, theme: &Theme) {
+    let body = chrome::draw(frame, app, theme);
+    match app.tab {
+        Tab::Overview => overview::draw(frame, app, theme, body),
+        Tab::Trunks => trunks::draw(frame, app, theme, body),
+        Tab::Calls => calls::draw(frame, app, theme, body),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{Msg, NodeSnapshot};
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    use siphon_ai_admin_api_types::{AdminCallRow, DrainStatus, RegistrationRow};
+
+    /// Fleet fixture per DESIGN_SIGHTGLASS.md §11: two nodes, one
+    /// down, call-id collision across nodes.
+    fn fixture_app() -> App {
+        let mut app = App::new(vec!["prod-1".into(), "prod-2".into()], false);
+        app.update(Msg::Snapshot {
+            node: 0,
+            result: Ok(NodeSnapshot {
+                calls: vec![
+                    AdminCallRow {
+                        call_id: "siphon-aa11".into(),
+                        sip_call_id: "aa11@pbx".into(),
+                        direction: "inbound".into(),
+                    },
+                    AdminCallRow {
+                        call_id: "siphon-bb22".into(),
+                        sip_call_id: "bb22@pbx".into(),
+                        direction: "outbound".into(),
+                    },
+                ],
+                registrations: vec![RegistrationRow {
+                    name: "pbx-a".into(),
+                    server_addr: "10.0.0.9:5060".into(),
+                    status: "registered".into(),
+                    last_attempt_at: None,
+                    expires_at: Some("2026-08-17T00:05:00Z".into()),
+                    last_error: None,
+                }],
+                drain: DrainStatus {
+                    draining: false,
+                    active_calls: 2,
+                    drain_timeout_secs: 30,
+                    remaining_secs: None,
+                },
+            }),
+        });
+        app.update(Msg::Snapshot {
+            node: 1,
+            result: Err("connection refused".into()),
+        });
+        app.update(Msg::Tick);
+        app
+    }
+
+    fn render(app: &App, width: u16, height: u16) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let theme = Theme::new(false);
+        terminal.draw(|f| draw(f, app, &theme)).unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let mut out = String::new();
+        for y in 0..buffer.area.height {
+            for x in 0..buffer.area.width {
+                out.push_str(buffer[(x, y)].symbol());
+            }
+            out.push('\n');
+        }
+        out
+    }
+
+    #[test]
+    fn overview_shows_fleet_grid_with_down_node() {
+        let app = fixture_app();
+        let screen = render(&app, 100, 30);
+        assert!(screen.contains("prod-1"), "{screen}");
+        assert!(screen.contains("prod-2"), "{screen}");
+        assert!(screen.contains("connection refused"), "{screen}");
+        // Fleet rollup in the header: one of two nodes up, two calls.
+        assert!(screen.contains("1/2 up"), "{screen}");
+        assert!(screen.contains("2 calls"), "{screen}");
+    }
+
+    #[test]
+    fn calls_tab_lists_both_id_namespaces_with_node_column() {
+        let mut app = fixture_app();
+        app.tab = Tab::Calls;
+        let screen = render(&app, 100, 30);
+        assert!(screen.contains("siphon-aa11"), "{screen}");
+        assert!(screen.contains("aa11@pbx"), "{screen}");
+        assert!(screen.contains("outbound"), "{screen}");
+        // Multi-node fleet → Node column present.
+        assert!(screen.contains("NODE"), "{screen}");
+    }
+
+    #[test]
+    fn single_node_fleet_hides_node_column() {
+        let mut app = App::new(vec!["solo".into()], false);
+        app.tab = Tab::Calls;
+        let screen = render(&app, 100, 30);
+        assert!(!screen.contains("NODE"), "{screen}");
+    }
+
+    #[test]
+    fn trunks_tab_renders_registration_rows() {
+        let mut app = fixture_app();
+        app.tab = Tab::Trunks;
+        let screen = render(&app, 100, 30);
+        assert!(screen.contains("pbx-a"), "{screen}");
+        assert!(screen.contains("registered"), "{screen}");
+        assert!(screen.contains("10.0.0.9:5060"), "{screen}");
+    }
+
+    #[test]
+    fn narrow_terminal_still_renders_every_tab() {
+        // Layout must degrade, not panic or overflow (§7).
+        for tab in Tab::ALL {
+            let mut app = fixture_app();
+            app.tab = tab;
+            let screen = render(&app, 60, 20);
+            assert!(screen.contains("sightglass"), "{tab:?}: {screen}");
+        }
+    }
+
+    #[test]
+    fn read_only_flag_shows_in_header() {
+        let mut app = fixture_app();
+        app.read_only = true;
+        let screen = render(&app, 100, 30);
+        assert!(screen.contains("read-only"), "{screen}");
+    }
+
+    #[test]
+    fn node_filter_scopes_calls_tab_and_shows_chip() {
+        let mut app = fixture_app();
+        app.tab = Tab::Calls;
+        app.cycle_node_filter();
+        app.cycle_node_filter(); // -> prod-2 (down, no calls)
+        let screen = render(&app, 100, 30);
+        assert!(screen.contains("node: prod-2"), "{screen}");
+        assert!(!screen.contains("siphon-aa11"), "{screen}");
+    }
+}

--- a/bins/sightglass/src/ui/overview.rs
+++ b/bins/sightglass/src/ui/overview.rs
@@ -1,0 +1,116 @@
+//! Overview tab: fleet health grid + aggregate activity.
+//!
+//! Per-node version/uptime columns arrive with `GET /admin/v1/status`
+//! (DESIGN_SIGHTGLASS.md §6.2, PR 4); until then the grid shows what
+//! the existing endpoints answer.
+
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Cell, Row, Sparkline, Table};
+use ratatui::Frame;
+
+use crate::model::{App, NodeHealth, NodeState};
+
+use super::Theme;
+
+pub fn draw(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
+    let [grid_area, spark_area] =
+        Layout::vertical([Constraint::Min(0), Constraint::Length(5)]).areas(area);
+
+    draw_grid(frame, app, theme, grid_area);
+    draw_activity(frame, app, theme, spark_area);
+}
+
+fn draw_grid(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
+    let header = Row::new(
+        ["", "NODE", "STATUS", "CALLS", "REGISTRATIONS", "DRAIN"]
+            .into_iter()
+            .map(|h| Cell::from(Span::styled(h, theme.dim_text()))),
+    );
+
+    let rows = app
+        .nodes
+        .iter()
+        .filter(|_| true)
+        .enumerate()
+        .filter(|(id, _)| app.node_filter.is_none_or(|f| f == *id))
+        .map(|(_, n)| node_row(n, theme));
+
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Length(1),
+            Constraint::Length(18),
+            Constraint::Min(24),
+            Constraint::Length(6),
+            Constraint::Length(14),
+            Constraint::Length(16),
+        ],
+    )
+    .header(header)
+    .block(
+        Block::new()
+            .borders(Borders::ALL)
+            .border_style(theme.dim_text())
+            .title(Span::styled(" fleet ", theme.title())),
+    );
+    frame.render_widget(table, area);
+}
+
+fn node_row<'a>(n: &'a NodeState, theme: &Theme) -> Row<'a> {
+    let (glyph, color) = theme.health_glyph(&n.health);
+    // A down node keeps its last-seen numbers but renders dimmed —
+    // stale data must not read as live (§2).
+    let data_style = match n.health {
+        NodeHealth::Down { .. } => theme.dim_text(),
+        _ => theme.text(),
+    };
+    let status: Line = match &n.health {
+        NodeHealth::Up => Line::styled("up", theme.text().fg(theme.ok)),
+        NodeHealth::Connecting => Line::styled("connecting…", theme.text().fg(theme.warn)),
+        NodeHealth::Down { error } => Line::styled(
+            format!("down (retrying) — {error}"),
+            theme.text().fg(theme.err),
+        ),
+    };
+    let registered = n
+        .registrations
+        .iter()
+        .filter(|r| r.status == "registered")
+        .count();
+    let regs = if n.registrations.is_empty() {
+        "—".to_string()
+    } else {
+        format!("{registered}/{}", n.registrations.len())
+    };
+    let drain = match &n.drain {
+        Some(d) if d.draining => match d.remaining_secs {
+            Some(s) => format!("draining ({s}s)"),
+            None => "draining".to_string(),
+        },
+        Some(_) => "idle".to_string(),
+        None => "—".to_string(),
+    };
+    Row::new(vec![
+        Cell::from(Span::styled(glyph, theme.text().fg(color))),
+        Cell::from(Span::styled(n.name.as_str(), data_style)),
+        Cell::from(status),
+        Cell::from(Span::styled(n.calls.len().to_string(), data_style)),
+        Cell::from(Span::styled(regs, data_style)),
+        Cell::from(Span::styled(drain, data_style)),
+    ])
+}
+
+fn draw_activity(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
+    let history: Vec<u64> = app.fleet_history.iter().copied().collect();
+    let spark = Sparkline::default()
+        .data(&history)
+        .style(theme.text().fg(theme.accent))
+        .block(
+            Block::new()
+                .borders(Borders::ALL)
+                .border_style(theme.dim_text())
+                .title(Span::styled(" active calls (fleet) ", theme.title())),
+        );
+    frame.render_widget(spark, area);
+}

--- a/bins/sightglass/src/ui/theme.rs
+++ b/bins/sightglass/src/ui/theme.rs
@@ -1,0 +1,78 @@
+//! One theme, used everywhere (DESIGN_SIGHTGLASS.md §7).
+//!
+//! Every color in the UI comes off this palette — no ad-hoc
+//! `Color::…` in widget code. Status is always glyph + color, never
+//! color alone, and `--ascii` swaps the glyph set for terminals
+//! without Unicode fonts.
+
+use ratatui::style::{Color, Modifier, Style};
+
+use crate::model::NodeHealth;
+
+/// Catppuccin-Macchiato-adjacent palette: one accent, semantic
+/// green/amber/red, and a dim tone for de-emphasis.
+#[derive(Debug, Clone, Copy)]
+pub struct Theme {
+    pub fg: Color,
+    pub accent: Color,
+    pub dim: Color,
+    pub ok: Color,
+    pub warn: Color,
+    pub err: Color,
+    pub surface: Color,
+    pub ascii: bool,
+}
+
+impl Theme {
+    pub fn new(ascii: bool) -> Self {
+        Self {
+            fg: Color::Rgb(0xca, 0xd3, 0xf5),
+            accent: Color::Rgb(0x8a, 0xad, 0xf4),
+            dim: Color::Rgb(0x6e, 0x73, 0x8d),
+            ok: Color::Rgb(0xa6, 0xda, 0x95),
+            warn: Color::Rgb(0xee, 0xd4, 0x9f),
+            err: Color::Rgb(0xed, 0x87, 0x96),
+            surface: Color::Rgb(0x36, 0x3a, 0x4f),
+            ascii,
+        }
+    }
+
+    pub fn text(&self) -> Style {
+        Style::new().fg(self.fg)
+    }
+
+    pub fn dim_text(&self) -> Style {
+        Style::new().fg(self.dim)
+    }
+
+    pub fn title(&self) -> Style {
+        Style::new().fg(self.accent).add_modifier(Modifier::BOLD)
+    }
+
+    pub fn selected_row(&self) -> Style {
+        Style::new()
+            .bg(self.surface)
+            .fg(self.fg)
+            .add_modifier(Modifier::BOLD)
+    }
+
+    /// Status glyph + color for a node's health. Glyph and color move
+    /// together so the state survives monochrome terminals.
+    pub fn health_glyph(&self, health: &NodeHealth) -> (&'static str, Color) {
+        match health {
+            NodeHealth::Up => (if self.ascii { "o" } else { "●" }, self.ok),
+            NodeHealth::Connecting => (if self.ascii { "~" } else { "◐" }, self.warn),
+            NodeHealth::Down { .. } => (if self.ascii { "x" } else { "○" }, self.err),
+        }
+    }
+
+    /// Registration status → color, keyed on the daemon's status
+    /// strings ("registered" is healthy; anything failed-ish is red).
+    pub fn registration_color(&self, status: &str) -> Color {
+        match status {
+            "registered" => self.ok,
+            s if s.contains("fail") || s.contains("error") => self.err,
+            _ => self.warn,
+        }
+    }
+}

--- a/bins/sightglass/src/ui/trunks.rs
+++ b/bins/sightglass/src/ui/trunks.rs
@@ -1,0 +1,98 @@
+//! Trunks tab: every `[[register]]` binding across the fleet.
+//!
+//! Gateway (IP-auth) trunk health is an open question deliberately
+//! deferred (DESIGN_SIGHTGLASS.md §6.6); this tab shows registration
+//! state, which is what the daemon has live data for today.
+
+use ratatui::layout::{Constraint, Rect};
+use ratatui::text::Span;
+use ratatui::widgets::{Block, Borders, Cell, Row, Table};
+use ratatui::Frame;
+
+use crate::model::{App, NodeHealth};
+
+use super::Theme;
+
+pub fn draw(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
+    let multi_node = app.nodes.len() > 1;
+
+    let mut headers = vec!["NAME", "SERVER", "STATUS", "EXPIRES", "LAST ERROR"];
+    if multi_node {
+        headers.insert(0, "NODE");
+    }
+    let header = Row::new(
+        headers
+            .into_iter()
+            .map(|h| Cell::from(Span::styled(h, theme.dim_text()))),
+    );
+
+    let mut rows = Vec::new();
+    for (id, n) in app.nodes.iter().enumerate() {
+        if app.node_filter.is_some_and(|f| f != id) {
+            continue;
+        }
+        let stale = matches!(n.health, NodeHealth::Down { .. });
+        for r in &n.registrations {
+            let base = if stale {
+                theme.dim_text()
+            } else {
+                theme.text()
+            };
+            let status_style = if stale {
+                theme.dim_text()
+            } else {
+                theme.text().fg(theme.registration_color(&r.status))
+            };
+            let mut cells = vec![
+                Cell::from(Span::styled(r.name.as_str(), base)),
+                Cell::from(Span::styled(r.server_addr.as_str(), base)),
+                Cell::from(Span::styled(r.status.as_str(), status_style)),
+                Cell::from(Span::styled(r.expires_at.as_deref().unwrap_or("—"), base)),
+                Cell::from(Span::styled(
+                    r.last_error.as_deref().unwrap_or(""),
+                    theme.dim_text(),
+                )),
+            ];
+            if multi_node {
+                cells.insert(0, Cell::from(Span::styled(n.name.as_str(), base)));
+            }
+            rows.push(Row::new(cells));
+        }
+    }
+
+    let mut widths = vec![
+        Constraint::Length(16),
+        Constraint::Length(22),
+        Constraint::Length(12),
+        Constraint::Length(22),
+        Constraint::Min(10),
+    ];
+    if multi_node {
+        widths.insert(0, Constraint::Length(12));
+    }
+
+    let empty = rows.is_empty();
+    let table = Table::new(rows, widths).header(header).block(
+        Block::new()
+            .borders(Borders::ALL)
+            .border_style(theme.dim_text())
+            .title(Span::styled(" trunks ", theme.title())),
+    );
+    frame.render_widget(table, area);
+
+    if empty {
+        let inner = Rect {
+            x: area.x + 2,
+            y: area.y + 2,
+            width: area.width.saturating_sub(4),
+            height: 1,
+        };
+        frame.render_widget(
+            ratatui::widgets::Paragraph::new(Span::styled(
+                "no [[register]] bindings on the visible nodes",
+                theme.dim_text(),
+            )),
+            inner,
+        );
+    }
+}

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -1607,7 +1607,8 @@ impl CallRegistryHandle for RuntimeCallRegistry {
                 direction: match c.direction {
                     Direction::Inbound => "inbound",
                     Direction::Outbound => "outbound",
-                },
+                }
+                .to_string(),
             })
             .collect()
     }

--- a/crates/admin-api-types/Cargo.toml
+++ b/crates/admin-api-types/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name        = "siphon-ai-admin-api-types"
+description = "Admin API wire types shared by the daemon (serializer) and admin clients such as sightglass (deserializer)."
+version.workspace      = true
+edition.workspace      = true
+rust-version.workspace = true
+license.workspace      = true
+authors.workspace      = true
+repository.workspace   = true
+
+[dependencies]
+serde.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/crates/admin-api-types/src/lib.rs
+++ b/crates/admin-api-types/src/lib.rs
@@ -1,0 +1,369 @@
+//! Admin API wire types.
+//!
+//! The request/response JSON shapes served under `/admin/v1/*`,
+//! extracted from `siphon-ai-telemetry` so the daemon (which
+//! serializes them) and admin *clients* — sightglass first
+//! (DESIGN_SIGHTGLASS.md §2) — share one definition and cannot
+//! drift. Everything here derives both `Serialize` and `Deserialize`
+//! for that reason, even though each side only exercises one
+//! direction.
+//!
+//! **These shapes are a public wire contract.** The admin API is ops
+//! tooling surface: existing fields don't change shape or meaning;
+//! additions are new optional fields. Field *order* in each struct is
+//! kept as-serialized today — the wire snapshot tests at the bottom
+//! lock the exact JSON.
+//!
+//! Server-side traits, error enums, and dispatch stay in
+//! `siphon-ai-telemetry` (they are implementation, not wire).
+
+use serde::{Deserialize, Serialize};
+
+// ─── GET /admin/v1/calls ───────────────────────────────────────────
+
+/// One active call in the `GET /admin/v1/calls` response.
+///
+/// `call_id` is the **bridge** id — the value on the WS `start` message
+/// and the CDR, and the id every `/admin/v1/calls/:id/…` route
+/// (`/hangup`, `/park`, `/retrieve`, `/stats`) and `/admin/v1/conferences/*`
+/// take. `sip_call_id` is the **SIP** Call-ID, the id the deprecated
+/// `POST /admin/calls/:id/hangup` alias takes. Exposing both
+/// (with `direction`) is the fix for issue #311, where the listing gave
+/// only the SIP Call-ID and the bridge id had no admin source.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AdminCallRow {
+    pub call_id: String,
+    pub sip_call_id: String,
+    /// `"inbound"` | `"outbound"`.
+    pub direction: String,
+}
+
+/// `GET /admin/v1/calls` response envelope.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CallsResponse {
+    pub count: usize,
+    pub calls: Vec<AdminCallRow>,
+}
+
+// ─── GET /admin/v1/registrations ───────────────────────────────────
+
+/// One row of the `GET /admin/v1/registrations` response. Mirrors
+/// `sip_glue::RegistrationState` but defined here so neither
+/// telemetry nor clients depend on the upstream crate.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RegistrationRow {
+    pub name: String,
+    pub server_addr: String,
+    pub status: String,
+    pub last_attempt_at: Option<String>,
+    pub expires_at: Option<String>,
+    pub last_error: Option<String>,
+}
+
+/// `GET /admin/v1/registrations` response envelope.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RegistrationsResponse {
+    pub count: usize,
+    pub registrations: Vec<RegistrationRow>,
+}
+
+// ─── GET /admin/v1/conferences ─────────────────────────────────────
+
+/// One conference room in the `GET /admin/v1/conferences` response.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConferenceRow {
+    pub room_id: String,
+    pub sample_rate: u32,
+    /// Member call-ids (bridge ids) currently in the room.
+    pub participants: Vec<String>,
+}
+
+/// `GET /admin/v1/conferences` response envelope.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConferencesResponse {
+    pub count: usize,
+    pub conferences: Vec<ConferenceRow>,
+}
+
+// ─── GET /admin/v1/parked ──────────────────────────────────────────
+
+/// One parked call in the `GET /admin/v1/parked` response.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ParkedRow {
+    pub call_id: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub slot: Option<String>,
+    pub parked_secs: u64,
+}
+
+/// `GET /admin/v1/parked` response envelope.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ParkedResponse {
+    pub count: usize,
+    pub parked: Vec<ParkedRow>,
+}
+
+// ─── GET /admin/v1/drain ───────────────────────────────────────────
+
+/// Snapshot of the daemon's graceful-shutdown drain state (0.17.0),
+/// served by `GET /admin/v1/drain`. Lets an operator / deploy script
+/// confirm a pod has entered drain and watch the countdown.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DrainStatus {
+    /// `true` once a shutdown signal has put the daemon into drain
+    /// (new INVITEs are 503'd and `/ready` is false), until it exits.
+    pub draining: bool,
+    /// Calls still active right now (the drain waits for this to hit 0).
+    pub active_calls: usize,
+    /// Configured `[shutdown].drain_timeout_secs` (`0` = drain disabled,
+    /// immediate exit).
+    pub drain_timeout_secs: u64,
+    /// Seconds left until the drain deadline force-terminates
+    /// stragglers. `Some` only while `draining`; `None` otherwise.
+    pub remaining_secs: Option<u64>,
+}
+
+// ─── Request bodies (server deserializes, clients serialize) ───────
+
+/// `POST /admin/v1/calls` request body — originate an outbound call (0.6.0).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OriginateRequest {
+    /// Dialed destination (E.164 number or SIP user) — becomes the
+    /// Request-URI user dialed through the gateway.
+    pub to: String,
+    /// Name of the `[[gateway]]` (or `[[register]]` reuse) to dial through.
+    pub gateway: String,
+    /// WS server to bridge the answered call to. Falls back to
+    /// `[bridge].ws_url` when omitted.
+    #[serde(default)]
+    pub ws_url: Option<String>,
+    /// Caller-ID override (a `sip:` URI). Falls back to the gateway's `from`.
+    #[serde(default)]
+    pub from: Option<String>,
+    /// Place the call as a **delayed offer** (RFC 3264): send an INVITE
+    /// with no SDP and answer the peer's offer in the ACK. Default `false`
+    /// (early offer — SiphonAI offers in the INVITE).
+    #[serde(default)]
+    pub delayed_offer: bool,
+    /// Recording override for this leg (0.26.0): `"off"` / `"always"` /
+    /// `"on_demand"`. Falls back to the gateway's `recording` default.
+    #[serde(default)]
+    pub recording: Option<String>,
+}
+
+/// `POST /admin/v1/conferences` body — pre-create a room.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateConferenceRequest {
+    /// Optional room id; the daemon generates one when omitted.
+    #[serde(default)]
+    pub room_id: Option<String>,
+    /// Rate the room locks to (8000 or 16000). Defaults to 8000 — the
+    /// most common PSTN rate; a join at a different rate is rejected.
+    #[serde(default)]
+    pub sample_rate: Option<u32>,
+}
+
+/// `POST /admin/v1/conferences/:id/participants` body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AddParticipantRequest {
+    /// Bridge `call_id` of the active call to add to the room.
+    pub call_id: String,
+}
+
+/// `POST /admin/v1/calls/:id/park` body (all optional).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ParkRequest {
+    #[serde(default)]
+    pub slot: Option<String>,
+}
+
+/// `POST /admin/v1/calls/:id/retrieve` body (all optional).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RetrieveRequest {
+    /// Redirect the retrieved session to a different WS server.
+    /// Defaults to the call's original `ws_url`.
+    #[serde(default)]
+    pub ws_url: Option<String>,
+}
+
+// ─── Error envelope ────────────────────────────────────────────────
+
+/// The `{"error": "…"}` body every admin endpoint answers non-2xx
+/// statuses with. Defined here for clients; the server builds these
+/// inline at each rejection site.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ErrorBody {
+    pub error: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// The wire snapshots below are the *contract*: they assert the
+    /// exact JSON the daemon serves today (pre-extraction `json!`
+    /// output, byte-for-byte modulo key order which serde_json
+    /// preserves from struct declaration order). A failure here means
+    /// the admin API wire format changed — that needs a deliberate
+    /// decision, not a type tweak.
+    #[test]
+    fn calls_response_wire_shape() {
+        let resp = CallsResponse {
+            count: 1,
+            calls: vec![AdminCallRow {
+                call_id: "siphon-abc".into(),
+                sip_call_id: "abc@host".into(),
+                direction: "inbound".into(),
+            }],
+        };
+        assert_eq!(
+            serde_json::to_value(&resp).unwrap(),
+            json!({
+                "count": 1,
+                "calls": [{
+                    "call_id": "siphon-abc",
+                    "sip_call_id": "abc@host",
+                    "direction": "inbound",
+                }],
+            })
+        );
+    }
+
+    #[test]
+    fn registrations_response_wire_shape() {
+        let resp = RegistrationsResponse {
+            count: 1,
+            registrations: vec![RegistrationRow {
+                name: "pbx-a".into(),
+                server_addr: "10.0.0.9:5060".into(),
+                status: "registered".into(),
+                last_attempt_at: Some("2026-08-17T00:00:00Z".into()),
+                expires_at: None,
+                last_error: None,
+            }],
+        };
+        assert_eq!(
+            serde_json::to_value(&resp).unwrap(),
+            json!({
+                "count": 1,
+                "registrations": [{
+                    "name": "pbx-a",
+                    "server_addr": "10.0.0.9:5060",
+                    "status": "registered",
+                    "last_attempt_at": "2026-08-17T00:00:00Z",
+                    "expires_at": null,
+                    "last_error": null,
+                }],
+            })
+        );
+    }
+
+    #[test]
+    fn conferences_response_wire_shape() {
+        let resp = ConferencesResponse {
+            count: 1,
+            conferences: vec![ConferenceRow {
+                room_id: "room-1".into(),
+                sample_rate: 8000,
+                participants: vec!["siphon-abc".into()],
+            }],
+        };
+        assert_eq!(
+            serde_json::to_value(&resp).unwrap(),
+            json!({
+                "count": 1,
+                "conferences": [{
+                    "room_id": "room-1",
+                    "sample_rate": 8000,
+                    "participants": ["siphon-abc"],
+                }],
+            })
+        );
+    }
+
+    #[test]
+    fn parked_row_omits_absent_slot() {
+        let resp = ParkedResponse {
+            count: 1,
+            parked: vec![ParkedRow {
+                call_id: "siphon-abc".into(),
+                slot: None,
+                parked_secs: 12,
+            }],
+        };
+        assert_eq!(
+            serde_json::to_value(&resp).unwrap(),
+            json!({
+                "count": 1,
+                "parked": [{ "call_id": "siphon-abc", "parked_secs": 12 }],
+            })
+        );
+    }
+
+    #[test]
+    fn drain_status_wire_shape() {
+        let status = DrainStatus {
+            draining: true,
+            active_calls: 3,
+            drain_timeout_secs: 30,
+            remaining_secs: Some(21),
+        };
+        assert_eq!(
+            serde_json::to_value(&status).unwrap(),
+            json!({
+                "draining": true,
+                "active_calls": 3,
+                "drain_timeout_secs": 30,
+                "remaining_secs": 21,
+            })
+        );
+    }
+
+    #[test]
+    fn originate_request_round_trips_with_defaults() {
+        // A client-minimal body deserializes with every optional field
+        // defaulted — the same leniency the daemon has always had.
+        let req: OriginateRequest =
+            serde_json::from_value(json!({ "to": "+15550100", "gateway": "twilio" })).unwrap();
+        assert_eq!(req.to, "+15550100");
+        assert!(req.ws_url.is_none() && req.from.is_none() && !req.delayed_offer);
+
+        let full: OriginateRequest = serde_json::from_value(
+            serde_json::to_value(&OriginateRequest {
+                to: "+15550100".into(),
+                gateway: "twilio".into(),
+                ws_url: Some("wss://bot.example/ws".into()),
+                from: None,
+                delayed_offer: true,
+                recording: Some("always".into()),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(full.ws_url.as_deref(), Some("wss://bot.example/ws"));
+        assert!(full.delayed_offer);
+    }
+
+    #[test]
+    fn responses_deserialize_from_wire_json() {
+        // The client direction: parse exactly what the daemon emits.
+        let parsed: CallsResponse = serde_json::from_value(json!({
+            "count": 2,
+            "calls": [
+                { "call_id": "a", "sip_call_id": "a@h", "direction": "inbound" },
+                { "call_id": "b", "sip_call_id": "b@h", "direction": "outbound" },
+            ],
+        }))
+        .unwrap();
+        assert_eq!(parsed.count, 2);
+        assert_eq!(parsed.calls[1].direction, "outbound");
+
+        let parked: ParkedResponse = serde_json::from_value(json!({
+            "count": 1,
+            "parked": [{ "call_id": "a", "parked_secs": 5 }],
+        }))
+        .unwrap();
+        assert!(parked.parked[0].slot.is_none());
+    }
+}

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -24,6 +24,9 @@ thiserror.workspace                   = true
 # Signed audit-event stream (0.20.0): admin requests emit AuditEvents.
 # Only depends on siphon-ai-http, so no dep cycle.
 siphon-ai-audit.workspace             = true
+# Admin wire shapes, shared with admin clients (sightglass) so the
+# serializer and deserializer are the same structs. Serde-only dep.
+siphon-ai-admin-api-types.workspace   = true
 # Admin bearer-token auth: SHA-256 the token + constant-time compare.
 sha2.workspace                        = true
 subtle.workspace                      = true

--- a/crates/telemetry/src/admin.rs
+++ b/crates/telemetry/src/admin.rs
@@ -64,11 +64,22 @@ use http_body_util::Full;
 use hyper::body::Bytes;
 use hyper::header::CONTENT_TYPE;
 use hyper::{Response, StatusCode};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use serde_json::json;
 
 use crate::log_filter::LogFilterHandle;
 use crate::HepTelemetry;
+
+// The request/response wire shapes live in `siphon-ai-admin-api-types`
+// so admin clients (sightglass, DESIGN_SIGHTGLASS.md) share the exact
+// structs the daemon serializes. Re-exported here so existing
+// `siphon_ai_telemetry::admin::…` paths keep working; the server-side
+// traits and error enums below stay in this crate.
+pub use siphon_ai_admin_api_types::{
+    AddParticipantRequest, AdminCallRow, CallsResponse, ConferenceRow, ConferencesResponse,
+    CreateConferenceRequest, DrainStatus, OriginateRequest, ParkRequest, ParkedResponse, ParkedRow,
+    RegistrationRow, RegistrationsResponse, RetrieveRequest,
+};
 
 /// Bundle of dependencies the admin handlers may need. Each is
 /// optional so partially-configured deployments don't crash on
@@ -113,24 +124,6 @@ pub struct AdminState {
 /// telemetry crate's deps.
 pub type QualityStatsFn = Arc<dyn Fn(&str) -> Option<serde_json::Value> + Send + Sync>;
 
-/// Snapshot of the daemon's graceful-shutdown drain state (0.17.0),
-/// served by `GET /admin/v1/drain`. Lets an operator / deploy script
-/// confirm a pod has entered drain and watch the countdown.
-#[derive(Debug, Clone, Serialize)]
-pub struct DrainStatus {
-    /// `true` once a shutdown signal has put the daemon into drain
-    /// (new INVITEs are 503'd and `/ready` is false), until it exits.
-    pub draining: bool,
-    /// Calls still active right now (the drain waits for this to hit 0).
-    pub active_calls: usize,
-    /// Configured `[shutdown].drain_timeout_secs` (`0` = drain disabled,
-    /// immediate exit).
-    pub drain_timeout_secs: u64,
-    /// Seconds left until the drain deadline force-terminates
-    /// stragglers. `Some` only while `draining`; `None` otherwise.
-    pub remaining_secs: Option<u64>,
-}
-
 /// Closure producing a fresh [`DrainStatus`] per request. Same
 /// indirection rationale as [`CallRegistryHandle`] — keeps the drain
 /// flag / call registry types out of the telemetry crate's deps.
@@ -152,23 +145,6 @@ pub trait CallRegistryHandle: Send + Sync + 'static {
     fn hangup(&self, sip_call_id: &str) -> bool;
 }
 
-/// One active call in the `GET /admin/v1/calls` response.
-///
-/// `call_id` is the **bridge** id — the value on the WS `start` message
-/// and the CDR, and the id every `/admin/v1/calls/:id/…` route
-/// (`/hangup`, `/park`, `/retrieve`, `/stats`) and `/admin/v1/conferences/*`
-/// take. `sip_call_id` is the **SIP** Call-ID, the id the deprecated
-/// `POST /admin/calls/:id/hangup` alias takes. Exposing both
-/// (with `direction`) is the fix for issue #311, where the listing gave
-/// only the SIP Call-ID and the bridge id had no admin source.
-#[derive(Debug, Clone, serde::Serialize)]
-pub struct AdminCallRow {
-    pub call_id: String,
-    pub sip_call_id: String,
-    /// `"inbound"` | `"outbound"`.
-    pub direction: &'static str,
-}
-
 /// Boxed clone-friendly handle the runtime constructs.
 pub type AdminCallRegistry = Arc<dyn CallRegistryHandle>;
 
@@ -176,32 +152,6 @@ pub type AdminCallRegistry = Arc<dyn CallRegistryHandle>;
 /// admin request. Same indirection rationale as `CallRegistryHandle`
 /// — keeps `siphon-ai-sip-glue` out of the telemetry crate's deps.
 pub type RegistrationSnapshotFn = Arc<dyn Fn() -> Vec<RegistrationRow> + Send + Sync>;
-
-/// `POST /admin/v1/calls` request body — originate an outbound call (0.6.0).
-#[derive(Debug, Clone, Deserialize)]
-pub struct OriginateRequest {
-    /// Dialed destination (E.164 number or SIP user) — becomes the
-    /// Request-URI user dialed through the gateway.
-    pub to: String,
-    /// Name of the `[[gateway]]` (or `[[register]]` reuse) to dial through.
-    pub gateway: String,
-    /// WS server to bridge the answered call to. Falls back to
-    /// `[bridge].ws_url` when omitted.
-    #[serde(default)]
-    pub ws_url: Option<String>,
-    /// Caller-ID override (a `sip:` URI). Falls back to the gateway's `from`.
-    #[serde(default)]
-    pub from: Option<String>,
-    /// Place the call as a **delayed offer** (RFC 3264): send an INVITE
-    /// with no SDP and answer the peer's offer in the ACK. Default `false`
-    /// (early offer — SiphonAI offers in the INVITE).
-    #[serde(default)]
-    pub delayed_offer: bool,
-    /// Recording override for this leg (0.26.0): `"off"` / `"always"` /
-    /// `"on_demand"`. Falls back to the gateway's `recording` default.
-    #[serde(default)]
-    pub recording: Option<String>,
-}
 
 /// Why an originate request was refused synchronously (before the call is
 /// placed). The admin layer maps each to an HTTP status.
@@ -243,34 +193,6 @@ pub trait OutboundOriginateHandle: Send + Sync + 'static {
 /// Boxed handle the runtime installs into [`AdminState`].
 pub type AdminOutbound = Arc<dyn OutboundOriginateHandle>;
 
-/// One conference room in the `GET /admin/v1/conferences` response.
-#[derive(Debug, Clone, Serialize)]
-pub struct ConferenceRow {
-    pub room_id: String,
-    pub sample_rate: u32,
-    /// Member call-ids (bridge ids) currently in the room.
-    pub participants: Vec<String>,
-}
-
-/// `POST /admin/v1/conferences` body — pre-create a room.
-#[derive(Debug, Clone, Deserialize)]
-pub struct CreateConferenceRequest {
-    /// Optional room id; the daemon generates one when omitted.
-    #[serde(default)]
-    pub room_id: Option<String>,
-    /// Rate the room locks to (8000 or 16000). Defaults to 8000 — the
-    /// most common PSTN rate; a join at a different rate is rejected.
-    #[serde(default)]
-    pub sample_rate: Option<u32>,
-}
-
-/// `POST /admin/v1/conferences/:id/participants` body.
-#[derive(Debug, Clone, Deserialize)]
-pub struct AddParticipantRequest {
-    /// Bridge `call_id` of the active call to add to the room.
-    pub call_id: String,
-}
-
 /// Why a conference admin op was refused. The admin layer maps each to
 /// an HTTP status.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -307,31 +229,6 @@ pub trait ConferenceAdminHandle: Send + Sync + 'static {
 /// Boxed handle the runtime installs into [`AdminState`].
 pub type AdminConference = Arc<dyn ConferenceAdminHandle>;
 
-/// One parked call in the `GET /admin/v1/parked` response.
-#[derive(Debug, Clone, Serialize)]
-pub struct ParkedRow {
-    pub call_id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub slot: Option<String>,
-    pub parked_secs: u64,
-}
-
-/// `POST /admin/v1/calls/:id/park` body (all optional).
-#[derive(Debug, Clone, Default, Deserialize)]
-pub struct ParkRequest {
-    #[serde(default)]
-    pub slot: Option<String>,
-}
-
-/// `POST /admin/v1/calls/:id/retrieve` body (all optional).
-#[derive(Debug, Clone, Default, Deserialize)]
-pub struct RetrieveRequest {
-    /// Redirect the retrieved session to a different WS server.
-    /// Defaults to the call's original `ws_url`.
-    #[serde(default)]
-    pub ws_url: Option<String>,
-}
-
 /// Why a park-admin op was refused.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ParkAdminError {
@@ -355,19 +252,6 @@ pub trait ParkAdminHandle: Send + Sync + 'static {
 
 /// Boxed handle the runtime installs into [`AdminState`].
 pub type AdminPark = Arc<dyn ParkAdminHandle>;
-
-/// One row of the `GET /admin/registrations` response. Mirrors
-/// `sip_glue::RegistrationState` but defined here so telemetry
-/// doesn't depend on the upstream crate.
-#[derive(Debug, Clone, Serialize)]
-pub struct RegistrationRow {
-    pub name: String,
-    pub server_addr: String,
-    pub status: String,
-    pub last_attempt_at: Option<String>,
-    pub expires_at: Option<String>,
-    pub last_error: Option<String>,
-}
 
 /// Operator write action on one `[[register]]` binding (0.33.0,
 /// DESIGN_REGISTRATION_ADMIN.md).
@@ -598,7 +482,10 @@ fn list_calls(state: &AdminState) -> Response<Full<Bytes>> {
     let calls = reg.snapshot_calls();
     json_response(
         StatusCode::OK,
-        &json!({ "count": calls.len(), "calls": calls }),
+        &CallsResponse {
+            count: calls.len(),
+            calls,
+        },
     )
 }
 
@@ -699,7 +586,10 @@ fn list_registrations(state: &AdminState) -> Response<Full<Bytes>> {
     let rows = snapshot_fn();
     json_response(
         StatusCode::OK,
-        &json!({ "count": rows.len(), "registrations": rows }),
+        &RegistrationsResponse {
+            count: rows.len(),
+            registrations: rows,
+        },
     )
 }
 
@@ -842,7 +732,10 @@ fn list_conferences(state: &AdminState) -> Response<Full<Bytes>> {
     let rooms = svc.list();
     json_response(
         StatusCode::OK,
-        &json!({ "count": rooms.len(), "conferences": rooms }),
+        &ConferencesResponse {
+            count: rooms.len(),
+            conferences: rooms,
+        },
     )
 }
 
@@ -964,7 +857,10 @@ fn list_parked(state: &AdminState) -> Response<Full<Bytes>> {
     let parked = svc.list();
     json_response(
         StatusCode::OK,
-        &json!({ "count": parked.len(), "parked": parked }),
+        &ParkedResponse {
+            count: parked.len(),
+            parked,
+        },
     )
 }
 
@@ -1142,7 +1038,7 @@ mod tests {
                 .map(|sip| AdminCallRow {
                     call_id: format!("siphon-{sip}"),
                     sip_call_id: sip.clone(),
-                    direction: "inbound",
+                    direction: "inbound".into(),
                 })
                 .collect()
         }

--- a/docs/design/DESIGN_SIGHTGLASS.md
+++ b/docs/design/DESIGN_SIGHTGLASS.md
@@ -1,0 +1,300 @@
+# Design note — Sightglass: a terminal UI for siphon-ai
+
+> **Status: IN PROGRESS.** PR 1 is implemented: this doc, the
+> `crates/admin-api-types` extraction (wire-preserving, snapshot-
+> tested), and the `bins/sightglass` scaffold — multi-node model,
+> per-node pollers, theme/chrome, read-only Overview/Trunks/Calls.
+> PRs 2–6 in §10 are pending. Update this header as chunks land.
+
+A sight glass is the fitting on a pipe that lets you watch the fluid
+moving through it. `sightglass` is that for running siphon-ai nodes —
+one or many: a ratatui terminal application that fans out to each
+configured node's admin API and renders a live, tabbed operator
+console — trunk status, active calls with per-call media detail,
+system health, errors — plus the operator actions the admin API
+already supports (hangup, park/retrieve, originate, registration
+refresh, live log-level control). A single node is just the fleet of
+size one; multi-node is first-class from PR 1, not a bolt-on.
+
+---
+
+## 1. Naming and placement
+
+- **Crate:** `siphon-ai-sightglass`, at `bins/sightglass/` in this
+  workspace, next to `bins/siphon-ai/`.
+- **Binary:** `sightglass` (via `[[bin]] name`), k9s-style: the binary
+  claims nothing in the `siphon-*` namespace.
+- The `siphon-ai-*` crate prefix follows the existing convention
+  (`siphon-ai-bridge`, `siphon-ai-http`, `siphon-ai-testkit`). The bare
+  `siphon-*` prefix stays reserved for platform-level tools (siphon-rs,
+  forge-media, hep-rs lineage) and the future scriptable CLI keeps
+  `siphon-ai-ctl` available — sightglass is not that tool. Sightglass
+  itself covers the multi-node view (§2), so no separate fleet-monitor
+  name needs reserving.
+
+## 2. Architecture: a fleet-aware, pure admin-API client
+
+```
+                                          ┌─────────────────────┐
+┌──────────────┐   HTTPS + bearer token   │ siphon-ai [admin]   │
+│  sightglass  │ ───────────────────────► │  prod-1             │
+│  (ratatui)   │ ───────────────────────► │  prod-2   …  ×N     │
+└──────────────┘   one poller set/node    └─────────────────────┘
+```
+
+The TUI runs **out of process** — possibly on a different machine —
+and speaks only to each node's `[admin]` HTTP listener. It is a
+rendering client with zero privileged access:
+
+- No daemon embedding. The daemon is headless under systemd; a TTY in
+  the daemon is a liability and touches nothing it should.
+- No new aggregation layer. The admin API is already the sanctioned
+  cross-call view (CLAUDE.md §4.4 stays intact — sightglass sees what
+  any admin client sees, nothing more).
+- The daemon's dependency tree is untouched: ratatui/crossterm live
+  only in `bins/sightglass/Cargo.toml`.
+
+**Fleet model.** Multiple nodes are a client-side concern only —
+daemons stay entirely unaware of each other (CLAUDE.md §4.4 is
+untouched; there is no cross-node state anywhere server-side):
+
+- Every record in the TUI's state carries a `NodeId`. Call ids,
+  registration names, and room ids are unique **per node only** — the
+  composite key is always `(node, id)`, and every action dispatches to
+  the owning node's client. This is baked into the data model in PR 1;
+  it is the one thing that cannot be retrofitted cheaply.
+- One independent poller set per node, start times staggered so N
+  nodes don't burst-poll in phase. A slow or down node degrades only
+  its own rows — it never stalls rendering or other nodes' pollers.
+- Node reachability is itself first-class state: Overview shows a
+  fleet health grid, and a down node renders as `○ down (retrying)`
+  with its last-seen data greyed, never as an error screen.
+- Auth is **per node** (each node has its own token, possibly a
+  different role). Action keys grey out per row based on the owning
+  node's role, so a mixed fleet (operator on staging, readonly on
+  prod) behaves correctly.
+
+**Polling, not push (v1).** Per node: overview + calls list +
+registrations poll at 1 s; the per-call stats endpoint is polled
+**only for the focused call**, never fanned out across all calls. The
+TUI accumulates history
+client-side (ring of ~120 samples) for sparklines; the daemon stores
+nothing new. SSE/WS push on the admin listener is a possible v2 if
+polling ever proves annoying — it is explicitly out of scope for v1.
+
+**Shared response types.** The admin response shapes currently live as
+ad-hoc `json!` in `crates/telemetry/src/admin.rs`. PR 1 extracts them
+into a small `crates/admin-api-types` crate (serde structs only, no
+heavy deps) used by both the daemon and sightglass, so the client can
+never drift from what the server serializes. Existing wire shapes are
+preserved byte-for-byte — this is a refactor, not an API change
+(snapshot tests in `telemetry` guard it).
+
+## 3. Non-goals
+
+- Not a softphone; no SIP or RTP in the TUI.
+- Not the scriptable CLI (`siphon-ai-ctl`, future work, separate tool).
+- No central aggregator service. Multi-node view is client-side
+  fan-out from one sightglass process; nodes never learn about each
+  other, and no daemon grows fleet awareness.
+- No cross-node operations. Every action targets exactly one node;
+  there is no "drain all", no fleet-wide bulk hangup.
+- No config editing. Read-and-act only.
+- No historical analytics — Homer/Grafana own history; sightglass owns
+  "right now" plus a short in-memory tail.
+
+## 4. Tabs and their data sources
+
+All tables are fleet-unified: rows from every configured node merge
+into one view with a **Node** column (hidden automatically when only
+one node is configured), and `n` cycles a node filter
+(all → prod-1 → prod-2 → …) that scopes every tab at once.
+
+| Tab | Contents | Source (per node) | Exists today? |
+|---|---|---|---|
+| **Overview** | fleet health grid (one row per node: reachability, version, uptime, active calls, drain state, HEP collector up) + aggregate totals and calls/sec sparkline | `GET /admin/v1/status` (new, §6.2), `GET /admin/v1/drain` | partly |
+| **Trunks** | registrations across the fleet, grouped by node: state, expiry, last result; refresh/restart actions | `GET /admin/v1/registrations`, `POST …/{name}/refresh\|restart` | yes |
+| **Calls** | unified table of active calls (node, both id namespaces + direction per #311); detail pane for focused call: codec, duration, MOS gauge, jitter/loss sparklines, WS state; actions §5 | `GET /admin/v1/calls`, `GET …/{id}/stats` | yes |
+| **Rooms** | conferences + participants, parked calls, node-tagged; end room, kick, retrieve | `GET /admin/v1/conferences`, `GET /admin/v1/parked`, conference sub-resources | yes |
+| **Errors** | merged fleet tail of warn/error events, node-tagged, with call_id correlation | `GET /admin/v1/errors` (new, §6.1) | no |
+| **System** | acts on one node at a time (selected via the node filter): log filter get/set, HEP test probe, drain status/initiate | `PUT /admin/v1/log`, `POST /admin/v1/hep/test`, `GET /admin/v1/drain` | mostly |
+
+## 5. Operator actions (all against existing endpoints)
+
+| Key | Action | Endpoint | Min role |
+|---|---|---|---|
+| `x` | hang up focused call (confirm modal) | `POST /admin/v1/calls/{id}/hangup` | operator |
+| `p` | park focused call | `POST /admin/v1/calls/{id}/park` | operator |
+| `u` | retrieve parked call — optional new `ws_url` (move a live call to a fallback WS server) | `POST /admin/v1/calls/{id}/retrieve` | operator |
+| `o` | originate (dial form modal) | `POST /admin/v1/calls` | admin |
+| `c` | add focused call to a conference | `POST /admin/v1/conferences/{id}/participants` | operator |
+| `r` / `R` | refresh / restart focused registration | `POST /admin/v1/registrations/{name}/…` | operator |
+| `L` | set log filter (System tab) | `PUT /admin/v1/log` | operator |
+| `n` | cycle node filter (all → node → …) | — (client-side) | — |
+
+Rules:
+
+- **Actions are node-scoped.** Every action resolves through the
+  focused row's `(node, id)` key and dispatches to that node's client;
+  confirm modals name the node ("hang up abc@host **on prod-2**?") so
+  a fleet operator never acts on the wrong box.
+- **RBAC-aware keybinds, per node.** On connect, sightglass learns
+  each node's token role (`crates/telemetry/src/auth.rs`:
+  `readonly` < `operator` < `admin`) and greys out actions the owning
+  node's token cannot perform, rather than surfacing a 403 after the
+  keypress.
+- **`--read-only` flag** disables all mutating actions client-side
+  regardless of token role — for NOC wall screens.
+- Destructive actions (hangup, end-room, drain) always get a
+  confirmation modal. Everything flows through the existing admin
+  audit stream, attributed to the token — a deliberate reason to do
+  call-kill via the admin API rather than any side channel.
+
+## 6. Daemon-side work (each its own small PR, observability rules apply)
+
+### 6.1 Recent-errors ring buffer + `GET /admin/v1/errors`
+
+A `tracing` `Layer` in `crates/telemetry` captures `warn`/`error`
+events into a bounded ring (default 256, config-tunable). Off the hot
+path by construction — it is a subscriber layer; audio tasks never
+block on it (same non-blocking discipline as HEP, §4.7). Entries carry
+timestamp, level, target, message, and `call_id` when present in the
+span, so the Errors tab can jump-link to the call. Endpoint returns
+the ring newest-first; `readonly` role suffices.
+
+### 6.2 `GET /admin/v1/status` summary
+
+Small JSON: version, uptime_secs, active_calls, total_calls,
+registrations `{up, down, total}`, `hep_collector_up`, drain state.
+Everything already exists as metrics/state; this avoids the TUI
+parsing Prometheus text exposition. `readonly`.
+
+### 6.3 Recent-calls ring + `GET /admin/v1/cdrs/recent`
+
+In-memory ring (default 50) of completed-call CDR summaries
+(disposition, duration, hangup cause, MOS). Feeds a history section on
+the Calls tab. Reuses the CDR structs from `crates/cdr` — no second
+schema. `readonly`.
+
+### 6.4 Stats enrichment (additive fields on `…/{id}/stats`)
+
+Fields `CallController`/tap already know, plumbed into the stats
+response: VAD state (speaking/silent), last DTMF digits, WS reconnect
+count, recording state, STIR/SHAKEN verstat, SRTP on/off. Additive
+JSON — no version concerns.
+
+### 6.5 `POST /admin/v1/drain` (admin role)
+
+Programmatic equivalent of SIGTERM drain so the System tab can start a
+graceful drain with a confirm modal. Reuses the existing shutdown
+path; no new drain logic.
+
+### 6.6 Open question — gateway (IP-auth) trunk health
+
+Registrations have live state; static outbound gateways do not. V1
+shows configured gateways with last-used info only. Active OPTIONS
+probing toward gateways would be a real feature (likely touching
+siphon-rs) — deliberately deferred, tracked separately.
+
+## 7. Visual and interaction design
+
+**Discipline over decoration.** One theme, used everywhere:
+
+- A single palette struct (Catppuccin-adjacent: one accent, one dim,
+  semantic green/amber/red). No ad-hoc `Color::` in widget code.
+- Status is always dot + color (`●` up, `◐` degraded, `○` down), never
+  color alone (colorblind-safe).
+- Chrome: header (node name, version, uptime, active calls), tab bar
+  with accent underline, **context-sensitive footer** showing only the
+  keybinds valid right now.
+- Motion: braille sparklines/charts for calls-per-second and MOS trend;
+  `Gauge` for MOS; request-in-flight throbber; action-result toasts
+  ("hangup accepted (202)") that fade; centered modals over a dimmed
+  background.
+- Input: vim keys and arrows; `/` fuzzy-filter on tables; sortable
+  columns; crossterm mouse support (click tabs/rows).
+- Layout collapses detail pane below the table on narrow terminals;
+  nothing truncates silently.
+- Unicode/nerd-font glyphs degrade to ASCII via a `--ascii` flag.
+
+**Responsiveness:** tokio throughout. Poller tasks feed the render
+loop over channels; redraw on data or input; **no blocking call ever
+in the draw path**. Unreachable admin API renders a clear full-screen
+"can't reach <target> — is `[admin]` enabled?" state, retrying with
+backoff, never a stack trace.
+
+## 8. Configuration and connection
+
+`~/.config/sightglass/config.toml` (TOML, consistent with house
+rules) defines the fleet — one `[[node]]` per daemon, order = display
+order:
+
+```toml
+poll_interval_ms = 1000   # per node
+theme = "default"
+
+[[node]]
+name = "prod-1"
+url = "https://prod-1.example.com:9090"
+token_file = "~/.config/sightglass/prod-1.token"
+# ca = "/etc/ssl/private-ca.pem"   # optional, private CAs
+
+[[node]]
+name = "prod-2"
+url = "https://prod-2.example.com:9090"
+token_file = "~/.config/sightglass/prod-2.token"
+```
+
+- `node.name` must be unique — it is the `NodeId` shown in every Node
+  column and confirm modal.
+- Ad-hoc single-node use needs no config file:
+  `sightglass --target https://host:9090 --token-file ./token`
+  (defines an anonymous one-node fleet; mutually exclusive with the
+  config's node list).
+- TLS: respects each admin listener's TLS; per-node `ca` for private
+  CAs. Tokens via file or `SIGHTGLASS_TOKEN` env (single-node only) —
+  never as a CLI arg (visible in `ps`).
+- Requires the `[admin]` listener enabled on each daemon (omitted ⇒
+  not served); setup docs lead with this.
+
+## 9. Dependencies (new, confined to `bins/sightglass`)
+
+`ratatui`, `crossterm`, `tui-textarea` (originate form), plus the
+existing workspace `reqwest`/`siphon-ai-http` machinery for HTTP. None
+of these appear in any daemon crate. The release pipeline builds it
+with the existing musl/zigbuild flow — it is a pure HTTP client, so it
+needs none of the libopus static-link handling; ships in the existing
+.deb alongside the daemon and as its own GHCR artifact.
+
+## 10. Build plan (PR sequence)
+
+| PR | Contents | Daemon touched? |
+|---|---|---|
+| **1** | this doc; `crates/admin-api-types` extraction (wire-preserving); `bins/sightglass` scaffold: theme, chrome, event loop, **multi-node config + `NodeId` data model + per-node pollers + node filter/health states**, Overview/Trunks/Calls tabs read-only against existing endpoints | refactor only |
+| **2** | Calls-tab actions (hangup/park/retrieve/originate/conference) + confirm modals (node-named), toasts, per-node RBAC-aware keybinds, `--read-only` | no |
+| **3** | §6.1 errors ring + endpoint; Errors tab with live tail | yes (small) |
+| **4** | §6.2 status endpoint; Overview tab completed; Rooms tab | yes (small) |
+| **5** | §6.3 recent-CDR ring; history section; §6.4 stats enrichment; detail pane completed | yes (small) |
+| **6** | §6.5 drain endpoint; System tab (log filter, HEP probe, drain) | yes (small) |
+
+Each daemon-side PR carries its own metrics/logs/docs per CLAUDE.md
+§4.5; endpoint additions are documented in `docs/DEPLOY.md` in the
+same PR. Sightglass gets a user-facing guide (`docs/SIGHTGLASS.md`)
+once PR 2 lands.
+
+## 11. Testing
+
+- `admin-api-types`: snapshot tests locking wire shapes against the
+  current `json!` output (regression gate for the extraction).
+- Sightglass unit tests: state reducers and keymap dispatch (pure
+  functions — model/update separated from draw for exactly this).
+  Reducer fixtures are multi-node from the start: id collisions across
+  nodes (same call_id on two nodes stays two rows), action routing to
+  the owning node, one-node-down merge behavior.
+- Rendering: `ratatui::backend::TestBackend` golden tests for the main
+  screens at two terminal sizes, including a fleet view with one node
+  down and the single-node layout (Node column auto-hidden).
+- Daemon endpoints: same in-crate dispatch-test pattern already used
+  in `admin.rs` (stub registries, assert status + body).
+- Manual gate before each PR: run against a local daemon with the
+  §5.3 smoke-test stack; kill a live sipp call from the TUI.


### PR DESCRIPTION
First chunk of the sightglass plan — see `docs/design/DESIGN_SIGHTGLASS.md` (included) for the full design and the 6-PR sequence.

## What's in this PR

**The design note** — sightglass is a ratatui terminal operator console for one or more siphon-ai nodes, a pure client of each node's `[admin]` listener. Multi-node is client-side fan-out only: daemons never learn about each other (CLAUDE.md §4.4 untouched), and every action (from PR 2 on) targets exactly one node.

**`crates/admin-api-types`** — the `/admin/v1/*` wire shapes moved out of `siphon-ai-telemetry` into a serde-only crate shared by the daemon (serializer) and sightglass (deserializer):
- Wire-preserving: telemetry re-exports the same names at the same paths; the four list handlers now serialize typed envelopes producing byte-identical JSON; **all 79 existing admin dispatch tests pass unchanged**.
- New wire snapshot tests pin the exact JSON as the contract.
- One internal type change: `AdminCallRow.direction` is `String` (was `&'static str`) so the shared type can deserialize — wire-identical.

**`bins/sightglass`** (crate `siphon-ai-sightglass`, binary `sightglass`) — read-only Overview / Trunks / Calls tabs against existing endpoints:
- **Fleet model baked in from day one**: records keyed `(node, id)`, one staggered poller set per node, a down node renders as a dimmed `○ down (retrying)` row with last-seen data and never stalls the rest, Node column auto-hides on single-node fleets, `n` cycles a node filter scoping every tab.
- **Calls tab** shows both id namespaces + direction (#311's fix), with a focused-call detail pane fed by `GET /admin/v1/calls/:id/stats` (polled for the focused call only) and a client-side MOS sparkline.
- Config: `~/.config/sightglass/config.toml` (`[[node]]` name/url/token_file/ca) or `--target` for an ad-hoc node; `--read-only` and `--ascii` flags.
- The daemon binary is untouched — ratatui/crossterm exist only in the new crate.

## Testing

- `cargo test --workspace` green (60 test binaries); `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt` applied.
- Reducer fixtures: cross-node call-id collisions stay distinct rows, node-down merge behavior, selection clamping when calls end, stats-pane reset on focus change (stale in-flight stats dropped).
- `TestBackend` renders: fleet grid with a down node, calls-tab id namespaces, single-node column hiding, narrow-terminal degradation, read-only badge, node-filter chip.
- `scripts/check-version-consistency.py` and `check-doc-links.py` pass.
- Not yet done: an interactive smoke against a live daemon (start the local stack, `sightglass --target http://127.0.0.1:<admin-port> --token-file …`) — recommended before merge.

## Not in this PR (per the design's build plan)

PR 2: actions (hangup/park/retrieve/originate/conference) + node-named confirm modals + per-node RBAC-aware keybinds. PR 3–6: errors ring buffer, status endpoint, recent-CDR ring + stats enrichment, drain endpoint + System tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKZiLBTLQDR9YHNJGsr7H8
