### PR TITLE
chore(release): 0.49.0 — sightglass, the fleet operator console

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,17 +155,21 @@ jobs:
       - name: Build (release, static musl)
         run: |
           cargo zigbuild --release --locked \
-            -p siphon-ai --target ${{ matrix.target }}
+            -p siphon-ai -p siphon-ai-sightglass --target ${{ matrix.target }}
 
-      # Package: the binary + both licenses + README into a versioned
-      # tarball. The binary is fully static, so the tarball is the whole
-      # delivery for that arch.
+      # Package: the daemon + the sightglass operator console (0.49.0)
+      # + both licenses + README into a versioned tarball. Both
+      # binaries are fully static, so the tarball is the whole
+      # delivery for that arch. (The .deb below stays daemon-only on
+      # purpose: sightglass is a client tool that usually runs on a
+      # workstation, not the service host — tarball users get both.)
       - name: Package
         run: |
           version="${TAG#v}"
           dist="siphon-ai-${version}-${{ matrix.target }}"
           mkdir -p "staging/${dist}"
           cp "target/${{ matrix.target }}/release/siphon-ai" "staging/${dist}/"
+          cp "target/${{ matrix.target }}/release/sightglass" "staging/${dist}/"
           cp LICENSE-APACHE LICENSE-MIT README.md "staging/${dist}/"
           tar -C staging -czf "${dist}.tar.gz" "${dist}"
           ls -l "${dist}.tar.gz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.49.0] - 2026-08-17
+
 ### Added
 
 - **`POST /admin/v1/drain` and sightglass's System tab — the plan's final chunk** (DESIGN_SIGHTGLASS.md §6.5, PR 6 of 6). The daemon gains an admin-role **programmatic drain**: the endpoint fires a `Notify` the runtime's `run()` selects beside the SIGTERM future, entering the exact graceful path (503 new INVITEs, active calls finish, force-terminate at the deadline, exit) — `202 {drain_signalled, already_draining}`, idempotent, and deliberately not wired to the "second signal forces teardown" escape hatch, so repeating the POST can never kill calls. `GET`/`PUT /admin/v1/log` responses move to typed wire structs (byte-identical JSON). Sightglass gains the **System tab** (`6`): one row per node with live log filter, drain state, HEP, and version — `L` sets the tracing filter on the selected node (live, no restart), `H` emits a HEP probe, `D` starts the drain behind a deliberately loud node-named confirm; all admin-gated per node. This completes the six-PR sightglass plan.
+
+- **Release tarballs now carry two binaries: `siphon-ai` and `sightglass`.** The release workflow builds and packages the operator console alongside the daemon for both musl targets. The `.deb` stays daemon-only on purpose — sightglass is a client tool that usually runs on an operator's workstation, not the service host; take it from the tarball.
 
 - **A recent-CDRs ring behind `GET /admin/v1/cdrs/recent`, richer live stats, and sightglass's call history** (DESIGN_SIGHTGLASS.md §6.3/§6.4, PR 5 of 6). A ring-capturing sink joins the runtime's CDR fanout and keeps the last `[observability].cdr_ring_size` (default 50) completed calls' **CDR records verbatim** in memory — the CDR schema is the one schema, served newest-first on the readonly endpoint, working with zero `[cdr]` sinks configured and surviving SIGHUP sink rebuilds. The live-stats endpoint `GET /admin/v1/calls/:id/stats` gains **static call facts**, registered once per call beside the quality feed: `direction`, `from`, `to`, `sip_call_id`, `sample_rate`, `srtp_profile` (absent = plaintext RTP), `verstat_attest` — all additive JSON. (The design's dynamic fields — live VAD state, last DTMF, WS reconnect count — are deferred; each needs tap→registry streaming that isn't worth building unasked. The design note records the split.) Sightglass's calls tab grows a **recent pane** under the active table (ended time, from → to, hangup cause, duration, MOS — read defensively off the versioned CDR records) and the detail pane renders the new static facts. Pre-0.49 daemons degrade to an absent pane, never a down node.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4077,7 +4077,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.48.19"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4126,7 +4126,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-admin-api-types"
-version = "0.48.19"
+version = "0.49.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -4134,7 +4134,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.48.19"
+version = "0.49.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4150,7 +4150,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.48.19"
+version = "0.49.0"
 dependencies = [
  "base64",
  "bytes",
@@ -4172,7 +4172,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.48.19"
+version = "0.49.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4189,7 +4189,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.48.19"
+version = "0.49.0"
 dependencies = [
  "regex",
  "serde",
@@ -4208,7 +4208,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.48.19"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4254,7 +4254,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.48.19"
+version = "0.49.0"
 dependencies = [
  "base64",
  "hmac 0.12.1",
@@ -4277,7 +4277,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.48.19"
+version = "0.49.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4303,7 +4303,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.48.19"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4321,7 +4321,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.48.19"
+version = "0.49.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4339,7 +4339,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.48.19"
+version = "0.49.0"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4353,7 +4353,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.48.19"
+version = "0.49.0"
 dependencies = [
  "regex",
  "serde",
@@ -4365,7 +4365,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.48.19"
+version = "0.49.0"
 dependencies = [
  "schemars",
  "serde",
@@ -4375,7 +4375,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sightglass"
-version = "0.48.19"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4390,7 +4390,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.48.19"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4418,7 +4418,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.48.19"
+version = "0.49.0"
 dependencies = [
  "base64",
  "rcgen",
@@ -4436,7 +4436,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.48.19"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "forge-engine",
@@ -4468,7 +4468,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.48.19"
+version = "0.49.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.48.19"
+version = "0.49.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.48.19.** Production-deployed against real carriers
+**Current release: v0.49.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged. Daemon upgrades are near-drop-in


### PR DESCRIPTION
Release-prep for v0.49.0 per RELEASING.md: version bump + CHANGELOG cut + README marker, plus one workflow change — **the release tarballs now build and carry `sightglass` alongside the daemon** for both musl targets (pure-Rust static client, no native deps). The `.deb` stays daemon-only on purpose (workstation tool; documented in the CHANGELOG note).

Verified locally: `check-version-consistency.py` (plain and `--tag v0.49.0`), `extract-changelog.py 0.49.0`.

Plan after merge: validate the workflow change (first tag to build sightglass under zigbuild/musl) with a throwaway `v0.49.0-rc.1` pre-release tag per the runbook, then tag `v0.49.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKZiLBTLQDR9YHNJGsr7H8