### PR TITLE
docs(load): §11 reference call at 200 concurrent, and the two plan corrections it surfaced

### DIFF
--- a/test-harness/load/LOAD_TEST_PLAN.md
+++ b/test-harness/load/LOAD_TEST_PLAN.md
@@ -190,10 +190,24 @@ Per-step SLO — all must hold for the full 5 minutes:
 | Setup success | 100% reach `200 OK`; `invites_total` == `calls_total` |
 | Media quality | `siphon_ai_rtp_mos_estimate` p50 ≥ 4.0; loss p95 ≤ 0.01 **from the CDR** — `rtp_packet_loss_ratio` does not exist |
 | Jitter | `siphon_ai_rtp_rx_jitter_ms` p95 ≤ 30 ms (**not** `rtp_jitter_ms`) |
-| Playout | ~~`siphon_ai_outbound_audio_frames_dropped_total`~~ — **no such metric; this SLO has no data source** |
+| Playout | `siphon_ai_outbound_audio_frames_dropped_total` **0 for the whole step** — and if not, attribute it before blaming the bridge (see note) |
 | Setup latency | `sdp_negotiate_seconds` p95 ≤ 200 ms (see note) |
 | Headroom | bridge CPU ≤ 80% of total cores; RSS not growing within the step |
 | Not port-capped | concurrency < `rtp_port_range / 2` (else you measured §1.1) |
+
+**The playout SLO is assertable again — and it usually indicts the sink.**
+`siphon_ai_outbound_audio_frames_dropped_total` did not exist when this
+table was written; it shipped in 0.48.14 (#474) and publishes at zero, so
+the row is a real threshold rather than a struck-out one. Read a non-zero
+value as a *question*, not a verdict: the counter fires when the WS server
+hands the bridge audio faster than realtime and the 200 ms buffer trims the
+excess (PROTOCOL §5.5), which is far more often the sink's pacing than the
+bridge's scheduling. Attribute it before reporting it — one `WARN` per call
+(`server streaming outbound audio faster than realtime`) is systematic and
+points at the generator; drops scattered across a subset of calls point at
+the bridge. See §8's pacing traps: `ws_sink.mjs` under-runs at low
+connection counts and `paced_sink.mjs` over-runs at high ones, and a run at
+200 concurrent has been measured tripping the latter on every call.
 
 **Why 200 ms and not a rounder 250.** `SDP_NEGOTIATE_BUCKETS`
 (`crates/telemetry/src/metrics.rs`) tops out at a finite `0.2` — above that
@@ -424,6 +438,20 @@ us the first time someone hits the wall and reports it as a bug.
   `target = t0 + n × 20 ms; setTimeout(tick, target - now)`. **No tx-rate or
   timing number measured through an uncorrected sink is worth quoting** — CPU
   and RSS work is unaffected.
+- **…and the monotonic correction that fixes it *over*-runs at high
+  connection counts.** `paced_sink.mjs` sends to every connection inside one
+  tick. At 200 connections that loop takes longer than 20 ms, and because the
+  correction targets `t0 + n × 20 ms` it then fires immediately and catches up
+  in a **burst** — which the daemon correctly reads as faster-than-realtime and
+  trims to its 200 ms buffer (PROTOCOL §5.5). Measured at 200 concurrent:
+  69,155 `outbound_audio_frames_dropped_total` and exactly **one `WARN` per
+  call**, which is the signature — a per-call count that equals the call count
+  is systematic, i.e. the generator, not degradation. The two traps are mirror
+  images: `setInterval` under-runs when idle, monotonic correction over-runs
+  when saturated. **§1.4's "prove the sink is not the constraint" is therefore
+  not satisfied at 200 by a single-process sink** — shard it across processes
+  or pace per connection before quoting any aggregate outbound-path number at
+  that concurrency. A canary on a *separate* WS server (§11) is unaffected.
 - **Check the daemon actually started.** `Address in use` from a leftover
   instance produces failures that look exactly like load failures.
 - **`gh`-style exit codes**: `cmd | tail; echo $?` reports *tail's* status.
@@ -715,6 +743,33 @@ mode = "always"                    # strict override — verified, RC-03
 **Speak a fixed script** so dropouts are detectable afterwards rather than
 remembered. Counting `one … twenty` at a steady pace works: every gap,
 clip, or repeat is visible in the waveform and countable.
+
+**Turn barge-in off on the reference route, or you will measure the
+barge-in policy instead of the bridge.** If the WS server echoes the caller
+back — the obvious way to let a human judge the return path — then under
+`[bridge.barge_in] mode = "pause"` (or `auto_clear`) every spoken word
+suppresses playout of *its own echo*, and the caller hears exactly what a
+degraded call sounds like on a completely idle box. Measured: 44% echo
+retention under `pause` against 89% with it off, `barge_in_count` 20 for a
+count to twenty, and `tx_packets_sent` ~27% below the continuous-50 fps
+figure. The inbound half was pristine throughout, so no metric flags it —
+only the caller does.
+
+The artifact would appear in both halves of the A/B, so the comparison
+still technically holds; the reason to remove it anyway is that it makes a
+load-induced dropout indistinguishable from barge-in cutting the caller's
+own voice, which is the one signal this test exists to detect. Use a
+per-route override so production policy is untouched:
+
+```toml
+[route.bridge.barge_in]
+mode = "notify_only"               # VAD still reported; playout never cut
+```
+
+It is route-level, so `systemctl reload` applies it — no restart, no
+dropped calls. `notify_only` is the right mode rather than deleting the
+block: speech events keep flowing to the WS server, so the observability
+half of the call is unchanged.
 
 **Run it as an A/B.** Place the identical call with the load **off**, then
 again at full load, and compare:

--- a/test-harness/load/RESULTS-0.49.0-reference-call.md
+++ b/test-harness/load/RESULTS-0.49.0-reference-call.md
@@ -1,0 +1,256 @@
+# §11 reference call — a live PSTN canary at 200 concurrent
+
+Run 2026-08-18 against the **shipped 0.49.0 `.deb`** (sha256 `caf0f6bb1…`,
+byte-identical to the release tarball binary), on the reference node, driven by
+the tier-2 FreeSWITCH generator.
+
+Scope: `LOAD_TEST_PLAN.md` **§11** — stage the load, then place one more call
+from a real handset over the live Twilio trunk and use it normally while the box
+is saturated. Run as the **§11.2 A/B**: the identical call with the load off,
+then again at 200 concurrent.
+
+**Result: pass.** `first_audio_out_ms` was **identical** idle vs loaded (21 ms
+both), MOS moved **+0.0%**, zero packets were lost in either direction, and the
+caller's verdict was *"echo sounded the same as idle."*
+
+This is a canary, not a benchmark. The 200 are the load; call 201 is the probe.
+For the knee, the soak and the leak audit see `RESULTS-0.48.18.md`,
+`RESULTS-convergence-8h.md` and `RESULTS-tier2.md`.
+
+---
+
+## Environment
+
+| | Box A — under test | Box B — generator |
+|---|---|---|
+| Hardware | 4 vCPU, 7947 MB | 4 vCPU, 7.9 GB |
+| OS | Debian 13 (trixie), Linux 6.12.95+deb13-amd64 | Debian 12 |
+| Software | `siphon-ai 0.49.0` (shipped deb) on `:5060` udp / `:5061` tls | FreeSWITCH 1.11.0 `mod_sofia`, external profile `:5080` |
+| `ulimit -n` | 524288 | |
+
+Config knobs that materially change the result:
+
+| Knob | Value |
+|---|---|
+| `rtp_port_range` | `[40000, 41000]` — 500 pairs, widened from 250 for this run |
+| `[media].codecs` | `["pcmu", "pcma"]` (G.711) |
+| `[media].srtp` | `preferred` (inbound); `required` on the Twilio gateway |
+| `inactivity_timeout_secs` | 60 |
+| `[recording].mode` | **`off`** globally, `always` on the reference-call route only |
+| `[hep].enabled` | **true** |
+| `[route.media].vad` | **`neural`** on the reference-call route |
+
+### ⚠️ Posture is NOT the §2 baseline — the CPU number is not comparable
+
+§2's baseline posture for §§3–5 is recording off, HEP off, energy VAD, no
+webhooks, no audit. This run is deliberately the opposite: it is a
+**production-shaped node**, with HEP, webhooks, audit, quality records and
+neural VAD all live, because §11's whole point is to probe the box a real
+caller would reach.
+
+So the **136.9% of one core measured here at 200 concurrent must not be compared
+to tier-2's 129.9%** at the same concurrency — that run used the lean posture.
+The delta is posture, not a regression, and this run is not evidence either way.
+
+---
+
+## Topology — why two WS servers
+
+```
+   200 load calls   Box B FreeSWITCH ──LAN, plaintext──► :5060 ──► paced_sink.mjs :8767
+   the canary       handset ──PSTN──► Twilio SBC ──TLS+SRTP──► :5060 ──► driver_bot.js :8081
+```
+
+§11.4 requires the canary's WS server not be the saturated one carrying the
+load, and §1.4 requires the sink not be the bottleneck. Two separate processes
+satisfy both. The load route was overridden to `:8767` specifically to keep the
+200 **off** the node's real LLM bot on `:8080` — pointing them there would have
+billed live AI spend and measured that bot's scheduling rather than the bridge's.
+
+`srtp_profile` on the canary read `AES_CM_128_HMAC_SHA1_80` on both A and B
+calls, confirming §11.1's claim that this test exercises a path the LAN load
+never touches: real carrier SBC, TLS signalling, SRTP media.
+
+---
+
+## Methodology finding: barge-in makes echo mode unusable as a canary
+
+**The first idle call failed as a test and succeeded as a bug hunt.** The caller
+reported *"the echo was chopped off, i heard it but not the complete audio."*
+
+The node runs `[bridge.barge_in] mode = "pause"`, which suppresses outbound
+playout whenever the caller speaks. In echo mode the outbound audio **is** the
+caller's own voice, so every spoken word cut its own echo. The evidence was
+unambiguous:
+
+| | caller (rx) | bot (tx) | retention |
+|---|---|---|---|
+| barge-in `pause` | 27 utterances / 6.4 s | 15 utterances / 2.8 s | **44%** |
+| barge-in `notify_only` | 26 utterances / 5.3 s | 30 utterances / 4.7 s | **89%** |
+
+`barge_in_count` was **20** on the chopped call — exactly one per number counted
+— and `tx_packets_sent` was 1770 against the ~2430 that 48.6 s of continuous
+50 fps would produce, i.e. ~13 s of playout deliberately suppressed, ~660 ms per
+utterance (a spoken number plus the 200 ms debounce). The inbound half was
+pristine throughout: 2246 packets, **0 lost**.
+
+**Why this had to be fixed rather than tolerated.** The artifact would have
+appeared in *both* the idle and loaded calls, so the A/B would still have
+compared — but it makes a load-induced dropout indistinguishable from barge-in
+cutting the caller's own voice, which is precisely the signal the canary exists
+to detect.
+
+The fix is a **per-route** `[route.bridge.barge_in] mode = "notify_only"` on the
+reference-call route only: VAD events still flow to the WS server, but barge-in
+never touches playout. Production barge-in behaviour is untouched. It is
+route-level, so `systemctl reload` applied it with no restart and no dropped
+calls (`config_reloads_total{applied} 1`, uptime unbroken).
+
+**Fixed in this PR:** §11.2 now carries this as a step — an echo-mode canary
+requires barge-in off on that route, with the `notify_only` override and the
+measured retention figures, or the spoken-script test measures the barge-in
+policy instead of the bridge.
+
+---
+
+## The A/B — §11.2
+
+Both calls: same handset, same trunk, same spoken script (count *one … twenty*
+at ~1/second), same route, same WS server, same barge-in policy.
+
+| Compare | Idle | Loaded (200) | Delta |
+|---|---|---|---|
+| CDR `quality.first_audio_out_ms` | 21 | **21** | **0.0%** |
+| CDR `quality.avg_jitter_ms` | 1.964 | 2.056 | +4.6% |
+| CDR `quality.max_jitter_ms` | 2.375 | 2.500 | +5.3% |
+| CDR `quality.avg_packet_loss_ratio` | 0.0 | **0.0** | — |
+| CDR `quality.max_packet_loss_ratio` | 0.0 | **0.0** | — |
+| CDR `quality.avg_rtcp_rtt_ms` | 15.843 | 14.164 | **−10.6%** |
+| CDR `quality.mos_estimate_min` | 4.43467 | 4.43498 | +0.0% |
+| CDR `quality.mos_estimate_avg` | 4.43562 | 4.43580 | +0.0% |
+| CDR `quality.rx_packets_lost` | **0** / 1747 | **0** / 2249 | — |
+| Recording: rx utterances | 26 | **26** | — |
+| Recording: echo retention (tx/rx) | 88.7% | **90.2%** | +1.5 pt |
+| Subjective 1–5 | reference | *"sounded the same as idle"* | — |
+
+Call durations differed (35.5 s vs 46.9 s), which is why the raw packet counts
+rise 28.7%; that is call length, not a quality signal. **Compare ratios, not
+absolute packet or active-audio totals, across calls of unequal length** — an
+absolute "tx seconds" comparison reads as a spurious +17% improvement.
+
+`first_audio_out_ms` is the row §11.2 says to watch hardest, and it did not move
+at all. `avg_rtcp_rtt_ms` *improving* by 10.6% under load is the tell that the
+jitter deltas here are carrier-path variance rather than scheduler pressure —
+the absolute changes are 0.09 ms and 0.13 ms.
+
+---
+
+## §4 SLOs at 200 concurrent
+
+| SLO | Threshold | Measured | |
+|---|---|---|---|
+| Setup success | 100% reach `200 OK` | **207/207 accepted**, 0 rejected | ✅ |
+| Media quality | MOS p50 ≥ 4.0 | all **8090** samples > 4.4; mean **4.441** | ✅ |
+| Loss (from CDR) | p95 ≤ 0.01 | **0.0** on the canary, 0 packets lost | ✅ |
+| Jitter | `rtp_rx_jitter_ms` p95 ≤ 30 ms | **p95 ≤ 1 ms** (8184/8516 ≤ 1 ms), mean **0.284 ms** | ✅ |
+| Setup latency | `sdp_negotiate_seconds` p95 ≤ 200 ms | **p95 ≤ 1 ms** (204/207 ≤ 1 ms), mean 0.99 ms | ✅ |
+| Headroom | CPU ≤ 80% of total cores | **34.2%** (136.9% of one core, 4 vCPU) | ✅ |
+| Not port-capped | conc < `rtp_port_range`/2 | 200 < 500 | ✅ |
+| Playout | see finding below | 69,155 frames dropped — **generator artifact** | ⚠️ |
+
+RSS moved 87.7 MB → 103.4 MB across the loaded run. That is within the
+established per-call cost and not read as a leak here; `RESULTS-convergence-8h.md`
+is the authority on convergence and a single 10-minute run cannot speak to it.
+
+---
+
+## Findings
+
+### 1. §4's Playout SLO row is stale — the metric exists
+
+The plan stated `siphon_ai_outbound_audio_frames_dropped_total` was
+"**no such metric; this SLO has no data source**". It exists — it landed in
+0.48.14 via #474 — and read **69,155** during this run. **Fixed in this PR:**
+§4's row is now an assertable threshold, with a note on attributing a
+non-zero value before reporting it.
+
+### 2. The 69,155 drops are `paced_sink`, not the bridge
+
+Exactly **200** `WARN`s appeared, one per load call:
+
+> `server streaming outbound audio faster than realtime; dropping oldest beyond the 200 ms buffer (PROTOCOL §5.5)`
+
+One-per-call is systematic, not degradation. `paced_sink.mjs` sends to every
+connection inside a single 20 ms tick; at 200 connections that loop overruns the
+tick, and the monotonic-origin correction then fires immediately and catches up
+in a **burst** — which the daemon correctly sees as faster-than-realtime and
+trims to its 200 ms buffer.
+
+This is the mirror image of the known `ws_sink.mjs` trap (§8): that sink
+*under*-runs at low connection counts; `paced_sink` *over*-runs at high ones.
+**§1.4's "prove the sink is not the constraint" is NOT satisfied at 200 by
+`paced_sink` in its current form** — it needs per-connection pacing, or sharding
+across processes, before a run at this concurrency can call its outbound path
+clean. The canary was insulated (separate process on `:8081`) so the A/B stands,
+but any *aggregate* outbound-path claim from this run would not. **Fixed in this
+PR:** §8 now documents the over-run as the mirror of the existing `setInterval`
+under-run trap.
+
+### 3. §11.2's CDR field list is correct
+
+An earlier reading of this run wrongly concluded that `avg_jitter_ms`,
+`max_jitter_ms` and `avg_packet_loss_ratio` were absent from CDR v8. They are
+present — they are simply **skipped when the leg carries no RTCP**, which is why
+the FreeSWITCH LAN smoke calls lacked them and the Twilio leg has them. No plan
+change needed; worth a note so the next reader doesn't repeat the mistake.
+
+### 4. Unrelated: REGISTER client transactions are never reclaimed
+
+Not part of §11, found while checking the box before the run. On the
+pre-upgrade process, uptime 3 days:
+
+> `Client transaction limit reached, evicting oldest transaction key=… method: Register … current_count=10000 limit=10000`
+
+REGISTER refreshes run 1/min (`expires_secs = 120`), each producing a 401 plus an
+authenticated retry. A REGISTER client transaction should terminate in ~32 s, so
+steady state ought to be 1–2 live entries, not 10,000; 5,067 successful
+registrations over 3 days matches the fill rate. Bounded by the eviction, so
+nothing breaks, but the table fills with dead entries and then evicts on every
+refresh — and the eviction picks its victim by `start_time` alone, so once the
+table is full a live transaction can be the one taken.
+
+Root-caused and filed upstream as **siphon-rs#103**, fixed in **siphon-rs#104**:
+the terminal wait timers (K for non-INVITE, D for INVITE) set the FSM
+`Terminated` but emit `Cancel`, while the manager removed the entry only on
+`Terminate` — so a client transaction that *failed* was reclaimed and one that
+*succeeded* was not. Wider than REGISTER (every normally-completing client
+transaction, both transports) and client-side only; the server's Timer J/I
+already emit `Terminate`. Picked up here on the next siphon-rs bump.
+
+---
+
+## Reproducing
+
+```sh
+# generator (Box B) — self-terminating, so a lost session cannot strand calls
+/root/ramp-prod.sh 200 10 600      # 200 calls, 10 cps, 600 s hold
+
+# canary: arm echo for the next WS connection, then place the call
+curl -sX POST -H 'Content-Type: application/json' \
+     -d '{"mode":"echo"}' http://127.0.0.1:8082/nextmode
+```
+
+The reference-call route is keyed on the handset's `from_user`, with global
+recording off, so **only** the canary records — recording all 200 would turn the
+run into the disk-I/O benchmark §11.4 warns about. Verified: the CDR reports
+`route=reference-call` and exactly one `.wav` per canary call.
+
+---
+
+## The headline this earns
+
+> A live PSTN call, placed from a mobile handset over a real carrier trunk with
+> TLS and SRTP while **200 concurrent calls** were active on the same 4-vCPU
+> node, was indistinguishable from the same call placed on an idle box —
+> **identical 21 ms first-audio latency, MOS unchanged at 4.435, zero packet
+> loss**, and no audible difference to the person holding the phone.


### PR DESCRIPTION
Runs `LOAD_TEST_PLAN.md` **§11** — the human canary — against shipped 0.49.0, and folds back the two plan errors that running it exposed.

## Result: pass

200 concurrent staged from the tier-2 FreeSWITCH generator, then a live PSTN call from a mobile handset over the Twilio trunk, as the §11.2 idle-vs-loaded A/B.

| §11.2 | Idle | Loaded (200) | Delta |
|---|---|---|---|
| `first_audio_out_ms` | 21 | **21** | **0.0%** |
| `avg_jitter_ms` | 1.964 | 2.056 | +4.6% |
| `avg_packet_loss_ratio` | 0.0 | **0.0** | — |
| `avg_rtcp_rtt_ms` | 15.843 | 14.164 | **−10.6%** |
| `mos_estimate_min` | 4.43467 | 4.43498 | +0.0% |
| `rx_packets_lost` | **0** / 1747 | **0** / 2249 | — |
| Recording: rx utterances | 26 | **26** | — |
| Subjective | reference | *"echo sounded the same as idle"* | — |

`first_audio_out_ms` — the row §11.2 says to watch hardest — did not move at all. RTCP RTT *improving* under load is the tell that the jitter deltas are carrier-path variance, not scheduler pressure; the absolute changes are 0.09 ms and 0.13 ms.

Every §4 SLO holds with margin: 207/207 setups accepted, MOS p50 > 4.4 (all 8090 samples), jitter p95 ≤ 1 ms against a 30 ms bar, `sdp_negotiate` p95 ≤ 1 ms against 200 ms, CPU 34.2% of four cores, 200 RTP pairs of 500.

The doc is explicit that this run's posture is **not** §2's baseline — HEP, webhooks, audit, quality records and neural VAD are all live, because §11 exists to probe a production-shaped node. Its **136.9% of one core must not be read against tier-2's 129.9%** at the same concurrency. That comparison would look like a regression and would be posture.

## Plan correction 1 — §4's Playout row was stale

It struck out `siphon_ai_outbound_audio_frames_dropped_total` as "**no such metric; this SLO has no data source**". The counter shipped in 0.48.14 (#474) and read **69,155** during this run. Restored as a real threshold, plus a note that a non-zero value usually indicts the sink and has to be attributed before it is reported.

## Plan correction 2 — §11.2 did not warn about barge-in

This one cost a call to find. The first idle canary came back *"the echo was chopped off"* — on a completely idle box.

Under `[bridge.barge_in] mode = "pause"`, every spoken word suppresses playout of **its own echo**, so an echo-mode canary hears a degraded call with no load at all:

| | caller (rx) | bot (tx) | retention |
|---|---|---|---|
| barge-in `pause` | 27 utterances / 6.4 s | 15 utterances / 2.8 s | **44%** |
| barge-in `notify_only` | 26 utterances / 5.3 s | 30 utterances / 4.7 s | **89%** |

`barge_in_count` was 20 — one per number counted — and `tx_packets_sent` sat ~27% below the continuous-50 fps figure. **No metric flags it**: the inbound half was pristine (2246 packets, 0 lost). Only the caller does.

The artifact would appear in both halves of the A/B, so the comparison technically survives — the reason to remove it is that it makes a load-induced dropout indistinguishable from barge-in cutting the caller's own voice, which is the single signal the test exists to detect. §11.2 now carries the per-route `notify_only` override as a step.

## Also: the paced_sink over-run, into §8

At 200 connections `paced_sink.mjs`'s per-tick send loop overruns 20 ms, and the monotonic correction then catches up in a burst — which the daemon correctly trims to its 200 ms buffer (PROTOCOL §5.5). Signature: **exactly one WARN per call**, i.e. systematic, i.e. the generator.

Documented as the mirror of the existing `setInterval` under-run trap — one under-runs when idle, the other over-runs when saturated — and with the consequence stated plainly: **§1.4's "prove the sink is not the constraint" is not satisfied at 200 by a single-process sink.** The canary was on a separate WS server so the A/B stands, but no *aggregate* outbound-path claim should be drawn from this run.

## Unrelated find: the REGISTER transaction leak

Found while checking the box before the run — the pre-upgrade process had filled its client-transaction table:

```
Client transaction limit reached, evicting oldest transaction
  key=… method: Register … current_count=10000 limit=10000
```

Root-caused and filed as **siphon-rs#103**, fixed in **siphon-rs#104**: the terminal wait timers (K for non-INVITE, D for INVITE) set the FSM `Terminated` but emit `Cancel`, while the manager removed the entry only on `Terminate` — so a client transaction that *failed* was reclaimed and one that *succeeded* was not. Wider than REGISTER, and client-side only (the server's Timer J/I already emit `Terminate`). Arrives here on the next upstream bump; recorded in the results doc as finding 4.

## Notes

- Docs only — no code, no config, no schema change.
- 0.49.0 itself verified before the run: `dpkg` 0.49.0-1, binary sha256-identical to the release tarball, `check` rc=0 against the real config, `/admin/v1/status` live, 2 WARNs since restart (both routine REGISTER challenges).
- An earlier draft of the results doc wrongly claimed CDR v8 lacked the jitter fields §11.2 asks for. It has them — they are skipped when the leg carries no RTCP, which is why the LAN smoke calls lacked them and the Twilio leg has them. Corrected, and left as finding 3 so the next reader doesn't repeat it.
