### PR TITLE
chore(release): 0.49.1 — siphon-rs bump fixes the client-transaction leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.49.1] - 2026-08-18
+
+### Changed
+
+- **Bumped siphon-rs `9ad33983b0e9` → `15303bf847e6`** — [siphon-rs#104](https://github.com/thevoiceguy/siphon-rs/pull/104) (its issue #103, filed from this project): **a client SIP transaction that completed normally never left the transaction manager's table.** The terminal wait timers — K for non-INVITE (RFC 3261 §17.1.2.2), D for INVITE (§17.1.1.2) — set the FSM `Terminated` but emitted only `Cancel`, while the manager removed the entry solely on `Terminate`. `Terminate` is reserved for abnormal endings because it notifies the transaction user, so the normal path had no removal at all: **a transaction that failed was reclaimed, and one that succeeded was not.** With no periodic sweep, the only thing that ever removed a completed client transaction was the 10,000-entry eviction.
+  - **Found on this project's reference node**, which registers to a registrar every 60s. Each refresh costs two client transactions (the 401-challenged REGISTER plus the authenticated retry), so the table filled in **~3.5 days** and then evicted on every subsequent refresh, logging `Client transaction limit reached, evicting oldest transaction ... method: Register ... current_count=10000 limit=10000` once a minute.
+  - **Why it is a fix and not just tidiness:** the eviction picks its victim by `start_time` alone, so once the table is full the oldest entry can be a *live* transaction rather than a dead one. Everything before that point is bounded and harmless; past it, a long-running transaction is at risk.
+  - Scope is wider than REGISTER — every normally-completing client transaction (OPTIONS, INFO, MESSAGE, NOTIFY, SUBSCRIBE, UAC BYE via Timer K; INVITE after a non-2xx final via Timer D) — and both transports: on TCP/TLS the wait timer is zero, so those leaked immediately rather than after T4. Client-side only; the server's Timer J/I already emitted `Terminate`.
+  - Upstream fixes it by reaping on **FSM state** rather than on the action, so the transaction-user contract is unchanged — notably no extra `on_terminated` call, and therefore no new `WARN`, on a path that runs once per registration refresh and once per request on a busy proxy.
+  - **No code change here and nothing to configure.** The reap is entirely inside `TransactionManager`; nothing in this workspace changed. Operators get the fix by upgrading, and a restart clears an already-saturated table.
+  - Also carries [siphon-rs#105](https://github.com/thevoiceguy/siphon-rs/pull/105) (clears ~180 clippy warnings across 12 crates) and [siphon-rs#106](https://github.com/thevoiceguy/siphon-rs/pull/106) (a fmt + clippy CI gate on a pinned toolchain). Neither changes behaviour.
+  - Verified per CLAUDE.md §7.5: workspace suite green, fmt, clippy `-D warnings`, all check scripts, and the SIPp signalling suite re-run. No glue changes.
+
 ## [0.49.0] - 2026-08-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3848,7 +3848,7 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 [[package]]
 name = "sip-auth"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=9ad33983b0e9#9ad33983b0e9c5d0bd4e94bb89c46038d39b6d16"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6#15303bf847e6117f60f142a49a9662840381846b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3871,7 +3871,7 @@ dependencies = [
 [[package]]
 name = "sip-core"
 version = "0.7.6"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=9ad33983b0e9#9ad33983b0e9c5d0bd4e94bb89c46038d39b6d16"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6#15303bf847e6117f60f142a49a9662840381846b"
 dependencies = [
  "bytes",
  "httpdate",
@@ -3884,7 +3884,7 @@ dependencies = [
 [[package]]
 name = "sip-dialog"
 version = "0.3.3"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=9ad33983b0e9#9ad33983b0e9c5d0bd4e94bb89c46038d39b6d16"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6#15303bf847e6117f60f142a49a9662840381846b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3902,7 +3902,7 @@ dependencies = [
 [[package]]
 name = "sip-dns"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=9ad33983b0e9#9ad33983b0e9c5d0bd4e94bb89c46038d39b6d16"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6#15303bf847e6117f60f142a49a9662840381846b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3916,7 +3916,7 @@ dependencies = [
 [[package]]
 name = "sip-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=9ad33983b0e9#9ad33983b0e9c5d0bd4e94bb89c46038d39b6d16"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6#15303bf847e6117f60f142a49a9662840381846b"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -3927,7 +3927,7 @@ dependencies = [
 [[package]]
 name = "sip-identity"
 version = "0.1.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=9ad33983b0e9#9ad33983b0e9c5d0bd4e94bb89c46038d39b6d16"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6#15303bf847e6117f60f142a49a9662840381846b"
 dependencies = [
  "base64",
  "ring",
@@ -3940,7 +3940,7 @@ dependencies = [
 [[package]]
 name = "sip-observe"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=9ad33983b0e9#9ad33983b0e9c5d0bd4e94bb89c46038d39b6d16"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6#15303bf847e6117f60f142a49a9662840381846b"
 dependencies = [
  "once_cell",
  "tracing",
@@ -3949,7 +3949,7 @@ dependencies = [
 [[package]]
 name = "sip-parse"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=9ad33983b0e9#9ad33983b0e9c5d0bd4e94bb89c46038d39b6d16"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6#15303bf847e6117f60f142a49a9662840381846b"
 dependencies = [
  "bytes",
  "httpdate",
@@ -3963,12 +3963,21 @@ dependencies = [
 [[package]]
 name = "sip-ratelimit"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=9ad33983b0e9#9ad33983b0e9c5d0bd4e94bb89c46038d39b6d16"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6#15303bf847e6117f60f142a49a9662840381846b"
 dependencies = [
  "dashmap 5.5.3",
  "parking_lot",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "sip-sdp"
+version = "0.3.0"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6#15303bf847e6117f60f142a49a9662840381846b"
+dependencies = [
+ "nom 7.1.3",
+ "smol_str",
 ]
 
 [[package]]
@@ -3981,18 +3990,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "sip-sdp"
-version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=9ad33983b0e9#9ad33983b0e9c5d0bd4e94bb89c46038d39b6d16"
-dependencies = [
- "nom 7.1.3",
- "smol_str",
-]
-
-[[package]]
 name = "sip-transaction"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=9ad33983b0e9#9ad33983b0e9c5d0bd4e94bb89c46038d39b6d16"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6#15303bf847e6117f60f142a49a9662840381846b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4011,7 +4011,7 @@ dependencies = [
 [[package]]
 name = "sip-transport"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=9ad33983b0e9#9ad33983b0e9c5d0bd4e94bb89c46038d39b6d16"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6#15303bf847e6117f60f142a49a9662840381846b"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4032,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "sip-uac"
 version = "0.4.2"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=9ad33983b0e9#9ad33983b0e9c5d0bd4e94bb89c46038d39b6d16"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6#15303bf847e6117f60f142a49a9662840381846b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4045,7 +4045,7 @@ dependencies = [
  "sip-dialog",
  "sip-dns",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=9ad33983b0e9)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -4057,7 +4057,7 @@ dependencies = [
 [[package]]
 name = "sip-uas"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=9ad33983b0e9#9ad33983b0e9c5d0bd4e94bb89c46038d39b6d16"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6#15303bf847e6117f60f142a49a9662840381846b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4067,7 +4067,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=9ad33983b0e9)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -4077,7 +4077,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4126,7 +4126,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-admin-api-types"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -4134,7 +4134,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4150,7 +4150,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "base64",
  "bytes",
@@ -4172,7 +4172,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4189,7 +4189,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "regex",
  "serde",
@@ -4208,7 +4208,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4228,7 +4228,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=9ad33983b0e9)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6)",
  "sip-transaction",
  "sip-uac",
  "sip-uas",
@@ -4254,7 +4254,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "base64",
  "hmac 0.12.1",
@@ -4277,7 +4277,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4303,7 +4303,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4321,7 +4321,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4339,7 +4339,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4353,7 +4353,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "regex",
  "serde",
@@ -4365,7 +4365,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "schemars",
  "serde",
@@ -4375,7 +4375,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sightglass"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4390,7 +4390,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4418,7 +4418,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "base64",
  "rcgen",
@@ -4436,7 +4436,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "anyhow",
  "forge-engine",
@@ -4468,7 +4468,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.49.0"
+version = "0.49.1"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"
@@ -138,7 +138,29 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 # main branch and replace the rev hashes here (see CLAUDE.md §7.5).
 
 # siphon-rs — RFC 3261 SIP stack.
-# Bumped 2026-08-14 `9f70b83011f2` → `9ad33983b0e9` = siphon-rs #102:
+# Bumped 2026-08-18 `9ad33983b0e9` → `15303bf847e6` = siphon-rs #104
+# (its issue #103, filed from this project): client transactions that
+# completed normally never left the manager's table. The terminal wait
+# timers — K for non-INVITE (RFC 3261 §17.1.2.2), D for INVITE (§17.1.1.2) —
+# set the FSM `Terminated` but emitted only `Cancel`, while the manager
+# removed the entry solely on `Terminate`, which is reserved for abnormal
+# endings because it notifies the TU. So a client transaction that FAILED
+# was reclaimed and one that SUCCEEDED was not, and with no periodic sweep
+# the only thing that ever removed a completed client transaction was the
+# 10,000-entry eviction.
+# Found here: this project's reference node registers every 60 s, and each
+# refresh costs two client transactions (the 401'd REGISTER plus the
+# authenticated retry), so it filled the cap in ~3.5 days and then evicted
+# on every refresh — picking the victim by `start_time` alone, so a live
+# transaction could be the one taken. Wider than REGISTER (OPTIONS, INFO,
+# MESSAGE, NOTIFY, SUBSCRIBE, UAC BYE, and INVITE after a non-2xx) and both
+# transports; client-side only, as the server's Timer J/I already terminate.
+# **No code change here and nothing to configure** — the reap is entirely
+# inside `TransactionManager`, keyed on FSM state so the transaction-user
+# contract is unchanged. Operators get the fix by upgrading.
+# Also carries siphon-rs #105 (clippy backlog) and #106 (a pinned fmt+clippy
+# CI gate), neither of which changes behaviour.
+# (Prior: 2026-08-14 `9f70b83011f2` → `9ad33983b0e9` = siphon-rs #102:
 # `TransactionManager::ack_received` now returns whether it **absorbed** the
 # ACK (siphon-rs #101, filed from this project). It used to return `()` and
 # no-op on a miss, which hid the one distinction RFC 3261 §17.2.1 makes:
@@ -148,7 +170,7 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 # transaction on a 2xx and leaves it `Completed` on a non-2xx, so "matched
 # an entry" is exactly "ACK to a non-2xx" — and only had to say so.
 # Used immediately by the packet pump below, which stops handing absorbed
-# ACKs to the UAS; see `handle_packet` in `bins/siphon-ai/src/runtime.rs`.
+# ACKs to the UAS; see `handle_packet` in `bins/siphon-ai/src/runtime.rs`.)
 # (Prior: 2026-08-13 `b9f5a3bf66f2` → `9f70b83011f2` = siphon-rs #100: the UAC
 # session refresh reserves the CSeq it consumes *before* the request leaves,
 # instead of committing it after the response (siphon-rs #99, filed from this
@@ -206,31 +228,31 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 #  `6fd432270bb8` = #67 dialog_manager share, siphon-ai #324;
 #  `fcaff011f9c6` = #65 invite_with_from, siphon-ai #316;
 #  `3a4fc312ade3` = #64 TLS-SNI-is-hostname, siphon-ai #312.)
-sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "9ad33983b0e9" }
-sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "9ad33983b0e9" }
-sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "9ad33983b0e9", features = ["tls"] }
-sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "9ad33983b0e9" }
-sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "9ad33983b0e9" }
-sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "9ad33983b0e9" }
-sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "9ad33983b0e9" }
-sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "9ad33983b0e9" }
-sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "9ad33983b0e9" }
+sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "15303bf847e6" }
+sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "15303bf847e6" }
+sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "15303bf847e6", features = ["tls"] }
+sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "15303bf847e6" }
+sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "15303bf847e6" }
+sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "15303bf847e6" }
+sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "15303bf847e6" }
+sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "15303bf847e6" }
+sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "15303bf847e6" }
 # sip-sdp — the SAME sip-sdp sip-uac's SdpAnswerGenerator trait speaks
 # (distinct from forge-media's pinned sip-sdp). Used by the outbound
 # delayed-offer answer generator to hand the UAC a SessionDescription it
 # accepts. Must stay on the same siphon-rs rev as the rest below.
-sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "9ad33983b0e9" }
-sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "9ad33983b0e9" }
+sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "15303bf847e6" }
+sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "15303bf847e6" }
 # sip-observe — the transport-layer observability seam. We implement its
 # `TransportMetrics` trait in siphon-ai-telemetry and install it with
 # `set_transport_metrics`, which is the only way to see ingress
 # rate-limit drops: the hook is defaulted to a no-op upstream, so an
 # embedder that installs nothing (as we did until 0.48.11) silently gets
 # the `NoopTransportMetrics` fallback (siphon-ai #459).
-sip-observe     = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "9ad33983b0e9" }
+sip-observe     = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "15303bf847e6" }
 # sip-identity — STIR/SHAKEN Identity-header parsing + PASSporT verification
 # (ES256 + X.509 chain validation). Consumed by the stir-shaken verifier crate.
-sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "9ad33983b0e9" }
+sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "15303bf847e6" }
 
 # forge-media — RTP / codecs / SDP / DTMF / engine.
 #

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.49.0.** Production-deployed against real carriers
+**Current release: v0.49.1.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged. Daemon upgrades are near-drop-in


### PR DESCRIPTION
Bumps siphon-rs `9ad33983b0e9` → `15303bf847e6` and cuts **0.49.1** (patch: dependency bug fix, no API, protocol, or CDR change).

## What it fixes

[siphon-rs#104](https://github.com/thevoiceguy/siphon-rs/pull/104) (its issue #103, filed from this project): **a client SIP transaction that completed normally never left the transaction manager's table.** The terminal wait timers — K for non-INVITE (RFC 3261 §17.1.2.2), D for INVITE (§17.1.1.2) — set the FSM `Terminated` but emitted only `Cancel`, while the manager removed the entry solely on `Terminate`. That action is reserved for abnormal endings because it notifies the transaction user, so the normal path had no removal at all: **a transaction that failed was reclaimed; one that succeeded was not.**

Found on the reference node, which registers every 60s. Each refresh costs two client transactions (the 401-challenged REGISTER plus the authenticated retry), so the table filled in **~3.5 days** and then evicted on every refresh:

```
Client transaction limit reached, evicting oldest transaction
  ... method: Register ... current_count=10000 limit=10000
```

**Why it is a fix and not tidiness:** the eviction chooses its victim by `start_time` alone, so once the table is full the oldest entry can be a *live* transaction. Below the cap it is harmless; past it, a long-running transaction is at risk. Scope is wider than REGISTER — every normally-completing client transaction — and both transports (on TCP/TLS the wait timer is zero, so those leaked immediately rather than after T4).

**No code change here and nothing to configure.** The reap is entirely inside `TransactionManager`, keyed on FSM state so the transaction-user contract is unchanged. Operators get it by upgrading; a restart also clears an already-saturated table.

Also carries siphon-rs [#105](https://github.com/thevoiceguy/siphon-rs/pull/105) (clippy backlog) and [#106](https://github.com/thevoiceguy/siphon-rs/pull/106) (pinned fmt+clippy CI gate) — neither changes behaviour.

## Verification (CLAUDE.md §7.5)

| Gate | Result |
|---|---|
| `cargo build --workspace` | rc=0 — **no glue changes needed** |
| `cargo test --workspace` | **1,234 passed / 0 failed** |
| `cargo fmt --all --check` | clean |
| `cargo clippy --workspace --all-targets -D warnings` | rc=0 |
| version consistency | `Version consistent: 0.49.1` |
| doc links | all resolve |
| observability metrics | OK |
| protocol schema | 43 PROTOCOL.md examples, 38 message types |

## SIPp: deferring to CI on purpose

§7.5 wants the SIPp suite, and this box cannot give a clean run — **CI's job is the real gate here.** Two independent environmental blockers, both confirmed by log rather than assumed:

1. Seven auxiliary phases hardcode `OB_ADMIN_PORT=9091`, which the reference daemon on this host already holds — their daemons died with `bind observability HTTP 127.0.0.1:9091 / Address already in use (os error 98)` before any SIP was exchanged. `SIPHON_AI_CONFIG` only redirects the main phase.
2. A leftover `sipp` held UDP `:5080` (`Unable to bind main socket, errno = 98`); after clearing it the outbound phases still fail, with sipp exiting inside 300ms and the daemon taking SIGTERM 2ms after a `202` originate — `active_calls=0`, no SIP exchanged. This box also lacks the `setcap` the harness needs.

The main signalling phases pass. Since the outbound phases are precisely the client-transaction paths this change touches, **please confirm the SIPp job is green before merging** — that is the comparison that separates a regression from this host's environment, and I would rather it be checked than assumed.