### PR TITLE
chore(deps): h2 0.4.16 + crossbeam-epoch 0.9.20 (RUSTSEC-2026-0258, -0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1509,9 +1509,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
`cargo audit` reports two vulnerabilities against this workspace's lockfile:

- **RUSTSEC-2026-0258** — *h2 unbounded empty DATA frames*, published
  2026-08-17, fixed in 0.4.16. We were on 0.4.14. This is the copy under
  hyper 1.x, which serves every HTTP listener the daemon exposes: the admin
  API, `/metrics`, `/healthz`, and the webhook/CDR sink client.
- **RUSTSEC-2026-0204** — invalid pointer dereference in the `fmt::Pointer`
  impl for crossbeam-epoch's `Atomic`/`Shared`, fixed in 0.9.20. We were on
  0.9.18, reached via forge-vad → tract-onnx → rayon → crossbeam-deque.

Both are lockfile-only. No `Cargo.toml` changes, no API surface touched.

### Why the diff is 4 lines and not 22

`cargo update -p h2 --precise 0.4.16` also rewrote 11 unrelated lines:
`socket2` 0.6.3 → 0.5.10 under hyper, quinn and quinn-udp, and `windows-sys`
0.61.2 → 0.52.0 under errno, rustix, tempfile and winapi-util. Those are
*downgrades*, two of them on the network path, and nothing in this advisory
asks for them. So this starts from main's lockfile and edits only the two
version + checksum pairs. `cargo metadata --locked` accepts the result, which
means cargo considers it an exact, valid resolution.

### Verification

- `cargo metadata --locked` — clean
- `cargo test --workspace --locked` — **1234 passed / 0 failed / 3 ignored**
  across 60 test binaries
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo audit` — **0 vulnerabilities** (6 allowed warnings unchanged:
  audiopus_sys, paste, rustls-pemfile, anyhow, lru ×2)

The forge-media pin is deliberately unchanged. Its sibling fix
(thevoiceguy/forge-media#114) is a lockfile + `forge-ai-stream` manifest
change, and neither reaches this workspace — forge-media's lock does not
apply to a git dependency, and per CLAUDE.md §4.1 we do not depend on
forge-ai-stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWos69HjV9pxvUJhRusU4D