### PR TITLE
chore(release): 0.49.2 — a lockfile advisory fix and two upstream log levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.49.2] - 2026-08-19
+
+Housekeeping: a security advisory in our own lockfile, and two upstream log
+levels that stop a healthy node from writing noise. **No behaviour change, no
+config change, no protocol change** — the WS protocol stays `version: "1"` and
+the CDR schema stays v8.
+
+### Fixed
+
+- **Two `cargo audit` vulnerabilities in this workspace's lockfile** ([#522](https://github.com/thevoiceguy/siphon-ai/pull/522)). [RUSTSEC-2026-0258](https://rustsec.org/advisories/RUSTSEC-2026-0258) — *h2 unbounded empty DATA frames*, published 2026-08-17 — hit the h2 0.4.14 under hyper 1.x, which serves **every HTTP listener the daemon exposes**: the admin API, `/metrics`, `/healthz`, and the outbound webhook/CDR sink client. Bumped to 0.4.16. Alongside it, [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204) (invalid pointer dereference in crossbeam-epoch's `fmt::Pointer` impl, reached via forge-vad → tract-onnx → rayon) goes 0.9.18 → 0.9.20. Lockfile-only, no `Cargo.toml` change.
+  - The diff is deliberately **4 lines**. `cargo update -p h2 --precise 0.4.16` also rewrote 11 unrelated lines — `socket2` 0.6.3 → **0.5.10** under hyper, quinn and quinn-udp, and `windows-sys` 0.61.2 → **0.52.0** under errno, rustix, tempfile and winapi-util. Those are *downgrades*, two of them on the network path, and nothing in either advisory asks for them. This starts from the previous lockfile and edits only the two version + checksum pairs; `cargo metadata --locked` accepts the result, so cargo considers it an exact, valid resolution.
+  - **No `cargo audit` job exists in this repo's CI** (only `test.yml` and `release.yml`), so this surfaced from a hand run rather than a check. Worth adding — forge-media's Security Audit job caught the same advisory the day it published.
+
+### Changed
+
+- **Bumped siphon-rs `15303bf847e6` → `99da91f599e2`** — [siphon-rs#109](https://github.com/thevoiceguy/siphon-rs/pull/109) and [siphon-rs#110](https://github.com/thevoiceguy/siphon-rs/pull/110) (its issues #107 and #108, both filed from this project). **Two log levels; no behaviour change and nothing to configure.** Operators running at `info` get a materially quieter journal; anything already at `debug` is unaffected.
+  - **#109 — the expected first digest challenge drops from `warn!` to `debug!`.** `IntegratedUAC` warned whenever a 401/407 arrived while `auto_retry_auth` was set. That is RFC 3261 §22 working exactly as specified: the registrar is supposed to challenge, the stack answers it immediately, the request succeeds. Nothing had happened an operator could act on. **Measured on this project's reference node at a 120s granted expiry: ~1,440 WARNs/day on an idle, healthy box, 361 of them in a single 6-hour window** — a permanent non-zero warn baseline, which is what makes warn-level alerting useless. The two genuinely abnormal auth outcomes in the same function — "auth still rejected; retrying with refreshed credentials" and "auth retry limit reached; returning last challenge to caller" — keep their `warn!`.
+  - **#110 — four per-transaction `info!` sites drop to `debug!`**: the transaction start, the authenticated-retry start, and `on_final` in both `InviteTransactionUser` and `SimpleTransactionUser`. The precedent was already in the file — `on_provisional`, the sibling method handling the same class of event, has always been `debug!`, so a 180 was debug and a 200 was info for the same "a response arrived on the transaction I started" mechanic. At `info` the volume tracked request rate rather than operator intent: **~13,100 client transactions produced 52,568 lines from those four statements alone** — ~750 lines/s at a sustained 566 transactions/s, and a 20 MB log in 70s of driving.
+  - No code change in this workspace; both are log-level changes inside siphon-rs, and `cargo check --workspace` needed no glue edits.
+
+- **Bumped forge-media `1d7bbaba0c22` → `b161adedee5d`** — six commits, **all dependency bumps**: [#106](https://github.com/thevoiceguy/forge-media/pull/106) bytes 1.12.1, [#109](https://github.com/thevoiceguy/forge-media/pull/109) base64 0.23.1, [#110](https://github.com/thevoiceguy/forge-media/pull/110) validator 0.21.0, [#113](https://github.com/thevoiceguy/forge-media/pull/113) a 7-crate patch group, [#114](https://github.com/thevoiceguy/forge-media/pull/114) h2 0.4.16 for RUSTSEC-2026-0258 plus the deletion of `forge-ai-stream`'s unused reqwest 0.11, and [#107](https://github.com/thevoiceguy/forge-media/pull/107) redis 1.2.0 with the two call sites its 1.x API removed. **Taken to keep the pin current, not to collect a fix.**
+  - **No forge-media source change touches code we compile.** #114's h2 bump is in forge-media's own lockfile, which does not apply to a git dependency, and its only source edit is to `forge-ai-stream` — the crate CLAUDE.md §4.1 keeps us off. #107's redis sits behind `forge-engine`'s `persistence-redis` feature, which implies `ai`, which we disable; `redis` appears nowhere in this workspace's lockfile.
+  - One change does reach our build: #109 moves **forge-sdp to base64 0.23.1**, which now builds alongside the 0.22.1 we use ourselves. A duplicate version, harmless — dedupe when we move our own base64. Same situation as the sha1/hmac/sha2 duplicates noted at the 2026-08-07 pin.
+
 ## [0.49.1] - 2026-08-18
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1116,7 +1122,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "forge-codecs"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1d7bbaba0c22#1d7bbaba0c223d9686c3ae42595c13f2b409a980"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=b161adedee5d#b161adedee5de9757666ba07784b7bac2982a4a4"
 dependencies = [
  "audiopus",
  "ezk-g722",
@@ -1128,7 +1134,7 @@ dependencies = [
 [[package]]
 name = "forge-core"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1d7bbaba0c22#1d7bbaba0c223d9686c3ae42595c13f2b409a980"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=b161adedee5d#b161adedee5de9757666ba07784b7bac2982a4a4"
 dependencies = [
  "chrono",
  "serde",
@@ -1143,7 +1149,7 @@ dependencies = [
 [[package]]
 name = "forge-dtmf"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1d7bbaba0c22#1d7bbaba0c223d9686c3ae42595c13f2b409a980"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=b161adedee5d#b161adedee5de9757666ba07784b7bac2982a4a4"
 dependencies = [
  "chrono",
  "forge-core",
@@ -1155,7 +1161,7 @@ dependencies = [
 [[package]]
 name = "forge-engine"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1d7bbaba0c22#1d7bbaba0c223d9686c3ae42595c13f2b409a980"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=b161adedee5d#b161adedee5de9757666ba07784b7bac2982a4a4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1185,7 +1191,7 @@ dependencies = [
 [[package]]
 name = "forge-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1d7bbaba0c22#1d7bbaba0c223d9686c3ae42595c13f2b409a980"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=b161adedee5d#b161adedee5de9757666ba07784b7bac2982a4a4"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -1198,7 +1204,7 @@ dependencies = [
 [[package]]
 name = "forge-injection"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1d7bbaba0c22#1d7bbaba0c223d9686c3ae42595c13f2b409a980"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=b161adedee5d#b161adedee5de9757666ba07784b7bac2982a4a4"
 dependencies = [
  "forge-core",
  "rubato",
@@ -1211,7 +1217,7 @@ dependencies = [
 [[package]]
 name = "forge-mixer"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1d7bbaba0c22#1d7bbaba0c223d9686c3ae42595c13f2b409a980"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=b161adedee5d#b161adedee5de9757666ba07784b7bac2982a4a4"
 dependencies = [
  "bytes",
  "dashmap 6.2.1",
@@ -1225,7 +1231,7 @@ dependencies = [
 [[package]]
 name = "forge-recorder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1d7bbaba0c22#1d7bbaba0c223d9686c3ae42595c13f2b409a980"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=b161adedee5d#b161adedee5de9757666ba07784b7bac2982a4a4"
 dependencies = [
  "bytes",
  "forge-core",
@@ -1239,7 +1245,7 @@ dependencies = [
 [[package]]
 name = "forge-resampler"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1d7bbaba0c22#1d7bbaba0c223d9686c3ae42595c13f2b409a980"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=b161adedee5d#b161adedee5de9757666ba07784b7bac2982a4a4"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -1248,7 +1254,7 @@ dependencies = [
 [[package]]
 name = "forge-rtp"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1d7bbaba0c22#1d7bbaba0c223d9686c3ae42595c13f2b409a980"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=b161adedee5d#b161adedee5de9757666ba07784b7bac2982a4a4"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm 0.11.0",
@@ -1273,14 +1279,14 @@ dependencies = [
 [[package]]
 name = "forge-sdp"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1d7bbaba0c22#1d7bbaba0c223d9686c3ae42595c13f2b409a980"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=b161adedee5d#b161adedee5de9757666ba07784b7bac2982a4a4"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "chrono",
  "forge-core",
  "forge-rtp",
  "rand 0.10.1",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=1d7bbaba0c22)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/forge-media?rev=b161adedee5d)",
  "smol_str",
  "thiserror 2.0.18",
 ]
@@ -1288,7 +1294,7 @@ dependencies = [
 [[package]]
 name = "forge-transcoder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1d7bbaba0c22#1d7bbaba0c223d9686c3ae42595c13f2b409a980"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=b161adedee5d#b161adedee5de9757666ba07784b7bac2982a4a4"
 dependencies = [
  "bytes",
  "forge-codecs",
@@ -1301,7 +1307,7 @@ dependencies = [
 [[package]]
 name = "forge-vad"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1d7bbaba0c22#1d7bbaba0c223d9686c3ae42595c13f2b409a980"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=b161adedee5d#b161adedee5de9757666ba07784b7bac2982a4a4"
 dependencies = [
  "thiserror 2.0.18",
  "tract-onnx",
@@ -1814,7 +1820,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2364,7 +2370,7 @@ version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1db0d8f1fc9e62caebd0319e11eaec5822b0186c171568f0480b46a0137f9108"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "evmap",
  "http-body-util",
  "hyper",
@@ -2795,7 +2801,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -3334,7 +3340,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3848,7 +3854,7 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 [[package]]
 name = "sip-auth"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6#15303bf847e6117f60f142a49a9662840381846b"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=99da91f599e2#99da91f599e227477e05c9ddf3132b9fbdd66443"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3871,7 +3877,7 @@ dependencies = [
 [[package]]
 name = "sip-core"
 version = "0.7.6"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6#15303bf847e6117f60f142a49a9662840381846b"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=99da91f599e2#99da91f599e227477e05c9ddf3132b9fbdd66443"
 dependencies = [
  "bytes",
  "httpdate",
@@ -3884,7 +3890,7 @@ dependencies = [
 [[package]]
 name = "sip-dialog"
 version = "0.3.3"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6#15303bf847e6117f60f142a49a9662840381846b"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=99da91f599e2#99da91f599e227477e05c9ddf3132b9fbdd66443"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3902,7 +3908,7 @@ dependencies = [
 [[package]]
 name = "sip-dns"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6#15303bf847e6117f60f142a49a9662840381846b"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=99da91f599e2#99da91f599e227477e05c9ddf3132b9fbdd66443"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3916,7 +3922,7 @@ dependencies = [
 [[package]]
 name = "sip-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6#15303bf847e6117f60f142a49a9662840381846b"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=99da91f599e2#99da91f599e227477e05c9ddf3132b9fbdd66443"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -3927,9 +3933,9 @@ dependencies = [
 [[package]]
 name = "sip-identity"
 version = "0.1.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6#15303bf847e6117f60f142a49a9662840381846b"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=99da91f599e2#99da91f599e227477e05c9ddf3132b9fbdd66443"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
@@ -3940,7 +3946,7 @@ dependencies = [
 [[package]]
 name = "sip-observe"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6#15303bf847e6117f60f142a49a9662840381846b"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=99da91f599e2#99da91f599e227477e05c9ddf3132b9fbdd66443"
 dependencies = [
  "once_cell",
  "tracing",
@@ -3949,7 +3955,7 @@ dependencies = [
 [[package]]
 name = "sip-parse"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6#15303bf847e6117f60f142a49a9662840381846b"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=99da91f599e2#99da91f599e227477e05c9ddf3132b9fbdd66443"
 dependencies = [
  "bytes",
  "httpdate",
@@ -3963,7 +3969,7 @@ dependencies = [
 [[package]]
 name = "sip-ratelimit"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6#15303bf847e6117f60f142a49a9662840381846b"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=99da91f599e2#99da91f599e227477e05c9ddf3132b9fbdd66443"
 dependencies = [
  "dashmap 5.5.3",
  "parking_lot",
@@ -3974,7 +3980,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6#15303bf847e6117f60f142a49a9662840381846b"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=99da91f599e2#99da91f599e227477e05c9ddf3132b9fbdd66443"
 dependencies = [
  "nom 7.1.3",
  "smol_str",
@@ -3983,7 +3989,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1d7bbaba0c22#1d7bbaba0c223d9686c3ae42595c13f2b409a980"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=b161adedee5d#b161adedee5de9757666ba07784b7bac2982a4a4"
 dependencies = [
  "nom 7.1.3",
  "smol_str",
@@ -3992,7 +3998,7 @@ dependencies = [
 [[package]]
 name = "sip-transaction"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6#15303bf847e6117f60f142a49a9662840381846b"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=99da91f599e2#99da91f599e227477e05c9ddf3132b9fbdd66443"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4011,7 +4017,7 @@ dependencies = [
 [[package]]
 name = "sip-transport"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6#15303bf847e6117f60f142a49a9662840381846b"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=99da91f599e2#99da91f599e227477e05c9ddf3132b9fbdd66443"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4032,7 +4038,7 @@ dependencies = [
 [[package]]
 name = "sip-uac"
 version = "0.4.2"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6#15303bf847e6117f60f142a49a9662840381846b"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=99da91f599e2#99da91f599e227477e05c9ddf3132b9fbdd66443"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4045,7 +4051,7 @@ dependencies = [
  "sip-dialog",
  "sip-dns",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=99da91f599e2)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -4057,7 +4063,7 @@ dependencies = [
 [[package]]
 name = "sip-uas"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6#15303bf847e6117f60f142a49a9662840381846b"
+source = "git+https://github.com/thevoiceguy/siphon-rs?rev=99da91f599e2#99da91f599e227477e05c9ddf3132b9fbdd66443"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4067,7 +4073,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=99da91f599e2)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -4077,7 +4083,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.49.1"
+version = "0.49.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4126,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-admin-api-types"
-version = "0.49.1"
+version = "0.49.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -4134,7 +4140,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.49.1"
+version = "0.49.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4150,9 +4156,9 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.49.1"
+version = "0.49.2"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures",
  "parking_lot",
@@ -4172,7 +4178,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.49.1"
+version = "0.49.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4189,7 +4195,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.49.1"
+version = "0.49.2"
 dependencies = [
  "regex",
  "serde",
@@ -4208,7 +4214,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.49.1"
+version = "0.49.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4228,7 +4234,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=15303bf847e6)",
+ "sip-sdp 0.3.0 (git+https://github.com/thevoiceguy/siphon-rs?rev=99da91f599e2)",
  "sip-transaction",
  "sip-uac",
  "sip-uas",
@@ -4254,9 +4260,9 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.49.1"
+version = "0.49.2"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "hmac 0.12.1",
  "http-body-util",
  "hyper",
@@ -4277,7 +4283,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.49.1"
+version = "0.49.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4303,7 +4309,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.49.1"
+version = "0.49.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -4321,7 +4327,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.49.1"
+version = "0.49.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4339,7 +4345,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.49.1"
+version = "0.49.2"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4353,7 +4359,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.49.1"
+version = "0.49.2"
 dependencies = [
  "regex",
  "serde",
@@ -4365,7 +4371,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.49.1"
+version = "0.49.2"
 dependencies = [
  "schemars",
  "serde",
@@ -4375,7 +4381,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sightglass"
-version = "0.49.1"
+version = "0.49.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -4390,7 +4396,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.49.1"
+version = "0.49.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4418,9 +4424,9 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.49.1"
+version = "0.49.2"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "rcgen",
  "reqwest",
  "ring",
@@ -4436,7 +4442,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.49.1"
+version = "0.49.2"
 dependencies = [
  "anyhow",
  "forge-engine",
@@ -4468,7 +4474,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.49.1"
+version = "0.49.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5107,7 +5113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "http",
  "http-body",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.49.1"
+version = "0.49.2"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"
@@ -138,7 +138,30 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 # main branch and replace the rev hashes here (see CLAUDE.md §7.5).
 
 # siphon-rs — RFC 3261 SIP stack.
-# Bumped 2026-08-18 `9ad33983b0e9` → `15303bf847e6` = siphon-rs #104
+# Bumped 2026-08-18 `15303bf847e6` → `99da91f599e2` = siphon-rs #109 + #110
+# (its issues #107 and #108, both filed from this project). Two log levels;
+# no behaviour change and nothing to configure.
+# #109: `IntegratedUAC` warned on every 401/407 while `auto_retry_auth` was
+# set. That is RFC 3261 §22 working exactly as specified — the registrar is
+# supposed to challenge, the stack answers it immediately, the request
+# succeeds — so nothing had happened an operator could act on. Measured on
+# this project's reference node at a 120 s granted expiry: ~1,440 WARNs/day
+# on an idle, healthy box, 361 of them in a single 6-hour window. A
+# permanent non-zero warn baseline is what makes warn-level alerting
+# useless. The two genuinely abnormal auth outcomes in the same function —
+# "auth still rejected" and "auth retry limit reached" — keep their `warn!`.
+# #110: four per-transaction `info!` sites (transaction start, the
+# authenticated-retry start, and `on_final` in both `InviteTransactionUser`
+# and `SimpleTransactionUser`) drop to `debug!`, matching `on_provisional`,
+# which was always `debug!` for the same "a response arrived on the
+# transaction I started" mechanic. At `info` the volume tracked request
+# rate rather than operator intent: ~13,100 client transactions produced
+# 52,568 lines from those four statements alone — ~750 lines/s at a
+# sustained 566 txn/s, and a 20 MB log in 70 s of driving.
+# **No code change here**: both are log-level changes inside siphon-rs.
+# Anyone running `RUST_LOG=siphon=info` gets a quieter journal; anything
+# already at `debug` is unaffected.
+# (Prior: 2026-08-18 `9ad33983b0e9` → `15303bf847e6` = siphon-rs #104
 # (its issue #103, filed from this project): client transactions that
 # completed normally never left the manager's table. The terminal wait
 # timers — K for non-INVITE (RFC 3261 §17.1.2.2), D for INVITE (§17.1.1.2) —
@@ -159,7 +182,7 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 # inside `TransactionManager`, keyed on FSM state so the transaction-user
 # contract is unchanged. Operators get the fix by upgrading.
 # Also carries siphon-rs #105 (clippy backlog) and #106 (a pinned fmt+clippy
-# CI gate), neither of which changes behaviour.
+# CI gate), neither of which changes behaviour.)
 # (Prior: 2026-08-14 `9f70b83011f2` → `9ad33983b0e9` = siphon-rs #102:
 # `TransactionManager::ack_received` now returns whether it **absorbed** the
 # ACK (siphon-rs #101, filed from this project). It used to return `()` and
@@ -228,31 +251,31 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 #  `6fd432270bb8` = #67 dialog_manager share, siphon-ai #324;
 #  `fcaff011f9c6` = #65 invite_with_from, siphon-ai #316;
 #  `3a4fc312ade3` = #64 TLS-SNI-is-hostname, siphon-ai #312.)
-sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "15303bf847e6" }
-sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "15303bf847e6" }
-sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "15303bf847e6", features = ["tls"] }
-sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "15303bf847e6" }
-sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "15303bf847e6" }
-sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "15303bf847e6" }
-sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "15303bf847e6" }
-sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "15303bf847e6" }
-sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "15303bf847e6" }
+sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "99da91f599e2" }
+sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "99da91f599e2" }
+sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "99da91f599e2", features = ["tls"] }
+sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "99da91f599e2" }
+sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "99da91f599e2" }
+sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "99da91f599e2" }
+sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "99da91f599e2" }
+sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "99da91f599e2" }
+sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "99da91f599e2" }
 # sip-sdp — the SAME sip-sdp sip-uac's SdpAnswerGenerator trait speaks
 # (distinct from forge-media's pinned sip-sdp). Used by the outbound
 # delayed-offer answer generator to hand the UAC a SessionDescription it
 # accepts. Must stay on the same siphon-rs rev as the rest below.
-sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "15303bf847e6" }
-sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "15303bf847e6" }
+sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "99da91f599e2" }
+sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "99da91f599e2" }
 # sip-observe — the transport-layer observability seam. We implement its
 # `TransportMetrics` trait in siphon-ai-telemetry and install it with
 # `set_transport_metrics`, which is the only way to see ingress
 # rate-limit drops: the hook is defaulted to a no-op upstream, so an
 # embedder that installs nothing (as we did until 0.48.11) silently gets
 # the `NoopTransportMetrics` fallback (siphon-ai #459).
-sip-observe     = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "15303bf847e6" }
+sip-observe     = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "99da91f599e2" }
 # sip-identity — STIR/SHAKEN Identity-header parsing + PASSporT verification
 # (ES256 + X.509 chain validation). Consumed by the stir-shaken verifier crate.
-sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "15303bf847e6" }
+sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "99da91f599e2" }
 
 # forge-media — RTP / codecs / SDP / DTMF / engine.
 #
@@ -262,7 +285,24 @@ sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "153
 # AI logic belongs in the WS server, never here. See CLAUDE.md §4.1 and the
 # upstream gate at https://github.com/thevoiceguy/forge-media/pull/39.
 #
-# forge-media is pinned to a `main` rev. Bumped 2026-08-14 to 1d7bbaba0c22
+# forge-media is pinned to a `main` rev. Bumped 2026-08-18 to b161adedee5d
+# = six commits, all dependency bumps: #106 bytes 1.12.1, #109 base64
+# 0.23.1, #110 validator 0.21.0, #113 a 7-crate patch group, #114 h2 0.4.16
+# (RUSTSEC-2026-0258) plus the deletion of forge-ai-stream's unused reqwest
+# 0.11, and #107 redis 1.2.0 with the two call sites its 1.x API removed.
+# **No forge-media source change touches code we compile, and no fix here
+# is one we needed.** #114's h2 bump lives in forge-media's own lockfile,
+# which does not apply to a git dependency, and its only source edit is to
+# forge-ai-stream — the crate CLAUDE.md §4.1 keeps us off. #107's redis
+# sits behind forge-engine's `persistence-redis`, which implies `ai`, which
+# we disable; `redis` appears nowhere in this workspace's lockfile. Our own
+# copy of RUSTSEC-2026-0258 was fixed here separately, in #522 (h2 0.4.16 +
+# crossbeam-epoch 0.9.20). Bumped to keep the pin current, not for a fix.
+# One thing does reach our build: #109 moves forge-sdp to **base64 0.23.1**,
+# which now builds alongside the 0.22.1 we use ourselves. Same situation as
+# the sha1/hmac/sha2 note below — a duplicate version, harmless, dedupe
+# when we move our own base64.
+# (Prior: 2026-08-14 to 1d7bbaba0c22
 # = forge-media #112 (its issue #111, filed from this project's #504): a
 # port bind that hits AddrInUse now retries the next pair instead of
 # failing the session. `PortPool` allocates from its own bookkeeping and
@@ -276,7 +316,7 @@ sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "153
 # `ForgeError`, so the new variant changes no code here.
 # The `net.ipv4.ip_local_reserved_ports` guidance in docs/DEPLOY.md stays
 # correct and is still worth applying — this removes the *requirement*,
-# not the value, of reserving the range.
+# not the value, of reserving the range.)
 # (Prior: 2026-08-07 to b4f8df5c8f09
 # = forge-media #102 + #104 + #105 (plus dependabot bumps #88/#89/#91/#99).
 # #102: every facade metric family gets describe_*! HELP text and every
@@ -330,20 +370,20 @@ sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", rev = "153
 # comment for the current rev.) Prior forge pins: forge 1c996ae5fb4f = #86
 # neural VAD; forge 3c59b5f6e464 = #82-#85 dependency migrations; forge
 # 5fa76fb38675 = #81.
-forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "1d7bbaba0c22" }
-forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "1d7bbaba0c22" }
-forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "1d7bbaba0c22", default-features = false, features = ["g722", "dtls", "opus", "neural-vad"] }
-forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "1d7bbaba0c22" }
-forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "1d7bbaba0c22" }
-forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "1d7bbaba0c22" }
-forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "1d7bbaba0c22" }
-forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "1d7bbaba0c22" }
+forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "b161adedee5d" }
+forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "b161adedee5d" }
+forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "b161adedee5d", default-features = false, features = ["g722", "dtls", "opus", "neural-vad"] }
+forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "b161adedee5d" }
+forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "b161adedee5d" }
+forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "b161adedee5d" }
+forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "b161adedee5d" }
+forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "b161adedee5d" }
 # Conference rooms (0.7.0): forge-mixer is the per-room AudioMixer;
 # forge-injection provides ToneGenerator (join/leave tones now, MOH
 # for park later). Deliberately NOT forge-conference — its DTMF
 # IVR/PIN/host-control layer is unused per DEV_PLAN_0.7.0.md §9.4.
-forge-mixer     = { git = "https://github.com/thevoiceguy/forge-media", rev = "1d7bbaba0c22" }
-forge-injection = { git = "https://github.com/thevoiceguy/forge-media", rev = "1d7bbaba0c22" }
+forge-mixer     = { git = "https://github.com/thevoiceguy/forge-media", rev = "b161adedee5d" }
+forge-injection = { git = "https://github.com/thevoiceguy/forge-media", rev = "b161adedee5d" }
 
 # hep-rs — HEP3 codec, transport, HepSink trait. Owned by the same
 # author as siphon-rs and forge-media; lives in its own repo.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.49.1.** Production-deployed against real carriers
+**Current release: v0.49.2.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged. Daemon upgrades are near-drop-in


### PR DESCRIPTION
Housekeeping release. No behaviour change, no config change, no protocol
change: the WS protocol stays `version: "1"` and the CDR schema stays v8.

### Our own lockfile had two advisories (#522)

RUSTSEC-2026-0258 — *h2 unbounded empty DATA frames*, published 2026-08-17 —
hit the h2 0.4.14 under hyper 1.x, which serves every HTTP listener the daemon
exposes: the admin API, /metrics, /healthz, and the outbound webhook/CDR sink
client. Bumped to 0.4.16. Alongside it RUSTSEC-2026-0204 (crossbeam-epoch's
`fmt::Pointer` impl, reached via forge-vad → tract-onnx → rayon) goes 0.9.18 →
0.9.20.

That diff is 4 lines on purpose. `cargo update -p h2 --precise` also rewrote 11
unrelated ones — socket2 0.6.3 → 0.5.10 under hyper, quinn and quinn-udp, and
windows-sys 0.61.2 → 0.52.0 under errno, rustix, tempfile and winapi-util.
Those are downgrades, two of them on the network path. The lockfile instead
edits only the two version + checksum pairs, and `cargo metadata --locked`
accepts it as an exact resolution.

Worth noting: this repo has no `cargo audit` job in CI, so the advisory
surfaced from a hand run rather than a check. forge-media's Security Audit job
caught the same one the day it published.

### siphon-rs 15303bf847e6 → 99da91f599e2

siphon-rs#109 and #110, its issues #107 and #108, both filed from this project.
Two log levels; no behaviour change and nothing to configure.

#109: the expected first digest challenge drops from `warn!` to `debug!`. The
UAC warned on every 401/407 while `auto_retry_auth` was set — RFC 3261 §22
working exactly as specified. Measured on this project's reference node at a
120 s granted expiry: ~1,440 WARNs/day on an idle, healthy box, 361 of them in
one 6-hour window. The two genuinely abnormal auth outcomes keep their `warn!`.

#110: four per-transaction `info!` sites drop to `debug!`, matching
`on_provisional`, which was always debug for the same class of event. ~13,100
client transactions produced 52,568 lines from those four statements alone.

### forge-media 1d7bbaba0c22 → b161adedee5d

Six commits, all dependency bumps (#106 bytes, #109 base64, #110 validator,
#113 a patch group, #114 h2 for RUSTSEC-2026-0258, #107 redis 1.2). Taken to
keep the pin current, not to collect a fix — no forge-media source change
touches code we compile. #114's h2 bump is in forge-media's own lockfile, which
does not apply to a git dependency, and its only source edit is to
forge-ai-stream, the crate CLAUDE.md §4.1 keeps us off; #107's redis sits behind
`persistence-redis`, which implies `ai`, which we disable.

One change does reach our build: #109 moves forge-sdp to base64 0.23.1, which
now builds alongside the 0.22.1 we use ourselves. A harmless duplicate version,
same as the existing sha1/hmac/sha2 pairs; dedupe when we move our own base64.

### Verification (CLAUDE.md §7.5)

- `cargo check --workspace` clean with the new pins — no glue changes needed
- `cargo test --workspace --locked` — 1,234 passed / 0 failed / 3 ignored
- `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets
  --locked -- -D warnings` — clean
- all four check scripts: version consistency, doc links, observability
  metrics, protocol schema
- `cargo audit` — 0 vulnerabilities (6 allowed warnings, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWos69HjV9pxvUJhRusU4D