### PR TITLE
chore(release): 0.49.3 — a SIP ladder you can read from the calls tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.49.3] - 2026-08-19
+
+Two additions, both operator-facing: a per-call SIP ladder you can read
+without leaving the terminal, and advisory scanning in CI so the next
+RUSTSEC finding arrives as a failing check rather than a hand run. **No
+protocol change** (WS stays `version: "1"`), **no CDR change** (still
+v8), and no upstream dependency movement — siphon-rs and forge-media are
+pinned exactly where 0.49.2 left them.
+
+Upgrade note: `[observability].sip_ring_size` defaults to `50`, so SIP
+capture is **on** after this upgrade. It holds recent messages
+unredacted in memory and the endpoint serving them is `operator`-gated —
+see *Admin auth & RBAC* in `docs/DEPLOY.md`, and set it to `0` to opt
+out.
+
 ### Added
 
 - **Per-call SIP ladder: `GET /admin/v1/calls/{id}/sip` and sightglass's `s` pane** (DESIGN_SIP_LADDER.md). Select a call on sightglass's calls tab, press `s`, and see its signaling — the SIP messages the daemon captured for it, oldest first, timestamped relative to the call's first message because the gaps are what a ladder is read for. `⏎` expands one message to full raw text, `y` copies it via OSC 52 (works over SSH; no clipboard dependency added).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4083,7 +4083,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.49.2"
+version = "0.49.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4132,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-admin-api-types"
-version = "0.49.2"
+version = "0.49.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -4140,7 +4140,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.49.2"
+version = "0.49.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4156,7 +4156,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.49.2"
+version = "0.49.3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4178,7 +4178,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.49.2"
+version = "0.49.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4195,7 +4195,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.49.2"
+version = "0.49.3"
 dependencies = [
  "regex",
  "serde",
@@ -4214,7 +4214,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.49.2"
+version = "0.49.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4260,7 +4260,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.49.2"
+version = "0.49.3"
 dependencies = [
  "base64 0.22.1",
  "hmac 0.12.1",
@@ -4283,7 +4283,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.49.2"
+version = "0.49.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4309,7 +4309,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.49.2"
+version = "0.49.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -4327,7 +4327,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.49.2"
+version = "0.49.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4345,7 +4345,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.49.2"
+version = "0.49.3"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4359,7 +4359,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.49.2"
+version = "0.49.3"
 dependencies = [
  "regex",
  "serde",
@@ -4371,7 +4371,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.49.2"
+version = "0.49.3"
 dependencies = [
  "schemars",
  "serde",
@@ -4381,7 +4381,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sightglass"
-version = "0.49.2"
+version = "0.49.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -4396,7 +4396,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.49.2"
+version = "0.49.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4424,7 +4424,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.49.2"
+version = "0.49.3"
 dependencies = [
  "base64 0.22.1",
  "rcgen",
@@ -4442,7 +4442,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.49.2"
+version = "0.49.3"
 dependencies = [
  "anyhow",
  "forge-engine",
@@ -4474,7 +4474,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.49.2"
+version = "0.49.3"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.49.2"
+version = "0.49.3"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.49.2.** Production-deployed against real carriers
+**Current release: v0.49.3.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged. Daemon upgrades are near-drop-in


### PR DESCRIPTION
Two operator-facing additions. No protocol change (WS stays version
"1"), no CDR change (still v8), and no dependency movement — siphon-rs
and forge-media are pinned exactly where 0.49.2 left them, so the whole
diff is this workspace's own code.

### Per-call SIP ladder (#525 design, #526 daemon, #527 sightglass)

Select a call in sightglass, press `s`, and see its signaling —
timestamped relative to the call's first message, because the gaps are
what a ladder is read for. Behind it: `GET /admin/v1/calls/{id}/sip`,
served from a bounded in-memory ring.

The mechanism is a new sink leg, not a new capture path: siphon-rs's
sip-hep owns no transport, so every SIP message already passed through
the process as a HepPacket. No siphon-rs change, no second parse of the
wire, no new dependency.

**operator role, deliberately unredacted** — the first GET on this API
above readonly. A redacted ladder invites the wrong conclusion about
what went over the wire, so the boundary is the token role, not the
content.

Three bounds, the third found while implementing: per-call messages,
completed calls, and a pending population — because REGISTER refreshes,
OPTIONS and scanner INVITEs all carry a Call-ID, reach the sink, and
never become calls, so a completed-call window alone would never evict
them.

### cargo audit in CI (#524)

This repo had no advisory scanning, which is why RUSTSEC-2026-0258 sat
in the lockfile for two days and surfaced from a hand run. Daily
schedule (the case that matters — an advisory lands against code nobody
touched, so only a clock will catch it), push to main, and PRs gated on
dependency files only.

### Upgrade note

`[observability].sip_ring_size` defaults to 50, so **SIP capture is on
after this upgrade**. It holds recent messages unredacted in memory
behind an operator-gated endpoint; `sip_ring_size = 0` opts out and is a
supported configuration. See *Admin auth & RBAC* in docs/DEPLOY.md.

### Verification (CLAUDE.md §7.5)

Run against a cold target — the version bump invalidated the cache, and
the old one had grown to 96.5 GB and filled the disk, so it was cleared
first.

- cargo test --workspace --locked — 1,267 passed / 0 failed / 3 ignored
- cargo fmt, clippy --all-targets -D warnings — clean
- all four check scripts (version consistency, doc links, observability
  metrics, protocol schema)
- cargo audit — 0 vulnerabilities, 6 allowed warnings unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWos69HjV9pxvUJhRusU4D