### PR TITLE
fix(sightglass): advertise the SIP ladder key in the calls-tab footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The SIP ladder key was bound but never advertised, so the feature was undiscoverable.** The calls tab's footer listed `j/k`, `x`, `p`, `u`, `c` and `o` but not `s` — reported by an operator who had the pane working only because they had been told the key existed. A keymap without a hint is half a feature. The footer now lists `s sip`, greyed with the `✗` marker for a `readonly` token like every other gated key, because a key nobody can see is a key nobody uses.
+  - While the ladder is **open**, the footer swaps to its own keys (`j/k scroll`, `⏎ expand`, `y copy`, `s close sip`). The overlay owns `j/k` while it is up, so continuing to advertise "select" described a key that no longer did that.
+  - Adding one hint pushed the footer past 110 columns and silently truncated `originate`, trading one discoverability bug for another. The two navigation labels are now terse (`⇥ tabs`, `n nodes`) — both are already visible in the tab bar and the header chip, whereas the action keys have no other source. A render test pins the fit at 110 columns.
+
 ## [0.49.4] - 2026-08-19
 
 ### Fixed

--- a/bins/sightglass/src/ui/chrome.rs
+++ b/bins/sightglass/src/ui/chrome.rs
@@ -99,10 +99,16 @@ fn draw_footer(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
             spans.push(Span::styled(format!("{what}✗  "), theme.dim_text()));
         }
     };
+    // These two are kept terse on purpose: the tab bar above already
+    // shows the tab names and the header shows the node filter chip,
+    // so spending footer columns on them squeezes out the action keys
+    // — which are the only thing the footer is the sole source of.
+    // Adding the `s` hint overflowed 110 columns and truncated
+    // `originate`; a render test pins the fit.
     hint("q".into(), "quit", true);
-    hint("⇥/1-3".into(), "tabs", true);
+    hint("⇥".into(), "tabs", true);
     if app.nodes.len() > 1 {
-        hint("n".into(), "node filter", true);
+        hint("n".into(), "nodes", true);
     }
     if app.tab == Tab::System {
         hint("j/k".into(), "select node", true);
@@ -129,11 +135,25 @@ fn draw_footer(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
         hint("u".into(), "retrieve", operator_ok);
     }
     if app.tab == Tab::Calls {
-        hint("j/k".into(), "select", true);
         // Action keys grey out per the focused call's node.
         let focus_node = app.focus().map(|(n, _)| n);
         let operator_ok = focus_node.is_some_and(|n| app.can(n, crate::model::Role::Operator));
         let admin_node = app.node_filter.or(focus_node).unwrap_or(0);
+        if app.ladder.open {
+            // The overlay owns j/k while it is up, so saying "select"
+            // here would be a lie about what the key does.
+            hint("j/k".into(), "scroll", true);
+            hint("⏎".into(), "expand", true);
+            hint("y".into(), "copy", true);
+            hint("s".into(), "close sip", true);
+        } else {
+            hint("j/k".into(), "select", true);
+            // Reading raw SIP needs operator, so it greys out for a
+            // readonly token like every other gated key — but it is
+            // listed either way, because a key nobody can see is a
+            // feature nobody uses.
+            hint("s".into(), "sip", operator_ok);
+        }
         hint("x".into(), "hangup", operator_ok);
         hint("p".into(), "park", operator_ok);
         hint("u".into(), "retrieve", operator_ok);

--- a/bins/sightglass/src/ui/mod.rs
+++ b/bins/sightglass/src/ui/mod.rs
@@ -135,6 +135,39 @@ mod tests {
         assert!(screen.contains("NODE"), "{screen}");
     }
 
+    // Shipped in 0.49.3 with the `s` key bound but absent from the
+    // hint line, so the ladder was undiscoverable — a user with a live
+    // call reported it. The keymap is only half the feature.
+    #[test]
+    fn calls_tab_advertises_the_sip_ladder_key() {
+        let mut app = fixture_app();
+        app.tab = Tab::Calls;
+        app.select_first();
+        let screen = render(&app, 120, 30);
+        assert!(
+            screen.contains(" s ") && screen.contains("sip"),
+            "the calls tab must advertise the ladder key: {screen}"
+        );
+    }
+
+    // While the overlay is up, j/k scroll it rather than moving the
+    // call selection, so the hint must not keep claiming "select".
+    #[test]
+    fn open_ladder_swaps_the_hints_for_its_own_keys() {
+        let mut app = fixture_app();
+        app.tab = Tab::Calls;
+        app.select_first();
+        app.toggle_ladder();
+        let screen = render(&app, 120, 30);
+        assert!(screen.contains("scroll"), "{screen}");
+        assert!(screen.contains("expand"), "{screen}");
+        assert!(screen.contains("copy"), "{screen}");
+        assert!(
+            !screen.contains("j/k select"),
+            "j/k no longer selects while the ladder owns them: {screen}"
+        );
+    }
+
     #[test]
     fn single_node_fleet_hides_node_column() {
         let mut app = App::new(vec!["solo".into()], false);


### PR DESCRIPTION
The `s` key worked from 0.49.3 but appeared nowhere in the UI. The
footer listed j/k, x, p, u, c and o; an operator with a live call
found the pane only because they had been told the key existed. A
keymap without a hint is half a feature — this is the half I skipped.

The footer now lists `s sip`, greyed with the ✗ marker for a readonly
token exactly like the other gated keys. Listing it either way matters:
the ladder is the one read on the admin API that needs operator, so a
readonly user seeing `s sip✗` learns the capability exists and what it
would take, where hiding it teaches nothing.

While the ladder is open the footer swaps to its own keys — j/k scroll,
⏎ expand, y copy, s close sip. The overlay owns j/k while it is up, so
continuing to advertise "select" described a key that no longer did
that.

Adding one hint pushed the line past 110 columns and silently truncated
`originate`, which would have traded one discoverability bug for
another. The two navigation labels are now terse (`⇥ tabs`, `n nodes`):
both are already visible in the tab bar and the header chip, whereas
the action keys have no other source in the UI. The existing readonly
footer test asserts `originate✗` at 110 columns, so it now doubles as
the truncation guard.

Two render tests added, both from the reported failure rather than
constructed: one asserts the calls tab advertises the key, the other
that an open ladder swaps the hints and stops claiming j/k selects.

---

Reported from a live 51-call session on prod: the pane worked, but nothing in the TUI said `s` existed.

Client-side only — the daemon is untouched. Left under `[Unreleased]`; happy to cut it as 0.49.5 or let it ride with the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWos69HjV9pxvUJhRusU4D