### PR TITLE
chore(release): 0.49.5 — the SIP ladder key is visible in sightglass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.49.5] - 2026-08-19
+
+A one-line UX fix with a two-line consequence: the SIP ladder's key is
+now visible in sightglass. **Sightglass-only** — the daemon binary is
+byte-for-byte 0.49.4 in behaviour, so there is no reason to restart a
+node for this. Sightglass ships in the release **tarball**, never the
+`.deb`; take it from there.
+
 ### Fixed
 
 - **The SIP ladder key was bound but never advertised, so the feature was undiscoverable.** The calls tab's footer listed `j/k`, `x`, `p`, `u`, `c` and `o` but not `s` — reported by an operator who had the pane working only because they had been told the key existed. A keymap without a hint is half a feature. The footer now lists `s sip`, greyed with the `✗` marker for a `readonly` token like every other gated key, because a key nobody can see is a key nobody uses.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4083,7 +4083,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.49.4"
+version = "0.49.5"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4132,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-admin-api-types"
-version = "0.49.4"
+version = "0.49.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -4140,7 +4140,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.49.4"
+version = "0.49.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4156,7 +4156,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.49.4"
+version = "0.49.5"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4178,7 +4178,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.49.4"
+version = "0.49.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4195,7 +4195,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.49.4"
+version = "0.49.5"
 dependencies = [
  "regex",
  "serde",
@@ -4214,7 +4214,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.49.4"
+version = "0.49.5"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4260,7 +4260,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.49.4"
+version = "0.49.5"
 dependencies = [
  "base64 0.22.1",
  "hmac 0.12.1",
@@ -4283,7 +4283,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.49.4"
+version = "0.49.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4309,7 +4309,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.49.4"
+version = "0.49.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -4327,7 +4327,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.49.4"
+version = "0.49.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4345,7 +4345,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.49.4"
+version = "0.49.5"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4359,7 +4359,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.49.4"
+version = "0.49.5"
 dependencies = [
  "regex",
  "serde",
@@ -4371,7 +4371,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.49.4"
+version = "0.49.5"
 dependencies = [
  "schemars",
  "serde",
@@ -4381,7 +4381,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sightglass"
-version = "0.49.4"
+version = "0.49.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -4396,7 +4396,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.49.4"
+version = "0.49.5"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4424,7 +4424,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.49.4"
+version = "0.49.5"
 dependencies = [
  "base64 0.22.1",
  "rcgen",
@@ -4442,7 +4442,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.49.4"
+version = "0.49.5"
 dependencies = [
  "anyhow",
  "forge-engine",
@@ -4474,7 +4474,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.49.4"
+version = "0.49.5"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.49.4"
+version = "0.49.5"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.49.4.** Production-deployed against real carriers
+**Current release: v0.49.5.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged. Daemon upgrades are near-drop-in


### PR DESCRIPTION
Sightglass-only. The daemon's behaviour is identical to 0.49.4, so
there is no reason to restart a node for this; and since sightglass
ships in the release tarball and never in the .deb, upgrading it means
taking the binary from there.

The `s` key has worked since 0.49.3 but appeared nowhere in the UI —
the calls-tab footer listed j/k, x, p, u, c and o, and an operator with
a live call found the pane only because they had been told the key
existed. The footer now lists `s sip`, greyed with the ✗ marker for a
readonly token like every other gated key, and swaps to the ladder's
own keys while the overlay is open, since it owns j/k while up.

Adding one hint pushed the footer past 110 columns and silently
truncated `originate` — caught by a test, and fixed by shortening the
two navigation labels rather than by widening the test. Both are
already visible in the tab bar and header chip; the action keys have
no other source in the UI.

No protocol change (WS stays version "1"), no CDR change (still v8),
no config change, and no dependency moved — siphon-rs and forge-media
are pinned exactly where 0.49.2 left them.

Verification: cargo test --workspace --locked 1,271 passed / 0 failed,
clippy -D warnings, fmt, all four check scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWos69HjV9pxvUJhRusU4D