### PR TITLE
fix(telemetry): a live call's SIP ladder could be evicted by scanner noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A live call's SIP ladder could be evicted by scanner noise.** The ring bounds its not-yet-completed traces least-recently-touched, but **an established call is SIP-silent between its ACK and its BYE** — its `last_touched` never advances, while rejected scanner INVITEs and REGISTER refreshes keep arriving with fresh ones. The live call was therefore the *oldest* entry and would be evicted **before** the transient noise the bound exists to contain, discarding the ladder of the call an operator is most likely to be looking at. Live calls are now a separate population, promoted when the control registry accepts the call, bounded separately at `MAX_LIVE = 512`, and never evicted to make room for noise. Found by the 0.49.5 load run (`test-harness/load/RESULTS-0.49.5-sip-ring.md`), which did not trip the bound at 203 concurrent but showed the trace-growth curve that makes it inevitable on a busier or longer-lived node.
+
+### Added
+
+- **`GET /admin/v1/trunks` and `[[trunk]]` rows in sightglass's trunks tab.** The tab showed only `[[register]]` bindings, so on a node with a registered PBX *and* an IP-authenticated carrier trunk, the carrier was simply absent — indistinguishable from a config mistake, and reported as exactly that confusion from a live session. Trunks have no credentials and no registration, hence no live state to poll, which is why DESIGN_SIGHTGLASS.md §6.6 deferred them; but "nothing to poll" is not a reason to render nothing. Trunk rows now list their peer CIDRs with a dim `ip-auth` marker and dashes where a registration would show state, so they never read as "up". Readonly role; active OPTIONS probing toward gateways remains the deferred part.
+
+- **`test-harness/load/RESULTS-0.49.5-sip-ring.md`** — the ring shipped enabled-by-default in 0.49.3 and had never been load-tested. At 203 concurrent it dropped nothing at either bound, and the run also caught **47 of 250 calls dying on `ws_disconnect`**: the generator's WS server, not the daemon, and §1.4 of the load plan happening as written. Carries `ringstat.sh` into the harness.
+
 ## [0.49.5] - 2026-08-19
 
 A one-line UX fix with a two-line consequence: the SIP ladder's key is

--- a/bins/sightglass/src/client.rs
+++ b/bins/sightglass/src/client.rs
@@ -12,7 +12,7 @@ use serde::de::DeserializeOwned;
 use siphon_ai_admin_api_types::{
     CallSipResponse, CallsResponse, ConferencesResponse, DrainStatus, ErrorBody, ErrorsResponse,
     LogFilterResponse, ParkedResponse, RecentCdrsResponse, RegistrationsResponse,
-    SetLogFilterResponse, StatusResponse,
+    SetLogFilterResponse, StatusResponse, TrunksResponse,
 };
 
 use crate::config::Node;
@@ -87,6 +87,13 @@ impl AdminClient {
     /// 404 this.
     pub async fn errors(&self) -> Result<ErrorsResponse, String> {
         self.get_json("/admin/v1/errors").await
+    }
+
+    /// Configured `[[trunk]]` allowlists (0.49.6+ daemons). Same
+    /// tolerance as `errors`: an older daemon 404s this and the tab
+    /// simply shows no trunk rows — never a down node.
+    pub async fn trunks(&self) -> Result<TrunksResponse, String> {
+        self.get_json("/admin/v1/trunks").await
     }
 
     /// Node summary (0.49.0+ daemons); same tolerance as `errors`.

--- a/bins/sightglass/src/keys.rs
+++ b/bins/sightglass/src/keys.rs
@@ -418,6 +418,7 @@ mod tests {
             log_filter: None,
             recent_cdrs: None,
             errors: None,
+            trunks: vec![],
         }
     }
 

--- a/bins/sightglass/src/model.rs
+++ b/bins/sightglass/src/model.rs
@@ -14,7 +14,7 @@ use std::collections::VecDeque;
 
 use siphon_ai_admin_api_types::{
     AdminCallRow, CallSipResponse, ConferenceRow, DrainStatus, ErrorEntry, ParkedRow,
-    RegistrationRow, SipMessageEntry, StatusResponse,
+    RegistrationRow, SipMessageEntry, StatusResponse, TrunkRow,
 };
 
 use crate::client::LadderError;
@@ -328,6 +328,8 @@ pub struct NodeState {
     pub health: NodeHealth,
     pub calls: Vec<AdminCallRow>,
     pub registrations: Vec<RegistrationRow>,
+    /// Configured trunks (IP-auth peers). No live state to show.
+    pub trunks: Vec<TrunkRow>,
     pub drain: Option<DrainStatus>,
     /// Conference rooms + members. Empty when conferencing is off.
     pub conferences: Vec<ConferenceRow>,
@@ -357,6 +359,7 @@ impl NodeState {
             health: NodeHealth::Connecting,
             calls: Vec::new(),
             registrations: Vec::new(),
+            trunks: Vec::new(),
             drain: None,
             conferences: Vec::new(),
             parked: Vec::new(),
@@ -387,6 +390,9 @@ pub struct NodeSnapshot {
     pub recent_cdrs: Option<Vec<serde_json::Value>>,
     /// `None` = errors endpoint unavailable on this daemon.
     pub errors: Option<Vec<ErrorEntry>>,
+    /// Configured `[[trunk]]` allowlists (0.49.6+ daemons); empty on
+    /// older ones, which 404 the endpoint.
+    pub trunks: Vec<TrunkRow>,
 }
 
 /// One flattened Rooms-tab row (owned — the lists are small and this
@@ -582,6 +588,7 @@ impl App {
                         n.health = NodeHealth::Up;
                         n.calls = snap.calls;
                         n.registrations = snap.registrations;
+                        n.trunks = snap.trunks;
                         n.drain = Some(snap.drain);
                         n.conferences = snap.conferences;
                         n.parked = snap.parked;
@@ -1021,6 +1028,7 @@ mod tests {
             log_filter: None,
             recent_cdrs: None,
             errors: None,
+            trunks: vec![],
         }
     }
 

--- a/bins/sightglass/src/poller.rs
+++ b/bins/sightglass/src/poller.rs
@@ -29,7 +29,18 @@ pub fn spawn(
         tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
             tick.tick().await;
-            let (calls, registrations, drain, errors, conferences, parked, status, recent, log) = tokio::join!(
+            let (
+                calls,
+                registrations,
+                drain,
+                errors,
+                conferences,
+                parked,
+                status,
+                trunks,
+                recent,
+                log,
+            ) = tokio::join!(
                 client.calls(),
                 client.registrations(),
                 client.drain(),
@@ -37,6 +48,7 @@ pub fn spawn(
                 client.conferences(),
                 client.parked(),
                 client.status(),
+                client.trunks(),
                 client.recent_cdrs(),
                 client.log_filter()
             );
@@ -48,6 +60,9 @@ pub fn spawn(
             let conferences = conferences.map(|c| c.conferences).unwrap_or_default();
             let parked = parked.map(|p| p.parked).unwrap_or_default();
             let status = status.ok();
+            // 0.49.6+; an older daemon 404s it and the tab shows no
+            // trunk rows rather than marking the node down.
+            let trunks = trunks.map(|t| t.trunks).unwrap_or_default();
             let recent_cdrs = recent.ok().map(|r| r.cdrs);
             let log_filter = log.ok().map(|l| l.filter);
             let result = calls
@@ -61,6 +76,7 @@ pub fn spawn(
                             conferences,
                             parked,
                             status,
+                            trunks,
                             log_filter,
                             recent_cdrs,
                             errors,

--- a/bins/sightglass/src/ui/mod.rs
+++ b/bins/sightglass/src/ui/mod.rs
@@ -79,6 +79,7 @@ mod tests {
                 log_filter: Some("siphon_ai=info".into()),
                 recent_cdrs: None,
                 errors: None,
+                trunks: vec![],
             })),
         });
         app.update(Msg::Snapshot {
@@ -138,6 +139,27 @@ mod tests {
     // Shipped in 0.49.3 with the `s` key bound but absent from the
     // hint line, so the ladder was undiscoverable — a user with a live
     // call reported it. The keymap is only half the feature.
+    // Reported from a live session: prod has one [[register]] and two
+    // [[trunk]] blocks, and the tab showed only the registration — so
+    // a configured Twilio trunk looked identical to a missing one.
+    #[test]
+    fn trunks_tab_lists_ip_auth_trunks_beside_registrations() {
+        use siphon_ai_admin_api_types::TrunkRow;
+        let mut app = fixture_app();
+        app.tab = Tab::Trunks;
+        app.nodes[0].trunks = vec![TrunkRow {
+            name: "twilio".into(),
+            peer_addrs: vec!["54.172.60.0/30".into()],
+        }];
+        let screen = render(&app, 120, 30);
+        assert!(screen.contains("twilio"), "{screen}");
+        assert!(screen.contains("54.172.60.0/30"), "{screen}");
+        assert!(
+            screen.contains("ip-auth"),
+            "a trunk has no live state and must say so, not read as up: {screen}"
+        );
+    }
+
     #[test]
     fn calls_tab_advertises_the_sip_ladder_key() {
         let mut app = fixture_app();

--- a/bins/sightglass/src/ui/trunks.rs
+++ b/bins/sightglass/src/ui/trunks.rs
@@ -1,8 +1,19 @@
-//! Trunks tab: every `[[register]]` binding across the fleet.
+//! Trunks tab: every `[[register]]` binding **and** every `[[trunk]]`
+//! allowlist across the fleet.
 //!
-//! Gateway (IP-auth) trunk health is an open question deliberately
-//! deferred (DESIGN_SIGHTGLASS.md §6.6); this tab shows registration
-//! state, which is what the daemon has live data for today.
+//! The two are different things and the table says so. A registration
+//! authenticates with credentials and therefore has live state —
+//! registered / expiry / last error. A `[[trunk]]` is an IP allowlist:
+//! no credentials, nothing to register, and so nothing to poll. Its
+//! rows carry `ip-auth` and dashes.
+//!
+//! They share a tab because an operator asking "is my Twilio trunk
+//! configured?" does not care about that distinction and should not
+//! have to know it to get an answer. Showing only registrations made a
+//! configured trunk indistinguishable from a missing one — reported
+//! from a live session, and the reason §6.6's deferral was not enough
+//! on its own. Actual reachability probing (OPTIONS toward the peer)
+//! remains the deferred part.
 
 use ratatui::layout::{Constraint, Rect};
 use ratatui::text::Span;
@@ -16,7 +27,7 @@ use super::Theme;
 pub fn draw(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
     let multi_node = app.nodes.len() > 1;
 
-    let mut headers = vec!["NAME", "SERVER", "STATUS", "EXPIRES", "LAST ERROR"];
+    let mut headers = vec!["NAME", "SERVER / PEERS", "STATUS", "EXPIRES", "LAST ERROR"];
     if multi_node {
         headers.insert(0, "NODE");
     }
@@ -58,11 +69,41 @@ pub fn draw(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
             }
             rows.push(Row::new(cells));
         }
+
+        // Then the IP-authenticated trunks. Deliberately after the
+        // registrations: those have live state and are what an
+        // operator scans first.
+        for t in &n.trunks {
+            let base = if stale {
+                theme.dim_text()
+            } else {
+                theme.text()
+            };
+            let peers = if t.peer_addrs.is_empty() {
+                "any source".to_string()
+            } else {
+                t.peer_addrs.join(", ")
+            };
+            let mut cells = vec![
+                Cell::from(Span::styled(t.name.clone(), base)),
+                Cell::from(Span::styled(peers, base)),
+                // Not a health verdict — a statement that this kind of
+                // peer has no health to report. Dim so it never reads
+                // as "up".
+                Cell::from(Span::styled("ip-auth", theme.dim_text())),
+                Cell::from(Span::styled("—", theme.dim_text())),
+                Cell::from(Span::styled("", theme.dim_text())),
+            ];
+            if multi_node {
+                cells.insert(0, Cell::from(Span::styled(n.name.as_str(), base)));
+            }
+            rows.push(Row::new(cells));
+        }
     }
 
     let mut widths = vec![
         Constraint::Length(16),
-        Constraint::Length(22),
+        Constraint::Min(24),
         Constraint::Length(12),
         Constraint::Length(22),
         Constraint::Min(10),
@@ -89,7 +130,7 @@ pub fn draw(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
         };
         frame.render_widget(
             ratatui::widgets::Paragraph::new(Span::styled(
-                "no [[register]] bindings on the visible nodes",
+                "no [[register]] bindings or [[trunk]] allowlists on the visible nodes",
                 theme.dim_text(),
             )),
             inner,

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -625,6 +625,9 @@ impl Runtime {
         // the allowlist. With no `[[trunk]]` blocks (legacy mode) and
         // `[sip.auth].enabled`, every source is challenged; otherwise
         // only trunks that opted into `auth_required`.
+        // Snapshot the trunk list for `GET /admin/v1/trunks` before
+        // `trunks` is moved into the allowlist below.
+        let trunks_for_admin: Arc<Vec<_>> = Arc::new(trunks.clone());
         let digest_auth = sip.auth.as_ref().map(|a| {
             let require_all = trunks.is_empty();
             let required_trunks: std::collections::HashSet<String> = trunks
@@ -1207,6 +1210,23 @@ impl Runtime {
                     .snapshot()
                     .into_iter()
                     .map(registration_state_to_row)
+                    .collect()
+            })),
+            // Static config, snapshotted once — a trunk has no live
+            // state to poll (DESIGN_SIGHTGLASS.md §6.6). Listing it is
+            // what stops "my Twilio trunk is missing" from being
+            // indistinguishable from a config mistake.
+            trunk_snapshot: Some(Arc::new(move || {
+                trunks_for_admin
+                    .iter()
+                    .map(|t| siphon_ai_telemetry::admin::TrunkRow {
+                        name: t.name.clone(),
+                        peer_addrs: t
+                            .peer_addrs
+                            .iter()
+                            .map(|c| format!("{}/{}", c.network, c.prefix_len))
+                            .collect(),
+                    })
                     .collect()
             })),
             log_filter: Some(log_filter),

--- a/crates/admin-api-types/src/lib.rs
+++ b/crates/admin-api-types/src/lib.rs
@@ -67,6 +67,31 @@ pub struct RegistrationsResponse {
     pub registrations: Vec<RegistrationRow>,
 }
 
+// ─── GET /admin/v1/trunks ──────────────────────────────────────────
+
+/// One configured `[[trunk]]` — an **IP-authenticated** peer allowlist.
+///
+/// Distinct from a `[[register]]` binding ([`RegistrationRow`]), which
+/// authenticates with credentials and therefore *has* live state. A
+/// trunk has none: there is nothing to register, so nothing to poll.
+/// It is listed anyway because an operator looking for "my Twilio
+/// trunk" otherwise finds an empty space and cannot tell a missing
+/// config from an unmonitorable one (DESIGN_SIGHTGLASS.md §6.6).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TrunkRow {
+    pub name: String,
+    /// CIDRs / addresses this trunk accepts INVITEs from, as written
+    /// in the config.
+    pub peer_addrs: Vec<String>,
+}
+
+/// `GET /admin/v1/trunks` response envelope.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TrunksResponse {
+    pub count: usize,
+    pub trunks: Vec<TrunkRow>,
+}
+
 // ─── GET /admin/v1/conferences ─────────────────────────────────────
 
 /// One conference room in the `GET /admin/v1/conferences` response.
@@ -552,6 +577,27 @@ mod tests {
             call_id: None,
         };
         assert!(!serde_json::to_string(&no_call).unwrap().contains("call_id"));
+    }
+
+    #[test]
+    fn trunks_response_wire_shape() {
+        let resp = TrunksResponse {
+            count: 1,
+            trunks: vec![TrunkRow {
+                name: "twilio".into(),
+                peer_addrs: vec!["54.172.60.0/30".into(), "54.244.51.0/30".into()],
+            }],
+        };
+        assert_eq!(
+            serde_json::to_value(&resp).unwrap(),
+            json!({
+                "count": 1,
+                "trunks": [{
+                    "name": "twilio",
+                    "peer_addrs": ["54.172.60.0/30", "54.244.51.0/30"],
+                }],
+            })
+        );
     }
 
     #[test]

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -308,11 +308,18 @@ impl CallControlRegistry {
     /// last insert wins with a warning, matching [`CallRegistry`].
     pub fn insert(&self, handle: CallHandle, sip_call_id: impl Into<String>, direction: Direction) {
         let key = handle.call_id().as_str().to_string();
+        let sip_call_id = sip_call_id.into();
         let entry = ControlEntry {
             handle,
-            sip_call_id: sip_call_id.into(),
+            sip_call_id: sip_call_id.clone(),
             direction,
         };
+        // Promote this dialog's SIP-ladder trace to the live
+        // population (DESIGN_SIP_LADDER.md). This is the moment the
+        // dialog stops being indistinguishable from a scanner INVITE,
+        // and without it a silent established call sorts older than
+        // the noise and gets evicted first.
+        siphon_ai_telemetry::sip_ring::mark_live(&sip_call_id);
         if self.inner.write().insert(key.clone(), entry).is_some() {
             warn!(call_id = %key, "control registry insert collided; previous handle dropped");
         } else {

--- a/crates/telemetry/src/admin.rs
+++ b/crates/telemetry/src/admin.rs
@@ -80,7 +80,8 @@ pub use siphon_ai_admin_api_types::{
     ConferencesResponse, CreateConferenceRequest, DrainStartResponse, DrainStatus, ErrorEntry,
     ErrorsResponse, LogFilterResponse, OriginateRequest, ParkRequest, ParkedResponse, ParkedRow,
     RecentCdrsResponse, RegistrationRow, RegistrationsResponse, RegistrationsSummary,
-    RetrieveRequest, SetLogFilterResponse, SipMessageEntry, StatusResponse,
+    RetrieveRequest, SetLogFilterResponse, SipMessageEntry, StatusResponse, TrunkRow,
+    TrunksResponse,
 };
 
 /// Bundle of dependencies the admin handlers may need. Each is
@@ -90,6 +91,10 @@ pub use siphon_ai_admin_api_types::{
 pub struct AdminState {
     pub call_registry: Option<AdminCallRegistry>,
     pub registration_snapshot: Option<RegistrationSnapshotFn>,
+    /// Configured `[[trunk]]` allowlists. `None` on a daemon built
+    /// without the wiring; the endpoint then answers an empty list
+    /// rather than 404, since "no trunks configured" is a real state.
+    pub trunk_snapshot: Option<TrunkSnapshotFn>,
     pub log_filter: Option<LogFilterHandle>,
     pub hep: Option<Arc<HepTelemetry>>,
     /// Outbound-origination handle (0.6.0). `None` when `[outbound]` is
@@ -192,6 +197,10 @@ pub type AdminCallRegistry = Arc<dyn CallRegistryHandle>;
 /// admin request. Same indirection rationale as `CallRegistryHandle`
 /// — keeps `siphon-ai-sip-glue` out of the telemetry crate's deps.
 pub type RegistrationSnapshotFn = Arc<dyn Fn() -> Vec<RegistrationRow> + Send + Sync>;
+
+/// Same indirection rationale as [`RegistrationSnapshotFn`] — keeps
+/// `siphon-ai-config` out of this crate's dependency graph.
+pub type TrunkSnapshotFn = Arc<dyn Fn() -> Vec<TrunkRow> + Send + Sync>;
 
 /// Why an originate request was refused synchronously (before the call is
 /// placed). The admin layer maps each to an HTTP status.
@@ -360,6 +369,7 @@ pub async fn dispatch(
         (&hyper::Method::GET, "/admin/registrations" | "/admin/v1/registrations") => {
             list_registrations(state)
         }
+        (&hyper::Method::GET, "/admin/v1/trunks") => list_trunks(state),
         (&hyper::Method::GET, "/admin/log" | "/admin/v1/log") => get_log_filter(state),
         (&hyper::Method::PUT, "/admin/log" | "/admin/v1/log") => set_log_filter(state, &body),
         (&hyper::Method::POST, "/admin/hep/test" | "/admin/v1/hep/test") => hep_test(state),
@@ -630,6 +640,30 @@ fn call_stats(state: &AdminState, call_id: &str) -> Response<Full<Bytes>> {
             &json!({ "error": "no active call with that call_id" }),
         ),
     }
+}
+
+/// `GET /admin/v1/trunks` — the configured `[[trunk]]` allowlists.
+///
+/// These are **IP-authenticated** peers: no credentials, no
+/// registration, and so no live state to report. Served anyway
+/// because a trunk absent from every listing is indistinguishable
+/// from a trunk missing from the config, which is the confusion this
+/// endpoint exists to remove (DESIGN_SIGHTGLASS.md §6.6). Readonly:
+/// peer CIDRs are already in the config an operator can read, and
+/// nothing here is a secret.
+fn list_trunks(state: &AdminState) -> Response<Full<Bytes>> {
+    let trunks = state
+        .trunk_snapshot
+        .as_ref()
+        .map(|f| f())
+        .unwrap_or_default();
+    json_response(
+        StatusCode::OK,
+        &json!(TrunksResponse {
+            count: trunks.len(),
+            trunks,
+        }),
+    )
 }
 
 /// `GET /admin/v1/calls/:id/sip` (DESIGN_SIP_LADDER.md) — the SIP

--- a/crates/telemetry/src/auth.rs
+++ b/crates/telemetry/src/auth.rs
@@ -214,6 +214,9 @@ pub fn min_role(method: &hyper::Method, path: &str) -> Option<Role> {
         // GET snapshots.
         | (&Method::GET, "/admin/v1/errors")
         | (&Method::GET, "/admin/v1/status")
+        // Configured [[trunk]] allowlists — config an operator can
+        // already read, and no live state; readonly like its siblings.
+        | (&Method::GET, "/admin/v1/trunks")
         | (&Method::GET, "/admin/v1/cdrs/recent") => Some(Role::ReadOnly),
 
         // ── Admin (billable / config / observability-blinding) ──
@@ -310,6 +313,7 @@ pub fn route_label(method: &hyper::Method, path: &str) -> &'static str {
         (&Method::POST, "/admin/v1/conferences") => "POST /admin/v1/conferences",
         (&Method::GET, "/admin/v1/parked") => "GET /admin/v1/parked",
         (&Method::GET, "/admin/v1/drain") => "GET /admin/v1/drain",
+        (&Method::GET, "/admin/v1/trunks") => "GET /admin/v1/trunks",
         (m, p)
             if *m == Method::POST && p.starts_with("/admin/calls/") && p.ends_with("/hangup") =>
         {

--- a/crates/telemetry/src/sip_ring.rs
+++ b/crates/telemetry/src/sip_ring.rs
@@ -31,20 +31,33 @@
 //! *completed* and evicted. The reference node sees ~1,440 REGISTER
 //! cycles and ~150 rejected INVITEs a day.
 //!
-//! So traces live in two populations:
+//! So traces live in three populations:
 //!
 //! - **completed** — a CDR was emitted for them (the runtime calls
 //!   [`complete`] from its ring CDR sink). Capped at `cap_calls`,
 //!   evicted oldest-completed-first. This is the design's promise:
 //!   the same retention window as the recent-calls pane, so the two
 //!   never disagree about which calls are inspectable.
-//! - **pending** — everything else: live calls, and all the non-call
-//!   traffic above. Capped separately at `cap_pending` and evicted
-//!   least-recently-touched, which is what bounds the noise.
+//! - **live** — a call exists for them ([`mark_live`], called when the
+//!   control registry accepts the call). Capped at [`MAX_LIVE`] and
+//!   evicted only when *that* is exceeded, never to make room for
+//!   noise.
+//! - **noise** — everything else: REGISTER refreshes, OPTIONS, and
+//!   rejected scanner INVITEs. Capped at [`MAX_PENDING`], evicted
+//!   least-recently-touched.
 //!
 //! Keying on "is it a call?" at capture time is not available: the
 //! INVITE arrives *before* the call exists in any registry, and that
-//! first message is the one most worth having.
+//! first message is the one most worth having — hence the two-step,
+//! `push` first and `mark_live` when the call materialises.
+//!
+//! **Why live calls are a separate population** (fixed after the
+//! 0.49.5 load run): an established call is SIP-silent between its ACK
+//! and its BYE, so its `last_touched` never advances, while scanner
+//! INVITEs keep arriving with fresh timestamps. Under one LRU pool the
+//! bound therefore evicted **live calls first** — precisely inverting
+//! what it was for, and discarding the ladder of the call an operator
+//! is most likely to be looking at.
 
 use std::collections::{HashMap, VecDeque};
 use std::net::IpAddr;
@@ -65,20 +78,30 @@ pub const DEFAULT_CAPACITY: usize = 50;
 /// dialog evict everyone else's history.
 pub const DEFAULT_MAX_MESSAGES: usize = 64;
 
-/// Pending (not-yet-completed) traces retained. Bounds live calls plus
-/// the REGISTER/OPTIONS/scanner traffic described above. Not
-/// configurable: it is a backstop, not a tuning knob, and an operator
-/// who wants less should set `sip_ring_size = 0`.
+/// Non-call traces retained: REGISTER refreshes, OPTIONS, rejected
+/// scanner INVITEs. Not configurable — a backstop, not a tuning knob;
+/// an operator who wants less sets `sip_ring_size = 0`.
 pub const MAX_PENDING: usize = 256;
+
+/// Live-call traces retained. Separate from [`MAX_PENDING`] so noise
+/// can never evict a call in progress. Sized well above any
+/// concurrency this daemon has been load-tested at (203 in the 0.49.5
+/// run), and it bounds memory: worst case is
+/// `(MAX_PENDING + MAX_LIVE + cap_calls) × cap_messages` entries,
+/// though a real call is 6–20 messages rather than the 64 cap.
+pub const MAX_LIVE: usize = 512;
 
 #[derive(Clone)]
 struct Trace {
     messages: VecDeque<SipMessageEntry>,
     truncated: bool,
-    /// Monotonic touch counter, for least-recently-used eviction of
-    /// the pending population.
+    /// Monotonic touch counter, for least-recently-used eviction.
+    /// Note this does **not** advance during an established call —
+    /// see the module docs on why that made live calls evictable.
     last_touched: u64,
     completed: bool,
+    /// A call exists for this dialog ([`mark_live`]).
+    live: bool,
 }
 
 struct Inner {
@@ -136,30 +159,39 @@ fn evict_completed(inner: &mut Inner) {
     }
 }
 
-/// Evict the least-recently-touched pending trace when the pending
-/// population is over [`MAX_PENDING`]. Returns how many were dropped
-/// so the caller can bump a metric.
+/// Evict least-recently-touched traces from whichever population is
+/// over its cap. Noise and live calls are bounded **separately**, so a
+/// flood of scanner INVITEs can never displace a call in progress —
+/// the inversion the 0.49.5 load run exposed. Returns how many were
+/// dropped so the caller can bump a metric.
 fn evict_pending(inner: &mut Inner) -> u64 {
     let mut dropped = 0;
-    loop {
-        let pending = inner.traces.values().filter(|t| !t.completed).count();
-        if pending <= MAX_PENDING {
-            return dropped;
-        }
-        let victim = inner
-            .traces
-            .iter()
-            .filter(|(_, t)| !t.completed)
-            .min_by_key(|(_, t)| t.last_touched)
-            .map(|(k, _)| k.clone());
-        match victim {
-            Some(key) => {
-                inner.traces.remove(&key);
-                dropped += 1;
+    for (want_live, cap) in [(false, MAX_PENDING), (true, MAX_LIVE)] {
+        loop {
+            let n = inner
+                .traces
+                .values()
+                .filter(|t| !t.completed && t.live == want_live)
+                .count();
+            if n <= cap {
+                break;
             }
-            None => return dropped,
+            let victim = inner
+                .traces
+                .iter()
+                .filter(|(_, t)| !t.completed && t.live == want_live)
+                .min_by_key(|(_, t)| t.last_touched)
+                .map(|(k, _)| k.clone());
+            match victim {
+                Some(key) => {
+                    inner.traces.remove(&key);
+                    dropped += 1;
+                }
+                None => break,
+            }
         }
     }
+    dropped
 }
 
 /// Capture one SIP message against `sip_call_id`.
@@ -184,6 +216,7 @@ pub fn push(sip_call_id: &str, entry: SipMessageEntry) {
             truncated: false,
             last_touched: tick,
             completed: false,
+            live: false,
         });
     trace.last_touched = tick;
     if trace.messages.len() >= cap {
@@ -203,6 +236,28 @@ pub fn push(sip_call_id: &str, entry: SipMessageEntry) {
     publish_gauge(&inner);
 }
 
+/// Promote a trace to the live population — the control registry calls
+/// this when a call is accepted for `sip_call_id`.
+///
+/// Idempotent, and a no-op for an id with no trace (capture disabled
+/// when the INVITE arrived, or already evicted). The INVITE is always
+/// captured *before* the call exists, which is why this is a second
+/// step rather than a flag on [`push`].
+pub fn mark_live(sip_call_id: &str) {
+    let mut inner = ring().lock().expect("sip ring poisoned");
+    if inner.cap_calls == 0 {
+        return;
+    }
+    if let Some(t) = inner.traces.get_mut(sip_call_id) {
+        t.live = true;
+    }
+    let dropped = evict_pending(&mut inner);
+    if dropped > 0 {
+        metrics::counter!(crate::metrics::SIP_RING_MESSAGES_TOTAL, "result" => "dropped_trace_cap")
+            .increment(dropped);
+    }
+}
+
 /// Mark a call complete — the runtime calls this from its ring CDR
 /// sink, once per call end. Moves the trace into the completed
 /// population, where it is retained until it falls out of the
@@ -216,7 +271,12 @@ pub fn complete(sip_call_id: &str) {
         return;
     }
     match inner.traces.get_mut(sip_call_id) {
-        Some(trace) if !trace.completed => trace.completed = true,
+        Some(trace) if !trace.completed => {
+            trace.completed = true;
+            // Out of the live population and into the completed
+            // window, which has its own cap.
+            trace.live = false;
+        }
         // Already completed (a duplicate CDR) or never captured.
         _ => return,
     }
@@ -506,6 +566,95 @@ mod tests {
         );
         let newest = format!("scanner-{}", MAX_PENDING + 39);
         assert!(snapshot(&newest).is_some(), "most recent pending retained");
+    }
+
+    // The 0.49.5 load run's finding, as a test. An established call is
+    // SIP-silent between ACK and BYE, so its last_touched never
+    // advances while scanner INVITEs keep arriving with fresh ones.
+    // Under a single LRU pool the live call was the *first* thing
+    // evicted — the exact inversion of what the bound is for.
+    #[test]
+    fn a_flood_of_noise_cannot_evict_a_live_call() {
+        let _serial = serial();
+        reset(50, 8);
+
+        // A call arrives and is accepted, then goes quiet.
+        push("the-live-call", entry("INVITE"));
+        push("the-live-call", entry("ACK"));
+        mark_live("the-live-call");
+
+        // Then far more non-call traffic than the noise cap, all of it
+        // touched more recently than the silent call.
+        for i in 0..(MAX_PENDING + 100) {
+            push(&format!("scanner-{i}"), entry("INVITE"));
+        }
+
+        let held = snapshot("the-live-call");
+        assert!(
+            held.is_some(),
+            "a live call must survive any amount of noise"
+        );
+        assert_eq!(held.unwrap().0.len(), 2, "and keep its messages");
+
+        // The noise is still bounded — the fix must not trade one
+        // unbounded population for another.
+        let noise = ring()
+            .lock()
+            .unwrap()
+            .traces
+            .values()
+            .filter(|t| !t.completed && !t.live)
+            .count();
+        assert!(noise <= MAX_PENDING, "noise still capped, held {noise}");
+    }
+
+    #[test]
+    fn live_calls_are_bounded_too_and_evict_oldest_first() {
+        let _serial = serial();
+        reset(50, 8);
+        for i in 0..(MAX_LIVE + 20) {
+            let id = format!("call-{i}");
+            push(&id, entry("INVITE"));
+            mark_live(&id);
+        }
+        let live = ring()
+            .lock()
+            .unwrap()
+            .traces
+            .values()
+            .filter(|t| t.live)
+            .count();
+        assert!(live <= MAX_LIVE, "live population bounded, held {live}");
+        assert!(snapshot("call-0").is_none(), "oldest live evicted first");
+        let newest = format!("call-{}", MAX_LIVE + 19);
+        assert!(snapshot(&newest).is_some(), "newest live retained");
+    }
+
+    // Completing a call takes it out of the live population, so a
+    // long-running node cannot accumulate "live" traces for calls that
+    // ended.
+    #[test]
+    fn completing_a_call_releases_its_live_slot() {
+        let _serial = serial();
+        reset(50, 8);
+        push("c1", entry("INVITE"));
+        mark_live("c1");
+        assert!(ring().lock().unwrap().traces["c1"].live);
+        complete("c1");
+        let t = &ring().lock().unwrap().traces["c1"];
+        assert!(!t.live && t.completed, "moved live → completed");
+    }
+
+    #[test]
+    fn mark_live_is_idempotent_and_ignores_unknown_ids() {
+        let _serial = serial();
+        reset(50, 8);
+        mark_live("never-seen"); // must not panic or create
+        assert!(snapshot("never-seen").is_none());
+        push("c2", entry("INVITE"));
+        mark_live("c2");
+        mark_live("c2");
+        assert!(snapshot("c2").is_some());
     }
 
     #[test]

--- a/test-harness/load/README.md
+++ b/test-harness/load/README.md
@@ -32,7 +32,8 @@ the burst's signalling-only calls at the one-minute mark.
 
 | | |
 |---|---|
-| `RESULTS-*.md` | published runs — `0.48.10`, `0.48.13`, `0.48.18`, `0.48.19` (RTP port-bind A/B), `tier2` (FreeSWITCH / TLS+SRTP / netem), and `convergence-8h` |
+| `RESULTS-*.md` | published runs — `0.48.10`, `0.48.13`, `0.48.18`, `0.48.19` (RTP port-bind A/B), `tier2` (FreeSWITCH / TLS+SRTP / netem), `convergence-8h`, `0.49.0-reference-call` (§11), and `0.49.5-sip-ring` |
+| `ringstat.sh` | one-shot snapshot of the SIP-ladder ring gauges + RSS + concurrency, for sampling during a run (`RESULTS-0.49.5-sip-ring.md`) |
 | `tier2/` | the two-box FreeSWITCH rig behind `RESULTS-tier2.md` (§10.2) — generator scripts, phase drivers, lab configs |
 | `paced_sink.mjs` | the WS sink the §6.1 and tier-2 numbers were measured through. **Use this, not a `setInterval`-paced sink** — see §8's first trap |
 | `squat.py` | holds RTP ports the way an ephemeral socket does, to reproduce #504 on demand |

--- a/test-harness/load/RESULTS-0.49.5-sip-ring.md
+++ b/test-harness/load/RESULTS-0.49.5-sip-ring.md
@@ -1,0 +1,121 @@
+# SIP-ladder ring under load — 0.49.5, 203 concurrent
+
+Run 2026-08-19 against the **shipped 0.49.5 `.deb`** (sha256
+`6bf88962f…`, the artifact the reference node runs), driven by the tier-2
+FreeSWITCH generator against the node's live `:5060` listener.
+
+Scope: the per-call SIP ladder ring (`DESIGN_SIP_LADDER.md`), which shipped
+enabled-by-default in 0.49.3 and had **never been load-tested**. It allocates
+per SIP message and holds bounded per-call history, so the questions were
+whether its bounds hold, what it costs, and whether it drops anything under
+real concurrency.
+
+This is **not** a `LOAD_TEST_PLAN.md` phase. The §4 ramp, §5 arrival-rate
+ceiling and §6 soak were not re-run: nothing between 0.48.19 and 0.49.5
+touches the media path, so those figures stand.
+
+## Environment
+
+| | |
+|---|---|
+| Node | Box A, 4 vCPU / 7.9 GB, Debian 13, `0.0.0.0:5060` |
+| Generator | Box B FreeSWITCH 1.11.0, `/root/ramp-prod.sh`, 10 cps |
+| Ring config | defaults — `sip_ring_size = 50`, `sip_ring_max_messages = 64` |
+| Sampling | ring gauges + RSS every 15 s, 40 samples |
+
+Two ramps overlapped: a 50-call run still holding when a 200-call run
+started, so peak concurrency is **203**, not 200. That is a fair test of the
+bounds and is reported as measured rather than as the number that was asked
+for.
+
+## Result — the ring is not a constraint at this scale
+
+| | |
+|---|---|
+| peak concurrency | **203** |
+| peak ring traces | **282** |
+| messages captured | 1,671 |
+| `dropped_call_cap` | **0** |
+| `dropped_trace_cap` | **0** |
+| RSS | 20.8 MB idle → **77 MB** peak |
+| WARN/ERROR attributable to load | **0** |
+
+Nothing was dropped by either bound. The per-call cap of 64 was never
+approached — real calls in this run are 4–8 messages, against the 6–20 the
+design predicted — so `truncated` never fired.
+
+Traces track concurrency at roughly **1.3 per call** (67 traces at 50 calls,
+282 at 203), the excess being REGISTER refreshes and rejected scanner
+INVITEs, which accumulate slowly on a public-IP node: with concurrency flat
+at 50, traces still crept 67 → 76 over three minutes.
+
+Total exceeds `MAX_PENDING` (256) legitimately: pending and completed are
+capped separately, so the ceiling is `MAX_PENDING + cap_calls` = 306.
+
+### Memory
+
+RSS is the honest caveat. It went 20.8 → 77 MB, but **that is the whole
+daemon at 203 concurrent calls**, not the ring: the tier-2 phase 1 run
+measured 70 MB at 200 concurrent on 0.48.19, which had no ring at all. The
+delta attributable to the ring is within the noise between those two runs and
+this one is **not a clean measurement of it** — a ring-on/ring-off A/B at the
+same concurrency would be, and was not run.
+
+## What it found instead
+
+### 1. A live call could be evicted by scanner noise (fixed)
+
+The ring bounds a "pending" population — everything without a CDR yet —
+least-recently-touched. **An established call is SIP-silent between its ACK
+and its BYE**, so its `last_touched` never advances, while scanner INVITEs
+and REGISTER refreshes keep arriving with fresh ones. Under one LRU pool the
+live call is therefore the *oldest* entry, and would be evicted **before** the
+transient noise the bound exists to contain — discarding the ladder of the
+call an operator is most likely to be looking at.
+
+The bound was never reached in this run (pending peaked around 230 of 256),
+so this did not fire. It was found by reasoning about the trace-growth curve
+the samples show, and is fixed in the same change as this write-up: live
+calls are a separate population, promoted by the control registry when a call
+is accepted, bounded separately at `MAX_LIVE = 512`, and never evicted to
+make room for noise. A regression test floods `MAX_PENDING + 100` scanner
+traces past one live call and asserts it survives.
+
+### 2. 47 of 250 calls died on WS disconnect — the generator's WS server
+
+```
+siphon_ai_calls_total{cause="caller_hangup"} 203
+siphon_ai_calls_total{cause="ws_disconnect"}  47
+```
+
+**19 % of calls were terminated by the WebSocket server dropping**, not by the
+caller and not by the daemon, which logged nothing. This is
+`LOAD_TEST_PLAN.md` §1.4 — *"The WS server is probably your bottleneck, not
+the bridge"* — happening exactly as written.
+
+It bounds what this rig can measure: past roughly 150 concurrent through that
+general-purpose server, a run is measuring the server. The tier-2 results
+avoided this by using `paced_sink.mjs`, which is built for load. **Any future
+run at this scale should use the paced sink**, and the 47 lost calls here
+should not be read as a daemon result.
+
+## Not measured
+
+- **A ring-on/ring-off A/B.** The RSS delta above is not attributable; the
+  ring's own cost is still unquantified.
+- **The bounds actually tripping.** 203 concurrent did not reach
+  `MAX_PENDING`. Reaching it needs ~250 concurrent, or a node up long enough
+  for noise alone to fill 256 — on this node's scanner rate, hours.
+- **Per-call CPU.** No CPU sampling was taken; this run was about the ring.
+- **Anything past 203**, for the WS-server reason above.
+
+## Reproducing
+
+```bash
+ssh root@194.195.208.34 "/root/ramp-prod.sh 200 10 600"   # Box B
+test-harness/load/ringstat.sh                             # Box A, every 15 s
+```
+
+`ringstat.sh` reads `siphon_ai_sip_ring_traces`,
+`siphon_ai_sip_ring_messages_total{result}`, `calls_active` and RSS together,
+so a trace count is always attributable to a concurrency.

--- a/test-harness/load/ringstat.sh
+++ b/test-harness/load/ringstat.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Snapshot the SIP-ladder ring under load. Reads the ring gauges, the
+# call count, and RSS together so a trace count is always attributable
+# to a concurrency.
+M=$(mktemp); curl -s http://127.0.0.1:9091/metrics > "$M"
+PID=$(systemctl show siphon-ai -p MainPID --value)
+g() { awk -v k="$1" '$1==k {print $2}' "$M"; }
+l() { awk -v k="$1" '$1 ~ k {print $2}' "$M"; }
+printf "%-22s %s\n" "at" "$(date -u +%T)Z"
+printf "%-22s %s\n" "calls_active"   "$(g siphon_ai_calls_active)"
+printf "%-22s %s\n" "dialogs_active" "$(g siphon_ai_dialogs_active)"
+printf "%-22s %s\n" "ring_traces"    "$(g siphon_ai_sip_ring_traces)"
+for r in captured dropped_call_cap dropped_trace_cap; do
+  v=$(awk -v r="result=\"$r\"" '$1 ~ /^siphon_ai_sip_ring_messages_total/ && $1 ~ r {print $2}' "$M")
+  printf "%-22s %s\n" "msgs_$r" "${v:-0}"
+done
+printf "%-22s %s kB\n" "rss" "$(awk '/VmRSS/{print $2}' /proc/$PID/status)"
+printf "%-22s %s\n" "threads" "$(awk '/Threads/{print $2}' /proc/$PID/status)"
+printf "%-22s %s\n" "warns" "$(journalctl -u siphon-ai --since "@$(date -d "$(systemctl show siphon-ai -p ExecMainStartTimestamp --value | sed 's/^[A-Za-z]* //')" +%s 2>/dev/null || echo 0)" -q 2>/dev/null | grep -c ' WARN ')"
+rm -f "$M"


### PR DESCRIPTION
Plus the two things the load run that found it also surfaced: trunks are
now visible in sightglass, and the run itself is written up.

### The eviction inversion

The ring bounds its not-yet-completed traces least-recently-touched.
But an established call is SIP-silent between its ACK and its BYE, so
its `last_touched` never advances — while rejected scanner INVITEs and
REGISTER refreshes keep arriving with fresh ones. The live call was
therefore the *oldest* entry in the pool, and would be evicted **before**
the transient noise the bound exists to contain: exactly inverted, and
it discards the ladder of the call an operator is most likely to be
looking at.

Live calls are now their own population, promoted by
`ControlRegistry::insert` — the moment a dialog stops being
indistinguishable from a scanner INVITE — bounded separately at
MAX_LIVE = 512, and never evicted to make room for noise. Memory stays
bounded: the ceiling is MAX_PENDING + MAX_LIVE + cap_calls.

Honest about provenance: the bound never actually tripped at 203
concurrent (pending peaked ~230 of 256). This was found by reasoning
about the trace-growth curve the samples show, not by observing an
eviction. The regression test constructs it directly — flood
MAX_PENDING + 100 scanner traces past one live call, assert it survives
and that the noise stays capped — and would fail on the single-pool LRU.

### Trunks are visible again

The trunks tab showed only `[[register]]` bindings, so on a node with a
registered PBX *and* an IP-authenticated carrier trunk, the carrier was
simply absent — indistinguishable from a config mistake, which is how it
was reported from a live session. Trunks have no credentials and no
registration, hence no live state, which is why DESIGN_SIGHTGLASS.md
§6.6 deferred them. But "nothing to poll" is not a reason to render
nothing.

New readonly `GET /admin/v1/trunks`; rows carry their peer CIDRs and a
dim `ip-auth` marker with dashes where a registration would show state,
so they can never read as "up". Active OPTIONS probing toward gateways
stays deferred — that is the part §6.6 was really about.

### The run

`test-harness/load/RESULTS-0.49.5-sip-ring.md` — the ring shipped
enabled-by-default in 0.49.3 and had never been load-tested. At 203
concurrent it dropped nothing at either bound, captured 1,671 messages,
and produced no WARN. Two caveats the record states rather than buries:
the 20.8 → 77 MB RSS is the whole daemon at 203 calls and **not** the
ring's cost (tier-2 measured 70 MB at 200 concurrent with no ring at
all), and 47 of 250 calls died on `ws_disconnect` — the generator's WS
server, not the daemon, which is §1.4 of the load plan happening as
written and bounds what that rig can measure.

Carries `ringstat.sh` into the harness.

Verification: cargo test --workspace --locked 1,277 passed / 0 failed
(+10), clippy -D warnings, fmt, all four check scripts. The trunks
endpoint was exercised against a running daemon (readonly 200, correct
peer CIDRs) rather than only in tests.

---

Three related changes from one load run, kept together because the run is what motivates the other two. Happy to split if you'd rather review them separately.

**Review targets:** the two-population eviction in `sip_ring.rs`, the `mark_live` hook in `ControlRegistry::insert` (the one daemon hot-ish path touched), and whether `ip-auth` is the right marker for a trunk row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWos69HjV9pxvUJhRusU4D