### PR TITLE
chore(release): 0.49.6 — what one load run turned up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.49.6] - 2026-08-19
+
+Everything a single load run turned up. The ring's own bounds held at
+203 concurrent — nothing dropped, no warning logged — but the run
+surfaced an eviction flaw waiting for a busier node, a trunk an operator
+could not see, and a test harness that reported port collisions as
+product regressions.
+
+**Upgrade note:** this is the first release since 0.49.2 that changes
+daemon behaviour, so unlike 0.49.5 it wants a restart to take effect.
+No config change, no protocol change (WS stays version `"1"`), no CDR
+change (still v8), and no dependency moved.
+
 ### Fixed
 
 - **The SIPp harness now fails fast on a port collision instead of reporting one as 17 scenario failures.** Thirteen auxiliary phases hard-coded `9091` for their `[observability]` listener — the same port `configs/local-dev.toml` uses, and therefore the same port a daemon already running on the box is using. The daemon exited at startup with `Address already in use` and every affected phase reported as a *scenario* failure, which reads like a signalling regression: a local run scored 17 of 40 red on 2026-08-19, none of it real. `SIPHON_AI_CONFIG` only ever fixed the main phase, because the auxiliary phases generate their own configs. Every port the harness binds (`SIPP_PORT`, `DAEMON_PORT`, `ADMIN_API_PORT`, the new shared `AUX_OBS_PORT`, `ECHO_WS_PORT`) now reads from the environment, and a preflight check refuses to start on a busy TCP listener, naming the variable and a free port to use — the same treatment the missing-echo-server case already got, and for the same reason.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4083,7 +4083,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.49.5"
+version = "0.49.6"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4132,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-admin-api-types"
-version = "0.49.5"
+version = "0.49.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -4140,7 +4140,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.49.5"
+version = "0.49.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4156,7 +4156,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.49.5"
+version = "0.49.6"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4178,7 +4178,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.49.5"
+version = "0.49.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4195,7 +4195,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.49.5"
+version = "0.49.6"
 dependencies = [
  "regex",
  "serde",
@@ -4214,7 +4214,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.49.5"
+version = "0.49.6"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4260,7 +4260,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.49.5"
+version = "0.49.6"
 dependencies = [
  "base64 0.22.1",
  "hmac 0.12.1",
@@ -4283,7 +4283,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.49.5"
+version = "0.49.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4309,7 +4309,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.49.5"
+version = "0.49.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -4327,7 +4327,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.49.5"
+version = "0.49.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4345,7 +4345,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.49.5"
+version = "0.49.6"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4359,7 +4359,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.49.5"
+version = "0.49.6"
 dependencies = [
  "regex",
  "serde",
@@ -4371,7 +4371,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.49.5"
+version = "0.49.6"
 dependencies = [
  "schemars",
  "serde",
@@ -4381,7 +4381,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sightglass"
-version = "0.49.5"
+version = "0.49.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -4396,7 +4396,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.49.5"
+version = "0.49.6"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4424,7 +4424,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.49.5"
+version = "0.49.6"
 dependencies = [
  "base64 0.22.1",
  "rcgen",
@@ -4442,7 +4442,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.49.5"
+version = "0.49.6"
 dependencies = [
  "anyhow",
  "forge-engine",
@@ -4474,7 +4474,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.49.5"
+version = "0.49.6"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.49.5"
+version = "0.49.6"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.49.5.** Production-deployed against real carriers
+**Current release: v0.49.6.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged. Daemon upgrades are near-drop-in


### PR DESCRIPTION
The SIP-ladder ring shipped enabled-by-default in 0.49.3 and had never
been load-tested. At 203 concurrent its own bounds held — nothing
dropped at either cap, 1,671 messages captured, not one warning logged.
The run's value was everything else it exposed.

  fix   A live call's ladder could be evicted by scanner noise. An
        established call is SIP-silent between its ACK and its BYE, so
        its last_touched never advances while rejected scanner INVITEs
        keep arriving with fresh ones — making the live call the oldest
        entry, and the first evicted, by the bound meant to contain the
        noise. Live calls are now a separate population, promoted when
        the control registry accepts the call and never evicted for
        noise.
  add   GET /admin/v1/trunks, and [[trunk]] rows in sightglass. A node
        with a registered PBX and an IP-authenticated carrier showed
        only the PBX, so a configured trunk was indistinguishable from
        a missing one.
  test  Harness ports are overridable and collisions preflight, instead
        of surfacing as 17 of 40 scenario failures that look like a
        signalling regression.
  docs  test-harness/load/RESULTS-0.49.5-sip-ring.md

The eviction bug never actually fired at 203 concurrent — pending
peaked around 230 of 256. It was found by reasoning about the
trace-growth curve the samples show, and the results file says so
rather than implying it was observed. Two other things that file
declines to claim: the 20.8 → 77 MB RSS is the whole daemon at 203
calls and not the ring's cost, and 47 of 250 calls died on
ws_disconnect — the generator's WS server, which is §1.4 of the load
plan happening exactly as written.

**Upgrade note:** first release since 0.49.2 to change daemon
behaviour, so unlike 0.49.5 it wants a restart. No config change, no
protocol change (WS stays version "1"), no CDR change (still v8), and
no dependency moved — siphon-rs and forge-media are pinned where
0.49.2 left them.

Verification: cargo test --workspace --locked 1,277 passed / 0 failed,
clippy -D warnings, fmt, all four check scripts, cargo audit clean.
The SIPp suite was additionally run locally at 39/40 (the one failure
needs a cap_net_raw this box cannot grant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWos69HjV9pxvUJhRusU4D