### PR TITLE
fix(sightglass): a trunk's peer list could be clipped mid-CIDR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A trunk's peer list could be clipped mid-CIDR in sightglass.** `35.156.191.128/30` rendered as `35.156.191.128/3` — not merely ugly, because `/3` is itself a valid prefix length, so the table stated a range the config does not contain. Reported from a live session on a node with Twilio's eight CIDRs. The column now packs whole addresses only and appends an honest count of the rest (`54.172.60.0/30, 54.244.51.0/30, +6 more`), scaling with terminal width; where not even one address and its count fit, it degrades to a bare `8 peers` rather than clipping the count itself. The peers column also takes an exact width instead of a `Min`, so the budget is the real column rather than a guess at how leftover space gets divided. DESIGN_SIGHTGLASS.md §7: nothing truncates silently.
+
+
 ## [0.49.6] - 2026-08-19
 
 Everything a single load run turned up. The ring's own bounds held at

--- a/bins/sightglass/src/ui/mod.rs
+++ b/bins/sightglass/src/ui/mod.rs
@@ -149,14 +149,43 @@ mod tests {
         app.tab = Tab::Trunks;
         app.nodes[0].trunks = vec![TrunkRow {
             name: "twilio".into(),
-            peer_addrs: vec!["54.172.60.0/30".into()],
+            // Prod's real list — eight CIDRs is what overflowed.
+            peer_addrs: [
+                "54.172.60.0/30",
+                "54.244.51.0/30",
+                "54.171.127.192/30",
+                "35.156.191.128/30",
+                "54.65.63.192/30",
+                "54.169.127.128/30",
+                "54.252.254.64/30",
+                "177.71.206.192/30",
+            ]
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
         }];
-        let screen = render(&app, 120, 30);
-        assert!(screen.contains("twilio"), "{screen}");
-        assert!(screen.contains("54.172.60.0/30"), "{screen}");
+        // Wide: whole CIDRs plus an honest count of the rest. The
+        // reported bug clipped this to `35.156.191.128/3`, which reads
+        // as a valid /3 rather than as a truncation.
+        let wide = render(&app, 160, 30);
+        assert!(wide.contains("twilio"), "{wide}");
+        assert!(wide.contains("54.172.60.0/30"), "{wide}");
+        assert!(wide.contains("35.156.191.128/30"), "{wide}");
+        assert!(wide.contains("+4 more"), "{wide}");
+        assert!(!wide.contains("/3 "), "a CIDR was cut mid-value: {wide}");
         assert!(
-            screen.contains("ip-auth"),
-            "a trunk has no live state and must say so, not read as up: {screen}"
+            wide.contains("ip-auth"),
+            "a trunk has no live state and must say so, not read as up: {wide}"
+        );
+
+        // Narrow: no room for even one address and its count, so it
+        // degrades to a bare count rather than clipping either.
+        let narrow = render(&app, 100, 30);
+        assert!(narrow.contains("twilio"), "{narrow}");
+        assert!(narrow.contains("8 peers"), "{narrow}");
+        assert!(
+            !narrow.contains("+7 mo"),
+            "the tail itself clipped: {narrow}"
         );
     }
 

--- a/bins/sightglass/src/ui/trunks.rs
+++ b/bins/sightglass/src/ui/trunks.rs
@@ -24,6 +24,70 @@ use crate::model::{App, NodeHealth};
 
 use super::Theme;
 
+/// Render a trunk's peer list to fit `budget` columns **without ever
+/// cutting a CIDR in half**.
+///
+/// A truncated CIDR is not merely ugly, it is wrong-looking in a
+/// specific way: `35.156.191.128/30` clipped to `35.156.191.128/3`
+/// reads as a valid `/3`, so the table would state a prefix the config
+/// does not contain. Whole values only, and a count of what is not
+/// shown — the full list is always available from
+/// `GET /admin/v1/trunks`. DESIGN_SIGHTGLASS.md §7: nothing truncates
+/// silently.
+///
+/// Never emits more than `budget` characters, for any `budget` at or
+/// above [`MIN_PEER_W`] — the caller clamps to that, and below it no
+/// output is meaningful anyway. When even one address plus its "+N
+/// more" tail will not fit, it degrades to a bare count (`"8 peers"`)
+/// rather than letting the terminal clip either: a clipped tail
+/// (`"+7 mo"`) is the same class of bug as a clipped CIDR, just less
+/// obvious about it.
+/// Narrowest column `peer_summary` promises to respect. Below this
+/// even `"NN peers"` does not fit, so there is nothing honest to draw.
+const MIN_PEER_W: usize = 12;
+
+fn peer_summary(addrs: &[String], budget: usize) -> String {
+    if addrs.is_empty() {
+        // Not "none": an empty `peer_addrs` means the IP check is
+        // skipped for this trunk, which is the opposite of restrictive.
+        return "any source".to_string();
+    }
+    let mut shown = 0usize;
+    let mut len = 0usize;
+    for (i, a) in addrs.iter().enumerate() {
+        let sep = if i == 0 { 0 } else { 2 }; // ", "
+                                              // Reserve room for the "+N more" tail, unless this is the last
+                                              // address and it fits exactly — then nothing is being hidden.
+        let remaining = addrs.len() - i - 1;
+        let tail = if remaining == 0 {
+            0
+        } else {
+            format!(", +{remaining} more").len()
+        };
+        if shown > 0 && len + sep + a.len() + tail > budget {
+            break;
+        }
+        len += sep + a.len();
+        shown += 1;
+    }
+    let hidden = addrs.len() - shown;
+    let mut out = addrs[..shown].join(", ");
+    if hidden > 0 {
+        out.push_str(&format!(", +{hidden} more"));
+    }
+    if out.len() > budget {
+        // Too narrow for even one whole address and its count. Say how
+        // many there are and stop; `GET /admin/v1/trunks` has the list.
+        let n = addrs.len();
+        return if n == 1 {
+            "1 peer".to_string()
+        } else {
+            format!("{n} peers")
+        };
+    }
+    out
+}
+
 pub fn draw(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
     let multi_node = app.nodes.len() > 1;
 
@@ -36,6 +100,24 @@ pub fn draw(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
             .into_iter()
             .map(|h| Cell::from(Span::styled(h, theme.dim_text()))),
     );
+
+    // The peers column is given an *exact* width rather than a Min,
+    // so the budget handed to `peer_summary` is the real thing rather
+    // than a guess at how ratatui will divide leftover space between
+    // two Min columns. Guessing is what made the first attempt at this
+    // show one CIDR where four fit.
+    const NAME_W: usize = 16;
+    const STATUS_W: usize = 12;
+    const EXPIRES_W: usize = 22;
+    const NODE_W: usize = 12;
+    const ERROR_W: usize = 10; // LAST ERROR keeps the Min and any slack
+    let columns = if multi_node { 6 } else { 5 };
+    let fixed = NAME_W + STATUS_W + EXPIRES_W + ERROR_W + if multi_node { NODE_W } else { 0 };
+    let peer_budget = (area.width as usize)
+        .saturating_sub(2) // borders
+        .saturating_sub(columns - 1) // inter-column spacing
+        .saturating_sub(fixed)
+        .max(MIN_PEER_W);
 
     let mut rows = Vec::new();
     for (id, n) in app.nodes.iter().enumerate() {
@@ -79,11 +161,7 @@ pub fn draw(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
             } else {
                 theme.text()
             };
-            let peers = if t.peer_addrs.is_empty() {
-                "any source".to_string()
-            } else {
-                t.peer_addrs.join(", ")
-            };
+            let peers = peer_summary(&t.peer_addrs, peer_budget);
             let mut cells = vec![
                 Cell::from(Span::styled(t.name.clone(), base)),
                 Cell::from(Span::styled(peers, base)),
@@ -102,14 +180,14 @@ pub fn draw(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
     }
 
     let mut widths = vec![
-        Constraint::Length(16),
-        Constraint::Min(24),
-        Constraint::Length(12),
-        Constraint::Length(22),
-        Constraint::Min(10),
+        Constraint::Length(NAME_W as u16),
+        Constraint::Length(peer_budget as u16),
+        Constraint::Length(STATUS_W as u16),
+        Constraint::Length(EXPIRES_W as u16),
+        Constraint::Min(ERROR_W as u16),
     ];
     if multi_node {
-        widths.insert(0, Constraint::Length(12));
+        widths.insert(0, Constraint::Length(NODE_W as u16));
     }
 
     let empty = rows.is_empty();
@@ -135,5 +213,103 @@ pub fn draw(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
             )),
             inner,
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{peer_summary, MIN_PEER_W};
+
+    fn twilio() -> Vec<String> {
+        [
+            "54.172.60.0/30",
+            "54.244.51.0/30",
+            "54.171.127.192/30",
+            "35.156.191.128/30",
+            "54.65.63.192/30",
+            "54.169.127.128/30",
+            "54.252.254.64/30",
+            "177.71.206.192/30",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect()
+    }
+
+    /// The reported bug: at a realistic width the row clipped to
+    /// `…35.156.191.128/3`, which reads as a valid /3 prefix.
+    #[test]
+    fn never_cuts_a_cidr_in_half() {
+        for budget in MIN_PEER_W..120 {
+            let out = peer_summary(&twilio(), budget);
+            // The count form is not a CIDR list and is checked
+            // separately; everything else must be whole addresses.
+            if out.ends_with("peers") || out.ends_with("peer") {
+                continue;
+            }
+            for p in out.split(", ").filter(|p| !p.starts_with('+')) {
+                assert!(
+                    twilio().iter().any(|a| a == p),
+                    "emitted a partial CIDR {p:?} at budget {budget} in {out:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn says_how_many_it_is_hiding() {
+        let out = peer_summary(&twilio(), 40);
+        assert!(out.contains("more"), "{out}");
+        let shown = out.split(", ").filter(|p| !p.starts_with('+')).count();
+        assert!(out.contains(&format!("+{} more", 8 - shown)), "{out}");
+    }
+
+    #[test]
+    fn a_list_that_fits_gets_no_tail() {
+        let one = vec!["10.0.0.0/8".to_string()];
+        assert_eq!(peer_summary(&one, 40), "10.0.0.0/8");
+        // Exactly-fitting full list must not spend room on a tail it
+        // does not need.
+        let two = vec!["10.0.0.0/8".to_string(), "10.1.0.0/16".to_string()];
+        assert_eq!(peer_summary(&two, 23), "10.0.0.0/8, 10.1.0.0/16");
+    }
+
+    /// Width 100 in the reported terminal gave a 21-column budget, and
+    /// an earlier fix emitted `54.172.60.0/30, +7 more` (23 chars) into
+    /// it — so the *tail* clipped to `+7 mo`. Degrading to a count is
+    /// the only form that cannot be cut.
+    #[test]
+    fn degrades_to_a_count_when_even_one_address_will_not_fit() {
+        assert_eq!(peer_summary(&twilio(), 21), "8 peers");
+        assert_eq!(peer_summary(&twilio(), MIN_PEER_W), "8 peers");
+        // A single address short enough to fit is still shown whole —
+        // degrading is a last resort, not a width policy.
+        assert_eq!(
+            peer_summary(&["10.0.0.0/8".to_string()], MIN_PEER_W),
+            "10.0.0.0/8"
+        );
+        // One that genuinely cannot fit degrades rather than clipping.
+        let v6 = vec!["2001:0db8:85a3:0000:0000:8a2e:0370:7334/128".to_string()];
+        assert_eq!(peer_summary(&v6, MIN_PEER_W), "1 peer");
+    }
+
+    /// The invariant the whole function exists for.
+    #[test]
+    fn never_exceeds_its_budget() {
+        for budget in MIN_PEER_W..120 {
+            let out = peer_summary(&twilio(), budget);
+            assert!(
+                out.len() <= budget,
+                "emitted {} chars into a {budget}-wide column: {out:?}",
+                out.len()
+            );
+        }
+    }
+
+    /// Empty means the IP check is skipped for this trunk — the
+    /// opposite of restrictive, so it must not read as "none".
+    #[test]
+    fn empty_peer_list_says_any_source() {
+        assert_eq!(peer_summary(&[], 40), "any source");
     }
 }


### PR DESCRIPTION
Reported from a live session on a node carrying Twilio's eight ranges:
the row rendered `35.156.191.128/3`. That is not merely untidy — `/3` is
a valid prefix length, so the table stated a range the config does not
contain. DESIGN_SIGHTGLASS.md §7 says nothing truncates silently, and
this truncated in the one way that reads as a value rather than as a
truncation.

The column now packs whole addresses and appends a count of what it is
holding back, scaling with terminal width:

  160 cols  54.172.60.0/30, 54.244.51.0/30, 54.171.127.192/30,
            35.156.191.128/30, +4 more
  120 cols  54.172.60.0/30, 54.244.51.0/30, +6 more
  100 cols  8 peers

Two things fell out of building it, both worth naming because each was
a smaller instance of the same mistake:

  * The first attempt derived the column budget by *estimating* how
    ratatui divides leftover space between two `Min` columns. It was
    wrong in the safe direction — one CIDR shown where four fit — but
    wrong is wrong; the peers column now takes an exact `Length`, so
    the budget is the real column.
  * The second attempt still overflowed at 100 columns, clipping the
    tail to `+7 mo`. A clipped count is the same class of bug as a
    clipped CIDR, just less obvious, so a budget too small for one
    address and its count degrades to a bare `8 peers` instead.

An empty `peer_addrs` still reads "any source" rather than "none": it
means the IP check is skipped for that trunk, which is the opposite of
restrictive.

Seven tests. The load-bearing ones are a property check that no emitted
piece is ever a partial CIDR across every width from the floor up, and
that the output never exceeds its budget — the second of which failed
first time and caught the `+7 mo` case.

---

Sightglass-only; the daemon and `GET /admin/v1/trunks` are untouched. Left under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWos69HjV9pxvUJhRusU4D