### PR TITLE
chore(release): 0.49.7 — trunk peer lists stop clipping mid-CIDR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.49.7] - 2026-08-19
+
+One sightglass fix. **Sightglass-only** — the daemon is behaviourally
+identical to 0.49.6, so there is no reason to restart a node for this.
+Sightglass ships in the release **tarball**, never the `.deb`; take it
+from there, or the TUI stays on whatever version was last installed by
+hand while the daemon moves on without it.
+
 ### Fixed
 
 - **A trunk's peer list could be clipped mid-CIDR in sightglass.** `35.156.191.128/30` rendered as `35.156.191.128/3` — not merely ugly, because `/3` is itself a valid prefix length, so the table stated a range the config does not contain. Reported from a live session on a node with Twilio's eight CIDRs. The column now packs whole addresses only and appends an honest count of the rest (`54.172.60.0/30, 54.244.51.0/30, +6 more`), scaling with terminal width; where not even one address and its count fit, it degrades to a bare `8 peers` rather than clipping the count itself. The peers column also takes an exact width instead of a `Min`, so the budget is the real column rather than a guess at how leftover space gets divided. DESIGN_SIGHTGLASS.md §7: nothing truncates silently.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4083,7 +4083,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.49.6"
+version = "0.49.7"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4132,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-admin-api-types"
-version = "0.49.6"
+version = "0.49.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -4140,7 +4140,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.49.6"
+version = "0.49.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4156,7 +4156,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.49.6"
+version = "0.49.7"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4178,7 +4178,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.49.6"
+version = "0.49.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4195,7 +4195,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.49.6"
+version = "0.49.7"
 dependencies = [
  "regex",
  "serde",
@@ -4214,7 +4214,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.49.6"
+version = "0.49.7"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4260,7 +4260,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.49.6"
+version = "0.49.7"
 dependencies = [
  "base64 0.22.1",
  "hmac 0.12.1",
@@ -4283,7 +4283,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.49.6"
+version = "0.49.7"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4309,7 +4309,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.49.6"
+version = "0.49.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -4327,7 +4327,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.49.6"
+version = "0.49.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4345,7 +4345,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.49.6"
+version = "0.49.7"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4359,7 +4359,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.49.6"
+version = "0.49.7"
 dependencies = [
  "regex",
  "serde",
@@ -4371,7 +4371,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.49.6"
+version = "0.49.7"
 dependencies = [
  "schemars",
  "serde",
@@ -4381,7 +4381,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sightglass"
-version = "0.49.6"
+version = "0.49.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -4396,7 +4396,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.49.6"
+version = "0.49.7"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4424,7 +4424,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.49.6"
+version = "0.49.7"
 dependencies = [
  "base64 0.22.1",
  "rcgen",
@@ -4442,7 +4442,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.49.6"
+version = "0.49.7"
 dependencies = [
  "anyhow",
  "forge-engine",
@@ -4474,7 +4474,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.49.6"
+version = "0.49.7"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.49.6"
+version = "0.49.7"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.49.6.** Production-deployed against real carriers
+**Current release: v0.49.7.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged. Daemon upgrades are near-drop-in


### PR DESCRIPTION
Sightglass-only. The daemon is behaviourally identical to 0.49.6, so
there is no reason to restart a node for this — and since sightglass
ships in the release tarball and never in the .deb, upgrading it means
taking the binary from there. A daemon-only upgrade leaves the TUI on
whatever version was last installed by hand, which cost two round trips
on 2026-08-19 alone.

A trunk carrying Twilio's eight CIDRs rendered `35.156.191.128/3`. Not
merely untidy: `/3` is a valid prefix length, so the table stated a
range the config does not contain. The column now packs whole addresses
with an honest count of the rest, scaling with width — four CIDRs plus
"+4 more" at 160 columns, two plus "+6 more" at 120, a bare "8 peers"
where not even one address and its count fit.

No protocol change (WS stays version "1"), no CDR change (still v8), no
config change, and no dependency moved. siphon-rs has two commits ahead
of our pin but both are docs and version metadata with no code in them,
so the pin stays where 0.49.2 left it rather than moving for nothing.

Verification: cargo test --workspace --locked 1,283 passed / 0 failed,
clippy -D warnings, fmt, all four check scripts, cargo audit clean —
re-run from a cold target after the disk filled at 149/157 GB and made
the first attempt report failures it had no business reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWos69HjV9pxvUJhRusU4D