### PR TITLE
docs(load): measure the SIP-ladder ring's memory cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **`test-harness/load/RESULTS-0.49.7-ring-ab.md` — the SIP-ladder ring's memory cost, measured.** `RESULTS-0.49.5-sip-ring.md` recorded it as unquantified because a call-based comparison could not resolve it: the expected signal is 1–2 MB against run-to-run RSS variance larger than that, and at 203 concurrent that rig loses 19 % of its calls to the WS server, so the two arms would not carry the same load. Isolating the ring instead — synthetic SIP from loopback, no media, no WS, no call setup, identical flood in both arms so transaction memory cancels — puts it at **~1.9 MB at a realistic 200-concurrent shape** (about 2.5 % of that node's 77 MB), **~17 MB with the pending bound saturated at its per-call cap**, and a computed **~55 MB** ceiling at the bounds that needs 512 concurrent calls each having exchanged 64+ messages. Per-message cost is roughly `1.34 × payload + 285 B`, the slope being allocator size-class rounding. Carries `abrun.sh`, `ringflood.py` and the two configs into the harness.
+
+
 ## [0.49.7] - 2026-08-19
 
 One sightglass fix. **Sightglass-only** — the daemon is behaviourally

--- a/test-harness/load/README.md
+++ b/test-harness/load/README.md
@@ -32,8 +32,9 @@ the burst's signalling-only calls at the one-minute mark.
 
 | | |
 |---|---|
-| `RESULTS-*.md` | published runs — `0.48.10`, `0.48.13`, `0.48.18`, `0.48.19` (RTP port-bind A/B), `tier2` (FreeSWITCH / TLS+SRTP / netem), `convergence-8h`, `0.49.0-reference-call` (§11), and `0.49.5-sip-ring` |
+| `RESULTS-*.md` | published runs — `0.48.10`, `0.48.13`, `0.48.18`, `0.48.19` (RTP port-bind A/B), `tier2` (FreeSWITCH / TLS+SRTP / netem), `convergence-8h`, `0.49.0-reference-call` (§11), `0.49.5-sip-ring`, and `0.49.7-ring-ab` |
 | `ringstat.sh` | one-shot snapshot of the SIP-ladder ring gauges + RSS + concurrency, for sampling during a run (`RESULTS-0.49.5-sip-ring.md`) |
+| `abrun.sh` + `ringflood.py` + `ab-{on,off}.toml` | the ring-memory A/B (`RESULTS-0.49.7-ring-ab.md`) — one arm per invocation, fresh daemon each time |
 | `tier2/` | the two-box FreeSWITCH rig behind `RESULTS-tier2.md` (§10.2) — generator scripts, phase drivers, lab configs |
 | `paced_sink.mjs` | the WS sink the §6.1 and tier-2 numbers were measured through. **Use this, not a `setInterval`-paced sink** — see §8's first trap |
 | `squat.py` | holds RTP ports the way an ephemeral socket does, to reproduce #504 on demand |

--- a/test-harness/load/RESULTS-0.49.5-sip-ring.md
+++ b/test-harness/load/RESULTS-0.49.5-sip-ring.md
@@ -103,6 +103,10 @@ should not be read as a daemon result.
 
 - **A ring-on/ring-off A/B.** The RSS delta above is not attributable; the
   ring's own cost is still unquantified.
+  **CLOSED by `RESULTS-0.49.7-ring-ab.md`**: isolating the ring from media,
+  WS and call setup puts it at **~1.9 MB** at this run's shape — about
+  2.5 % of the 77 MB measured here, and well inside the variance that made
+  this figure unattributable in the first place.
 - **The bounds actually tripping.** 203 concurrent did not reach
   `MAX_PENDING`. Reaching it needs ~250 concurrent, or a node up long enough
   for noise alone to fill 256 — on this node's scanner rate, hours.

--- a/test-harness/load/RESULTS-0.49.7-ring-ab.md
+++ b/test-harness/load/RESULTS-0.49.7-ring-ab.md
@@ -1,0 +1,113 @@
+# SIP-ladder ring memory — an on/off A/B
+
+Run 2026-08-20 against the **shipped 0.49.7 tarball binary**
+(`siphon-ai-0.49.7-x86_64-unknown-linux-musl`), on a lab second instance.
+
+This closes the item `RESULTS-0.49.5-sip-ring.md` left open:
+
+> **A ring-on/ring-off A/B.** The RSS delta above is not attributable; the
+> ring's own cost is still unquantified.
+
+It is now quantified. **~1.9 MB at a realistic 200-concurrent shape**, and
+**~17 MB with the pending bound saturated at its per-call cap** — the
+configuration an operator would have to work to reach.
+
+## Why not a call-based run
+
+The obvious A/B — same load through the tier-2 generator, ring on then off —
+cannot answer this. The expected signal is 1–2 MB, and the 0.49.5 run's own
+RSS varied by more than that between samples at fixed concurrency. Worse, at
+203 concurrent that rig loses 19 % of its calls to the WS server (§1.4), so
+the two arms would not even carry the same load.
+
+So the ring is isolated instead: synthetic SIP dialogs from loopback, no
+media, no WS server, no call setup. Both arms take the identical flood, so
+transaction-layer memory — which is much larger than the ring's — is present
+in both and cancels in the difference. What remains is the ring.
+
+## Method
+
+Fresh daemon per arm (never reused: a drained process's free pool absorbs the
+next arm's allocations invisibly, the trap `RESULTS-0.48.10.md` fell into),
+idle RSS recorded after a 3 s settle, flood, 8 s settle, loaded RSS. Arms
+alternate `on, off, on, off …` so any drift lands on both. Configs are
+byte-identical but for `[observability].sip_ring_size` — `50` vs `0`.
+
+Two things had to be fixed before the numbers meant anything, both recorded
+here because each silently produced a plausible wrong answer first:
+
+- **`[sip].udp_rate_limit_pps` defaults to 200 per source**, so the first
+  flood delivered **3,162 of 16,384 messages** and filled 60 of 256 traces.
+  It measured a quarter of the ring and looked fine. Set to `0` in *both*
+  arms. `docs/CONFIG.md` warns about exactly this for load generators.
+- **INVITE was the wrong probe.** Unanswered INVITEs leave server
+  transactions retransmitting their 403 for ~32 s; that storm's timing
+  dominated, and the ring-on arm swung **61 → 125 MB** while ring-off held
+  ±1.3 MB. `OPTIONS` is one request, one 200, no retransmission — after the
+  switch, ring-on repeated to **±0.2 MB** across four runs.
+
+## Results
+
+Medians of the alternating pairs, RSS delta from idle, in kB.
+
+| shape | messages | ring on | ring off | **ring cost** |
+|---|---|---|---|---|
+| 256 traces × 64 msg, small (~287 B avg) | 16,384 | 38,562 | 27,840 | **10.7 MB** |
+| 256 traces × 64 msg, realistic (~591 B avg) | 16,384 | 44,116 | 26,900 | **16.8 MB** |
+| 282 traces × 6 msg, realistic | 1,692 | 5,520 | 3,616 | **1.9 MB** |
+
+Two payload sizes give the shape of the per-message cost:
+
+```
+  ~287 B avg payload →   670 B/message
+  ~591 B avg payload → 1,076 B/message
+  ⇒ roughly  1.34 × payload + ~285 B
+```
+
+The slope above 1.0 is allocator size-class rounding, not bookkeeping: an
+882-byte string does not occupy 882 bytes. The ~285 B intercept is the entry
+itself — timestamp, `src`/`dst`, direction, and the `String`/`VecDeque`/map
+overhead around them.
+
+The realistic row is the one to quote. **A prod-shaped node at ~200
+concurrent pays about 1.9 MB for the ring** — against the 77 MB that node's
+whole daemon occupied at that load, i.e. **~2.5 %**, and comfortably inside
+the run-to-run RSS variance that made the 0.49.5 figure unattributable.
+
+## The ceiling, computed not measured
+
+The bounds permit `MAX_PENDING (256) + MAX_LIVE (512) + cap_calls (50)` =
+818 traces, each up to `sip_ring_max_messages` (64) messages. At the measured
+~1.05 kB/message that is **~55 MB**.
+
+**This is arithmetic on a measured rate, not an observed number**, and it is
+not reachable by accident: it needs 512 concurrent calls *each* having
+exchanged 64+ SIP messages. Real calls in these runs carry 4–8. Treat it as
+the bound the design guarantees, not a figure any node is likely to approach
+— and note it scales linearly with `sip_ring_max_messages`, which is the knob
+to reach for if it ever matters.
+
+## Not measured
+
+- **The live population's cost specifically.** All 282 traces in the
+  realistic row are noise (the pending bound capped them at 256, visible in
+  the run). Live traces cost the same per message — same struct, same
+  storage — but a run with 512 genuinely live calls would confirm rather than
+  assume it.
+- **Whether freed ring memory returns to the OS.** Every arm here starts
+  fresh; nothing tests `sip_ring_size = 0` on a *running* daemon that had a
+  full ring.
+- **Real message-size distribution.** `591 B` average is a padded synthetic.
+  A node carrying large SDP or many headers will sit above the realistic row;
+  the formula above is how to re-estimate it.
+
+## Reproducing
+
+`ringflood.py` and `abrun.sh` are alongside this file.
+
+```bash
+for i in 1 2 3; do
+  PAD=600 ./abrun.sh on  282 3
+  PAD=600 ./abrun.sh off 282 3
+done
+```

--- a/test-harness/load/ab-off.toml
+++ b/test-harness/load/ab-off.toml
@@ -1,0 +1,66 @@
+# A/B arm 'off' for RESULTS-0.49.7-ring-ab.md. The two files are
+# byte-identical but for [observability].sip_ring_size below — keep
+# them that way or the difference stops meaning anything.
+#
+# Ports: SIP 5070, metrics 9591, admin 9592. Change them together
+# in BOTH files if they collide with a daemon on this box; the
+# harness lesson from run-all.sh applies here too.
+# Lab config for verifying the 0.49.3 SIP ladder on the SHIPPED binary.
+# Ports deliberately clear of prod (5060/5061, 9091, 9092, 40000-41000).
+[node]
+id = "lab-ladder"
+
+[sip]
+# Identical in both arms. The default 200 pps/source silently drops
+# most of the flood (3,162 of 16,384 landed), which would measure a
+# fraction of the ring rather than its bounds. docs/CONFIG.md says to
+# raise it before load-testing from a single generator.
+udp_rate_limit_pps = 0
+listen = "127.0.0.1:5070"
+transports = ["udp"]
+
+[media]
+codecs = ["pcmu", "pcma"]
+rtp_port_range = [41500, 41600]
+inactivity_timeout_secs = 0
+
+[bridge]
+ws_url = "ws://127.0.0.1:8765/"
+
+# No trunk covers loopback, so every INVITE is rejected 403 — which is
+# exactly the "non-call dialog" the ring's third bound exists for.
+[[trunk]]
+name = "loopback"
+peer_addrs = ["127.0.0.1/32"]
+
+[[route]]
+name = "default"
+[route.match]
+any = true
+
+# rtp_call_uac.py expects a 401 challenge — it aborts with
+# "expected 401, got 200" against a config with no [sip.auth].
+[sip.auth]
+realm = "lab"
+
+[[sip.auth.user]]
+username = "labuser"
+password = "labpw123"
+
+[observability]
+sip_ring_size = 0
+enabled = true
+http_listen = "127.0.0.1:9591"
+
+[admin]
+listen = "127.0.0.1:9592"
+
+[[admin.token]]
+name = "ro"
+token = "lab-readonly-token"
+role = "readonly"
+
+[[admin.token]]
+name = "op"
+token = "lab-operator-token"
+role = "operator"

--- a/test-harness/load/ab-on.toml
+++ b/test-harness/load/ab-on.toml
@@ -1,0 +1,66 @@
+# A/B arm 'on' for RESULTS-0.49.7-ring-ab.md. The two files are
+# byte-identical but for [observability].sip_ring_size below — keep
+# them that way or the difference stops meaning anything.
+#
+# Ports: SIP 5070, metrics 9591, admin 9592. Change them together
+# in BOTH files if they collide with a daemon on this box; the
+# harness lesson from run-all.sh applies here too.
+# Lab config for verifying the 0.49.3 SIP ladder on the SHIPPED binary.
+# Ports deliberately clear of prod (5060/5061, 9091, 9092, 40000-41000).
+[node]
+id = "lab-ladder"
+
+[sip]
+# Identical in both arms. The default 200 pps/source silently drops
+# most of the flood (3,162 of 16,384 landed), which would measure a
+# fraction of the ring rather than its bounds. docs/CONFIG.md says to
+# raise it before load-testing from a single generator.
+udp_rate_limit_pps = 0
+listen = "127.0.0.1:5070"
+transports = ["udp"]
+
+[media]
+codecs = ["pcmu", "pcma"]
+rtp_port_range = [41500, 41600]
+inactivity_timeout_secs = 0
+
+[bridge]
+ws_url = "ws://127.0.0.1:8765/"
+
+# No trunk covers loopback, so every INVITE is rejected 403 — which is
+# exactly the "non-call dialog" the ring's third bound exists for.
+[[trunk]]
+name = "loopback"
+peer_addrs = ["127.0.0.1/32"]
+
+[[route]]
+name = "default"
+[route.match]
+any = true
+
+# rtp_call_uac.py expects a 401 challenge — it aborts with
+# "expected 401, got 200" against a config with no [sip.auth].
+[sip.auth]
+realm = "lab"
+
+[[sip.auth.user]]
+username = "labuser"
+password = "labpw123"
+
+[observability]
+sip_ring_size = 50
+enabled = true
+http_listen = "127.0.0.1:9591"
+
+[admin]
+listen = "127.0.0.1:9592"
+
+[[admin.token]]
+name = "ro"
+token = "lab-readonly-token"
+role = "readonly"
+
+[[admin.token]]
+name = "op"
+token = "lab-operator-token"
+role = "operator"

--- a/test-harness/load/abrun.sh
+++ b/test-harness/load/abrun.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# One A/B arm: fresh daemon, idle baseline, flood, settle, measure.
+# Fresh process each time so the allocator starts from the same place —
+# reusing one daemon would let the first arm's freed memory absorb the
+# second's, which is exactly the trap RESULTS-0.48.10 fell into.
+set -u
+SP="$(cd "$(dirname "$0")" && pwd)"
+BIN="${SIPHON_AI_BIN:-$SP/../../target/debug/siphon-ai}"
+ARM="$1"; TRACES="$2"; MSGS="$3"
+cd "$SP"
+nohup "$BIN" --config "$SP/ab-$ARM.toml" > "$SP/ab-$ARM.log" 2>&1 &
+PID=$!
+for _ in $(seq 1 40); do
+    grep -q "daemon ready" "$SP/ab-$ARM.log" 2>/dev/null && break
+    sleep 0.25
+done
+sleep 3                                   # let startup allocations settle
+IDLE=$(awk '/VmRSS/{print $2}' /proc/$PID/status)
+python3 "$SP/ringflood.py" --traces "$TRACES" --messages "$MSGS" --pad "${PAD:-0}" >/dev/null
+sleep 8                                   # let the sink drain its queue
+LOADED=$(awk '/VmRSS/{print $2}' /proc/$PID/status)
+HWM=$(awk '/VmHWM/{print $2}' /proc/$PID/status)
+STATS=$(curl -s http://127.0.0.1:9591/metrics | awk '
+  /^siphon_ai_sip_ring_traces/{t=$2}
+  /^siphon_ai_sip_ring_messages_total.*captured/{c=$2}
+  END{printf "traces=%s captured=%s", (t==""?"-":t), (c==""?"0":c)}')
+printf "%-4s idle=%-8s loaded=%-8s delta=%-7s hwm=%-8s %s\n" \
+    "$ARM" "$IDLE" "$LOADED" "$((LOADED - IDLE))" "$HWM" "$STATS"
+kill $PID 2>/dev/null
+wait $PID 2>/dev/null
+sleep 1

--- a/test-harness/load/ringflood.py
+++ b/test-harness/load/ringflood.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Flood a siphon-ai node with N distinct SIP dialogs x M messages each.
+
+Isolates the SIP-ladder ring's memory cost: no media, no WS server, no
+call setup — just SIP messages carrying Call-IDs the ring will file.
+Every message is a fresh transaction (unique branch + CSeq) so nothing
+is absorbed as a retransmission before it reaches the HEP sink.
+"""
+import argparse, socket, sys, time
+
+ap = argparse.ArgumentParser()
+ap.add_argument("--host", default="127.0.0.1")
+ap.add_argument("--port", type=int, default=5070)
+ap.add_argument("--traces", type=int, default=256)
+ap.add_argument("--messages", type=int, default=64, help="per trace")
+ap.add_argument("--pad", type=int, default=0, help="extra header bytes per message")
+a = ap.parse_args()
+
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+s.setblocking(False)
+pad = ("X-Pad: " + "p" * a.pad + "\r\n") if a.pad else ""
+sent = 0
+for t in range(a.traces):
+    cid = f"ringflood-{t}"
+    for m in range(a.messages):
+        body = (
+            # OPTIONS, not INVITE: an unACKed INVITE leaves a server
+            # transaction retransmitting its 403 for ~32 s, and that
+            # storm's timing swamped the very thing being measured
+            # (the ring-on arm swung 61-125 MB while ring-off held
+            # +/-1.3). OPTIONS is one request, one 200, done.
+            f"OPTIONS sip:911@{a.host}:{a.port} SIP/2.0\r\n"
+            f"Via: SIP/2.0/UDP 127.0.0.1:9;branch=z9hG4bKrf{t}x{m};rport\r\n"
+            f"From: <sip:flood@example.net>;tag=f{t}x{m}\r\n"
+            f"To: <sip:911@{a.host}>\r\n"
+            f"Call-ID: {cid}\r\n"
+            f"CSeq: {m + 1} OPTIONS\r\n"
+            f"Contact: <sip:flood@127.0.0.1:9>\r\n"
+            f"{pad}"
+            f"Max-Forwards: 70\r\nContent-Length: 0\r\n\r\n"
+        )
+        try:
+            s.sendto(body.encode(), (a.host, a.port))
+            sent += 1
+        except OSError:
+            time.sleep(0.01)
+        # Pace to stay under the kernel's UDP receive buffer. Without
+        # this the socket, not the ring, decides what gets measured.
+        if sent % 100 == 0:
+            time.sleep(0.02)
+print(f"sent {sent} messages across {a.traces} traces", flush=True)


### PR DESCRIPTION
RESULTS-0.49.5-sip-ring.md left this open, and said why: its 20.8 → 77 MB
was the whole daemon at 203 concurrent, not the ring. Closing it needed a
different experiment, not a bigger version of the same one.

A call-based A/B cannot resolve this. The expected signal is 1–2 MB and
that run's RSS varied by more than that between samples at fixed
concurrency; worse, at 203 concurrent the rig loses 19 % of its calls to
the WS server (§1.4), so the two arms would not even carry the same load.

So the ring is isolated: synthetic SIP dialogs from loopback, no media,
no WS server, no call setup. Both arms take the identical flood, so
transaction-layer memory — much larger than the ring's — is present in
both and cancels in the difference.

  realistic (282 traces × 6 msg)     ~1.9 MB   ≈ 2.5 % of that node's RSS
  pending bound saturated (× 64)    ~16.8 MB
  ceiling at the bounds (computed)    ~55 MB

Per message it is roughly `1.34 × payload + 285 B`. The slope above 1.0
is allocator size-class rounding, not bookkeeping — an 882-byte string
does not occupy 882 bytes.

Two setup errors are recorded in the file because each produced a
plausible wrong answer before it was caught:

  * `[sip].udp_rate_limit_pps` defaults to 200 per source, so the first
    flood delivered 3,162 of 16,384 messages and filled 60 of 256
    traces. It measured a quarter of the ring and looked healthy.
  * INVITE was the wrong probe: unanswered INVITEs leave transactions
    retransmitting for ~32 s, and that storm's timing swamped the
    signal — ring-on swung 61 → 125 MB while ring-off held ±1.3. With
    OPTIONS, ring-on repeats to ±0.2 MB.

The ~55 MB ceiling is arithmetic on a measured rate, labelled as such,
and needs 512 concurrent calls each having exchanged 64+ SIP messages —
real calls here carry 4–8. It scales linearly with
`sip_ring_max_messages`, which is the knob if it ever matters.

Also states what this still does not cover: the live population's cost
specifically (every trace measured here is noise, capped at 256 by the
pending bound as designed), whether freed ring memory returns to the OS,
and the real-world message-size distribution.

---

Docs + test-harness only; no daemon, sightglass, or protocol code touched. Closes the one item `RESULTS-0.49.5-sip-ring.md` left open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWos69HjV9pxvUJhRusU4D