### PR TITLE
chore(release): 0.49.8 — the daemon says who it is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.49.8] - 2026-08-21
+
+`[sip].user_agent` finally does what this repo has documented it doing
+since it was added, a `[[register]]` block can no longer be silently
+dead, and the SIPp harness stops reporting its own port collisions as
+product regressions. Three siphon-rs releases are absorbed along the
+way, two of them cut for fixes this project filed.
+
+**Upgrade note: this changes what your node says on the wire**, so it
+wants a restart to take effect. No config change is required (the new
+validation only refuses a combination that never worked), no protocol
+change (WS stays version `"1"`), and no CDR change (still v8).
+
+### On the wire: one change to `User-Agent` / `Server`
+
+Four entries below touch these two headers, which reads like four
+changes. For anyone who deploys **releases**, it is exactly one:
+
+| | 0.49.7 and every release before it | 0.49.8 |
+|---|---|---|
+| `Server` on responses | `siphon-rs/0.1.0` | **`siphon-ai/0.49.8`** |
+| `User-Agent` on requests | `siphon-rs/0.1.0` | **`siphon-ai/0.49.8`** |
+| with `[sip].user_agent` set | *ignored* — still `siphon-rs/0.1.0` | **the configured value**, both headers |
+
+`siphon-rs/0.1.0` was a version number that never corresponded to
+anything: it was hardcoded upstream before any release existed, and
+this daemon took it because `[sip].user_agent` was wired to nothing.
+The intermediate values you will see in the entries below —
+`sip-uas/0.3.0`, `sip-uac/0.5.0`, `sip-uac/0.6.0` — existed only in
+unreleased builds between the dependency bumps; no tagged siphon-ai
+ever shipped them.
+
+**What to check before upgrading:** anything that matches on either
+header — a carrier-side rule, a Homer search, a log or capture filter,
+an SBC's UA-based routing. If you would rather keep a stable string
+across this transition, set `[sip].user_agent` to whatever you were
+matching on; it is honoured now.
+
 ### Fixed
 
 - **A `[[register]]` block on an ephemeral SIP port is now refused at config load, instead of dying quietly at runtime.** The Contact a registrar routes calls back through is built from the *configured* `[sip].listen` port — `[node].public_address` replaces only the host — so `listen = "0.0.0.0:0"` produced `sip:user@0.0.0.0:0`, which is not a valid SIP URI. Until siphon-rs v2026.08.20.1 that panicked the registration's drive task; after it, the task ends with a `warn!` and that registration is simply dead on a daemon whose `/ready`, metrics and other registrations all look fine. CLAUDE.md §4.6 puts this class of check at load time, so `siphon-ai check` and startup both refuse it now, naming the block and quoting the listen. An ephemeral bind with no `[[register]]` blocks is untouched — nothing needs advertising.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4083,7 +4083,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.49.7"
+version = "0.49.8"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4132,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-admin-api-types"
-version = "0.49.7"
+version = "0.49.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -4140,7 +4140,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.49.7"
+version = "0.49.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4156,7 +4156,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.49.7"
+version = "0.49.8"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4178,7 +4178,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.49.7"
+version = "0.49.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4195,7 +4195,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.49.7"
+version = "0.49.8"
 dependencies = [
  "regex",
  "serde",
@@ -4214,7 +4214,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.49.7"
+version = "0.49.8"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4260,7 +4260,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.49.7"
+version = "0.49.8"
 dependencies = [
  "base64 0.22.1",
  "hmac 0.12.1",
@@ -4283,7 +4283,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.49.7"
+version = "0.49.8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4309,7 +4309,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.49.7"
+version = "0.49.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -4327,7 +4327,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.49.7"
+version = "0.49.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4345,7 +4345,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.49.7"
+version = "0.49.8"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4359,7 +4359,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.49.7"
+version = "0.49.8"
 dependencies = [
  "regex",
  "serde",
@@ -4371,7 +4371,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.49.7"
+version = "0.49.8"
 dependencies = [
  "schemars",
  "serde",
@@ -4381,7 +4381,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sightglass"
-version = "0.49.7"
+version = "0.49.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -4396,7 +4396,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.49.7"
+version = "0.49.8"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4424,7 +4424,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.49.7"
+version = "0.49.8"
 dependencies = [
  "base64 0.22.1",
  "rcgen",
@@ -4442,7 +4442,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.49.7"
+version = "0.49.8"
 dependencies = [
  "anyhow",
  "forge-engine",
@@ -4474,7 +4474,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.49.7"
+version = "0.49.8"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.49.7"
+version = "0.49.8"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.49.7.** Production-deployed against real carriers
+**Current release: v0.49.8.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged. Daemon upgrades are near-drop-in


### PR DESCRIPTION
`[sip].user_agent` finally does what this repo has documented it doing since it
was added, a `[[register]]` block can no longer be silently dead, and the SIPp
harness stops reporting its own port collisions as product regressions. Three
siphon-rs releases are absorbed along the way, two of them cut for fixes filed
from here.

## On the wire: one change, not four

Four changelog entries touch `User-Agent` / `Server`, which reads like four
changes. For anyone who deploys **releases**, it is exactly one:

| | 0.49.7 and every release before it | 0.49.8 |
|---|---|---|
| `Server` on responses | `siphon-rs/0.1.0` | **`siphon-ai/0.49.8`** |
| `User-Agent` on requests | `siphon-rs/0.1.0` | **`siphon-ai/0.49.8`** |
| with `[sip].user_agent` set | *ignored* | **the configured value**, both headers |

`siphon-rs/0.1.0` was a version number that never corresponded to anything —
hardcoded upstream before any release existed, and taken by this daemon because
`[sip].user_agent` reached exactly one call site that threw it away. The
intermediate tokens the entries mention (`sip-uas/0.3.0`, `sip-uac/0.5.0`,
`sip-uac/0.6.0`) existed only in unreleased builds between dependency bumps; no
tagged siphon-ai ever shipped them.

**Before upgrading**, check anything matching on either header: a carrier-side
rule, a Homer search, a log or capture filter, UA-based SBC routing. A
deployment that wants to keep a stable string across the transition can set
`[sip].user_agent` to whatever it was matching on — that key is honoured now.

## What's in it

**Fixed** — the `[[register]]` ephemeral-port refusal (#546), both halves of
`[sip].user_agent` (#542, #545 closing #539), and the SIPp harness preflight
(#543 closing #541).

**Changed** — siphon-rs `99da91f5` → v2026.08.19 → v2026.08.20 → v2026.08.20.1
(#540, #544, #545). The pins are release tags now rather than revs, per
upstream's `RELEASING.md`.

**Documentation** — the ring-memory A/B, and the design note whose worst-case
bound was an order of magnitude low (#537, #538).

## Upgrade note

Wants a restart. No config change required — the new validation refuses only a
combination that never worked. No protocol change (WS stays version `"1"`), no
CDR change (still v8).

## Verification

- `cargo test --workspace --locked` — **1,288 passed / 0 failed**
- clippy `-D warnings`, `cargo fmt --all --check` — clean
- all four check scripts (doc links, version consistency, observability
  artifacts, protocol schema) — pass
- `cargo audit` — clean; the 6 allowed informational warnings are unchanged
- SIPp signalling — **39 of 40**; `barge_in_pause` needs a `setcap` this host
  does not grant and fails identically on `main`

After merge: tag `v0.49.8` and cut the GitHub release. Remember sightglass ships
in the **tarball**, never the `.deb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011FQwSJ3QXEnPQXGazUXvv5