### PR TITLE
fix(core): retire an outbound leg's dialog at teardown (#548)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Outbound calls no longer leak a dialog apiece** (#548). Gateway UACs
+  are built with the UAS's `DialogManager` (#324), so an originated
+  call's confirmed dialog lands in the shared store — but only the
+  inbound teardown retired one, so the store grew by one entry per
+  originated call for the life of the process and
+  `siphon_ai_dialogs_active` never came back down. Past `sip-dialog`'s
+  `MAX_CONFIRMED_DIALOGS` (10,000) `insert` fails silently and in-dialog
+  requests stop matching — for inbound calls too, since the store is
+  shared. The outbound teardown now retires its dialog after the BYE
+  exchange, on the same deferred grace window the inbound path uses
+  (#458), whichever side hung up. Present since #458 first shipped in
+  0.48.13; a node that only accepts inbound calls was never affected.
+
 ## [0.49.8] - 2026-08-21
 
 `[sip].user_agent` finally does what this repo has documented it doing

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -951,7 +951,10 @@ impl Runtime {
             Arc::clone(&transfer_uac),
             dialog_manager,
             consult_registry.clone(),
-            dialog_reaper,
+            // Cloned, not moved: the outbound service needs the same
+            // reaper to retire its own legs' dialogs (#548). The gateway
+            // UACs share this store, so both paths must reclaim.
+            dialog_reaper.clone(),
         );
 
         // ─── Per-registration UAC drive tasks ──────────────────────
@@ -1064,6 +1067,12 @@ impl Runtime {
             // Refuse origination while draining, same DrainFlag the
             // inbound routing handler uses to 503 new INVITEs (#343).
             service = service.with_drain(drain.clone());
+            // Reclaim each finished outbound leg's dialog from the shared
+            // store. The gateway UACs are built with the UAS's
+            // DialogManager (#324), so without this the store grew by one
+            // entry per originated call for the process's lifetime and
+            // `siphon_ai_dialogs_active` never came back down (#548).
+            service = service.with_dialog_reaper(dialog_reaper.clone());
             // Hold music for the WS-reconnect gap on outbound legs (0.7.3) —
             // the same [media].moh_file the inbound acceptor uses.
             service = service.with_moh_file(media.moh_file.clone());

--- a/crates/core/src/outbound_service.rs
+++ b/crates/core/src/outbound_service.rs
@@ -245,6 +245,13 @@ pub struct OutboundService {
     /// INVITEs. `None` in tests / when the runtime never installs one, in
     /// which case origination is never gated (issue #343).
     drain: Option<siphon_ai_sip_glue::DrainFlag>,
+    /// Reclaims each finished outbound leg's dialog from the shared store
+    /// (#548). The gateway UACs are built with the UAS's `DialogManager`
+    /// (#324), so an originated call's confirmed dialog lands in the very
+    /// store the reaper sweeps — but only the inbound teardown retired it,
+    /// so the store grew by one entry per originated call for the life of
+    /// the process. `None` in tests / when the runtime never installs one.
+    dialog_reaper: Option<crate::dialog_reaper::DialogReaper>,
 }
 
 impl OutboundService {
@@ -275,6 +282,7 @@ impl OutboundService {
             recording_upload: None,
             session_timers: None,
             drain: None,
+            dialog_reaper: None,
         }
     }
 
@@ -298,6 +306,20 @@ impl OutboundService {
     /// refused while draining (issue #343). Unset → never gated.
     pub fn with_drain(mut self, drain: siphon_ai_sip_glue::DrainFlag) -> Self {
         self.drain = Some(drain);
+        self
+    }
+
+    /// Share the daemon's dialog reaper so a finished outbound leg's
+    /// dialog is reclaimed from the shared store (#548).
+    ///
+    /// Unset → the dialog is never removed and `siphon_ai_dialogs_active`
+    /// climbs by one per originated call for the life of the process,
+    /// which is the pre-#548 behaviour. Past `sip-dialog`'s
+    /// `MAX_CONFIRMED_DIALOGS` (10,000) `insert` fails silently and
+    /// in-dialog requests stop matching — on inbound legs too, since the
+    /// store is shared (#458).
+    pub fn with_dialog_reaper(mut self, reaper: crate::dialog_reaper::DialogReaper) -> Self {
+        self.dialog_reaper = Some(reaper);
         self
     }
 
@@ -502,6 +524,7 @@ impl OutboundOriginateHandle for OutboundService {
         let control_registry = self.control_registry.clone();
         let call_registry = self.call_registry.clone();
         let park = self.park.clone();
+        let dialog_reaper = self.dialog_reaper.clone();
         // WS reconnect (0.7.3) — outbound legs reconnect on the same daemon
         // defaults as inbound; extracted before the spawn (no `self` inside).
         let ws_reconnect_enabled = self.defaults.ws_reconnect_enabled;
@@ -586,6 +609,7 @@ impl OutboundOriginateHandle for OutboundService {
                         recording_upload,
                         barge_in_mode,
                         ws_failure_prompt,
+                        dialog_reaper,
                     };
                     run_call(originator, call, bridge, ctx).await;
                 }
@@ -682,6 +706,10 @@ struct OutboundCallContext {
     /// WS-failure prompt (0.34.0), from the daemon `[bridge]` defaults
     /// (no route on originated calls). `None` = plain hangup.
     ws_failure_prompt: Option<std::path::PathBuf>,
+    /// Retires this leg's dialog once the BYE exchange is done (#548).
+    /// `None` leaves the dialog in the shared store forever, exactly as
+    /// before — which is what the CDR-shape tests below expect.
+    dialog_reaper: Option<crate::dialog_reaper::DialogReaper>,
 }
 
 /// Run an answered outbound call's audio bridge to completion, tear it
@@ -765,9 +793,14 @@ async fn run_call(
     // Outbound legs are transferable too (DEV_PLAN_0.6.1 §2.4): the
     // bot can consult an agent and hand this callee off. The REFER
     // goes through this gateway's own UAC (digest credentials), on
-    // the dialog we hold directly — each gateway UAC keeps a private
-    // DialogManager, so the shared lookup the inbound path uses
-    // can't see this dialog.
+    // the dialog we hold directly — resolved from the `Direct` source
+    // below rather than by call-id lookup, because this task already
+    // owns the dialog. (The store itself *is* shared: `build_outbound_uac`
+    // is built with the UAS's `DialogManager` so the far end's in-dialog
+    // requests dispatch against a dialog it can see — #324. An earlier
+    // version of this comment claimed the gateway UACs kept private
+    // stores; they do not, which is why their dialogs must be retired at
+    // teardown — #548.)
     // One shared, advancing dialog for every in-dialog request on this
     // leg — transfer REFER, hold/resume re-INVITE, and the teardown BYE
     // below all resolve from and commit back to it, so its local CSeq
@@ -1113,6 +1146,16 @@ async fn run_call(
         let final_dialog = shared_dialog.lock().clone();
         originator.hangup(&final_dialog).await;
     }
+    // Retire the dialog now that the BYE exchange is done, whichever side
+    // sent it. Removal is deferred by the reaper's grace window, so a BYE
+    // retransmit arriving after this still matches — the same ordering the
+    // inbound teardown keeps (#458). Outbound legs share the UAS's store
+    // (#324), so without this the store grew by one entry per originated
+    // call until `MAX_CONFIRMED_DIALOGS` silently broke in-dialog matching
+    // for *every* call, inbound ones included (#548).
+    if let Some(reaper) = ctx.dialog_reaper.as_ref() {
+        reaper.retire(outbound_dialog_id.clone());
+    }
     originator.stop_session(&call_id).await;
     drop(call_handle); // stop keepalives / session-timer tasks
 
@@ -1429,6 +1472,7 @@ mod tests {
             recording_upload: None,
             barge_in_mode: siphon_ai_bridge::BargeInModeInfo::AutoClear,
             ws_failure_prompt: None,
+            dialog_reaper: None,
         };
         let view = CallTerminationView {
             cause: CdrTerminationCause::ServerHangup,

--- a/test-harness/sipp-scenarios/README.md
+++ b/test-harness/sipp-scenarios/README.md
@@ -83,6 +83,26 @@ backgrounds SIPp as the callee, then POSTs `/admin/v1/calls`. Pass = SIPp
 completed INVITE → ACK → BYE **and** the daemon's
 `siphon_ai_outbound_calls_total{result="answered"}` metric reads 1.
 
+That phase is followed by **outbound_dialog_reclaimed** (#548), which reuses
+the same daemon and asserts `siphon_ai_dialogs_active` returns to `0` after
+the leg ends. Outbound gateway UACs share the UAS's `DialogManager` (#324),
+so an originated call's dialog lands in the store the reaper sweeps; before
+#548 only the inbound teardown retired one and the gauge climbed by one per
+originated call forever, until `MAX_CONFIRMED_DIALOGS` silently broke
+in-dialog matching for every call. It is the **slowest check in the suite**
+(up to ~50 s): removal is deferred by `DialogReaper::DEFAULT_GRACE` — 32 s,
+SIP Timer H/J — so a retransmitted BYE still matches, and that window is not
+configurable. It polls once a second rather than sleeping flat, and runs only
+when the outbound phase itself passed.
+
+It asserts in two steps — gauge becomes non-zero, *then* returns to `0` —
+and the order matters. The UAC inserts the dialog into the store when it
+sends the BYE, and the reaper republishes the gauge only on its 5 s sweep,
+so for a few seconds after teardown the gauge still reads the pre-BYE `0`.
+A single `== 0` assertion passes on that stale sample even against a daemon
+that reclaims nothing: the first cut of this check went green against the
+unfixed binary for exactly that reason.
+
 And an always-on **outbound_srtp** auxiliary phase (0.7.1): the same setup
 but the `[[gateway]]` sets `srtp = "required"`, so SiphonAI's INVITE offers
 `RTP/SAVP` + `a=crypto` (SDES). `outbound_srtp_uas_answer.xml` answers SAVP

--- a/test-harness/sipp-scenarios/run-all.sh
+++ b/test-harness/sipp-scenarios/run-all.sh
@@ -689,6 +689,56 @@ else
     failures=$((failures + 1))
 fi
 
+# ─── The finished leg's dialog must leave the shared store (#548) ──
+# The gateway UACs are built with the UAS's DialogManager (#324), so an
+# originated call's confirmed dialog lands in the store the reaper
+# sweeps. Until #548 only the *inbound* teardown retired one, so this
+# gauge climbed by one per originated call and never came back down —
+# and past sip-dialog's MAX_CONFIRMED_DIALOGS (10,000) `insert` fails
+# silently and in-dialog requests stop matching for every call.
+#
+# This is the one assertion in the suite that has to wait out a real
+# timer: removal is deliberately deferred by DialogReaper::DEFAULT_GRACE
+# (32 s = Timer H/J) so a retransmitted BYE still matches, and that
+# window is not configurable. Polls rather than sleeps flat, so it costs
+# only what it must, and only when the preceding call actually answered.
+total=$((total + 1))
+echo "─── outbound_dialog_reclaimed ────────────────────────"
+ob_reclaim_ok=0
+ob_gauge() {
+    curl -s "http://127.0.0.1:$OB_ADMIN_PORT/metrics" \
+        | awk '/^siphon_ai_dialogs_active /{print $2}'
+}
+if (( ob_ok )); then
+    # Two-step on purpose. The gauge is republished by the reaper's
+    # sweep (every 5 s), and the UAC inserts the dialog when it sends
+    # the BYE — so for a few seconds after teardown it still reads the
+    # pre-BYE `0`. Asserting `== 0` straight away passes on that stale
+    # sample even against a daemon that never reclaims anything, which
+    # is exactly how a first cut of this check went green on the bug.
+    # So: wait for the store to publish the dialog, *then* wait for it
+    # to go away.
+    ob_tracked=0
+    for _ in $(seq 1 12); do
+        [[ "$(ob_gauge)" != "0" ]] && { ob_tracked=1; break; }
+        sleep 1
+    done
+    if (( ob_tracked )); then
+        for _ in $(seq 1 50); do
+            [[ "$(ob_gauge)" == "0" ]] && { ob_reclaim_ok=1; break; }
+            sleep 1
+        done
+    else
+        echo "  (dialog never published as tracked — check the gauge//metrics wiring)"
+    fi
+fi
+if (( ob_reclaim_ok )); then
+    echo "  OK"
+else
+    echo "  FAIL (dialog not reclaimed past the 32s grace: gauge=$(ob_gauge); daemon: $OB_DAEMON_LOG)"
+    failures=$((failures + 1))
+fi
+
 ob_cleanup
 trap - EXIT
 


### PR DESCRIPTION
Closes #548.

## The bug

`build_outbound_uac` is deliberately built with the UAS's `DialogManager` (#324) — a private store would register an originated call's confirmed dialog where inbound dispatch can't see it, so the far end's in-dialog requests would get `481`. That sharing is correct. What was missing is the other half: only the **inbound** teardown ever retired a dialog, so the shared store grew by one entry per originated call for the life of the process.

Past `sip-dialog`'s `MAX_CONFIRMED_DIALOGS` (10,000), `insert` fails silently and in-dialog requests stop matching — and because the store is shared, that degrades **inbound** calls too. Present since #458's fix first shipped in 0.48.13, which wired `reaper.retire` into `acceptor.rs` only. A node that never originates was never affected.

Found while verifying the 0.49.8 deploy: two originated calls took `siphon_ai_dialogs_active` from 0 → 1 → 2, where it stayed with `calls_active 0` and `/admin/v1/calls` empty.

## The fix

Retire the dialog in the outbound teardown after the BYE exchange, whichever side sent it, deferred by the same grace window the inbound path uses (`acceptor.rs:3836-3841`) so a BYE retransmit still matches. The reaper reaches the outbound service through a new `with_dialog_reaper`; unset it and you get exactly the pre-#548 behaviour, which is what the existing tests expect.

## Proof

A/B on one rig — a single originated call, SIPp as the callee, WS-side hangup:

| build | dialog tracked | outcome |
|---|---|---|
| shipped 0.49.8 | yes, gauge 1 at t=3s | **gauge still 1 at t=50s** — never reclaimed |
| this build | yes, gauge 1 at t=3s | **gauge back to 0 at t=35s** — 32 s grace + one sweep |

## The test, and a trap worth reading

The harness gets that A/B as a new always-on `outbound_dialog_reclaimed` phase, reusing the existing outbound daemon.

It asserts in **two steps** — gauge becomes non-zero, *then* returns to `0`. The order is load-bearing: the UAC inserts the dialog into the store when it sends the BYE, and the reaper republishes the gauge only on its 5 s sweep, so for a few seconds after teardown the gauge still reads the pre-BYE `0`. My first cut asserted `== 0` directly and **went green against the unfixed binary** on that stale sample. Both the script and the README say so, so nobody simplifies it back.

**It costs up to ~50 s**, which makes it the slowest check in a suite whose longest existing sleep is 3 s. That is irreducible without making `DialogReaper::DEFAULT_GRACE` (32 s = SIP Timer H/J) configurable, which I didn't want to do for a test. It polls rather than sleeping flat and runs only when the outbound phase itself passed — happy to drop it or gate it behind a flag if you'd rather not pay that in CI.

## Also

Corrects the comment at `outbound_service.rs` claiming each gateway UAC keeps a private `DialogManager`. They share the UAS's — which is precisely why their dialogs must be retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FF7ymKTPqhd7d5CNxjG8bg