### PR TITLE
chore(deps): bump siphon-rs to v2026.08.21, closing #549

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **In-dialog requests on outbound legs stop swapping their `From` URI
+  mid-dialog** (#549), via siphon-rs `v2026.08.20.1` → `v2026.08.21`
+  (its #121, opened from here). A UAC dialog's local URI now comes from
+  the dialog-forming request's `From` rather than the client's configured
+  identity, per RFC 3261 §12.2.1.1. Every outbound leg sets a per-call
+  `From` — a `[[gateway]]`'s `from`, or its `[[register]]` AOR, is the
+  caller-ID — so our BYE went out as `sip:siphon@<public_address>` on a
+  dialog the INVITE had opened as the AOR, same tag. FreeSWITCH tolerated
+  it (it matches on Call-ID + tags); a URI-validating peer answers `481`
+  and the leg then hangs to the far end's media timeout, and From-based
+  CDR correlation splits one call across two identities. The same release
+  stamps `User-Agent` on the 15 of 27 upstream request builders that never
+  did — our ACK and BYE carried none, so 0.49.8's product token covered
+  only part of a call's traffic. Tag bump only; no API change, no config
+  change, sip-uac 0.7.0 → 0.7.1.
+
 - **Outbound calls no longer leak a dialog apiece** (#548). Gateway UACs
   are built with the UAS's `DialogManager` (#324), so an originated
   call's confirmed dialog lands in the shared store — but only the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3854,7 +3854,7 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 [[package]]
 name = "sip-auth"
 version = "0.4.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.20.1#ff51505bf8616d8687db3a7c3dae9c03d733ace3"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.21#e280e42fd01009c81cead1fd9455ace8e015e4bf"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3877,7 +3877,7 @@ dependencies = [
 [[package]]
 name = "sip-core"
 version = "0.7.7"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.20.1#ff51505bf8616d8687db3a7c3dae9c03d733ace3"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.21#e280e42fd01009c81cead1fd9455ace8e015e4bf"
 dependencies = [
  "bytes",
  "httpdate",
@@ -3890,7 +3890,7 @@ dependencies = [
 [[package]]
 name = "sip-dialog"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.20.1#ff51505bf8616d8687db3a7c3dae9c03d733ace3"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.21#e280e42fd01009c81cead1fd9455ace8e015e4bf"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3908,7 +3908,7 @@ dependencies = [
 [[package]]
 name = "sip-dns"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.20.1#ff51505bf8616d8687db3a7c3dae9c03d733ace3"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.21#e280e42fd01009c81cead1fd9455ace8e015e4bf"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3922,7 +3922,7 @@ dependencies = [
 [[package]]
 name = "sip-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.20.1#ff51505bf8616d8687db3a7c3dae9c03d733ace3"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.21#e280e42fd01009c81cead1fd9455ace8e015e4bf"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -3933,7 +3933,7 @@ dependencies = [
 [[package]]
 name = "sip-identity"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.20.1#ff51505bf8616d8687db3a7c3dae9c03d733ace3"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.21#e280e42fd01009c81cead1fd9455ace8e015e4bf"
 dependencies = [
  "base64 0.22.1",
  "ring",
@@ -3946,7 +3946,7 @@ dependencies = [
 [[package]]
 name = "sip-observe"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.20.1#ff51505bf8616d8687db3a7c3dae9c03d733ace3"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.21#e280e42fd01009c81cead1fd9455ace8e015e4bf"
 dependencies = [
  "once_cell",
  "tracing",
@@ -3955,7 +3955,7 @@ dependencies = [
 [[package]]
 name = "sip-parse"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.20.1#ff51505bf8616d8687db3a7c3dae9c03d733ace3"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.21#e280e42fd01009c81cead1fd9455ace8e015e4bf"
 dependencies = [
  "bytes",
  "httpdate",
@@ -3969,7 +3969,7 @@ dependencies = [
 [[package]]
 name = "sip-ratelimit"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.20.1#ff51505bf8616d8687db3a7c3dae9c03d733ace3"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.21#e280e42fd01009c81cead1fd9455ace8e015e4bf"
 dependencies = [
  "dashmap 5.5.3",
  "parking_lot",
@@ -3989,7 +3989,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.20.1#ff51505bf8616d8687db3a7c3dae9c03d733ace3"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.21#e280e42fd01009c81cead1fd9455ace8e015e4bf"
 dependencies = [
  "nom 7.1.3",
  "smol_str",
@@ -3998,7 +3998,7 @@ dependencies = [
 [[package]]
 name = "sip-transaction"
 version = "0.6.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.20.1#ff51505bf8616d8687db3a7c3dae9c03d733ace3"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.21#e280e42fd01009c81cead1fd9455ace8e015e4bf"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4017,7 +4017,7 @@ dependencies = [
 [[package]]
 name = "sip-transport"
 version = "0.4.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.20.1#ff51505bf8616d8687db3a7c3dae9c03d733ace3"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.21#e280e42fd01009c81cead1fd9455ace8e015e4bf"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4037,8 +4037,8 @@ dependencies = [
 
 [[package]]
 name = "sip-uac"
-version = "0.7.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.20.1#ff51505bf8616d8687db3a7c3dae9c03d733ace3"
+version = "0.7.1"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.21#e280e42fd01009c81cead1fd9455ace8e015e4bf"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4063,7 +4063,7 @@ dependencies = [
 [[package]]
 name = "sip-uas"
 version = "0.4.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.20.1#ff51505bf8616d8687db3a7c3dae9c03d733ace3"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.21#e280e42fd01009c81cead1fd9455ace8e015e4bf"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,21 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 # impossible type mismatches.
 
 # siphon-rs — RFC 3261 SIP stack.
-# Bumped 2026-08-20 **v2026.08.20** → **v2026.08.20.1** = siphon-rs #119
+# Bumped 2026-08-21 **v2026.08.20.1** → **v2026.08.21** = siphon-rs #121
+# (opened from this project against its own #549, found while verifying the
+# 0.49.8 deploy): a UAC dialog's local URI now comes from the dialog-forming
+# request's `From` instead of the client's configured identity, per RFC 3261
+# §12.2.1.1. The two agree for a client that always dials as itself and
+# diverge for one that sets a per-call `From` — which every outbound leg here
+# does, since a `[[gateway]]`'s `from` (or its `[[register]]` AOR) is the
+# caller-ID. So our BYE went out as `sip:siphon@<public>` on a dialog the
+# INVITE had opened as `sip:1000@<pbx>`, same tag: FreeSWITCH tolerated it
+# (it matches Call-ID + tags), a URI-validating peer answers 481, and
+# From-based CDR correlation splits one call in two. The same release stamps
+# `User-Agent` on the 15 of 27 request builders that never did — our ACK and
+# BYE carried none. No API change, so this is a tag bump and nothing else;
+# sip-uac 0.7.0 → 0.7.1, every other crate unchanged.
+# (Prior: 2026-08-20 **v2026.08.20** → **v2026.08.20.1** = siphon-rs #119
 # (its #118, filed from this project while bumping onto v2026.08.20): the
 # integrated builders' `local_uri` / `contact_uri` now return `Result`
 # instead of parsing with `.ok()` and discarding the failure. A rejected
@@ -158,7 +172,7 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 # on `listen = "0.0.0.0:0"` took down its task. **Breaking**: the four
 # call sites below (UAS, transfer UAC, gateway UAC, per-`[[register]]`
 # UAC) now carry the `?` and name themselves in the error. sip-uac
-# 0.6.0 → 0.7.0, sip-uas 0.3.0 → 0.4.0; every other crate unchanged.
+# 0.6.0 → 0.7.0, sip-uas 0.3.0 → 0.4.0; every other crate unchanged.)
 # (Prior: 2026-08-20 **v2026.08.19** → **v2026.08.20** = siphon-rs #116,
 # opened from this project against its own #539: `UACConfig::user_agent`
 # now reaches the `User-Agent` header. The field was documented as the
@@ -305,31 +319,31 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 #  `6fd432270bb8` = #67 dialog_manager share, siphon-ai #324;
 #  `fcaff011f9c6` = #65 invite_with_from, siphon-ai #316;
 #  `3a4fc312ade3` = #64 TLS-SNI-is-hostname, siphon-ai #312.)
-sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.20.1" }
-sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.20.1" }
-sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.20.1", features = ["tls"] }
-sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.20.1" }
-sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.20.1" }
-sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.20.1" }
-sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.20.1" }
-sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.20.1" }
-sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.20.1" }
+sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.21" }
+sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.21" }
+sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.21", features = ["tls"] }
+sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.21" }
+sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.21" }
+sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.21" }
+sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.21" }
+sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.21" }
+sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.21" }
 # sip-sdp — the SAME sip-sdp sip-uac's SdpAnswerGenerator trait speaks
 # (distinct from forge-media's pinned sip-sdp). Used by the outbound
 # delayed-offer answer generator to hand the UAC a SessionDescription it
 # accepts. Must stay on the same siphon-rs rev as the rest below.
-sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.20.1" }
-sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.20.1" }
+sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.21" }
+sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.21" }
 # sip-observe — the transport-layer observability seam. We implement its
 # `TransportMetrics` trait in siphon-ai-telemetry and install it with
 # `set_transport_metrics`, which is the only way to see ingress
 # rate-limit drops: the hook is defaulted to a no-op upstream, so an
 # embedder that installs nothing (as we did until 0.48.11) silently gets
 # the `NoopTransportMetrics` fallback (siphon-ai #459).
-sip-observe     = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.20.1" }
+sip-observe     = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.21" }
 # sip-identity — STIR/SHAKEN Identity-header parsing + PASSporT verification
 # (ES256 + X.509 chain validation). Consumed by the stir-shaken verifier crate.
-sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.20.1" }
+sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.21" }
 
 # forge-media — RTP / codecs / SDP / DTMF / engine.
 #


### PR DESCRIPTION
Closes #549. Absorbs [siphon-rs#121](https://github.com/thevoiceguy/siphon-rs/pull/121), released as [v2026.08.21](https://github.com/thevoiceguy/siphon-rs/releases/tag/v2026.08.21).

## What it fixes here

A UAC dialog's local URI now comes from the dialog-forming request's `From` rather than the client's configured identity, per RFC 3261 §12.2.1.1.

That distinction is invisible to a client that always dials as itself and unavoidable for us: **every outbound leg sets a per-call `From`** — a `[[gateway]]`'s `from`, or its `[[register]]` AOR, is the caller-ID. So on every originated call our BYE went out as `sip:siphon@<public_address>` on a dialog the INVITE had opened as the AOR, keeping the tag. FreeSWITCH tolerated it (Call-ID + tags match); a URI-validating peer answers `481` and the leg then hangs to the far end's media timeout, and From-based CDR correlation splits one call across two identities.

The same release stamps `User-Agent` on the 15 of 27 upstream request builders that never did — ours were showing the token on the INVITE and nothing on the ACK or the BYE, so 0.49.8's "the daemon says who it is" only held for part of a call's traffic.

## Verified on this pin

Not the `[patch]` used while developing upstream — this is the real tag. One originated call, SIPp as the callee, from SIPp's own capture:

| | From | User-Agent |
|---|---|---|
| **before** INVITE | `<sip:harness@127.0.0.1>;tag=oj4l…` | `siphon-ai/0.49.8` |
| **before** ACK | `<sip:harness@127.0.0.1>;tag=oj4l…` | *(absent)* |
| **before** BYE | `<sip:siphon@127.0.0.1>;tag=oj4l…` | *(absent)* |
| **after** INVITE | `<sip:harness@127.0.0.1>;tag=xLeY…` | `siphon-ai/0.49.8` |
| **after** ACK | `<sip:harness@127.0.0.1>;tag=xLeY…` | `siphon-ai/0.49.8` |
| **after** BYE | `<sip:harness@127.0.0.1>;tag=xLeY…` | `siphon-ai/0.49.8` |

## Scope of the diff

No API change upstream, so this is the tag on all 13 `sip-*` pins plus a lockfile line. `sip-uac` 0.7.0 → 0.7.1; every other crate unchanged. The `Cargo.lock` diff touches nothing but the siphon-rs `source =` lines and that one version — hand-checked, because `cargo update --precise` has silently downgraded unrelated crates in this repo before.

60 test binaries green, clippy and fmt clean, `cargo metadata --locked` consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FF7ymKTPqhd7d5CNxjG8bg