### PR TITLE
chore(release): 0.49.9 — outbound legs stop leaking dialogs and identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.49.9] - 2026-08-21
+
+Two fixes to the **outbound** call path, both found while verifying the
+0.49.8 deploy and both older than it. Neither affects a node that only
+accepts inbound calls; both matter to one that originates.
+
+**No config change, no protocol change** (still `1`), CDR still v8. Wants
+a restart to take effect.
+
 ### Fixed
 
 - **In-dialog requests on outbound legs stop swapping their `From` URI

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4083,7 +4083,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.49.8"
+version = "0.49.9"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4132,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-admin-api-types"
-version = "0.49.8"
+version = "0.49.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -4140,7 +4140,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.49.8"
+version = "0.49.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4156,7 +4156,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.49.8"
+version = "0.49.9"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4178,7 +4178,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.49.8"
+version = "0.49.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4195,7 +4195,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.49.8"
+version = "0.49.9"
 dependencies = [
  "regex",
  "serde",
@@ -4214,7 +4214,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.49.8"
+version = "0.49.9"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4260,7 +4260,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.49.8"
+version = "0.49.9"
 dependencies = [
  "base64 0.22.1",
  "hmac 0.12.1",
@@ -4283,7 +4283,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.49.8"
+version = "0.49.9"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4309,7 +4309,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.49.8"
+version = "0.49.9"
 dependencies = [
  "anyhow",
  "clap",
@@ -4327,7 +4327,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.49.8"
+version = "0.49.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4345,7 +4345,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.49.8"
+version = "0.49.9"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4359,7 +4359,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.49.8"
+version = "0.49.9"
 dependencies = [
  "regex",
  "serde",
@@ -4371,7 +4371,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.49.8"
+version = "0.49.9"
 dependencies = [
  "schemars",
  "serde",
@@ -4381,7 +4381,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sightglass"
-version = "0.49.8"
+version = "0.49.9"
 dependencies = [
  "anyhow",
  "clap",
@@ -4396,7 +4396,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.49.8"
+version = "0.49.9"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4424,7 +4424,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.49.8"
+version = "0.49.9"
 dependencies = [
  "base64 0.22.1",
  "rcgen",
@@ -4442,7 +4442,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.49.8"
+version = "0.49.9"
 dependencies = [
  "anyhow",
  "forge-engine",
@@ -4474,7 +4474,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.49.8"
+version = "0.49.9"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.49.8"
+version = "0.49.9"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.49.8.** Production-deployed against real carriers
+**Current release: v0.49.9.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged. Daemon upgrades are near-drop-in


### PR DESCRIPTION
Release PR for 0.49.9. Version + CHANGELOG heading + README, nothing else — both fixes are already on main (#550, #551).

Two fixes to the **outbound** call path, both found while verifying the 0.49.8 deploy and both older than it. A node that only accepts inbound calls is unaffected by either; a node that originates wants both.

- **#548** — outbound calls leaked a dialog apiece. `siphon_ai_dialogs_active` climbed by one per originated call and never came back down; past `sip-dialog`'s `MAX_CONFIRMED_DIALOGS` (10,000) `insert` fails silently and in-dialog matching degrades for *every* call, inbound included, because the store is shared. Present since #458 shipped in 0.48.13.
- **#549** — in-dialog requests swapped their `From` URI mid-dialog. Fixed upstream (siphon-rs [v2026.08.21](https://github.com/thevoiceguy/siphon-rs/releases/tag/v2026.08.21)) and absorbed by a tag bump. Carries the `User-Agent` sweep with it, so 0.49.8's product token now covers a whole call's traffic instead of the INVITE alone.

**No config change. Protocol still `1`, CDR still v8.** Wants a restart to take effect.

Verified on main before cutting: 60 test binaries green, clippy and fmt clean, `cargo metadata --locked` consistent, and both fixes re-proven live on the real pin (the originate A/B and the SIPp capture are in #550 and #551).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FF7ymKTPqhd7d5CNxjG8bg