### PR TITLE
test(load): complete the load test plan — outbound, tier 3, mixed direction and soak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ Thumbs.db
 
 # Local config / secrets
 *.local.toml
+# Load-rig configs are copied from their .example and edited per box
+test-harness/load/**/outbound-lab.toml
+test-harness/load/**/tier2-lab.toml
+test-harness/load/**/tier2-tls.toml
 .env
 .env.*
 !.env.example

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ Thumbs.db
 *.local.toml
 # Load-rig configs are copied from their .example and edited per box
 test-harness/load/**/outbound-lab.toml
+test-harness/load/**/mixed-lab.toml
+test-harness/load/**/mixed-exhaust.toml
 test-harness/load/**/tier2-lab.toml
 test-harness/load/**/tier2-tls.toml
 .env

--- a/test-harness/load/LOAD_TEST_PLAN.md
+++ b/test-harness/load/LOAD_TEST_PLAN.md
@@ -676,8 +676,52 @@ run is enough.
 
 **The run:** 15 minutes at **30–50 concurrent**, after tiers 1 and 2. Only
 capture the deltas: per-call CPU against the tier-2 TLS+SRTP figure, MOS
-distribution against the netem figure, and carrier setup latency
-(`sdp_negotiate_seconds` p95).
+distribution against the netem figure, and carrier setup latency.
+
+🪤 **Setup latency is not `sdp_negotiate_seconds`.** That histogram times
+`prepare_call` — negotiate, port alloc, tap attach — which is *our* local
+work and says nothing about the carrier. On an outbound leg the number you
+want is INVITE → 200 OK, which is the CDR's `answered_at − started_at`, or
+the gap between the `outbound_initiated` and `outbound_answered` webhooks.
+Earlier revisions of this section named the wrong metric.
+
+**Your concurrency limit may make the run above impossible, and the test is
+still worth running.** Elastic SIP Trunking's concurrent-channel cap depends
+on the account's Customer Profile: an approved *Business* profile is
+effectively unlimited, but *Individual* is **3**, unapproved is 2, and trial
+is 4. Below ~30 channels, run it **sequentially** instead — see §10.3.1. What
+tier 3 uniquely supplies is per-call constants, and those come from *many
+calls*, not from *simultaneous* ones. A sequential run actually yields a
+better latency distribution: 60 samples spread over half an hour, rather than
+60 set up inside one 60-second window.
+
+### 10.3.1 The sequential (low-channel) form
+
+Rig in `tier3/`. Each call is a **trombone**: originate through the carrier
+gateway to a DID that routes back to this node, so the call returns as a
+second inbound leg and real media flows both ways with no human at either
+end and no AI spend.
+
+```
+siphon-ai ──INVITE──► carrier SBC ──► carrier routes the DID back
+    ▲                                          │
+    └────────────── inbound leg ◄──────────────┘
+```
+
+**A trombone occupies two channels**, one out and one back in. On a
+3-channel trunk that means exactly one call at a time, with one channel
+left free — deliberately, so a genuine inbound call is not rejected because
+a test is running. Do not parallelise it without recounting channels.
+
+What that costs you in the published claim is honesty about concurrency:
+
+> *Confirmed against a live carrier trunk, N sequential calls: setup p50/p95
+> X/Y ms, MOS p50 z.zz, packet loss L%.*
+
+No concurrency statement at all — §10.4's template assumes the 50-concurrent
+form. Tier 2 already carries concurrency scaling, so little is lost, but do
+not let the sentence imply a carrier concurrency number that was never
+measured.
 
 **Cost model:** `concurrent × minutes × per-minute rate × legs`. Both legs
 count if you trombone through Twilio to reach your own DID. The shape
@@ -701,6 +745,11 @@ Validated from a separate FreeSWITCH box over TLS + SRTP at M concurrent:
 Confirmed against a live Twilio trunk at 50 concurrent: setup p95 z ms.
 RTP port range caps concurrency at range/2 — size it for your target.
 ```
+
+If tier 3 ran in the §10.3.1 sequential form, its line becomes
+*"confirmed against a live trunk, N sequential calls: setup p95 z ms"* —
+and the claim carries no carrier-concurrency number, because none was
+measured.
 
 That is more credible than a single large loopback number, precisely
 because it shows the difference between the three is understood.

--- a/test-harness/load/LOAD_TEST_PLAN.md
+++ b/test-harness/load/LOAD_TEST_PLAN.md
@@ -1076,8 +1076,22 @@ Consequences for a node that both answers and originates:
 - to protect origination from inbound, cap inbound with `[sip.admission]` —
   there is no pool-level reservation to configure.
 
+### 13.2.1 Run it in BOTH orders — they are not symmetric
+
+`ORDER=outbound-first` reverses which direction gets the pool first, and the
+two answers differ in kind. When inbound holds it, outbound fails through
+the originate API's webhook and metric. When **outbound** holds it, inbound
+has to be refused on the wire — and measured on 0.49.9 that refusal is
+**`500 Server Internal Error`**, which is wrong for a capacity condition and
+inconsistent with the `503` + `Retry-After` that `[sip.admission]` and the
+drain path both use. Filed as **#554**; expect this row to change to `503`.
+
+A phase that only runs one order tests half the behaviour and would have
+missed it entirely.
+
 ### 13.3 Not covered
 
 Mixed at 200 + 200 rather than 50 + 50; a mixed *soak* rather than a
-steady-state snapshot; and exhaustion from the other side — what an
-outbound-saturated pool does to an arriving INVITE is untested.
+steady-state snapshot; and exhaustion under *concurrent* pressure — both
+runs let one direction establish first, so whether two simultaneous ramps
+into a too-small pool interleave fairly or one wins is untested.

--- a/test-harness/load/LOAD_TEST_PLAN.md
+++ b/test-harness/load/LOAD_TEST_PLAN.md
@@ -295,10 +295,22 @@ calls have ended:
 
 ```sh
 curl -s :9091/metrics | grep -E 'calls_active|conferences_active|parked_calls_active'   # all 0
+curl -s :9091/metrics | grep dialogs_active    # 0, but only after the 32s grace window
 ss -lnu | grep -c ':4[0-9]{4}'      # RTP ports released
 ls /proc/<pid>/fd | wc -l           # back to the idle count from §3
 ps -o rss= -p <pid>                 # within ~10% of pre-load idle
 ```
+
+**`dialogs_active` needs the grace window and a two-step read.** Removal is
+deferred by `DialogReaper::DEFAULT_GRACE` (32 s = SIP Timer H/J) so a
+retransmitted BYE still matches, and the gauge is only republished on the
+reaper's 5 s sweep — so a read taken immediately after teardown returns the
+*pre-BYE* value. Against an outbound run that is `0`, because the UAC inserts
+the dialog when it sends the BYE: assert `== 0` straight away and the audit
+goes green against a daemon that reclaims nothing. Wait for the gauge to
+publish non-zero, *then* wait for it to return to 0. This gauge was in §6.1's
+pass criteria and missing from this list, which is part of why #548 survived
+every audit run before §12 existed.
 
 **Pass:** every counter returns to its idle value. A gauge that doesn't come
 back down is a leak, and it matters more than the peak number.
@@ -496,7 +508,17 @@ claims we haven't tested:
 - **TLS + SRTP under load** — §§3–6 are plaintext loopback. §10 tier 2
   closes this; don't quote a secure-trunk number until it's run.
 - **Mid-call WS reconnect** — post-v1, and not exercised here.
-- **Sustained multi-hour behaviour** beyond the 1-hour soak.
+- **Sustained multi-hour behaviour** beyond the 1-hour soak. (Partly closed
+  by `RESULTS-convergence-8h.md`.)
+- **Outbound origination under load** was untested until §12 — every phase in
+  §§3–6 and every tier in §10 drives calls *into* the daemon, including the
+  `originate` commands in §10.2, which are FreeSWITCH originating **at** us.
+  Nothing exercised `POST /admin/v1/calls`, so no leak audit could see a
+  resource that only an originated leg allocates. Issue #548 — one dialog
+  leaked per originated call, for the life of the process — survived every
+  run in this document, including the 8-hour convergence soak, and was found
+  by hand during a deploy verification instead. §12 closes the gap; treat the
+  §§3–6 numbers as *inbound* numbers until an outbound run says otherwise.
 
 ---
 
@@ -826,3 +848,96 @@ If it passes, the honest headline is not a number at all:
 > *A live PSTN call placed while 500 concurrent calls were active was
 > indistinguishable from an idle one — same MOS, same first-audio latency,
 > no audible degradation.*
+
+---
+
+## 12. Outbound origination under load
+
+Everything above drives calls **into** the daemon. This phase drives them
+**out** of it, through `POST /admin/v1/calls`.
+
+The distinction is not cosmetic. An originated leg runs a different
+teardown path, a different dialog lifecycle, and a different admission
+gate (`[outbound].max_concurrent` / `rate_limit_per_sec`) from an accepted
+one, and none of it had ever been under load. The cost of that showed up as
+**issue #548**: one dialog leaked into the shared store per originated call,
+for the life of the process, until `sip-dialog`'s `MAX_CONFIRMED_DIALOGS`
+(10,000) is reached and in-dialog requests silently stop matching — for
+inbound calls too, since the store is shared. It survived every phase in
+this document, the 8-hour convergence soak included, and was found by hand
+while verifying a deploy. A leak audit cannot see a resource no phase
+allocates.
+
+Read the §§3–6 figures as **inbound** figures. This phase is what lets you
+say anything about the other direction.
+
+### 12.1 The rig
+
+`outbound/` in this directory. SIPp is the callee, the daemon is the caller,
+and `paced_sink.mjs` holds the WS side up for the duration:
+
+```
+ob_ramp.sh ──POST /admin/v1/calls──► siphon-ai ──INVITE──► SIPp (uas_hold.xml)
+                                         │
+                                         └──WS──► paced_sink.mjs
+```
+
+| | what it is |
+|---|---|
+| `phase-outbound.sh` | the driver: steps, sampling, drain, leak audit |
+| `ob_ramp.sh` | originate N at C cps, hold, tear down, wait for drain |
+| `obstat.sh` | one-shot JSON sample (CPU as a *rate*, RSS, fds, the gauges) |
+| `uas_hold.xml` | SIPp answers and holds until **we** BYE |
+| `uas_hold_remote_bye.xml` | SIPp answers, holds, then **it** BYEs |
+| `outbound-lab.toml.example` | daemon config — ports clear of a prod install |
+
+```sh
+cd test-harness/load/outbound
+cp outbound-lab.toml.example outbound-lab.toml
+export SP=/var/tmp/outbound-load
+HOLD=120 CPS=5 ./phase-outbound.sh /usr/bin/siphon-ai run-label 25 50 100
+TEARDOWN=remote ./phase-outbound.sh /usr/bin/siphon-ai run-label-remote 50
+```
+
+### 12.2 Run both teardown directions
+
+Who hangs up decides which branch of the teardown executes, and #548 sat on
+one of them. `uas_hold.xml` has the driver hang up through the admin API, so
+**we** send the BYE; `uas_hold_remote_bye.xml` has SIPp send it. A fix that
+retires the dialog in only one branch passes half this phase — which is why
+the phase runs both rather than picking the convenient one.
+
+### 12.3 What to measure
+
+Per step, the §§3–6 quantities plus the two the originate path adds:
+
+- `siphon_ai_outbound_calls_total{result}` — everything should be
+  `answered`. A `rejected`/`unreachable` count is the far end or the trunk,
+  not the daemon, and invalidates the step's per-call arithmetic.
+- **Originates the daemon refused.** `ob_ramp.sh` counts non-202 responses
+  and says so. A `503` is `max_concurrent`, a `429` is `rate_limit_per_sec`
+  — both are the daemon's own guardrails, and a step that silently ran at
+  half its target because of them is worse than no step at all.
+
+### 12.4 Pass criteria
+
+Everything in §6.3, run **with `dialogs_active` in it** and read the
+two-step way that section describes. Plus:
+
+- Every originate returns `202`, and every call ends `answered`.
+- `dialogs_active` returns to 0 after the grace window at **every** step, in
+  **both** teardown directions. This is the assertion #548 would have failed.
+- RTP ports released — an originated leg holds two, exactly like an accepted
+  one, so §1.1's ceiling is a ceiling on the *sum* of both directions.
+
+### 12.5 Traps
+
+- **The inactivity watchdog reaps originated legs too.** They are held open
+  by the driver, not by media, and the sink only feeds them once the bridge
+  is up. Set `inactivity_timeout_secs = 0` (§1.3).
+- **Don't use the echo server's `--auto-hangup-after-ms`.** It ends the call
+  from the WS side after a beat, which is right for a conformance scenario
+  and fatal for a hold.
+- **`[outbound]` is fail-closed**: unset `max_concurrent` means outbound is
+  *disabled*, and every originate returns `501`. That reads like a broken
+  rig rather than a config gap.

--- a/test-harness/load/LOAD_TEST_PLAN.md
+++ b/test-harness/load/LOAD_TEST_PLAN.md
@@ -979,6 +979,32 @@ two-step way that section describes. Plus:
 - RTP ports released — an originated leg holds two, exactly like an accepted
   one, so §1.1's ceiling is a ceiling on the *sum* of both directions.
 
+### 12.6 The outbound soak — make it churn
+
+§6.1's soak, in this direction, with one requirement that is easy to get
+wrong: **hold the concurrency by replacing calls as they end**, do not
+simply hold N calls open for an hour. Per-call leaks scale with
+*completions*, not with concurrency — #548 leaked one dialog per call, and
+a soak that parked 50 calls for an hour would have completed 50 and seen
+nothing. `ob_soak.sh` churns: an hour at 50 concurrent with a 60 s hold is
+~3,000 completed calls.
+
+**`dialogs_active` sits above concurrency during a churning soak, and that
+is correct.** Finished dialogs stay in the store for the 32 s grace window,
+so the steady-state reading is `concurrency + churn_rate × grace` — 76 at
+50 concurrent and ~50 calls/min. §6.1's "returns to 0 after the grace
+window" applies once load *stops*. A flat value above concurrency is
+health; a *climbing* one is the leak.
+
+**Finish with §6.3's test 1 — re-load the same process.** A churning soak
+grows RSS (measured: ~21 KB per completed call at constant concurrency,
+against ~6–10 KB/call for inbound), and that figure on its own cannot
+distinguish a leak from untrimmed arena. Re-loading the drained process
+settles it in fifteen minutes: measured 1.9 KB/call on the second pass
+against 21.4 on the first, i.e. the memory is reused. Quote the *second*
+number for capacity planning; the first is a fresh process reaching its
+working set.
+
 ### 12.5 Traps
 
 - **The inactivity watchdog reaps originated legs too.** They are held open
@@ -990,3 +1016,68 @@ two-step way that section describes. Plus:
 - **`[outbound]` is fail-closed**: unset `max_concurrent` means outbound is
   *disabled*, and every originate returns `501`. That reads like a broken
   rig rather than a config gap.
+
+---
+
+## 13. Both directions at once
+
+§§3–6 load inbound. §12 loads outbound. Neither says anything about what
+they do to each other — and they share three things: **one RTP port pool,
+one dialog store, one fd table**.
+
+Rig in `mixed/` (it reuses `outbound/`'s ramp, sampler and UAS scenario).
+`phase-mixed.sh` establishes the inbound legs first and then originates
+into a pool that is already partly consumed, which is the ordering that
+makes contention visible.
+
+```sh
+cd test-harness/load/mixed
+cp mixed-lab.toml.example mixed-lab.toml
+cp mixed-exhaust.toml.example mixed-exhaust.toml
+export SP=/var/tmp/mixed-load
+HOLD=120 CPS=5 ./phase-mixed.sh /usr/bin/siphon-ai run-label 50 50
+EXHAUST=1 HOLD=60 ./phase-mixed.sh /usr/bin/siphon-ai run-label-exhaust 50 20
+```
+
+### 13.1 What to expect
+
+Measured on 0.49.9 (`RESULTS-0.49.9-mixed-and-soak.md`): the two directions
+**compose linearly**. `fds = 13 + 3N` and `udp_sockets = 2N + 1` hold with
+N the *total* across both, and 100 mixed calls cost the same CPU as 100
+outbound-only. A mixed call costs what either kind costs alone.
+
+### 13.2 The pool has no reservation, and that is the finding
+
+Run the `EXHAUST` variant, whose port range is deliberately too small for
+the combined load. Measured: the inbound legs took the pool first and
+**every** subsequent originate failed —
+
+```
+WARN outbound call did not connect
+     error=forge session error: Resource limit exceeded: No available ports in pool
+siphon_ai_outbound_calls_total{result="failed"} N
+```
+
+— while inbound continued undisturbed. The failure is clean (no hang, no
+panic, no leaked dialog), but it is entirely one-sided: **an inbound surge
+can starve origination completely, with no inbound symptom.**
+
+🪤 **It is invisible on the originate API.** `POST /admin/v1/calls` returns
+`202` and the failure arrives later on the `outbound_failed` webhook. A
+driver that counts non-202 responses — `ob_ramp.sh` does — reports zero
+rejections for a run in which half the calls failed. Admission refusals
+(`503`/`429`) are the ones that show up synchronously; resource failures
+are not.
+
+Consequences for a node that both answers and originates:
+
+- size `rtp_port_range` for the **sum** of both directions plus headroom;
+- alert on `siphon_ai_outbound_calls_total{result="failed"}`;
+- to protect origination from inbound, cap inbound with `[sip.admission]` —
+  there is no pool-level reservation to configure.
+
+### 13.3 Not covered
+
+Mixed at 200 + 200 rather than 50 + 50; a mixed *soak* rather than a
+steady-state snapshot; and exhaustion from the other side — what an
+outbound-saturated pool does to an arriving INVITE is untested.

--- a/test-harness/load/README.md
+++ b/test-harness/load/README.md
@@ -32,12 +32,13 @@ the burst's signalling-only calls at the one-minute mark.
 
 | | |
 |---|---|
-| `RESULTS-*.md` | published runs — `0.48.10`, `0.48.13`, `0.48.18`, `0.48.19` (RTP port-bind A/B), `tier2` (FreeSWITCH / TLS+SRTP / netem), `convergence-8h`, `0.49.0-reference-call` (§11), `0.49.5-sip-ring`, `0.49.7-ring-ab`, `0.49.9-outbound` (§12), and `0.49.9-tier3` (§10.3 — live carrier) |
+| `RESULTS-*.md` | published runs — `0.48.10`, `0.48.13`, `0.48.18`, `0.48.19` (RTP port-bind A/B), `tier2` (FreeSWITCH / TLS+SRTP / netem), `convergence-8h`, `0.49.0-reference-call` (§11), `0.49.5-sip-ring`, `0.49.7-ring-ab`, `0.49.9-outbound` (§12), `0.49.9-tier3` (§10.3 — live carrier), and `0.49.9-mixed-and-soak` (§13 + §12.6) |
 | `ringstat.sh` | one-shot snapshot of the SIP-ladder ring gauges + RSS + concurrency, for sampling during a run (`RESULTS-0.49.5-sip-ring.md`) |
 | `abrun.sh` + `ringflood.py` + `ab-{on,off}.toml` | the ring-memory A/B (`RESULTS-0.49.7-ring-ab.md`) — one arm per invocation, fresh daemon each time |
 | `tier2/` | the two-box FreeSWITCH rig behind `RESULTS-tier2.md` (§10.2) — generator scripts, phase drivers, lab configs |
 | `paced_sink.mjs` | the WS sink the §6.1 and tier-2 numbers were measured through. **Use this, not a `setInterval`-paced sink** — see §8's first trap |
 | `squat.py` | holds RTP ports the way an ephemeral socket does, to reproduce #504 on demand |
+| `mixed/` | both directions at once (§13) — including the deliberately-too-small port range that proves there is no reservation between them |
 | `tier3/` | the live-carrier rig (§10.3) behind `RESULTS-0.49.9-tier3.md` — **dials the public PSTN and bills both legs**; read its README first |
 | `outbound/` | the origination load rig (§12) behind `RESULTS-0.49.9-outbound.md` — the only phase here that drives calls **out** of the daemon rather than into it |
 

--- a/test-harness/load/README.md
+++ b/test-harness/load/README.md
@@ -32,12 +32,13 @@ the burst's signalling-only calls at the one-minute mark.
 
 | | |
 |---|---|
-| `RESULTS-*.md` | published runs — `0.48.10`, `0.48.13`, `0.48.18`, `0.48.19` (RTP port-bind A/B), `tier2` (FreeSWITCH / TLS+SRTP / netem), `convergence-8h`, `0.49.0-reference-call` (§11), `0.49.5-sip-ring`, `0.49.7-ring-ab`, and `0.49.9-outbound` (§12) |
+| `RESULTS-*.md` | published runs — `0.48.10`, `0.48.13`, `0.48.18`, `0.48.19` (RTP port-bind A/B), `tier2` (FreeSWITCH / TLS+SRTP / netem), `convergence-8h`, `0.49.0-reference-call` (§11), `0.49.5-sip-ring`, `0.49.7-ring-ab`, `0.49.9-outbound` (§12), and `0.49.9-tier3` (§10.3 — live carrier) |
 | `ringstat.sh` | one-shot snapshot of the SIP-ladder ring gauges + RSS + concurrency, for sampling during a run (`RESULTS-0.49.5-sip-ring.md`) |
 | `abrun.sh` + `ringflood.py` + `ab-{on,off}.toml` | the ring-memory A/B (`RESULTS-0.49.7-ring-ab.md`) — one arm per invocation, fresh daemon each time |
 | `tier2/` | the two-box FreeSWITCH rig behind `RESULTS-tier2.md` (§10.2) — generator scripts, phase drivers, lab configs |
 | `paced_sink.mjs` | the WS sink the §6.1 and tier-2 numbers were measured through. **Use this, not a `setInterval`-paced sink** — see §8's first trap |
 | `squat.py` | holds RTP ports the way an ephemeral socket does, to reproduce #504 on demand |
+| `tier3/` | the live-carrier rig (§10.3) behind `RESULTS-0.49.9-tier3.md` — **dials the public PSTN and bills both legs**; read its README first |
 | `outbound/` | the origination load rig (§12) behind `RESULTS-0.49.9-outbound.md` — the only phase here that drives calls **out** of the daemon rather than into it |
 
 ## Prerequisites

--- a/test-harness/load/README.md
+++ b/test-harness/load/README.md
@@ -32,12 +32,13 @@ the burst's signalling-only calls at the one-minute mark.
 
 | | |
 |---|---|
-| `RESULTS-*.md` | published runs — `0.48.10`, `0.48.13`, `0.48.18`, `0.48.19` (RTP port-bind A/B), `tier2` (FreeSWITCH / TLS+SRTP / netem), `convergence-8h`, `0.49.0-reference-call` (§11), `0.49.5-sip-ring`, and `0.49.7-ring-ab` |
+| `RESULTS-*.md` | published runs — `0.48.10`, `0.48.13`, `0.48.18`, `0.48.19` (RTP port-bind A/B), `tier2` (FreeSWITCH / TLS+SRTP / netem), `convergence-8h`, `0.49.0-reference-call` (§11), `0.49.5-sip-ring`, `0.49.7-ring-ab`, and `0.49.9-outbound` (§12) |
 | `ringstat.sh` | one-shot snapshot of the SIP-ladder ring gauges + RSS + concurrency, for sampling during a run (`RESULTS-0.49.5-sip-ring.md`) |
 | `abrun.sh` + `ringflood.py` + `ab-{on,off}.toml` | the ring-memory A/B (`RESULTS-0.49.7-ring-ab.md`) — one arm per invocation, fresh daemon each time |
 | `tier2/` | the two-box FreeSWITCH rig behind `RESULTS-tier2.md` (§10.2) — generator scripts, phase drivers, lab configs |
 | `paced_sink.mjs` | the WS sink the §6.1 and tier-2 numbers were measured through. **Use this, not a `setInterval`-paced sink** — see §8's first trap |
 | `squat.py` | holds RTP ports the way an ephemeral socket does, to reproduce #504 on demand |
+| `outbound/` | the origination load rig (§12) behind `RESULTS-0.49.9-outbound.md` — the only phase here that drives calls **out** of the daemon rather than into it |
 
 ## Prerequisites
 

--- a/test-harness/load/RESULTS-0.49.9-mixed-and-soak.md
+++ b/test-harness/load/RESULTS-0.49.9-mixed-and-soak.md
@@ -5,10 +5,12 @@ Run 2026-08-21 against the **shipped 0.49.9 `.deb`** binary
 left open: what the two directions do to each other, and what the
 origination path does over an hour.
 
-**Result: pass on all three.** The directions compose linearly with no
-interaction penalty; the shared RTP pool fails outbound cleanly and leaves
-inbound untouched; and 3,745 originated calls over 75 minutes leaked
-nothing — the RSS growth is arena, proven by re-load, not a leak.
+**Result: pass on all three, with one bug found.** The directions compose
+linearly with no interaction penalty; the shared pool fails cleanly in both
+directions and leaves the other untouched; and 3,745 originated calls over
+75 minutes leaked nothing — the RSS growth is arena, proven by re-load, not
+a leak. The bug is the *code* the inbound side answers when the pool is
+empty: `500` where it should be `503` (#554).
 
 ---
 
@@ -85,7 +87,44 @@ admission refusals (`503` `max_concurrent`, `429` `rate_limit_per_sec`),
 not resource failures, which surface later on the `outbound_failed`
 webhook and the metric.
 
-**What to do about it**, since the daemon is behaving correctly here:
+### 2.1 The other direction is not symmetric — and answers the wrong code
+
+Same pool, order reversed: 50 **outbound** legs established first, then 20
+INVITEs arrived. Ten got ports; ten were rejected.
+
+| | inbound holds the pool | **outbound holds the pool** |
+|---|---|---|
+| who loses | outbound | inbound |
+| how it surfaces | `outbound_failed` webhook + `{result="failed"}` | a SIP response on the wire |
+| what the caller is told | nothing synchronous — the API said `202` | **`500 Server Internal Error`** |
+| the other direction | untouched | untouched |
+| leaks | none | none |
+
+SIPp's own view of the ten rejected INVITEs:
+
+```
+10 Aborting call
+10 500 Server Internal Error
+```
+
+🐛 **`500` is the wrong code, and it is filed as #554.** This is a capacity
+condition — the daemon is working exactly as designed and is simply full —
+but `500` tells the peer we have a bug. RFC 3261 §21.5.4 reserves `503` for
+"temporary overloading", and a proxy that receives one SHOULD try the next
+server in the target set, which is the behaviour you want when one node's
+pool is full and a sibling's is not. Carrier SBCs act on the difference, and
+some route away from an endpoint emitting non-`503` `5xx`.
+
+It is also inconsistent with the daemon's own overload signalling:
+`[sip.admission]` answers `503` + `Retry-After` for the concurrency cap and
+the rate limit, and the drain path answers `503`. An operator whose alerting
+says "503 means siphon-ai is full" gets an internal-error page instead.
+
+The type information to fix it already exists — `forge-core` has a typed
+`ForgeError::ResourceLimit`, and `crates/media-glue/src/setup.rs` discards
+it by flattening every forge error into `SetupError::Session(String)`.
+
+**What to do about it**, since the daemon is otherwise behaving correctly:
 
 - size `rtp_port_range` for the **sum** of both directions plus headroom,
   not for the busier one (§1.1);
@@ -158,9 +197,9 @@ warm.
   at 200 + 200, though nothing suggests it breaks either.
 - **Mixed direction over time.** §13 is a steady-state snapshot; there is
   no hour-long *mixed* soak.
-- **Pool exhaustion from the other side.** Inbound won the race here
-  because it was established first. What an *outbound*-saturated pool does
-  to arriving INVITEs (a 503? a 488? a hang?) is untested and is the
-  obvious next question.
+- **Pool exhaustion under *concurrent* pressure.** Both runs established one
+  direction first and then applied the other. What happens when both ramp
+  into a too-small pool simultaneously — whether they interleave fairly or
+  one wins — is untested.
 - **The carrier path.** All of this is loopback; §10.3's tier 3 covers the
   live trunk, at one call at a time.

--- a/test-harness/load/RESULTS-0.49.9-mixed-and-soak.md
+++ b/test-harness/load/RESULTS-0.49.9-mixed-and-soak.md
@@ -1,0 +1,166 @@
+# §13 mixed direction + §12.6 outbound soak — 0.49.9
+
+Run 2026-08-21 against the **shipped 0.49.9 `.deb`** binary
+(sha256 `ca7a6af19…`). Closes the two gaps `RESULTS-0.49.9-outbound.md`
+left open: what the two directions do to each other, and what the
+origination path does over an hour.
+
+**Result: pass on all three.** The directions compose linearly with no
+interaction penalty; the shared RTP pool fails outbound cleanly and leaves
+inbound untouched; and 3,745 originated calls over 75 minutes leaked
+nothing — the RSS growth is arena, proven by re-load, not a leak.
+
+---
+
+## Environment
+
+| | |
+|---|---|
+| Box | 4 vCPU, 7947 MB, Debian 13, Linux 6.12.95+deb13-amd64 |
+| Daemon | `siphon-ai 0.49.9` (shipped deb), `127.0.0.1:5070` |
+| Peers | SIPp as UAC (inbound) and as UAS (outbound), `paced_sink.mjs` on `:8770` |
+| Posture | PCMU, plaintext, `[cdr.file]` on, no HEP/webhooks/recording/VAD |
+
+---
+
+## 1. Mixed direction — the two compose linearly
+
+50 inbound legs established first, then 50 outbound originated into the
+same daemon, so the outbound side had to find ports in a pool already half
+consumed.
+
+| | idle | 50 inbound | **50 in + 50 out** |
+|---|---|---|---|
+| CPU (% of one core) | 0.0 | 14.0 | **27.2** |
+| RSS | 16.0 MB | 28.2 MB | 40.3 MB |
+| fds | 13 | 163 | **313** |
+| UDP sockets | 1 | 101 | **201** |
+| `calls_active` | 0 | 50 | 100 |
+
+🔑 **`fds = 13 + 3N` and `udp_sockets = 2N + 1` hold across the mix**, with
+N the *total* of both directions. An originated leg and an accepted leg
+cost the same three descriptors and the same port pair; nothing about the
+combination is special.
+
+🔑 **No interaction penalty.** 100 mixed calls cost 27.2 % of one core
+against **27.1 %** for 100 outbound-only in `RESULTS-0.49.9-outbound.md`.
+Within sampling noise, a mixed call costs what either kind costs alone.
+
+Teardown was clean in both directions: every inbound leg `caller_hangup`,
+every outbound leg `local_shutdown`, `dialogs_active` back to 0 at t=37 s,
+fds and sockets back to idle, **zero WARN/ERROR**.
+
+## 2. The shared RTP pool — and there is no reservation
+
+Same rig, `rtp_port_range` deliberately shrunk to **120 ports = 60 calls
+total**, then asked for 50 inbound + 20 outbound = 70.
+
+| | result |
+|---|---|
+| inbound established | **50 / 50** — unaffected throughout |
+| outbound answered | **10** |
+| outbound failed | **10** |
+| UDP sockets at peak | **121** = the whole pool + the SIP listener |
+| `dialogs_active` after drain | **0** — the failed originates leaked nothing |
+
+Each failure is explicit and correctly attributed:
+
+```
+WARN siphon_ai_core::outbound_service: outbound call did not connect
+     error=forge session error: Resource limit exceeded: No available ports in pool
+siphon_ai_outbound_calls_total{result="failed"} 10
+```
+
+🔑 **First-come-first-served, with no reservation between directions.**
+Inbound got there first and kept every port it took; outbound absorbed the
+entire shortfall. A node that both answers and originates can therefore
+have its origination *completely* starved by an inbound surge, with no
+inbound symptom at all — and outbound calls are usually the ones with a
+business deadline attached.
+
+🪤 **The originate API returns `202` and fails asynchronously**, so this is
+invisible to a caller watching HTTP status. `ob_ramp.sh` counted
+`rejected=0` for the run in which half the calls failed: its counter sees
+admission refusals (`503` `max_concurrent`, `429` `rate_limit_per_sec`),
+not resource failures, which surface later on the `outbound_failed`
+webhook and the metric.
+
+**What to do about it**, since the daemon is behaving correctly here:
+
+- size `rtp_port_range` for the **sum** of both directions plus headroom,
+  not for the busier one (§1.1);
+- alert on `siphon_ai_outbound_calls_total{result="failed"}` — on a node
+  that originates, it is the only signal this is happening;
+- if origination must be protected from inbound, the lever today is
+  `[sip.admission]` capping inbound, not a reservation in the pool.
+
+## 3. Outbound soak — 60 minutes, and it churns
+
+§6.1's soak in the outbound direction. **Not** 50 long calls: it holds 50
+concurrent by *replacing* each call as it ends, so an hour at a 60 s hold
+is ~3,000 completed calls. That matters — per-call leaks scale with
+completions, not concurrency, and #548 leaked one dialog per call. A soak
+that merely held 50 calls open for an hour would have missed it entirely.
+
+**2,995 placed, 2,995 completed, 0 failed. Zero WARN/ERROR in the whole
+75-minute session** (soak + re-load).
+
+| | during | at drain |
+|---|---|---|
+| `calls_active` | exactly 50, all hour | 0 |
+| `dialogs_active` | 50 → 76 | **0 at t=35 s** |
+| fds | 163, flat | **13** (idle) |
+| UDP sockets | 101, flat | **1** |
+| CPU | 13.8 – 15.4 % | 0 |
+
+🔑 **`dialogs_active` sits *above* concurrency under churn, and that is
+correct.** 50 active plus ~26 finished-but-still-in-grace (32 s window at
+~50 calls/min) = 76. §6.1's criterion — "returns to 0 after the grace
+window" — only applies once load *stops*; during sustained churn the
+steady-state value is `concurrency + churn_rate × grace`. Reading it as a
+leak would be a false alarm, and reading a *flat* 76 as healthy is the
+correct call.
+
+### 3.1 RSS grew, and the re-load test says it is not a leak
+
+RSS climbed 45.3 → 108.0 MB across the hour at **constant** concurrency —
+~21 KB per completed call, against the ~6–10 KB/call §6.3 documents for
+inbound. Pool sizing was paid in the first minute, so this is churn, and
+the growth was steppy (+16.6 MB then +22.5 MB between five-minute samples)
+rather than linear.
+
+§6.3's test 1 settles it. The same process, already drained, was given an
+identical load:
+
+| | calls | RSS | per call |
+|---|---|---|---|
+| first load | 2,995 | 45.3 → 108.0 MB (**+62.7**) | 21.4 KB |
+| **re-load, same process** | 750 | 108.0 → 109.4 MB (**+1.4**) | **1.9 KB** |
+
+A leak must allocate on top: 750 calls at 21.4 KB would have added ~16 MB.
+It added **1.4** — 91 % less per call on the second pass. Free-but-untrimmed
+glibc arena is handed straight back to the new calls; a leak cannot be.
+
+🔑 **The outbound path's memory is bounded and reused**, the same
+conclusion `RESULTS-0.48.13.md` reached for inbound (a drained 90.2 MB
+daemon absorbing a whole second load for +2.2 MB).
+
+⚠️ **Do not quote 21 KB/call as a capacity number.** It is the *first-fill*
+cost of a fresh process reaching its working set, not a recurring one. The
+number that matters for sizing is the second: ~2 KB/call once the arena is
+warm.
+
+---
+
+## What this does not cover
+
+- **Mixed direction at scale.** 50 + 50; nothing says the linearity holds
+  at 200 + 200, though nothing suggests it breaks either.
+- **Mixed direction over time.** §13 is a steady-state snapshot; there is
+  no hour-long *mixed* soak.
+- **Pool exhaustion from the other side.** Inbound won the race here
+  because it was established first. What an *outbound*-saturated pool does
+  to arriving INVITEs (a 503? a 488? a hang?) is untested and is the
+  obvious next question.
+- **The carrier path.** All of this is loopback; §10.3's tier 3 covers the
+  live trunk, at one call at a time.

--- a/test-harness/load/RESULTS-0.49.9-outbound.md
+++ b/test-harness/load/RESULTS-0.49.9-outbound.md
@@ -1,0 +1,174 @@
+# §12 outbound origination under load — 0.49.9
+
+Run 2026-08-21 against the **shipped 0.49.9 `.deb`** (`/usr/bin/siphon-ai`
+sha256 `ca7a6af19…`, extracted from `siphon-ai_0.49.9-1_amd64.deb`), with the
+**shipped 0.49.8 deb** (`44d1d3e3c…`) as the control.
+
+Scope: `LOAD_TEST_PLAN.md` **§12** — the direction nothing in this document
+had ever loaded. Every phase in §§3–6 and every tier in §10 drives calls
+*into* the daemon; the `originate` commands in §10.2 are FreeSWITCH
+originating **at** us. Nothing exercised `POST /admin/v1/calls`.
+
+**Result: pass on 0.49.9, and the phase fails the binary it was written
+for.** Three concurrency steps and both teardown directions returned every
+resource to idle, including `dialogs_active`. The same rig against 0.49.8
+leaves that gauge pinned at **exactly the cumulative call count** — the
+signature of issue #548, which survived every other phase in this plan
+including the 8-hour convergence soak.
+
+---
+
+## Environment
+
+| | |
+|---|---|
+| Box | 4 vCPU, 7947 MB, Debian 13 (trixie), Linux 6.12.95+deb13-amd64 |
+| Daemon | `siphon-ai 0.49.9` (shipped deb) on `127.0.0.1:5070` |
+| Control | `siphon-ai 0.49.8` (shipped deb), same config |
+| Callee | SIPp v3.7.7 on `:5075` — `uas_hold.xml` / `uas_hold_remote_bye.xml` |
+| WS sink | `paced_sink.mjs` on `:8770` (**not** `ws_sink.mjs` — §8) |
+| `ulimit -n` | 524288 |
+| Posture | PCMU, plaintext, `[cdr.file]` on, **no** HEP, webhooks, recording or VAD |
+| Pacing | 5 cps ramp, 120 s hold (45 s for the remote-BYE and control runs) |
+
+Single box: SIPp *answers* here rather than placing calls, which costs far
+less than generating. §10.1 still stands for any ceiling claim — **this
+phase is not one.** It measures what the outbound path costs and what it
+fails to release, not where it knees.
+
+---
+
+## 1. Concurrency steps — 0.49.9, we hang up
+
+`HOLD=120 CPS=5 ./phase-outbound.sh <deb-binary> 0.49.9-local 25 50 100`
+
+| concurrent | CPU (% of one core) | CPU per call | RSS under load | fds | RTP ports | originates refused |
+|---|---|---|---|---|---|---|
+| idle | 0.0 | — | 16.0 MB | 13 | 0 | — |
+| 25 | 8.4 | **0.336 %** | 26.0 MB | 88 | 50 | 0 |
+| 50 | 14.5 | **0.290 %** | 33–36 MB | 163 | 100 | 0 |
+| 100 | 27.1 | **0.271 %** | 49.9 MB | 313 | 200 | 0 |
+
+All 175 calls ended `answered`; `outbound_calls_total{result}` carried no
+other label. **Zero WARN or ERROR** in the daemon log for the whole run.
+
+🔑 **fds are exactly `13 + 3N`** at every step (88 / 163 / 313). Tier 1 and
+tier 2 both published `12 + 3N` for inbound; the extra descriptor here is
+the CDR file, which those postures did not have open. The *slope* is
+identical — an originated leg costs the same three descriptors as an
+accepted one.
+
+🔑 **Two RTP ports per originated leg**, exactly as for an accepted one. §1.1's
+range is therefore a ceiling on the **sum** of both directions, not on
+inbound alone — worth stating explicitly in any capacity figure, because a
+node that both answers and originates halves its headroom twice over.
+
+🔑 **Per-call CPU improves with concurrency** (0.336 → 0.290 → 0.271 %),
+the same flat-to-improving shape tier 2 found for inbound. Fixed per-call
+overhead amortises; nothing knees inside this range.
+
+⚠️ **Do not compare these percentages to the inbound figures.** Tier 1's
+0.53 %/call and tier 2's 0.650 %/call were measured at 200 concurrent, over a
+NIC in tier 2's case, and with a different feature posture. The comparable
+claim this run supports is narrower and still useful: *originating a call
+costs the same order as answering one, and scales the same way.*
+
+## 2. Both teardown directions
+
+Who hangs up decides which branch of the outbound teardown runs, and #548
+sat on one of them.
+
+| run | who BYEs | calls | `dialogs_active` after drain |
+|---|---|---|---|
+| `0.49.9-local` (25/50/100) | **we** do, via `POST /admin/v1/calls/:id/hangup` | 175 | 0 at t=38 s / 33 s / 37 s |
+| `0.49.9-remote` (50) | **SIPp** does | 50 | 0 at t=38 s |
+
+Reclamation lands 33–38 s after teardown in every case: the reaper's 32 s
+grace window (SIP Timer H/J, so a retransmitted BYE still matches) plus up
+to one 5 s sweep. That is the designed behaviour, not latency to fix.
+
+## 3. The leak audit — §6.3, with `dialogs_active` in it
+
+After every step, with all calls ended:
+
+```
+calls_active        0     ✓
+dialogs_active      0     ✓  (after the grace window — see below)
+fds                 13    ✓  exactly the idle count
+RTP ports bound     0     ✓
+threads             5     ✓  never moved at any concurrency
+outbound_calls_total{result} — answered only, no other label   ✓
+```
+
+RSS after drain rises with the **peak concurrency** the process has seen —
+26.7 MB after the 25-step, 36.0 after 50, 50.5 after 100 — and does not come
+back. That is §6.3's documented pool-sizing-plus-arena behaviour, not a
+leak; the decisive re-load test is in `RESULTS-0.48.13.md` and nothing here
+contradicts it.
+
+## 4. The control — the same rig against 0.49.8
+
+`HOLD=45 CPS=5 ./phase-outbound.sh <0.49.8-binary> 0.49.8-control 50 50`
+
+Two consecutive 50-call steps on the unfixed binary:
+
+| | 0.49.9 | 0.49.8 |
+|---|---|---|
+| calls_active after drain | 0 | 0 |
+| fds after drain | 13 (idle) | 13 (idle) |
+| RTP ports after drain | 0 | 0 |
+| **`dialogs_active` after drain** | **0** | **100** |
+
+The leak audit's poll never printed a reclamation line for either 0.49.8
+step — it waited out the full 50 s twice and gave up. The final gauge is
+**exactly the cumulative call count**, 50 + 50, which is what makes it a
+per-call leak rather than a fixed overhead: every other resource returned to
+idle, and only the shared dialog store did not.
+
+🔑 **This is the assertion the plan was missing.** Past `sip-dialog`'s
+`MAX_CONFIRMED_DIALOGS` (10,000) `insert` fails silently and in-dialog
+requests stop matching — for inbound calls too, since the store is shared.
+At the 100-call steps above, a node would reach that in a day of moderate
+origination.
+
+---
+
+## Traps this run cost us
+
+🪤 **A single `dialogs_active == 0` read passes against a leaking daemon.**
+The gauge is republished only on the reaper's 5 s sweep, and `sip-uac`
+inserts the dialog into the store when it *sends the BYE* — so for a few
+seconds after teardown the gauge still holds its pre-BYE value, which is
+`0`. The first cut of this check read once, immediately, and went green
+against 0.49.8. The audit now waits for the gauge to publish **non-zero**
+first, then waits for it to return to 0. §6.3 carries the same warning.
+
+🪤 **`[last_To:]` / `[last_From:]` expand to the whole header line**, field
+name included. Hand-writing the far end's BYE with them emits
+`From: To: <...>`; SIPp then retransmits the malformed BYE until it aborts
+the call, and 50 legs sat up until the run ended. It reads exactly like a
+daemon that ignores BYE. `outbound_remote_bye.xml` already documented this
+and captures the values with `ereg` instead — `uas_hold_remote_bye.xml` is
+derived from it rather than written fresh. **A red run here is the rig
+until proven otherwise.**
+
+🪤 **`Failed to delete FD from epoll, errno = 1` in SIPp's error log is
+benign** — it appears at teardown of a healthy run. Judge the run by the
+abort lines, not by the file being non-empty.
+
+🪤 **`[outbound]` is fail-closed.** No `max_concurrent`, no outbound, and
+every originate returns `501` — which reads like a broken rig rather than a
+config gap.
+
+---
+
+## What this does not cover
+
+- **A ceiling.** Steps stop at 100 and the generator shares the box (§10.1).
+- **Outbound over a real trunk.** §10.3 tier 3 is still unrun; these are
+  loopback legs to SIPp, so nothing here says anything about a carrier SBC.
+- **Mixed direction.** Every call in this run is outbound. A node doing both
+  at once shares one RTP port range and one dialog store, and that
+  interaction is untested.
+- **Long-hold outbound.** Holds are 45–120 s. §6.2's hour-long soak has no
+  outbound equivalent yet.

--- a/test-harness/load/RESULTS-0.49.9-tier3.md
+++ b/test-harness/load/RESULTS-0.49.9-tier3.md
@@ -1,0 +1,173 @@
+# §10.3 tier 3 — a live Twilio trunk, 0.49.9
+
+Run 2026-08-21 against **prod's shipped 0.49.9** (`/usr/bin/siphon-ai`
+sha256 `ca7a6af19…`) on the reference node, over the live Twilio Elastic SIP
+Trunk.
+
+Scope: `LOAD_TEST_PLAN.md` **§10.3 / §10.3.1** — the last unrun section of
+this plan. What a carrier uniquely adds is a real SBC and the public
+internet; both are per-call constants, which is why a small run suffices.
+
+**Result: pass, 60/60.** Every call connected, tore down cleanly, and the
+carrier path proved *milder* than the netem model tier 2 used to
+approximate it.
+
+> **This run dialled the public PSTN and billed both legs of every call.**
+> Twilio support was notified in advance with the exact traffic profile and
+> confirmed it needs no approval or account flag while it stays inside the
+> account's limits.
+
+---
+
+## The shape, and why it is not the shape §10.3 describes
+
+§10.3 asks for 15 minutes at 30–50 concurrent. **This account cannot do
+that**, and the reason is worth recording: Twilio's concurrent-channel cap
+follows the Customer Profile — an approved *Business* profile is effectively
+unlimited, but *Individual* is **3**, unapproved 2, trial 4. This account is
+Individual.
+
+A trombone (originate to our own DID so the call returns as a second leg)
+occupies **two** channels, so this ran **one call at a time**, sequentially,
+with one channel deliberately left free so a genuine inbound call would not
+be rejected mid-test.
+
+That trade is better than it sounds for the thing tier 3 measures. Sixty
+sequential calls give **60 latency samples spread over 35 minutes**, where
+the concurrent form would give 60 set up inside one 60-second window. For
+per-call constants, spread beats simultaneity.
+
+What it costs is any statement about carrier concurrency — see the claim at
+the bottom, which does not make one.
+
+| | |
+|---|---|
+| Node | `siphon-ai 0.49.9`, 4 vCPU / 7947 MB, Debian 13 |
+| Trunk | Twilio Elastic SIP Trunking, TLS + SRTP (`srtp = "required"`), IP-ACL authorised |
+| Path | originate → Twilio SBC → our own DID → back in to the same node |
+| Calls | 60 sequential, 30 s hold, 1 at a time (2 of 3 channels) |
+| Sinks | `driver_bot.js ?mode=sustain` on both legs — 50 fps filler, no AI spend |
+| Posture | prod's own: HEP, webhooks, quality records, neural VAD on the inbound route |
+| Cost | ~60 call-minutes across both legs |
+
+---
+
+## Carrier setup latency
+
+The number tier 3 exists to produce. From the outbound CDR,
+`answered_at − started_at`:
+
+| | min | p50 | **p95** | max |
+|---|---|---|---|---|
+| setup (INVITE → 200 OK) | 324 ms | 384 ms | **460 ms** | 524 ms |
+
+n=60, so the p95 is the 57th sample of 60 — a real percentile, but read it
+as "the slow end of sixty calls", not as a smooth tail.
+
+**The webhooks decompose it further**, which the CDR alone cannot. Our
+`outbound_initiated` to the returning leg's `call_start` is the carrier's
+own out-and-back, with our answer excluded:
+
+| | min | p50 | **p95** | max |
+|---|---|---|---|---|
+| carrier round trip | 260 ms | 281 ms | **383 ms** | 403 ms |
+
+So of a typical 384 ms setup, **~281 ms is Twilio** and the remaining
+~100 ms is our own answer propagating back out. That split matters: it says
+the carrier, not the daemon, owns three quarters of outbound setup time, and
+no amount of local optimisation will move it.
+
+## Quality — and the netem model was pessimistic
+
+Per-call `quality` blocks, both legs of all 60 calls:
+
+| | outbound leg | returning leg |
+|---|---|---|
+| MOS p50 | **4.435** | **4.435** |
+| MOS range | 4.434 – 4.435 | 4.434 – 4.436 |
+| jitter p50 | **1.94 ms** | **1.94 ms** |
+| jitter p95 | 2.17 ms | 2.15 ms |
+| jitter max | 2.25 ms | 2.19 ms |
+| packet loss | 1 / 88,104 = **0.001 %** | 1 / 89,398 = **0.001 %** |
+| calls with any loss | 1 of 60 | 1 of 60 |
+
+Against the two reference points tier 2 established:
+
+| | clean LAN (tier 2) | **live carrier (here)** | netem 20 ms ±5 ms / 0.5 % (tier 2) |
+|---|---|---|---|
+| jitter | 0.44 ms | **1.94 ms** | 3.35 ms |
+| MOS | 4.441 | **4.435** | 4.418 |
+| loss | 0.0 % | **0.001 %** | 0.495 % |
+
+🔑 **The real carrier path sits between the clean LAN and the impairment
+model, and much closer to the LAN.** Jitter is 4.4× the LAN figure but only
+58 % of the netem figure, and loss is **500× lower** than the 0.5 % netem
+injects.
+
+🔑 **So tier 2's netem numbers are a conservative bound, not a prediction.**
+That is the right way to read them and it was not previously demonstrated —
+publishing an impairment-model result alongside a live one is the only way
+to know which side of reality the model sits on. On this path, it is the
+pessimistic side.
+
+⚠️ **One path, one carrier, one afternoon.** A different region, a congested
+hour, or a different carrier's SBC could land anywhere. This does not
+generalise; it calibrates.
+
+## Daemon behaviour
+
+- **60/60 answered**, zero originates refused, zero trombones that failed to
+  close.
+- Termination: 60 `local_shutdown` (outbound legs, we hung up) + 60
+  `caller_hangup` (returning legs, Twilio hung up when we did).
+- **Zero WARN or ERROR attributable to the run.** The four in the window are
+  internet scanners hitting the public IP and being correctly 403'd for no
+  matching trunk, plus one rustls SNI complaint from the same scan.
+- `dialogs_active` returned to **0** — the #548 fix (`RESULTS-0.49.9-outbound.md`)
+  holding across 120 legs on a live carrier, not just loopback.
+
+**No per-call CPU figure**, deliberately. §10.3 asks for one against the
+tier-2 TLS+SRTP number, and it cannot be honestly produced here: at one
+concurrent call the fixed overhead dominates and the posture differs from
+tier 2's lean one (HEP, webhooks, quality records and neural VAD are all on).
+A CPU/call number from this run would be a comparison of postures wearing
+the clothes of a comparison of transports.
+
+---
+
+## The claim this earns
+
+Per §10.4, adjusted to what was actually measured:
+
+> 200 concurrent calls on 4 vCPU (SIPp loopback, G.711, plaintext, no
+> recording). Validated from a separate FreeSWITCH box over TLS + SRTP at
+> 200 concurrent: 0.663 % CPU per call, MOS p50 4.418 under 20 ms / 0.5 %
+> netem impairment. **Confirmed against a live Twilio trunk, 60 sequential
+> calls: setup p50 384 ms / p95 460 ms, of which ~281 ms is the carrier;
+> MOS p50 4.435, packet loss 0.001 %.** RTP port range caps concurrency at
+> range/2 — size it for your target.
+
+Note what it does **not** say: nothing about carrier concurrency, because
+none was measured. Tier 2 carries the concurrency scaling.
+
+## Traps
+
+🪤 **`sdp_negotiate_seconds` is not carrier setup latency**, though §10.3
+named it until this run. It times `prepare_call` — negotiate, port alloc,
+tap attach — which is our own local work. Use the CDR's
+`answered_at − started_at`, and the `outbound_initiated` → `call_start` gap
+to isolate the carrier.
+
+🪤 **Filter *both* the CDR and the webhook file by their start line.**
+`tier3_stats.py` filtered only the CDRs on its first outing and quietly
+mixed the earlier smoke call into the round-trip figures — visible only
+because the sample count came out larger than the call count.
+
+🪤 **A trombone costs two channels.** On a 3-channel trunk that is one call
+at a time. Sizing a run by the channel cap rather than the *call* cap will
+have the carrier reject half of it.
+
+🪤 **Point the outbound leg at a WS sink that generates audio.** With echo
+sinks on both ends of a trombone, nothing ever originates sound and the
+loop carries silence — measurable RTP, meaningless MOS. `?mode=sustain`
+fills at 50 fps.

--- a/test-harness/load/mixed/README.md
+++ b/test-harness/load/mixed/README.md
@@ -1,0 +1,65 @@
+# Mixed-direction rig
+
+`../LOAD_TEST_PLAN.md` §13. Reproduces `../RESULTS-0.49.9-mixed-and-soak.md`.
+
+§§3–6 load inbound. §12 loads outbound. Neither says anything about what
+they do to each other — and they share **one RTP port pool, one dialog
+store, one fd table**.
+
+```
+SIPp (uac_hold.xml) ──INVITE──► siphon-ai ──INVITE──► SIPp (../outbound/uas_hold.xml)
+        inbound legs                 │                        outbound legs
+                                     └──WS──► ../paced_sink.mjs
+```
+
+Reuses `../outbound/`'s ramp, sampler and UAS scenario; only the inbound
+caller and the configs are new.
+
+## Running it
+
+```sh
+cp mixed-lab.toml.example mixed-lab.toml
+cp mixed-exhaust.toml.example mixed-exhaust.toml
+export SP=/var/tmp/mixed-load
+
+# steady state: 50 in + 50 out on a pool big enough for both
+HOLD=120 CPS=5 ./phase-mixed.sh /usr/bin/siphon-ai run-label 50 50
+
+# exhaustion, BOTH orders — they are not symmetric
+EXHAUST=1 HOLD=60 ./phase-mixed.sh /usr/bin/siphon-ai exhaust-in 50 20
+ORDER=outbound-first EXHAUST=1 HOLD=60 ./phase-mixed.sh /usr/bin/siphon-ai exhaust-out 20 50
+```
+
+`ORDER` decides which direction gets the pool first. **Run both.** When
+inbound holds it, outbound fails through the originate API's webhook and
+metric; when outbound holds it, inbound must be refused on the wire, and
+that path answers a different code (see #554). A run in one order tests
+half the behaviour.
+
+## Reading the output
+
+Four JSON samples per run: `idle`, the direction that went first
+(`inbound-only` / `outbound-only`), `mixed`, and `drained`.
+
+Expect `fds = 13 + 3N` and `udp_sockets = 2N + 1` with **N the total across
+both directions** — that shared-pool arithmetic is the whole point. The
+`drained` line must show fds back to the idle count, `udp_sockets` back to
+1, and `dialogs_active` 0.
+
+The phase also prints what the inbound caller was told, parsed out of
+SIPp's error file, which is the only place an on-the-wire refusal shows up.
+
+## Traps
+
+- **The exhaust config is deliberately too small** (120 ports = 60 calls).
+  A run against it that reports failures is working; a run that reports
+  none did not actually exhaust anything — check the arithmetic against
+  your step sizes.
+- **`inactivity_timeout_secs = 0`.** Inbound legs here stream no RTP, so
+  the watchdog would reap them mid-hold (§1.3).
+- **A trunk must cover loopback** or every inbound INVITE is 403'd before
+  it can allocate a thing, and the run looks like a routing failure rather
+  than a pool test.
+- `../outbound/`'s traps all still apply — fail-closed `[outbound]`, the
+  paced sink rather than `--auto-hangup-after-ms`, and the two-step
+  `dialogs_active` read.

--- a/test-harness/load/mixed/mixed-exhaust.toml.example
+++ b/test-harness/load/mixed/mixed-exhaust.toml.example
@@ -1,0 +1,74 @@
+# Daemon config for the mixed-direction phase (LOAD_TEST_PLAN.md §13).
+#
+# Ports are deliberately clear of a prod-shaped install on the same box
+# (5060/5061, 9091, 9092, 40000-41000). Copy, adjust, pass with --config.
+[node]
+id = "lab-mixed-exhaust"
+public_address = "127.0.0.1"
+
+[sip]
+listen = "127.0.0.1:5070"
+transports = ["udp"]
+
+[media]
+codecs = ["pcmu"]
+# DELIBERATELY TOO SMALL: 120 ports = 60 calls total across BOTH
+# directions. The phase fills most of it with inbound and then originates
+# into the remainder, so the pool runs out mid-run. The question is not
+# whether it runs out — it is which direction notices, what the caller
+# sees, and whether the other direction stays healthy.
+rtp_port_range = [42000, 42120]
+# The originated legs are held open by the driver, not by media activity,
+# and paced_sink.mjs only feeds them once the bridge is up. Leave the
+# watchdog off so §1.3 can't reap a leg mid-hold.
+inactivity_timeout_secs = 0
+
+[bridge]
+ws_url = "ws://127.0.0.1:8770/"
+
+[observability]
+enabled = true
+http_listen = "127.0.0.1:9591"
+
+[admin]
+listen = "127.0.0.1:9592"
+
+[[admin.token]]
+name = "load"
+token = "lab-admin-token"
+role = "admin"
+
+# The originate endpoint's own guardrails, and the first thing to check
+# when a step plateaus below its target: `max_concurrent` 503s the excess
+# and `rate_limit_per_sec` 429s it. Both are deliberately above what the
+# steps ask for, so the daemon under test is the constraint and not its
+# own admission policy.
+[outbound]
+max_concurrent     = 250
+rate_limit_per_sec = 50
+
+# SIPp answers here (uas_hold.xml / uas_hold_remote_bye.xml).
+[[gateway]]
+name  = "sipp"
+proxy = "127.0.0.1:5075"
+# A caller-ID that is NOT the daemon's own `sip:siphon@<host>` identity —
+# the shape every real gateway has, and the one that exposed #549.
+from  = "sip:loadgen@127.0.0.1"
+
+# Inbound legs from SIPp arrive on loopback, so a trunk must cover it or
+# every INVITE is 403'd before it can allocate anything.
+[[trunk]]
+name = "loopback"
+peer_addrs = ["127.0.0.1/32"]
+
+[[route]]
+name = "default"
+[route.match]
+any = true
+
+[cdr]
+enabled = true
+
+[cdr.file]
+enabled = true
+path = "/var/tmp/mixed-load/cdr.jsonl"

--- a/test-harness/load/mixed/mixed-lab.toml.example
+++ b/test-harness/load/mixed/mixed-lab.toml.example
@@ -1,0 +1,73 @@
+# Daemon config for the mixed-direction phase (LOAD_TEST_PLAN.md §13).
+#
+# Ports are deliberately clear of a prod-shaped install on the same box
+# (5060/5061, 9091, 9092, 40000-41000). Copy, adjust, pass with --config.
+[node]
+id = "lab-mixed"
+public_address = "127.0.0.1"
+
+[sip]
+listen = "127.0.0.1:5070"
+transports = ["udp"]
+
+[media]
+codecs = ["pcmu"]
+# THE point of this phase: inbound and outbound legs draw from ONE pool.
+# 1000 ports = 500 calls TOTAL across both directions, not 500 each.
+# `mixed-exhaust.toml.example` deliberately shrinks this to force the
+# pool empty and observe which direction notices first.
+rtp_port_range = [42000, 43000]
+# The originated legs are held open by the driver, not by media activity,
+# and paced_sink.mjs only feeds them once the bridge is up. Leave the
+# watchdog off so §1.3 can't reap a leg mid-hold.
+inactivity_timeout_secs = 0
+
+[bridge]
+ws_url = "ws://127.0.0.1:8770/"
+
+[observability]
+enabled = true
+http_listen = "127.0.0.1:9591"
+
+[admin]
+listen = "127.0.0.1:9592"
+
+[[admin.token]]
+name = "load"
+token = "lab-admin-token"
+role = "admin"
+
+# The originate endpoint's own guardrails, and the first thing to check
+# when a step plateaus below its target: `max_concurrent` 503s the excess
+# and `rate_limit_per_sec` 429s it. Both are deliberately above what the
+# steps ask for, so the daemon under test is the constraint and not its
+# own admission policy.
+[outbound]
+max_concurrent     = 250
+rate_limit_per_sec = 50
+
+# SIPp answers here (uas_hold.xml / uas_hold_remote_bye.xml).
+[[gateway]]
+name  = "sipp"
+proxy = "127.0.0.1:5075"
+# A caller-ID that is NOT the daemon's own `sip:siphon@<host>` identity —
+# the shape every real gateway has, and the one that exposed #549.
+from  = "sip:loadgen@127.0.0.1"
+
+# Inbound legs from SIPp arrive on loopback, so a trunk must cover it or
+# every INVITE is 403'd before it can allocate anything.
+[[trunk]]
+name = "loopback"
+peer_addrs = ["127.0.0.1/32"]
+
+[[route]]
+name = "default"
+[route.match]
+any = true
+
+[cdr]
+enabled = true
+
+[cdr.file]
+enabled = true
+path = "/var/tmp/mixed-load/cdr.jsonl"

--- a/test-harness/load/mixed/phase-mixed.sh
+++ b/test-harness/load/mixed/phase-mixed.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# phase-mixed.sh <daemon-binary> <label> <inbound> <outbound>
+#
+# LOAD_TEST_PLAN.md §13 — both directions at once on one daemon.
+#
+# §§3-6 load inbound. §12 loads outbound. Neither says anything about the
+# resources the two share: ONE RTP port pool, ONE dialog store, one fd
+# table. This runs them together and watches those three.
+#
+# EXHAUST=1 swaps in a port range too small for the combined load, so the
+# pool empties mid-run and the failure mode becomes observable rather than
+# theoretical.
+set -uo pipefail
+BIN=${1:?usage: phase-mixed.sh <daemon-binary> <label> <inbound> <outbound>}
+LABEL=${2:?}; IN_N=${3:-50}; OUT_N=${4:-50}
+HERE=$(cd "$(dirname "$0")" && pwd)
+OB=$HERE/../outbound
+SP=${SP:-/var/tmp/mixed-load}; mkdir -p "$SP"
+HOLD=${HOLD:-120}
+CPS=${CPS:-5}
+OBS_PORT=${OBS_PORT:-9591}
+CONFIG=${CONFIG:-$HERE/mixed-lab.toml}
+[[ "${EXHAUST:-0}" == "1" ]] && CONFIG=${CONFIG_EXHAUST:-$HERE/mixed-exhaust.toml}
+[[ -f "$CONFIG" ]] || { echo "no config at $CONFIG (copy the .example)"; exit 2; }
+
+cleanup() { kill "${SINK_PID:-0}" "${DAEMON_PID:-0}" "${UAS_PID:-0}" "${UAC_PID:-0}" 2>/dev/null; }
+trap cleanup EXIT
+
+node "$HERE/../paced_sink.mjs" 8770 > "$SP/sink-$LABEL.log" 2>&1 & SINK_PID=$!
+RUST_LOG=siphon_ai=info "$BIN" --config "$CONFIG" > "$SP/daemon-$LABEL.log" 2>&1 & DAEMON_PID=$!
+sleep 2
+kill -0 "$DAEMON_PID" 2>/dev/null || { echo "daemon died on startup:"; tail -20 "$SP/daemon-$LABEL.log"; exit 1; }
+echo "daemon $($BIN --version) pid=$DAEMON_PID  config=$(basename "$CONFIG")"
+echo "mixed: ${IN_N} inbound + ${OUT_N} outbound, ${HOLD}s hold"
+
+echo "--- idle baseline"
+"$OB/obstat.sh" "$DAEMON_PID" "$OBS_PORT" | tee "$SP/$LABEL-idle.json"
+
+# Inbound first, so the outbound side has to find ports in a pool that is
+# already partly consumed — the ordering that makes contention observable.
+UAC_SCEN=$SP/uac_hold.$$.xml
+sed "s/PAUSE_MS/$(( HOLD * 1000 ))/" "$HERE/uac_hold.xml" > "$UAC_SCEN"
+sipp -i 127.0.0.1 -sf "$UAC_SCEN" 127.0.0.1:5070 -m "$IN_N" -r "$CPS" -l "$IN_N" \
+     -s loadtest -timeout 3600s -trace_err -bg > /dev/null 2>&1
+UAC_PID=$(pgrep -n -f "sipp -i 127.0.0.1 -sf $UAC_SCEN")
+
+sipp -i 127.0.0.1 -sf "$OB/uas_hold.xml" -p 5075 -m "$OUT_N" -l "$OUT_N" \
+     -timeout 3600s -trace_err -bg > /dev/null 2>&1
+UAS_PID=$(pgrep -n -f "sipp -i 127.0.0.1 -sf $OB/uas_hold.xml")
+sleep $(( IN_N / CPS + 5 ))
+echo "--- inbound settled"
+"$OB/obstat.sh" "$DAEMON_PID" "$OBS_PORT" | tee "$SP/$LABEL-inbound-only.json"
+
+SP="$SP" OBS_PORT="$OBS_PORT" "$OB/ob_ramp.sh" "$OUT_N" "$CPS" "$HOLD" local &
+RAMP_PID=$!
+sleep $(( OUT_N / CPS + 10 ))
+echo "--- both directions up"
+"$OB/obstat.sh" "$DAEMON_PID" "$OBS_PORT" | tee "$SP/$LABEL-mixed.json"
+wait "$RAMP_PID"
+
+# Inbound legs BYE themselves at the end of their own hold; wait them out
+# rather than killing SIPp, which would orphan them.
+for _ in $(seq 1 180); do
+  a=$(curl -s --max-time 3 "http://127.0.0.1:$OBS_PORT/metrics" | awk '/^siphon_ai_calls_active /{print $2}')
+  [[ "$a" == "0" ]] && break
+  sleep 2
+done
+
+echo "--- leak audit (both directions drained)"
+for i in $(seq 1 50); do
+  d=$(curl -s "http://127.0.0.1:$OBS_PORT/metrics" | awk '/^siphon_ai_dialogs_active /{print $2}')
+  [[ "$d" == "0" ]] && { echo "dialogs_active back to 0 at t=${i}s"; break; }
+  sleep 1
+done
+"$OB/obstat.sh" "$DAEMON_PID" "$OBS_PORT" | tee "$SP/$LABEL-drained.json"
+
+echo "=== rejections seen by the daemon"
+curl -s "http://127.0.0.1:$OBS_PORT/metrics" | grep -E '^siphon_ai_(calls_total|outbound_calls_total|rtp_port)' | head
+echo "=== WARN/ERROR"
+grep -cE "\bWARN\b|\bERROR\b" "$SP/daemon-$LABEL.log"
+grep -E "\bWARN\b|\bERROR\b" "$SP/daemon-$LABEL.log" | sed 's/call_id=[a-z0-9-]*//g' | sort | uniq -c | sort -rn | head -5
+rm -f "$UAC_SCEN"

--- a/test-harness/load/mixed/phase-mixed.sh
+++ b/test-harness/load/mixed/phase-mixed.sh
@@ -10,6 +10,12 @@
 # EXHAUST=1 swaps in a port range too small for the combined load, so the
 # pool empties mid-run and the failure mode becomes observable rather than
 # theoretical.
+#
+# ORDER decides WHICH direction gets there first, and the two answers are
+# not symmetric — one side fails through the originate API and its webhook,
+# the other has to fail on the wire with a SIP response code. Run both.
+#   inbound-first  (default) — inbound establishes, then originates fail
+#   outbound-first           — originates establish, then INVITEs arrive
 set -uo pipefail
 BIN=${1:?usage: phase-mixed.sh <daemon-binary> <label> <inbound> <outbound>}
 LABEL=${2:?}; IN_N=${3:-50}; OUT_N=${4:-50}
@@ -36,27 +42,44 @@ echo "mixed: ${IN_N} inbound + ${OUT_N} outbound, ${HOLD}s hold"
 echo "--- idle baseline"
 "$OB/obstat.sh" "$DAEMON_PID" "$OBS_PORT" | tee "$SP/$LABEL-idle.json"
 
-# Inbound first, so the outbound side has to find ports in a pool that is
-# already partly consumed — the ordering that makes contention observable.
 UAC_SCEN=$SP/uac_hold.$$.xml
 sed "s/PAUSE_MS/$(( HOLD * 1000 ))/" "$HERE/uac_hold.xml" > "$UAC_SCEN"
-sipp -i 127.0.0.1 -sf "$UAC_SCEN" 127.0.0.1:5070 -m "$IN_N" -r "$CPS" -l "$IN_N" \
-     -s loadtest -timeout 3600s -trace_err -bg > /dev/null 2>&1
-UAC_PID=$(pgrep -n -f "sipp -i 127.0.0.1 -sf $UAC_SCEN")
+UAC_ERR=$SP/$LABEL-inbound-sipp
 
+# SIPp answering outbound legs is started up front either way — it is
+# passive until the daemon dials it, so it cannot affect the ordering.
 sipp -i 127.0.0.1 -sf "$OB/uas_hold.xml" -p 5075 -m "$OUT_N" -l "$OUT_N" \
      -timeout 3600s -trace_err -bg > /dev/null 2>&1
 UAS_PID=$(pgrep -n -f "sipp -i 127.0.0.1 -sf $OB/uas_hold.xml")
-sleep $(( IN_N / CPS + 5 ))
-echo "--- inbound settled"
-"$OB/obstat.sh" "$DAEMON_PID" "$OBS_PORT" | tee "$SP/$LABEL-inbound-only.json"
 
-SP="$SP" OBS_PORT="$OBS_PORT" "$OB/ob_ramp.sh" "$OUT_N" "$CPS" "$HOLD" local &
-RAMP_PID=$!
-sleep $(( OUT_N / CPS + 10 ))
+start_inbound() {
+  sipp -i 127.0.0.1 -sf "$UAC_SCEN" 127.0.0.1:5070 -m "$IN_N" -r "$CPS" -l "$IN_N" \
+       -s loadtest -timeout 3600s -trace_err -error_file "$UAC_ERR" -bg > /dev/null 2>&1
+  UAC_PID=$(pgrep -n -f "sipp -i 127.0.0.1 -sf $UAC_SCEN")
+  sleep $(( IN_N / CPS + 5 ))
+}
+start_outbound() {
+  SP="$SP" OBS_PORT="$OBS_PORT" "$OB/ob_ramp.sh" "$OUT_N" "$CPS" "$HOLD" local &
+  RAMP_PID=$!
+  sleep $(( OUT_N / CPS + 10 ))
+}
+
+if [[ "${ORDER:-inbound-first}" == "outbound-first" ]]; then
+  echo "--- outbound first"
+  start_outbound
+  "$OB/obstat.sh" "$DAEMON_PID" "$OBS_PORT" | tee "$SP/$LABEL-outbound-only.json"
+  echo "--- now the inbound INVITEs arrive"
+  start_inbound
+else
+  echo "--- inbound first"
+  start_inbound
+  "$OB/obstat.sh" "$DAEMON_PID" "$OBS_PORT" | tee "$SP/$LABEL-inbound-only.json"
+  echo "--- now the originates go out"
+  start_outbound
+fi
 echo "--- both directions up"
 "$OB/obstat.sh" "$DAEMON_PID" "$OBS_PORT" | tee "$SP/$LABEL-mixed.json"
-wait "$RAMP_PID"
+wait "${RAMP_PID:-$$}" 2>/dev/null
 
 # Inbound legs BYE themselves at the end of their own hold; wait them out
 # rather than killing SIPp, which would orphan them.
@@ -74,8 +97,14 @@ for i in $(seq 1 50); do
 done
 "$OB/obstat.sh" "$DAEMON_PID" "$OBS_PORT" | tee "$SP/$LABEL-drained.json"
 
+echo "=== what the inbound caller was told (SIPp's own view)"
+if [[ -f "$UAC_ERR" ]]; then
+  grep -oE "Aborting call|[0-9]{3} [A-Za-z ]+|Unexpected" "$UAC_ERR" | sort | uniq -c | sort -rn | head -5
+else
+  echo "  (no SIPp error file — every INVITE was answered as the scenario expected)"
+fi
 echo "=== rejections seen by the daemon"
-curl -s "http://127.0.0.1:$OBS_PORT/metrics" | grep -E '^siphon_ai_(calls_total|outbound_calls_total|rtp_port)' | head
+curl -s "http://127.0.0.1:$OBS_PORT/metrics" | grep -E '^siphon_ai_(calls_total|calls_rejected|outbound_calls_total|rtp_port|sip_response)' | head -12
 echo "=== WARN/ERROR"
 grep -cE "\bWARN\b|\bERROR\b" "$SP/daemon-$LABEL.log"
 grep -E "\bWARN\b|\bERROR\b" "$SP/daemon-$LABEL.log" | sed 's/call_id=[a-z0-9-]*//g' | sort | uniq -c | sort -rn | head -5

--- a/test-harness/load/mixed/uac_hold.xml
+++ b/test-harness/load/mixed/uac_hold.xml
@@ -1,0 +1,80 @@
+<!--
+  uac_hold — SIPp as the CALLER, for the mixed-direction phase
+  (`../LOAD_TEST_PLAN.md` §13).
+
+  Derived from `../concurrent_burst_500.xml`; the only substantive change
+  is that the hold is `PAUSE_MS`, substituted by `phase-mixed.sh` so the
+  inbound legs live exactly as long as the outbound ones they are sharing
+  the box with. Killing SIPp instead would orphan the legs on the daemon
+  until a watchdog noticed, which is not a teardown anyone measures.
+
+  No RTP is streamed, deliberately — the daemon still negotiates SDP and
+  allocates a port pair per leg, which is the resource this phase is about.
+  `inactivity_timeout_secs` must therefore be 0 (§1.3).
+
+  The scenario is not runnable as-is: PAUSE_MS is a placeholder.
+-->
+<scenario name="uac_hold">
+  <send retrans="500">
+<![CDATA[
+INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+Max-Forwards: 70
+From: <sip:sipp-mixed@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:sipp-mixed@[local_ip]:[local_port]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=user1 53655765 2353687637 IN IP4 [local_ip]
+s=-
+c=IN IP4 [local_ip]
+t=0 0
+m=audio [auto_media_port] RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+]]>
+  </send>
+
+  <recv response="100" optional="true"/>
+  <recv response="180" optional="true"/>
+  <recv response="183" optional="true"/>
+  <recv response="200" rtd="true"/>
+
+  <send>
+<![CDATA[
+ACK sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]-ack
+Max-Forwards: 70
+From: <sip:sipp-mixed@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- Substituted from the phase's HOLD. -->
+  <pause milliseconds="PAUSE_MS"/>
+
+  <send retrans="500">
+<![CDATA[
+BYE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]-bye
+Max-Forwards: 70
+From: <sip:sipp-mixed@[local_ip]>;tag=[call_number]
+To: <sip:[service]@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 BYE
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="200"/>
+
+  <ResponseTimeRepartition value="200, 500, 1000, 2000"/>
+</scenario>

--- a/test-harness/load/outbound/README.md
+++ b/test-harness/load/outbound/README.md
@@ -1,0 +1,74 @@
+# Outbound origination load rig
+
+Reproduces `../RESULTS-0.49.9-outbound.md` (`../LOAD_TEST_PLAN.md` §12).
+
+Every other rig in this tree drives calls **into** the daemon. This one
+drives them **out**, through `POST /admin/v1/calls`, which is the direction
+nothing had ever loaded — and the direction issue #548 leaked a dialog in,
+undetected, through every phase in the plan including the 8-hour soak.
+
+```
+ob_ramp.sh ──POST /admin/v1/calls──► siphon-ai ──INVITE──► SIPp (uas_hold.xml)
+                                         │
+                                         └──WS──► ../paced_sink.mjs
+```
+
+Single box: unlike §10.2, the "generator" here is SIPp answering calls, which
+costs far less than placing them. §10.1 still applies to anything you intend
+to publish as a ceiling — this phase is about *what the outbound path leaks
+and costs*, not about finding the knee.
+
+## Files
+
+| | what it is |
+|---|---|
+| `phase-outbound.sh` | driver: steps, sampling, drain, leak audit |
+| `ob_ramp.sh` | originate N at C cps, hold, tear down, wait for drain |
+| `obstat.sh` | one-shot JSON sample — CPU as a rate, RSS, fds, gauges |
+| `uas_hold.xml` | SIPp answers, holds until **we** BYE |
+| `uas_hold_remote_bye.xml` | SIPp answers, holds, then **it** BYEs |
+| `outbound-lab.toml.example` | daemon config, ports clear of a prod install |
+
+## Running it
+
+```sh
+cp outbound-lab.toml.example outbound-lab.toml
+export SP=/var/tmp/outbound-load && mkdir -p $SP
+
+# both teardown directions — a fix that retires the dialog in only one
+# branch passes half of this
+HOLD=120 CPS=5 ./phase-outbound.sh /usr/bin/siphon-ai 0.49.9-local  25 50 100
+TEARDOWN=remote HOLD=120 CPS=5 ./phase-outbound.sh /usr/bin/siphon-ai 0.49.9-remote 50
+```
+
+Needs `sipp`, `node` (for `../paced_sink.mjs`), and a daemon binary. Every
+knob has a default: `SP`, `CONFIG`, `HOLD`, `CPS`, `OBS_PORT`, `TEARDOWN`,
+and `ADMIN`/`TOKEN`/`GATEWAY`/`TO` for `ob_ramp.sh` alone.
+
+## Reading the output
+
+One JSON line per sample, four per step: `idle`, `early` (ramp landed),
+`late` (mid-hold), `drained` (post-teardown, past the grace window).
+
+The line that matters is `drained`. **`dialogs_active` must be 0 there** —
+and the driver polls for it rather than reading once, because the gauge is
+republished only on the reaper's 5 s sweep and the UAC inserts the dialog
+when it sends the BYE. A single read taken straight after teardown returns
+the *pre-BYE* value, which is `0`, which passes against a daemon that
+reclaims nothing. That is not hypothetical: it is how the first cut of this
+check went green against the unfixed binary.
+
+## Traps
+
+- `[outbound]` is **fail-closed** — no `max_concurrent`, no outbound, and
+  every originate is a `501` that reads like a broken rig.
+- `inactivity_timeout_secs = 0`, or the watchdog reaps legs mid-hold: they
+  are held open by the driver, not by media (§1.3).
+- Use `../paced_sink.mjs`, **not** the echo server's
+  `--auto-hangup-after-ms` — that ends the call from the WS side after a
+  beat, which is right for a conformance scenario and fatal for a hold.
+- An originated leg holds two RTP ports like any other, so §1.1's range is a
+  ceiling on the *sum* of both directions.
+- `ob_ramp.sh` counts refused originates and prints them. A step that ran at
+  half its target because of `max_concurrent`/`rate_limit_per_sec` must not
+  be read as a step at its target.

--- a/test-harness/load/outbound/ob_ramp.sh
+++ b/test-harness/load/outbound/ob_ramp.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# ob_ramp.sh <concurrency> <cps> <hold_seconds> [teardown]
+#
+# Drive N outbound calls through the daemon's own originate endpoint at C
+# calls/sec, hold them, then tear them down. `teardown` is `local` (we BYE,
+# via the admin API — the default) or `remote` (SIPp BYEs, in which case
+# run uas_hold_remote_bye.xml and this script only waits).
+#
+# Reads ADMIN (host:port), TOKEN, GATEWAY and TO from the environment, with
+# the outbound-lab.toml.example defaults.
+set -uo pipefail
+CONC=${1:-25}; CPS=${2:-5}; HOLD=${3:-120}; TEARDOWN=${4:-local}
+ADMIN=${ADMIN:-127.0.0.1:9592}
+TOKEN=${TOKEN:-lab-admin-token}
+GATEWAY=${GATEWAY:-sipp}
+TO=${TO:-7001}
+SP=${SP:-/var/tmp/outbound-load}
+mkdir -p "$SP"
+IDS="$SP/call-ids.$$"; : > "$IDS"
+
+echo "ramp: $CONC calls at $CPS cps, hold ${HOLD}s, teardown=$TEARDOWN"
+SLEEP=$(awk -v c="$CPS" 'BEGIN{printf "%.4f", 1/c}')
+placed=0; rejected=0
+for _ in $(seq 1 "$CONC"); do
+  # 202 + a call_id means admitted. Anything else is the daemon's own
+  # guardrail talking (503 = max_concurrent, 429 = rate_limit_per_sec) and
+  # is counted, not retried — a step that cannot reach its target must say
+  # so rather than quietly running small.
+  body=$(curl -s --max-time 5 -X POST -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    "http://$ADMIN/admin/v1/calls" \
+    -d "{\"to\":\"$TO\",\"gateway\":\"$GATEWAY\"}" 2>/dev/null)
+  id=$(sed -n 's/.*"call_id":"\([^"]*\)".*/\1/p' <<<"$body")
+  if [[ -n "$id" ]]; then echo "$id" >> "$IDS"; placed=$((placed+1));
+  else rejected=$((rejected+1)); fi
+  sleep "$SLEEP"
+done
+echo "placed=$placed rejected=$rejected"
+(( rejected > 0 )) && echo "  !! $rejected originate(s) refused — see [outbound] caps before reading this step"
+
+echo "holding ${HOLD}s"
+sleep "$HOLD"
+
+if [[ "$TEARDOWN" == "local" ]]; then
+  echo "hanging up $placed calls"
+  while read -r id; do
+    curl -s -o /dev/null --max-time 5 -X POST -H "Authorization: Bearer $TOKEN" \
+      "http://$ADMIN/admin/v1/calls/$id/hangup"
+  done < "$IDS"
+else
+  echo "waiting for the far end to BYE"
+fi
+
+# Drain: calls_active must reach 0 before any leak audit is meaningful.
+for _ in $(seq 1 120); do
+  a=$(curl -s --max-time 3 "http://127.0.0.1:${OBS_PORT:-9591}/metrics" \
+      | awk '/^siphon_ai_calls_active /{print $2}')
+  [[ "$a" == "0" ]] && { echo "drained"; break; }
+  sleep 1
+done
+rm -f "$IDS"

--- a/test-harness/load/outbound/ob_soak.sh
+++ b/test-harness/load/outbound/ob_soak.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# ob_soak.sh <concurrency> <minutes> <hold_seconds>
+#
+# LOAD_TEST_PLAN.md §6.1's soak, in the outbound direction (§12.6).
+#
+# Not "N long calls": it CHURNS. It holds `concurrency` outbound calls
+# active for the whole window by replacing each one as it ends, so an hour
+# at 50 concurrent with a 60 s hold is ~3,000 completed calls rather than
+# 50. Per-call leaks scale with completions, not with concurrency — #548
+# leaked one dialog per call and would have been invisible in a soak that
+# merely held 50 calls open for an hour.
+set -uo pipefail
+CONC=${1:-50}; MINUTES=${2:-60}; HOLD=${3:-60}
+ADMIN=${ADMIN:-127.0.0.1:9592}
+OBS=${OBS:-127.0.0.1:9591}
+TOKEN=${TOKEN:-lab-admin-token}
+GATEWAY=${GATEWAY:-sipp}
+TO=${TO:-7001}
+WS=${WS:-ws://127.0.0.1:8770/}
+SP=${SP:-/var/tmp/outbound-load}; mkdir -p "$SP"
+LABEL=${LABEL:-soak}
+# Where obstat.sh lives. Overridable because a long soak should be run
+# from a FROZEN copy of this script: bash reads a script incrementally, so
+# editing the original mid-run makes the live process jump to mangled byte
+# offsets and fail in ways that look like logic bugs.
+RIG=${RIG:-$(cd "$(dirname "$0")" && pwd)}
+DAEMON_PID=${DAEMON_PID:?set DAEMON_PID so the sampler can read /proc}
+
+END=$(( $(date +%s) + MINUTES * 60 ))
+declare -A started            # call_id -> epoch it was placed
+# Same `set -u` hazard as the loops below: count via the guarded expansion.
+count_active() { local n=0 k; for k in ${started[@]+"${!started[@]}"}; do n=$((n+1)); done; echo "$n"; }
+placed=0; done_=0; failed=0
+next_sample=$(( $(date +%s) + 300 ))
+
+echo "soak: hold $CONC concurrent outbound for ${MINUTES}m, ${HOLD}s per call"
+"$RIG/obstat.sh" "$DAEMON_PID" "${OBS##*:}" | tee "$SP/$LABEL-t0.json"
+
+while (( $(date +%s) < END )); do
+  now=$(date +%s)
+  # Retire anything past its hold.
+  #
+  # `${arr[@]+"${!arr[@]}"}` is not decoration. Under `set -u` on bash 5.2
+  # an EMPTY associative array is "unset": both `${!started[@]}` and
+  # `${#started[@]}` abort the script, so the obvious loop and the obvious
+  # emptiness guard both die on the first pass, before a single call is
+  # placed. The `+` expansion is the one form that yields nothing when
+  # empty and the keys when populated.
+  for id in ${started[@]+"${!started[@]}"}; do
+    if (( now - started[$id] >= HOLD )); then
+      curl -s -o /dev/null --max-time 5 -X POST -H "Authorization: Bearer $TOKEN" \
+        "http://$ADMIN/admin/v1/calls/$id/hangup"
+      unset 'started[$id]'
+      done_=$(( done_ + 1 ))
+    fi
+  done
+  # Top back up to concurrency.
+  while (( $(count_active) < CONC && $(date +%s) < END )); do
+    body=$(curl -s --max-time 10 -X POST -H "Authorization: Bearer $TOKEN" \
+      -H "Content-Type: application/json" "http://$ADMIN/admin/v1/calls" \
+      -d "{\"to\":\"$TO\",\"gateway\":\"$GATEWAY\",\"ws_url\":\"$WS\"}")
+    id=$(sed -n 's/.*"call_id":"\([^"]*\)".*/\1/p' <<<"$body")
+    if [[ -n "$id" ]]; then started[$id]=$(date +%s); placed=$(( placed + 1 ));
+    else failed=$(( failed + 1 )); break; fi
+  done
+  # Periodic sample — the shape over time is the point, not the endpoints.
+  if (( $(date +%s) >= next_sample )); then
+    active=$(count_active)
+    echo "[$(date -u +%H:%M:%S)] placed=$placed completed=$done_ failed=$failed active=$active"
+    "$RIG/obstat.sh" "$DAEMON_PID" "${OBS##*:}" | tee -a "$SP/$LABEL-series.jsonl"
+    next_sample=$(( $(date +%s) + 300 ))
+  fi
+  sleep 1
+done
+
+echo "draining"
+for id in ${started[@]+"${!started[@]}"}; do
+  curl -s -o /dev/null --max-time 5 -X POST -H "Authorization: Bearer $TOKEN" \
+    "http://$ADMIN/admin/v1/calls/$id/hangup"
+  done_=$(( done_ + 1 ))
+done
+for _ in $(seq 1 120); do
+  [[ "$(curl -s --max-time 3 "http://$OBS/metrics" | awk '/^siphon_ai_calls_active /{print $2}')" == "0" ]] && break
+  sleep 1
+done
+echo "--- leak audit"
+for i in $(seq 1 50); do
+  d=$(curl -s "http://$OBS/metrics" | awk '/^siphon_ai_dialogs_active /{print $2}')
+  [[ "$d" == "0" ]] && { echo "dialogs_active back to 0 at t=${i}s"; break; }
+  sleep 1
+done
+"$RIG/obstat.sh" "$DAEMON_PID" "${OBS##*:}" | tee "$SP/$LABEL-drained.json"
+echo "soak done: placed=$placed completed=$done_ failed=$failed"

--- a/test-harness/load/outbound/obstat.sh
+++ b/test-harness/load/outbound/obstat.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 # One-shot sample of the gauges an outbound run turns on, as one JSON line.
+#
+# `udp_sockets` counts the daemon's unconnected UDP sockets: two RTP/RTCP
+# per active call plus its SIP listener(s), so expect 2N+1 on a UDP-only
+# config. It is a whole-process count, so it spans BOTH directions — which
+# is the point in the mixed phase (§13).
 # Companion to ../ringstat.sh. Usage: obstat.sh <daemon-pid> [obs-port]
 #
 # A series that does not exist yet reads 0, not null: several of these are
@@ -8,6 +13,19 @@
 set -uo pipefail
 PID=${1:?usage: obstat.sh <daemon-pid> [obs-port]}
 PORT=${2:-9591}
+
+# CPU as a rate, not ps's lifetime average (§8) — utime+stime over 5 s.
+# The window comes FIRST, and everything else is read after it closes, so
+# every field in the line below describes the same instant. Reading
+# /metrics before the sleep and /proc after it produced lines whose
+# `calls_active` and `fds` disagreed by 5 seconds of ramp — which reads as
+# a daemon that allocates no descriptors for outbound legs.
+read -r _ _ _ _ _ _ _ _ _ _ _ _ _ u1 s1 _ < "/proc/$PID/stat"
+sleep 5
+read -r _ _ _ _ _ _ _ _ _ _ _ _ _ u2 s2 _ < "/proc/$PID/stat"
+HZ=$(getconf CLK_TCK)
+CPU=$(awk -v d=$(( (u2-u1)+(s2-s1) )) -v hz="$HZ" 'BEGIN{printf "%.1f", d*100/hz/5}')
+
 M=$(curl -s --max-time 3 "http://127.0.0.1:$PORT/metrics" || true)
 
 # Exact series name, no labels.
@@ -15,20 +33,17 @@ g() { awk -v k="$1" '$1 == k {print $2; f=1} END{if(!f) print 0}' <<<"$M"; }
 # Sum every series matching a regex (label sets vary run to run).
 sum() { awk -v re="$1" '$1 ~ re {s+=$2} END{printf "%d", s+0}' <<<"$M"; }
 
-# CPU as a rate, not ps's lifetime average (§8) — utime+stime over 5 s.
-read -r _ _ _ _ _ _ _ _ _ _ _ _ _ u1 s1 _ < "/proc/$PID/stat"
-sleep 5
-read -r _ _ _ _ _ _ _ _ _ _ _ _ _ u2 s2 _ < "/proc/$PID/stat"
-HZ=$(getconf CLK_TCK)
-CPU=$(awk -v d=$(( (u2-u1)+(s2-s1) )) -v hz="$HZ" 'BEGIN{printf "%.1f", d*100/hz/5}')
-PORTS=$(ss -lnu 2>/dev/null | grep -cE ':4[23][0-9]{3}\b' || true)
+# RTP sockets are unconnected UDP, so `ss -l` is the right listing. Count
+# the daemon's own, not every 42xxx/43xxx socket on the box — a second
+# instance or a leftover run would otherwise be counted into this one.
+PORTS=$(ss -lunp 2>/dev/null | grep -c "pid=$PID," || true)
 
 printf '{"ts":"%s","cpu_pct_of_one_core":%s,"rss_kb":%s,"fds":%s,"threads":%s,' \
   "$(date -u +%FT%TZ)" "$CPU" \
   "$(awk '/^VmRSS/{print $2}' "/proc/$PID/status")" \
   "$(ls "/proc/$PID/fd" 2>/dev/null | wc -l)" \
   "$(awk '/^Threads/{print $2}' "/proc/$PID/status")"
-printf '"calls_active":%s,"dialogs_active":%s,"outbound_answered":%s,"outbound_not_answered":%s,"rtp_ports_bound":%s}\n' \
+printf '"calls_active":%s,"dialogs_active":%s,"outbound_answered":%s,"outbound_not_answered":%s,"udp_sockets":%s}\n' \
   "$(g siphon_ai_calls_active)" \
   "$(g siphon_ai_dialogs_active)" \
   "$(sum '^siphon_ai_outbound_calls_total\{result="answered"\}$')" \

--- a/test-harness/load/outbound/obstat.sh
+++ b/test-harness/load/outbound/obstat.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# One-shot sample of the gauges an outbound run turns on, as one JSON line.
+# Companion to ../ringstat.sh. Usage: obstat.sh <daemon-pid> [obs-port]
+#
+# A series that does not exist yet reads 0, not null: several of these are
+# published only once the first call has touched the code path, and an idle
+# baseline row of nulls is harder to diff than one of zeros.
+set -uo pipefail
+PID=${1:?usage: obstat.sh <daemon-pid> [obs-port]}
+PORT=${2:-9591}
+M=$(curl -s --max-time 3 "http://127.0.0.1:$PORT/metrics" || true)
+
+# Exact series name, no labels.
+g() { awk -v k="$1" '$1 == k {print $2; f=1} END{if(!f) print 0}' <<<"$M"; }
+# Sum every series matching a regex (label sets vary run to run).
+sum() { awk -v re="$1" '$1 ~ re {s+=$2} END{printf "%d", s+0}' <<<"$M"; }
+
+# CPU as a rate, not ps's lifetime average (§8) — utime+stime over 5 s.
+read -r _ _ _ _ _ _ _ _ _ _ _ _ _ u1 s1 _ < "/proc/$PID/stat"
+sleep 5
+read -r _ _ _ _ _ _ _ _ _ _ _ _ _ u2 s2 _ < "/proc/$PID/stat"
+HZ=$(getconf CLK_TCK)
+CPU=$(awk -v d=$(( (u2-u1)+(s2-s1) )) -v hz="$HZ" 'BEGIN{printf "%.1f", d*100/hz/5}')
+PORTS=$(ss -lnu 2>/dev/null | grep -cE ':4[23][0-9]{3}\b' || true)
+
+printf '{"ts":"%s","cpu_pct_of_one_core":%s,"rss_kb":%s,"fds":%s,"threads":%s,' \
+  "$(date -u +%FT%TZ)" "$CPU" \
+  "$(awk '/^VmRSS/{print $2}' "/proc/$PID/status")" \
+  "$(ls "/proc/$PID/fd" 2>/dev/null | wc -l)" \
+  "$(awk '/^Threads/{print $2}' "/proc/$PID/status")"
+printf '"calls_active":%s,"dialogs_active":%s,"outbound_answered":%s,"outbound_not_answered":%s,"rtp_ports_bound":%s}\n' \
+  "$(g siphon_ai_calls_active)" \
+  "$(g siphon_ai_dialogs_active)" \
+  "$(sum '^siphon_ai_outbound_calls_total\{result="answered"\}$')" \
+  "$(sum '^siphon_ai_outbound_calls_total\{result="(busy|declined|no_answer|rejected|unreachable|failed)"\}$')" \
+  "${PORTS:-0}"

--- a/test-harness/load/outbound/outbound-lab.toml.example
+++ b/test-harness/load/outbound/outbound-lab.toml.example
@@ -1,0 +1,66 @@
+# Daemon config for the outbound load phase (LOAD_TEST_PLAN.md §12).
+#
+# Ports are deliberately clear of a prod-shaped install on the same box
+# (5060/5061, 9091, 9092, 40000-41000). Copy, adjust, pass with --config.
+[node]
+id = "lab-outbound"
+public_address = "127.0.0.1"
+
+[sip]
+listen = "127.0.0.1:5070"
+transports = ["udp"]
+
+[media]
+codecs = ["pcmu"]
+# Every ACTIVE call holds two UDP ports, and an originated leg is no
+# different — §1.1's ceiling applies to outbound exactly as it does to
+# inbound. 1000 ports = 500 concurrent, well above this phase's steps.
+rtp_port_range = [42000, 43000]
+# The originated legs are held open by the driver, not by media activity,
+# and paced_sink.mjs only feeds them once the bridge is up. Leave the
+# watchdog off so §1.3 can't reap a leg mid-hold.
+inactivity_timeout_secs = 0
+
+[bridge]
+ws_url = "ws://127.0.0.1:8770/"
+
+[observability]
+enabled = true
+http_listen = "127.0.0.1:9591"
+
+[admin]
+listen = "127.0.0.1:9592"
+
+[[admin.token]]
+name = "load"
+token = "lab-admin-token"
+role = "admin"
+
+# The originate endpoint's own guardrails, and the first thing to check
+# when a step plateaus below its target: `max_concurrent` 503s the excess
+# and `rate_limit_per_sec` 429s it. Both are deliberately above what the
+# steps ask for, so the daemon under test is the constraint and not its
+# own admission policy.
+[outbound]
+max_concurrent     = 250
+rate_limit_per_sec = 50
+
+# SIPp answers here (uas_hold.xml / uas_hold_remote_bye.xml).
+[[gateway]]
+name  = "sipp"
+proxy = "127.0.0.1:5075"
+# A caller-ID that is NOT the daemon's own `sip:siphon@<host>` identity —
+# the shape every real gateway has, and the one that exposed #549.
+from  = "sip:loadgen@127.0.0.1"
+
+[[route]]
+name = "default"
+[route.match]
+any = true
+
+[cdr]
+enabled = true
+
+[cdr.file]
+enabled = true
+path = "/var/tmp/outbound-load/cdr.jsonl"

--- a/test-harness/load/outbound/phase-outbound.sh
+++ b/test-harness/load/outbound/phase-outbound.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# phase-outbound.sh <daemon-binary> <label> [steps...]
+#
+# The outbound concurrency phase (LOAD_TEST_PLAN.md §12): originate through
+# the daemon's own endpoint at each step, sample under load, drain, then run
+# the §6.3 leak audit with `dialogs_active` in it — the gauge that only an
+# outbound run can move, and the one issue #548 pinned at a non-zero value
+# for the life of the process.
+#
+# Brings up its own paced_sink and SIPp callee; expects the daemon config
+# from outbound-lab.toml.example (or $CONFIG).
+set -uo pipefail
+BIN=${1:?usage: phase-outbound.sh <daemon-binary> <label> [steps...]}
+LABEL=${2:?}
+shift 2
+STEPS=("${@:-25 50 100}")
+[[ $# -gt 0 ]] && STEPS=("$@")
+HERE=$(cd "$(dirname "$0")" && pwd)
+SP=${SP:-/var/tmp/outbound-load}; mkdir -p "$SP"
+CONFIG=${CONFIG:-$HERE/outbound-lab.toml}
+HOLD=${HOLD:-120}
+CPS=${CPS:-5}
+OBS_PORT=${OBS_PORT:-9591}
+TEARDOWN=${TEARDOWN:-local}
+SCEN=$HERE/uas_hold.xml
+if [[ "$TEARDOWN" == "remote" ]]; then
+  # The remote-BYE scenario carries a literal PAUSE_MS so the far end's
+  # hold matches the run's; substitute it into a temp copy rather than
+  # relying on a SIPp keyword, which is one more thing to get wrong.
+  SCEN=$SP/uas_hold_remote_bye.$$.xml
+  sed "s/PAUSE_MS/$(( HOLD * 1000 ))/" "$HERE/uas_hold_remote_bye.xml" > "$SCEN"
+fi
+
+[[ -f "$CONFIG" ]] || { echo "no config at $CONFIG (copy outbound-lab.toml.example)"; exit 2; }
+
+cleanup() { kill "${SINK_PID:-0}" "${DAEMON_PID:-0}" "${SIPP_PID:-0}" 2>/dev/null; }
+trap cleanup EXIT
+
+node "$HERE/../paced_sink.mjs" 8770 > "$SP/sink-$LABEL.log" 2>&1 & SINK_PID=$!
+RUST_LOG=siphon_ai=info "$BIN" --config "$CONFIG" > "$SP/daemon-$LABEL.log" 2>&1 & DAEMON_PID=$!
+sleep 2
+kill -0 "$DAEMON_PID" 2>/dev/null || { echo "daemon died on startup:"; tail -20 "$SP/daemon-$LABEL.log"; exit 1; }
+echo "daemon $($BIN --version) pid=$DAEMON_PID"
+
+echo "--- idle baseline"
+"$HERE/obstat.sh" "$DAEMON_PID" "$OBS_PORT" | tee "$SP/$LABEL-idle.json"
+
+STEP_N=0
+for CONC in "${STEPS[@]}"; do
+  # Index the sample files: a run may repeat a concurrency deliberately
+  # (§6.3 test 2 — the same step twice, to separate pool sizing from a
+  # leak), and naming by concurrency alone silently overwrites the first.
+  STEP_N=$((STEP_N + 1))
+  TAG="$LABEL-s$STEP_N-$CONC"
+  echo "=== step $STEP_N: $CONC concurrent, teardown=$TEARDOWN"
+  # One SIPp per step, sized to the step: -m ends it after N calls.
+  sipp -i 127.0.0.1 -sf "$SCEN" -p 5075 -m "$CONC" -l "$CONC" \
+       -timeout 3600s -trace_err -bg > /dev/null 2>&1
+  SIPP_PID=$(pgrep -n -f "sipp -i 127.0.0.1 -sf $SCEN")
+  sleep 0.5
+  SP="$SP" OBS_PORT="$OBS_PORT" "$HERE/ob_ramp.sh" "$CONC" "$CPS" "$HOLD" "$TEARDOWN" &
+  RAMP_PID=$!
+  # Sample twice under load: once the ramp has landed, once late in the hold.
+  sleep $(( CONC / CPS + 10 ))
+  "$HERE/obstat.sh" "$DAEMON_PID" "$OBS_PORT" | tee "$SP/$TAG-early.json"
+  sleep $(( HOLD / 2 ))
+  "$HERE/obstat.sh" "$DAEMON_PID" "$OBS_PORT" | tee "$SP/$TAG-late.json"
+  wait "$RAMP_PID"
+  pkill -f "sipp -i 127.0.0.1 -sf $SCEN" 2>/dev/null
+
+  # §6.3 leak audit, with the outbound-only gauge in it. Removal is
+  # deferred by DialogReaper::DEFAULT_GRACE (32 s) so a BYE retransmit
+  # still matches — poll past it rather than reading once.
+  echo "--- leak audit (waiting out the 32s dialog grace window)"
+  for i in $(seq 1 50); do
+    d=$(curl -s "http://127.0.0.1:$OBS_PORT/metrics" | awk '/^siphon_ai_dialogs_active /{print $2}')
+    [[ "$d" == "0" ]] && { echo "dialogs_active back to 0 at t=${i}s"; break; }
+    sleep 1
+  done
+  "$HERE/obstat.sh" "$DAEMON_PID" "$OBS_PORT" | tee "$SP/$TAG-drained.json"
+done
+
+echo "=== WARN/ERROR in the run"
+grep -cE "\bWARN\b|\bERROR\b" "$SP/daemon-$LABEL.log"
+grep -E "\bWARN\b|\bERROR\b" "$SP/daemon-$LABEL.log" | sed 's/call_id=[a-z0-9-]*//g' | sort | uniq -c | head

--- a/test-harness/load/outbound/uas_hold.xml
+++ b/test-harness/load/outbound/uas_hold.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  uas_hold — SIPp as the CALLEE for an outbound load run.
+
+  Roles are inverted from every other load scenario in this tree: SiphonAI
+  is the UAC here, placing each call through `POST /admin/v1/calls`, and
+  SIPp answers. That direction is the whole point of this phase — every
+  other rig drives calls *into* the daemon, so nothing has ever exercised
+  the origination path under load (see `../LOAD_TEST_PLAN.md` §12).
+
+  The call is held until SiphonAI tears it down: `ob_ramp.sh` hangs each
+  leg up through the admin API after the hold, so the teardown under test
+  is **our own** BYE — the branch where issue #548 leaked a dialog. Use
+  `uas_hold_remote_bye.xml` for the other branch.
+
+  No auto-hangup on the WS side: the sink must keep the leg up for the
+  whole hold, so run `paced_sink.mjs`, not the echo server's
+  `--auto-hangup-after-ms`.
+-->
+<scenario name="uas_hold">
+  <recv request="INVITE" rtd="true"/>
+
+  <send>
+<![CDATA[
+SIP/2.0 180 Ringing
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="100"/>
+
+  <send retrans="500">
+<![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=sipp 53655765 2353687637 IN IP4 [local_ip]
+s=-
+c=IN IP4 [local_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+]]>
+  </send>
+
+  <recv request="ACK" rtd="true"/>
+
+  <!-- Media flows for the hold; the driver ends the call from our side. -->
+  <recv request="BYE" rtd="true" timeout="3600000"/>
+
+  <send>
+<![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+</scenario>

--- a/test-harness/load/outbound/uas_hold_remote_bye.xml
+++ b/test-harness/load/outbound/uas_hold_remote_bye.xml
@@ -1,0 +1,122 @@
+<!--
+  uas_hold_remote_bye — SIPp as the CALLEE for an outbound load run, with
+  the FAR END tearing down.
+
+  Roles are inverted from every other load scenario in this tree: SiphonAI
+  is the UAC here, placing each call through `POST /admin/v1/calls`, and
+  SIPp answers. That direction is the whole point of this phase — every
+  other rig drives calls *into* the daemon, so nothing had ever exercised
+  the origination path under load (`../LOAD_TEST_PLAN.md` §12).
+
+  This is the sibling of `uas_hold.xml`, and the difference is who hangs
+  up. Here SIPp holds the call for `PAUSE_MS` and then sends the BYE, which
+  drives the `remote_bye_received()` branch of the outbound teardown — the
+  other half of the path issue #548 leaked a dialog on. A fix that retires
+  the dialog in only one branch passes half of §12, which is why the phase
+  runs both.
+
+  `PAUSE_MS` is substituted by `phase-outbound.sh` so the far end's hold
+  matches the run's step; the scenario is not runnable as-is.
+
+  Derived from `test-harness/sipp-scenarios/outbound_remote_bye.xml`,
+  including its Contact/From/To capture — the macros do NOT work here, and
+  the comments below say why.
+-->
+<scenario name="uas_hold_remote_bye">
+  <recv request="INVITE" rtd="true">
+    <action>
+      <!-- SiphonAI's Contact becomes our in-dialog Request-URI.
+           check_it fails the scenario loudly if the INVITE somehow
+           carries no Contact, rather than sending a BYE to an empty
+           URI and failing later with a confusing parse error. -->
+      <ereg regexp="sip:[^;&gt;]*"
+            search_in="hdr" header="Contact:"
+            check_it="true"
+            assign_to="remote_contact"/>
+      <!-- Header *values*, not whole lines. The `[last_From:]` /
+           `[last_To:]` macros expand to the complete header including
+           its field name, which is fine when echoing a header back
+           verbatim (the responses above) but wrong here: as the UAS our
+           From is built from the INVITE's To and vice versa, so echoing
+           the macro would emit `From: To: <...>`. Capture the values
+           and place them under the right field names instead. -->
+      <ereg regexp="&lt;sip:[^&gt;]*&gt;.*"
+            search_in="hdr" header="From:"
+            check_it="true"
+            assign_to="caller_from"/>
+      <ereg regexp="&lt;sip:[^&gt;]*&gt;"
+            search_in="hdr" header="To:"
+            check_it="true"
+            assign_to="callee_to"/>
+    </action>
+  </recv>
+
+  <send>
+<![CDATA[
+SIP/2.0 180 Ringing
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="200"/>
+
+  <send retrans="500">
+<![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=sipp 53655765 2353687637 IN IP4 [local_ip]
+s=-
+c=IN IP4 [local_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+]]>
+  </send>
+
+  <recv request="ACK" rtd="true"/>
+
+  <!-- The hold. Substituted by phase-outbound.sh from the step's HOLD, so
+       the leg lives as long as a locally-torn-down one does and the two
+       teardown directions are compared over the same call duration. -->
+  <pause milliseconds="PAUSE_MS"/>
+
+  <!-- The callee hangs up. As the UAS, From/To are the mirror of the
+       INVITE's — our From carries the tag we generated in the 180/200,
+       our To carries the caller's own tag as it arrived. CSeq runs in
+       our own sequence space, independent of the caller's. -->
+  <send retrans="500">
+<![CDATA[
+BYE [$remote_contact] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: [$callee_to];tag=[pid]SIPpTag01[call_number]
+To: [$caller_from]
+[last_Call-ID:]
+CSeq: 1 BYE
+Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- THE assertion. A 481 here is the #324 regression; under load it
+       would also mean the leg never reaches the teardown whose dialog
+       reclamation §12 is measuring. -->
+  <recv response="200" rtd="true"/>
+</scenario>

--- a/test-harness/load/tier3/README.md
+++ b/test-harness/load/tier3/README.md
@@ -1,0 +1,71 @@
+# Tier 3 rig — a live carrier trunk
+
+`LOAD_TEST_PLAN.md` §10.3 / §10.3.1. Reproduces `../RESULTS-0.49.9-tier3.md`.
+
+> **This dials the public PSTN and bills both legs of every call.** Read
+> §10.3's fraud-detection note before running anything, and tell your
+> carrier what you are doing. Sudden high-volume origination is the
+> signature of toll fraud; losing the trunk costs far more than the test.
+
+## The trombone
+
+Each call is originated through the carrier gateway to **a DID that routes
+back to this node**, so it returns as a second inbound leg. Real media
+flows both ways, with no human at either end and no AI spend — the outbound
+leg bridges to a WS sink, and the returning inbound leg matches a route
+that bridges to another.
+
+```
+siphon-ai ──INVITE──► carrier SBC ──► carrier routes the DID back
+    ▲                                          │
+    └────────────── inbound leg ◄──────────────┘
+```
+
+**Two channels per call**, one out and one back in. On a 3-channel trunk
+that is exactly one call at a time with one channel spare — deliberately,
+so a genuine inbound call is not rejected because a test is running. Do not
+parallelise without recounting channels.
+
+## Running it
+
+```sh
+export SP=/var/tmp/tier3 && mkdir -p $SP
+export TOKEN=<admin-role bearer token>
+export GATEWAY=<name of the carrier [[gateway]]>
+export TO=<DID that routes back to this node>
+./tier3_run.sh 60 30        # 60 sequential calls, 30s each
+```
+
+`WS` (default `ws://127.0.0.1:8081/?mode=sustain`) is the sink for the
+**outbound** leg; the returning leg's sink comes from the daemon's own route
+config. `sustain` generates a continuous 50 fps filler, which is what puts
+real audio on the wire in both directions.
+
+## Guardrails in the script
+
+A live trunk is not loopback: a run that has stopped working must stop
+dialling rather than keep paying to fail.
+
+- **Hard cap** of 200 calls, whatever you pass.
+- **Aborts after 3 consecutive failures** — a refused originate, a trombone
+  that never closed, or a channel that stayed busy.
+- **Never starts on top of existing traffic.** It waits for
+  `calls_active == 0`, so a genuine call in progress delays the next sample
+  instead of colliding with it and eating the spare channel.
+- **Requires both legs up** (`calls_active == 2`) before counting a sample.
+  One leg means the carrier took the call and never routed it back, which is
+  a failed sample, not a short one.
+
+## Reading the result
+
+Everything comes from the CDRs and the lifecycle webhooks, per call:
+
+| what | where |
+|---|---|
+| carrier setup latency | outbound CDR `answered_at − started_at` |
+| carrier round-trip alone | `outbound_initiated` → the returning leg's `call_start` |
+| MOS / jitter / loss | both CDRs' `quality` block |
+
+🪤 **Not `sdp_negotiate_seconds`.** Despite what earlier revisions of §10.3
+said, that histogram times `prepare_call` — our own local work — and says
+nothing about the carrier.

--- a/test-harness/load/tier3/tier3_run.sh
+++ b/test-harness/load/tier3/tier3_run.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# tier3_run.sh <calls> <hold_seconds>
+#
+# LOAD_TEST_PLAN.md §10.3 — the live-carrier run, in its low-concurrency
+# form. Places SEQUENTIAL trombone calls: originate through the carrier
+# gateway to our own DID, so the call comes back in as a second leg and
+# real media flows both ways with no human at either end.
+#
+# THIS DIALS THE PUBLIC PSTN AND BILLS BOTH LEGS OF EVERY CALL.
+#
+# One trombone at a time. A trombone occupies TWO channels (one out, one
+# back in), so on a 3-channel trunk this leaves exactly one free — which is
+# deliberate: a genuine inbound call must not be rejected because a test is
+# running. Do not "parallelise" this without recounting channels.
+set -uo pipefail
+CALLS=${1:-60}; HOLD=${2:-30}
+ADMIN=${ADMIN:-127.0.0.1:9092}
+OBS=${OBS:-127.0.0.1:9091}
+GATEWAY=${GATEWAY:?set GATEWAY to the carrier [[gateway]] name}
+TO=${TO:?set TO to the DID that routes back to this node}
+WS=${WS:-ws://127.0.0.1:8081/?mode=sustain}
+SP=${SP:-/var/tmp/tier3}; mkdir -p "$SP"
+: "${TOKEN:?set TOKEN to an admin-role bearer token}"
+
+# Guardrails. A live trunk is not a loopback: a run that has stopped
+# working must stop dialling, not keep paying to fail.
+MAX_CALLS=200
+CONSECUTIVE_FAIL_ABORT=3
+(( CALLS > MAX_CALLS )) && { echo "refusing $CALLS calls (cap $MAX_CALLS)"; exit 2; }
+
+active() { curl -s --max-time 5 "http://$OBS/metrics" | awk '/^siphon_ai_calls_active /{print $2}'; }
+
+echo "tier3: $CALLS sequential trombones, ${HOLD}s hold, gateway=$GATEWAY to=$TO"
+echo "  two channels per call; one left free for genuine inbound traffic"
+ok=0; fail=0; streak=0
+for i in $(seq 1 "$CALLS"); do
+  # Never start on top of existing traffic — that would both skew the
+  # measurement and eat the spare channel.
+  for _ in $(seq 1 30); do [[ "$(active)" == "0" ]] && break; sleep 2; done
+  if [[ "$(active)" != "0" ]]; then
+    echo "[$i] channel busy for 60s — skipping"; fail=$((fail+1)); streak=$((streak+1))
+  else
+    t0=$(date -u +%s.%N)
+    body=$(curl -s --max-time 10 -X POST -H "Authorization: Bearer $TOKEN" \
+      -H "Content-Type: application/json" "http://$ADMIN/admin/v1/calls" \
+      -d "{\"to\":\"$TO\",\"gateway\":\"$GATEWAY\",\"ws_url\":\"$WS\"}")
+    id=$(sed -n 's/.*"call_id":"\([^"]*\)".*/\1/p' <<<"$body")
+    if [[ -z "$id" ]]; then
+      echo "[$i] originate refused: $body"; fail=$((fail+1)); streak=$((streak+1))
+    else
+      # Both legs up = the trombone closed. One leg only means the carrier
+      # took the call but never routed it back, which is a failed sample.
+      up=0
+      for _ in $(seq 1 20); do [[ "$(active)" == "2" ]] && { up=1; break; }; sleep 0.5; done
+      if (( up )); then
+        sleep "$HOLD"
+        curl -s -o /dev/null --max-time 10 -X POST -H "Authorization: Bearer $TOKEN" \
+          "http://$ADMIN/admin/v1/calls/$id/hangup"
+        ok=$((ok+1)); streak=0
+        echo "[$i] ok ($id)"
+      else
+        echo "[$i] trombone did not close (active=$(active)) — hanging up"
+        curl -s -o /dev/null --max-time 10 -X POST -H "Authorization: Bearer $TOKEN" \
+          "http://$ADMIN/admin/v1/calls/$id/hangup"
+        fail=$((fail+1)); streak=$((streak+1))
+      fi
+    fi
+  fi
+  (( streak >= CONSECUTIVE_FAIL_ABORT )) && {
+    echo "ABORT: $streak consecutive failures — stopping so the trunk isn't billed for a broken run"; break; }
+  # Drain before the next one, so each sample is a clean single call.
+  for _ in $(seq 1 30); do [[ "$(active)" == "0" ]] && break; sleep 1; done
+done
+echo "done: ok=$ok fail=$fail"

--- a/test-harness/load/tier3/tier3_stats.py
+++ b/test-harness/load/tier3/tier3_stats.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Summarise a tier-3 run from the daemon's CDRs and lifecycle webhooks.
+
+Usage: tier3_stats.py <cdr.jsonl> [lifecycle.jsonl]
+                     [--since-line=N] [--since-lc-line=N]
+
+Both files are appended to by the running daemon and carry every call it
+has ever handled, so a run is identified by the line count each file had
+when it started. Filtering only the CDRs silently mixes earlier calls into
+the webhook-derived figures — which is how the round-trip sample count came
+out larger than the call count on the first run of this script.
+
+Everything here is per-call, which is the point: the sequential form of
+§10.3 trades concurrency for a distribution, so the output is percentiles
+over calls rather than a single loaded-system number.
+"""
+import json
+import sys
+from datetime import datetime
+
+
+def ts(v):
+    return datetime.fromisoformat(v.replace("Z", "+00:00")) if v else None
+
+
+def pct(xs, p):
+    """Nearest-rank percentile. With n=60 the p95 is the 57th of 60 — say so
+    next to the number rather than implying a smooth tail."""
+    if not xs:
+        return None
+    s = sorted(xs)
+    k = max(0, min(len(s) - 1, int(round(p / 100 * len(s) + 0.5)) - 1))
+    return s[k]
+
+
+def summarise(name, xs, unit="", nd=1):
+    if not xs:
+        print(f"  {name:24} (no samples)")
+        return
+    print(
+        f"  {name:24} n={len(xs):<4} min={min(xs):.{nd}f} p50={pct(xs,50):.{nd}f} "
+        f"p95={pct(xs,95):.{nd}f} max={max(xs):.{nd}f} {unit}"
+    )
+
+
+def main():
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    since = since_lc = 0
+    for a in sys.argv[1:]:
+        if a.startswith("--since-line"):
+            since = int(a.split("=", 1)[1])
+        elif a.startswith("--since-lc-line"):
+            since_lc = int(a.split("=", 1)[1])
+    cdr_path = args[0]
+    lc_path = args[1] if len(args) > 1 else None
+
+    rows = []
+    with open(cdr_path) as fh:
+        for n, line in enumerate(fh, 1):
+            if n <= since:
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+
+    out = [r for r in rows if r.get("direction") == "outbound"]
+    inb = [r for r in rows if r.get("direction") == "inbound"]
+
+    setup, dur = [], []
+    for r in out:
+        a, s = ts(r.get("answered_at")), ts(r.get("started_at"))
+        if a and s:
+            setup.append((a - s).total_seconds() * 1000)
+        if r.get("duration_ms"):
+            dur.append(r["duration_ms"] / 1000)
+
+    print(f"outbound legs: {len(out)}   inbound (returned) legs: {len(inb)}")
+    if len(out) != len(inb):
+        print(f"  !! {abs(len(out)-len(inb))} leg(s) unmatched — a trombone that "
+              f"did not close is a failed sample, not a short one")
+    print("\nCarrier setup latency (outbound INVITE -> 200 OK):")
+    summarise("setup_ms", setup, "ms", 0)
+    print("\nCall duration (sanity — should cluster at the hold):")
+    summarise("seconds", dur, "s", 1)
+
+    for label, rs in (("outbound", out), ("inbound (returned)", inb)):
+        q = [r.get("quality") or {} for r in rs]
+        print(f"\nQuality — {label} leg:")
+        summarise("mos_estimate_avg", [x["mos_estimate_avg"] for x in q
+                                       if x.get("mos_estimate_avg") is not None], "", 3)
+        summarise("avg_jitter_ms", [x["avg_jitter_ms"] for x in q
+                                    if x.get("avg_jitter_ms") is not None], "ms", 2)
+        lost = [x.get("rx_packets_lost", 0) or 0 for x in q]
+        recv = [x.get("rx_packets_received", 0) or 0 for x in q]
+        if recv:
+            tot_l, tot_r = sum(lost), sum(recv)
+            print(f"  {'packet loss':24} {tot_l}/{tot_r+tot_l} packets "
+                  f"= {100*tot_l/max(1,tot_r+tot_l):.3f}%   "
+                  f"(calls with any loss: {sum(1 for x in lost if x)}/{len(lost)})")
+
+    causes = {}
+    for r in rows:
+        c = (r.get("termination") or {}).get("cause", "?")
+        causes[c] = causes.get(c, 0) + 1
+    print("\nTermination causes:", ", ".join(f"{k}={v}" for k, v in sorted(causes.items())))
+
+    if lc_path:
+        # The carrier's own out-and-back: our INVITE goes out, and the call
+        # arriving BACK is a `call_start`. That isolates the SBC from our
+        # own answer, which the CDR's setup figure folds together.
+        events = []
+        with open(lc_path) as fh:
+            for n, line in enumerate(fh, 1):
+                if n <= since_lc:
+                    continue
+                try:
+                    b = json.loads(line).get("body", {})
+                except json.JSONDecodeError:
+                    continue
+                if b.get("type") in ("outbound_initiated", "call_start"):
+                    events.append((ts(b["timestamp"]), b["type"]))
+        events.sort()
+        rt = []
+        pending = None
+        for t, kind in events:
+            if kind == "outbound_initiated":
+                pending = t
+            elif kind == "call_start" and pending:
+                d = (t - pending).total_seconds() * 1000
+                if 0 < d < 10000:
+                    rt.append(d)
+                pending = None
+        print("\nCarrier round trip (our INVITE out -> the call arriving back):")
+        summarise("round_trip_ms", rt, "ms", 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Completes `LOAD_TEST_PLAN.md`. Two commits: the phase that was missing entirely (§12), and the one section that had never been run (§10.3 tier 3).

---

# §12 — outbound origination under load

Closes the gap that let #548 ship.

Every phase in the plan drives calls **into** the daemon. The `originate` commands in §10.2 are FreeSWITCH originating **at** us. Nothing ever exercised `POST /admin/v1/calls` — and a leak audit cannot see a resource no phase allocates. That is how **#548** (one dialog leaked into the shared store per originated call, until `MAX_CONFIRMED_DIALOGS` silently breaks in-dialog matching for *every* call) survived every run in the document, the 8-hour convergence soak included, and was found by hand during a deploy verification instead.

`test-harness/load/outbound/` — SIPp is the callee, the daemon is the caller, both teardown directions (a fix that retires the dialog in only one branch passes half the phase).

**0.49.9 passes.** 175 calls, zero WARN/ERROR, everything back to idle:

| concurrent | CPU/core | per call | RSS | fds | RTP ports |
|---|---|---|---|---|---|
| 25 | 8.4 % | 0.336 % | 26.0 MB | 88 | 50 |
| 50 | 14.5 % | 0.290 % | 33–36 MB | 163 | 100 |
| 100 | 27.1 % | 0.271 % | 49.9 MB | 313 | 200 |

fds are exactly **13 + 3N** — the same slope as the `12 + 3N` tiers 1–2 published for inbound. An originated leg holds two RTP ports like any other, so **§1.1's range caps the sum of both directions**, which no capacity figure had stated.

**0.49.8 fails it.** Same rig, two 50-call steps: `dialogs_active` ends at **exactly 100** while `calls_active`, fds and RTP ports all return to idle. Cumulative with call count — a per-call leak, not fixed overhead.

---

# §10.3 tier 3 — a live Twilio trunk

The last unrun section. **60/60 sequential calls, zero failures**, zero WARN/ERROR attributable to the run.

| | min | p50 | p95 | max |
|---|---|---|---|---|
| setup (INVITE → 200 OK) | 324 ms | **384 ms** | **460 ms** | 524 ms |
| of which the carrier itself | 260 ms | **281 ms** | 383 ms | 403 ms |

The webhook decomposition (`outbound_initiated` → the returning leg's `call_start`) isolates the SBC from our own answer: **~281 ms of a 384 ms setup is Twilio**. Three quarters of outbound setup is carrier-owned and no local work will move it.

**The netem model turns out to be pessimistic:**

| | clean LAN (tier 2) | **live carrier** | netem 20 ms ±5 ms / 0.5 % (tier 2) |
|---|---|---|---|
| jitter | 0.44 ms | **1.94 ms** | 3.35 ms |
| MOS | 4.441 | **4.435** | 4.418 |
| loss | 0.0 % | **0.001 %** | 0.495 % |

Jitter is 4.4× the LAN figure but only 58 % of netem's, and loss is **500× lower** than the 0.5 % netem injects. So tier 2's impairment numbers are a **conservative bound, not a prediction** — which could not be known until a live run sat beside them. One path, one carrier, one afternoon: this calibrates, it does not generalise.

**Shape.** §10.3 asks for 30–50 concurrent; this account cannot do it. Twilio's channel cap follows the Customer Profile, and Individual is **3**. A trombone (originate to our own DID so the call returns as a second leg) costs **two** channels, so this ran one call at a time with one channel left free so genuine inbound traffic would not be rejected. Sixty sequential calls give a better latency distribution than sixty simultaneous ones anyway; what is lost is any carrier-concurrency claim, and the results doc makes none.

**No per-call CPU figure, deliberately.** §10.3 asks for one against tier 2's TLS+SRTP number and it cannot be produced honestly here: at one concurrent call fixed overhead dominates, and prod's posture (HEP, webhooks, quality records, neural VAD) is not tier 2's lean one. It would be a comparison of postures dressed as a comparison of transports.

---

# Plan corrections these forced

- **§6.3's leak audit never checked `dialogs_active`** though §6.1's pass criteria names it — now added, *with the two-step read it needs*. The gauge is republished only on the reaper's 5 s sweep and the UAC inserts the dialog when it **sends the BYE**, so a read taken straight after teardown returns the pre-BYE `0` and passes against a daemon that reclaims nothing. My first cut did exactly that and went green on 0.49.8.
- **§9 implied coverage that didn't exist.** It now states outbound was untested and that §§3–6 are *inbound* numbers.
- **§10.3 named the wrong metric.** `sdp_negotiate_seconds` times `prepare_call` — our own local work, not the carrier. Corrected.
- **§10.3 assumed 30–50 channels.** It now documents the Customer Profile matrix and adds **§10.3.1**, the sequential form, with the honest consequence for §10.4's claim template.

# Safety

The tier-3 driver has real guardrails, because a live trunk is not loopback: a hard cap of 200 calls whatever you pass, abort after 3 consecutive failures, never start on top of existing traffic (a genuine call delays a sample rather than colliding with it and eating the spare channel), and a sample counts only if **both** legs came up. Twilio support was notified in advance with the exact profile and confirmed it needs no approval while inside account limits.


---

# §13 mixed direction + §12.6 outbound soak

The two gaps the §12 results doc left open.

**The directions compose linearly.** `fds = 13 + 3N` and `udp_sockets = 2N + 1` hold with N the *total* across both, and 100 mixed calls cost **27.2 %** of one core against **27.1 %** for 100 outbound-only. A mixed call costs what either kind costs alone.

**The shared RTP pool has no reservation — that is the finding.** With the range deliberately sized to 60 calls and 50 inbound legs established first, 10 of 20 originates failed:

```
WARN outbound call did not connect
     error=forge session error: Resource limit exceeded: No available ports in pool
siphon_ai_outbound_calls_total{result="failed"} 10
```

Clean failure — no hang, no panic, no leaked dialog — but entirely one-sided: inbound continued undisturbed. **An inbound surge can starve origination completely with no inbound symptom**, and it is invisible on the originate API, which returns `202` and fails later on the webhook. My own ramp counted `rejected=0` for the run in which half the calls failed, because that counter sees admission refusals (`503`/`429`), not resource failures.

**Outbound soak: 2,995 placed, 2,995 completed, 0 failed, zero WARN/ERROR across 75 minutes.** It *churns* — 50 concurrent held by replacing each call as it ends, so an hour is ~3,000 completions rather than 50. Per-call leaks scale with completions, not concurrency; #548 leaked one dialog per call and a park-50-calls soak would have seen nothing.

| | during | at drain |
|---|---|---|
| `dialogs_active` | 50 → 76 | **0 at t=35 s** |
| fds | 163 flat | **13** (idle) |
| UDP sockets | 101 flat | **1** |
| CPU | 13.8–15.4 % | 0 |

76 against 50 active is correct arithmetic, not a leak: 50 active plus ~26 inside the 32 s grace window at ~50 calls/min. §6.1's "returns to 0" applies once load *stops*.

**RSS grew, and the re-load test says it is arena, not a leak:**

| | calls | RSS delta | per call |
|---|---|---|---|
| first load | 2,995 | +62.7 MB | 21.4 KB |
| **re-load, same process** | 750 | **+1.4 MB** | **1.9 KB** |

A leak would have needed ~16 MB for those 750 calls. Quote the second number for sizing; the first is a fresh process reaching its working set.

### Three rig bugs found and fixed on the way, all documented in place

- `obstat.sh` read `/metrics` **before** its 5-second CPU window and `/proc` **after**, so one JSON line straddled two instants — during a ramp that made outbound legs look descriptor-free. I nearly reported it as a finding.
- Under `set -u` on bash 5.2 an **empty** associative array is "unset": `${!arr[@]}` *and* `${#arr[@]}` both abort. My first two fixes were themselves the bug; the working form is `${arr[@]+"${!arr[@]}"}`.
- Editing a running bash script corrupts it mid-execution — bash reads incrementally, so the live process jumped into mangled offsets. `ob_soak.sh` now takes `RIG` so a long soak runs from a frozen copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FF7ymKTPqhd7d5CNxjG8bg
