### PR TITLE
chore(release): 0.49.10 — a full RTP port pool says 503, not 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.49.10] - 2026-08-22
+
+One fix to the **inbound** call path: a full RTP port pool is a capacity
+condition, and it now answers like one. Relevant to any node that can run
+out of ports — most sharply to a node that also originates, since both
+directions draw from the same pool.
+
+**No config change, no protocol change** (still `1`), CDR still v8. Adds
+one metric label. Wants a restart to take effect.
+
 ### Fixed
 
 - **An exhausted RTP port pool now answers `503 Service Unavailable` +
@@ -31,7 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     separately alertable from `rejected`. On a node that also originates the
     pool is shared with outbound, so this counter is the only inbound-side
     signal that a surge in the other direction is refusing calls — see
-    `test-harness/load/RESULTS-0.49.9-mixed-and-soak.md` §2.1.
+    `test-harness/load/RESULTS-0.49.9-mixed-and-soak.md` §2.1. That pool
+    has no reservation between the two directions, which is tracked
+    separately as #556; this release changes only the answer given, not
+    who gets a port.
 
 ## [0.49.9] - 2026-08-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4083,7 +4083,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.49.9"
+version = "0.49.10"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4132,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-admin-api-types"
-version = "0.49.9"
+version = "0.49.10"
 dependencies = [
  "serde",
  "serde_json",
@@ -4140,7 +4140,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.49.9"
+version = "0.49.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4156,7 +4156,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.49.9"
+version = "0.49.10"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4178,7 +4178,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.49.9"
+version = "0.49.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4195,7 +4195,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.49.9"
+version = "0.49.10"
 dependencies = [
  "regex",
  "serde",
@@ -4214,7 +4214,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.49.9"
+version = "0.49.10"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4260,7 +4260,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.49.9"
+version = "0.49.10"
 dependencies = [
  "base64 0.22.1",
  "hmac 0.12.1",
@@ -4283,7 +4283,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.49.9"
+version = "0.49.10"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4309,7 +4309,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.49.9"
+version = "0.49.10"
 dependencies = [
  "anyhow",
  "clap",
@@ -4327,7 +4327,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.49.9"
+version = "0.49.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4345,7 +4345,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.49.9"
+version = "0.49.10"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4359,7 +4359,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.49.9"
+version = "0.49.10"
 dependencies = [
  "regex",
  "serde",
@@ -4371,7 +4371,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.49.9"
+version = "0.49.10"
 dependencies = [
  "schemars",
  "serde",
@@ -4381,7 +4381,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sightglass"
-version = "0.49.9"
+version = "0.49.10"
 dependencies = [
  "anyhow",
  "clap",
@@ -4396,7 +4396,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.49.9"
+version = "0.49.10"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4424,7 +4424,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.49.9"
+version = "0.49.10"
 dependencies = [
  "base64 0.22.1",
  "rcgen",
@@ -4442,7 +4442,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.49.9"
+version = "0.49.10"
 dependencies = [
  "anyhow",
  "forge-engine",
@@ -4474,7 +4474,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.49.9"
+version = "0.49.10"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.49.9"
+version = "0.49.10"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.49.9.** Production-deployed against real carriers
+**Current release: v0.49.10.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged. Daemon upgrades are near-drop-in


### PR DESCRIPTION
Release prep for **0.49.10**: version bump + `Cargo.lock` refresh, `CHANGELOG.md` `[Unreleased]` → `## [0.49.10] - 2026-08-22` with a fresh empty `[Unreleased]`, and the `README.md` current-release marker.

The release carries one fix, already on `main`:

- **#554 / #555** — an exhausted RTP port pool answered `500 Server Internal Error`; it now answers `503 Service Unavailable` + `Retry-After: 2`, with a new `siphon_ai_invites_total{result="rejected_capacity"}` label. `media-glue` stops flattening `ForgeError::ResourceLimit` into a stringly `SetupError::Session`, and the delayed-offer path — which hardcoded `500` and the flat `rejected` label — routes through the shared status table like every other rejection.

Found by `LOAD_TEST_PLAN.md` §13's exhaustion test run in the `outbound-first` order; the two directions are not symmetric, and a phase that runs one order tests half the behaviour.

The shared pool still has **no reservation between directions** — filed as #556. This release changes the answer given, not who gets a port.

**No config change, no protocol change** (still `1`), CDR still v8. Wants a restart.

Gates run locally before pushing:

```
python3 scripts/check-version-consistency.py            → Version consistent: 0.49.10.
python3 scripts/check-version-consistency.py --tag v0.49.10  → consistent (tag v0.49.10).
python3 scripts/extract-changelog.py 0.49.10            → notes present
```

Tag `v0.49.10` goes on the merge commit once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cECkSRCEGs3oyEG5DV4yL