### PR TITLE
test(harness): assert the outbound delayed-offer counter, not just "answered"

### DIFF
--- a/test-harness/sipp-scenarios/run-all.sh
+++ b/test-harness/sipp-scenarios/run-all.sh
@@ -936,8 +936,16 @@ odo_resp=$(curl -s -o /dev/null -w "%{http_code}" \
     -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "http://127.0.0.1:$ADMIN_API_PORT/admin/v1/calls" \
     -d '{"to": "7001", "gateway": "sipp", "delayed_offer": true}')
 if [[ "$odo_resp" == "202" ]] && wait "$ODO_SIPP_PID"; then
-    if curl -s "http://127.0.0.1:$ODO_ADMIN_PORT/metrics" \
-        | grep -q 'siphon_ai_outbound_calls_total{result="answered"} 1'; then
+    # Two counters, two different claims. `outbound_calls_total` says the
+    # call answered — true of any originate. `outbound_delayed_offer_total`
+    # (#406) says the *negotiation* reached `answered`: the peer's 2xx offer
+    # parsed and the ACK answer generator built a reply. The scenario's
+    # check_it proves the ACK carried an m-line; this proves the daemon
+    # agrees it negotiated, and is the only assertion anywhere in CI on
+    # that counter.
+    odo_metrics=$(curl -s "http://127.0.0.1:$ODO_ADMIN_PORT/metrics")
+    if grep -q 'siphon_ai_outbound_calls_total{result="answered"} 1' <<<"$odo_metrics" \
+        && grep -q 'siphon_ai_outbound_delayed_offer_total{result="answered"} 1' <<<"$odo_metrics"; then
         odo_ok=1
     fi
 fi


### PR DESCRIPTION
Closes the last unasserted claim in the `outbound_delayed_uas` phase.

That phase drives a full RFC 3264 delayed offer — SiphonAI INVITEs without SDP, SIPp offers in its 2xx, SiphonAI answers in the ACK — but it asserted only `siphon_ai_outbound_calls_total{result="answered"}`, which **any** originate satisfies. The counter that actually says the *negotiation* succeeded is `siphon_ai_outbound_delayed_offer_total` (#406): the peer's 2xx offer parsed and the ACK answer generator built a reply. Nothing in CI asserted it, so its documented result set could rot unnoticed.

The scenario's own `check_it` already proves the ACK carried an m-line. This adds the daemon's side of the same claim, and catches the case the old assertion misses: the call answers but the negotiation lands on a failure label (`missing_sdp_offer`, `invalid_remote_media`, `media_activate`, `srtp_policy`, `srtp_setup`).

Also scrapes `/metrics` once and greps it twice, rather than curling twice.

### Why now

Found while closing **OB-02** in the functional test plan, which had sat at 🟡 since 2026-07-27 on the note *"the ACK-answer path is unreachable here — needs a SIPp UAS or PBX peer."* It wasn't: this repo's own `outbound_delayed_uas.xml` and this phase were already that peer. Verified end-to-end against the shipped 0.49.10 binary — offerless INVITE (`Content-Length: 0`), SIPp's 200 carrying the offer, our ACK carrying `m=audio 16492 RTP/AVP 0` / `a=rtpmap:0 PCMU/8000` / `a=ptime:20` / `a=sendrecv`, then `siphon_ai_outbound_delayed_offer_total{result="answered"} 1`.

(The row's other note — that the counter "never appears on /metrics" — conflated two counters. `siphon_ai_delayed_offer_total` is the *inbound* one and correctly stays absent on an outbound test.)

### Verification

Full harness locally: **40 of 41 OK**, `outbound_delayed_uas` among them. The single failure is `barge_in_pause`, which fails on this box for unrelated local reasons and passes in CI.

Negative-tested the new condition — it fails, as it must, against a scrape where the counter is absent, and against one where the negotiation landed on `missing_sdp_offer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cECkSRCEGs3oyEG5DV4yL