### PR TITLE
docs: bring the CHANGELOG and README up to current state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The SIPp harness asserts the outbound delayed-offer counter, not just
+  "answered"** (#558). The `outbound_delayed_uas` phase drives a full
+  RFC 3264 delayed offer — offerless INVITE out, the peer's offer in its
+  2xx, our answer in the ACK — but asserted only
+  `siphon_ai_outbound_calls_total{result="answered"}`, which *any*
+  originate satisfies. `siphon_ai_outbound_delayed_offer_total` (#406) is
+  the counter that says the negotiation itself succeeded, and nothing in
+  CI asserted it, so its documented result set could rot unnoticed. The
+  scenario's own `check_it` proves the ACK carried an m-line; this adds
+  the daemon's side of the same claim, and catches an originate that
+  answers while the negotiation lands on `missing_sdp_offer`,
+  `invalid_remote_media`, `media_activate` or an `srtp_*` label.
+
 ## [0.49.10] - 2026-08-22
 
 One fix to the **inbound** call path: a full RTP port pool is a capacity
@@ -45,6 +60,31 @@ one metric label. Wants a restart to take effect.
     has no reservation between the two directions, which is tracked
     separately as #556; this release changes only the answer given, not
     who gets a port.
+
+### Documentation
+
+- **The load test plan is complete — outbound origination, a live-carrier
+  tier, both directions at once, and a churning soak** (#553). Everything
+  through §11 loaded *inbound* only, which is how a per-originated-call
+  dialog leak (#548) reached production unnoticed; the plan now has a §12
+  outbound phase, §13 mixed-direction phase, and the tier-3 live run its
+  three tiers always promised. Three results documents land with it:
+  - `RESULTS-0.49.9-outbound.md` — origination under load. `fds = 13 + 3N`
+    and two RTP ports per originated leg; a 60-minute churning soak
+    (2,995 placed / 2,995 completed / 0 failed / 0 WARN) whose RSS growth
+    is **arena, not a leak** — the same drained process absorbed 750 more
+    calls at 1.9 KB each where a leak needed ~16 MB.
+  - `RESULTS-0.49.9-tier3.md` — 60 sequential calls over a live Twilio
+    trunk (TLS + SRTP), out through the carrier and back in to the same
+    node. MOS p50 **4.435**, jitter p50 **1.94 ms**, loss **0.001 %**,
+    setup p95 **460 ms**. It also proves the tier-2 netem model
+    *pessimistic*: live jitter 1.94 ms against netem's 3.35, live loss
+    0.001 % against 0.495 %.
+  - `RESULTS-0.49.9-mixed-and-soak.md` — the two directions compose
+    linearly (`fds = 13 + 3N`, `udp_sockets = 2N + 1`, N the *total*), and
+    the shared RTP pool is first-come-first-served with **no reservation
+    between them** (#556). Running the exhaustion test in the reverse
+    order is what found #554, fixed above.
 
 ## [0.49.9] - 2026-08-21
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,32 @@ DTMF, and the WebSocket protocol:
   (`siphon-ai-testkit`) that plays the daemon side against any WS server
   and validates its behavior (`docs/CONFORMANCE.md`).
 
+### Measured capacity
+
+Numbers, not adjectives — all on **4 vCPU / 7.9 GB, Debian 13**, G.711
+µ-law, from `test-harness/load/`. Each row names the release it was
+measured on; the load plan and its results documents are in that
+directory.
+
+| | measured |
+|---|---|
+| **Sustained concurrent calls** | **≥ 250**, every quality SLO held — *not* a measured ceiling: nothing had degraded at the top of the ramp (0.48.13) |
+| **Setup rate** | **≥ 75 cps**, p95 ≤ 0.5 ms, zero failures (0.48.13) |
+| CPU per call | **0.54 %** of one core at 250 concurrent, *falling* with concurrency; **0.65 %** at 200 against a real FreeSWITCH (0.48.19) |
+| CPU at 250 concurrent | 134.5 % of one core = **33.6 % of the box** (0.48.13) |
+| Cost of TLS + SRTP | **+2 %** daemon CPU at 200 concurrent — the generator paid far more than we did (0.48.19) |
+| Memory | ~0.43 MB/call at 200 concurrent, measured at two hours (0.48.13); RSS **converges by hour 4** of an 8-hour soak — the last four hours added 1.6 MB (0.48.19) |
+| Quality over a **live carrier** | MOS p50 **4.435**, jitter p50 **1.94 ms**, loss **0.001 %**, setup p95 **460 ms** — 60 calls out through Twilio (TLS + SRTP) and back in (0.49.9) |
+| Behaviour past the cap | admission shed is **503**, exact, admitted calls unaffected (0.48.13); an exhausted RTP pool answers **503 + `Retry-After`** (0.49.10) |
+
+**State the limit with the number.** Concurrency is capped by
+`[media].rtp_port_range` before it is capped by CPU — every call holds two
+UDP ports, so a 4,000-port range is 2,000 calls and no amount of CPU
+changes that. The runs above used `[41000, 45000]`. On a node that both
+answers and originates, both directions draw from that one pool with no
+reservation between them ([#556](https://github.com/thevoiceguy/siphon-ai/issues/556)),
+so size it for the sum.
+
 See [`docs/DEV_PLAN.md`](docs/DEV_PLAN.md) for design rationale. Still
 deliberately out of scope: multi-tenancy, video, and WebRTC client support.
 


### PR DESCRIPTION
Documentation only — no code, no config, no protocol.

### 1. `[Unreleased]` gains #558

The SIPp harness assertion on `siphon_ai_outbound_delayed_offer_total`. **Merge #558 first** — this entry describes it.

### 2. The 0.49.10 section was missing half of what shipped in the tag

It documented the `503` fix and nothing else, but #553 is an ancestor of `v0.49.10` too. Backfills a `### Documentation` entry for the load plan's completion — §12 outbound origination, §13 both directions at once, the tier-3 live-carrier run, and the three results documents — with the headline numbers from each. That work is what found #554 and #556, so the release carrying the #554 fix ought to say where it came from.

Note this edits a section for an already-published tag. The GitHub release notes for `v0.49.10` were extracted at publish time and still show the old text; `RELEASING.md` documents a `workflow_dispatch` re-run that refreshes notes in place if you want them to match. Happy to run it or leave it.

### 3. The README had no capacity numbers

The load plan's §7 exists to produce a table "suitable for the README", and the README never got one. Adds **Measured capacity**:

- **≥ 250** sustained concurrent, every SLO held — flagged explicitly as *not* a measured ceiling
- **≥ 75 cps** setup rate, zero failures
- **0.54 %** of one core per call at 250 concurrent, falling with concurrency; **0.65 %** against a real FreeSWITCH
- **+2 %** CPU for TLS + SRTP at 200 concurrent
- RSS **converges by hour 4** of an 8-hour soak (last four hours: +1.6 MB)
- Live carrier: MOS p50 **4.435**, jitter p50 **1.94 ms**, loss **0.001 %**, setup p95 **460 ms**

Every figure is quoted from a results document in `test-harness/load/`; none is extrapolated, and each row names the release it was measured on, since they span 0.48.13 → 0.49.10 rather than a single run.

Per the plan's §7.3 it states the limit with the number: concurrency is capped by `[media].rtp_port_range` before CPU — two ports per call — and on a node that both answers and originates the two directions share that pool with no reservation (#556).

### Gates

`check-version-consistency.py`, `extract-changelog.py 0.49.10`, and `check-doc-links.py` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cECkSRCEGs3oyEG5DV4yL