### PR TITLE
chore(release): 0.50.0 — reserve RTP ports for origination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.50.0] - 2026-08-23
+
+**One new config key and one dependency bump that reaches the wire.**
+
+`[media].reserved_outbound_calls` closes the last gap the load plan found:
+inbound and outbound calls draw RTP ports from one pool, first-come-first-served,
+so on a node that both answers and originates an inbound surge could starve
+origination *completely* with no inbound-side symptom. Set it and the inbound
+allocator stops at a floor, leaving the rest to origination. Default `0` is the
+old unreserved behaviour, so **upgrading changes nothing until you set it**.
+
+⚠️ **DTLS-SRTP deployments read the forge-media bump below before upgrading.**
+The certificate moves from RSA-2048 to ECDSA P-256, which is live wherever
+`[media].srtp_offer = "dtls"` is set. Almost every peer prefers P-256 already —
+it is what browsers present — but a peer that can only do RSA key exchange
+would newly fail.
+
+**No protocol change** (still `1`), CDR still v8. Adds one config key, two
+metrics, and a `--inspect-config` line. Wants a restart to take effect.
+
 ### Changed
 
 - **forge-media pinned to `1fe94a502efa`** — nine commits, three of them

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4084,7 +4084,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.49.10"
+version = "0.50.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4133,7 +4133,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-admin-api-types"
-version = "0.49.10"
+version = "0.50.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -4141,7 +4141,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.49.10"
+version = "0.50.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4157,7 +4157,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.49.10"
+version = "0.50.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4179,7 +4179,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.49.10"
+version = "0.50.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4196,7 +4196,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.49.10"
+version = "0.50.0"
 dependencies = [
  "regex",
  "serde",
@@ -4215,7 +4215,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.49.10"
+version = "0.50.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4261,7 +4261,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.49.10"
+version = "0.50.0"
 dependencies = [
  "base64 0.22.1",
  "hmac 0.12.1",
@@ -4284,7 +4284,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.49.10"
+version = "0.50.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4310,7 +4310,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.49.10"
+version = "0.50.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4328,7 +4328,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.49.10"
+version = "0.50.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4346,7 +4346,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.49.10"
+version = "0.50.0"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4360,7 +4360,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.49.10"
+version = "0.50.0"
 dependencies = [
  "regex",
  "serde",
@@ -4372,7 +4372,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.49.10"
+version = "0.50.0"
 dependencies = [
  "schemars",
  "serde",
@@ -4382,7 +4382,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sightglass"
-version = "0.49.10"
+version = "0.50.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4397,7 +4397,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.49.10"
+version = "0.50.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4425,7 +4425,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.49.10"
+version = "0.50.0"
 dependencies = [
  "base64 0.22.1",
  "rcgen",
@@ -4443,7 +4443,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.49.10"
+version = "0.50.0"
 dependencies = [
  "anyhow",
  "forge-engine",
@@ -4475,7 +4475,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.49.10"
+version = "0.50.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.49.10"
+version = "0.50.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.49.10.** Production-deployed against real carriers
+**Current release: v0.50.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged. Daemon upgrades are near-drop-in


### PR DESCRIPTION
Release-prep commit per `RELEASING.md`: version bump, dated CHANGELOG section, README marker, refreshed `Cargo.lock`.

Contents of 0.50.0 (all already merged):

- **#560** — `[media].reserved_outbound_calls`, the #556 fix.
- **#561** — forge-media pin bump to `1fe94a502efa`, which makes that floor exact (forge-media #120) and carries the **RSA-2048 → ECDSA P-256 DTLS certificate change** on `srtp_offer = "dtls"`. The release notes lead with that, since it is the one thing that can break an existing deployment.
- **#558** — the SIPp harness asserts the outbound delayed-offer counter.

Preflight, run locally:

```
python3 scripts/check-version-consistency.py            → Version consistent: 0.50.0.
python3 scripts/check-version-consistency.py --tag v0.50.0 → consistent (tag v0.50.0)
python3 scripts/extract-changelog.py 0.50.0             → notes extract cleanly
```

Tag goes on the merge commit once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vb8yYGZV28UmjUp2nwVMc1