### PR TITLE
chore(release): 0.50.1 — trunk-gate + admin-label metric fixes, upstream pin rolls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.50.1] - 2026-08-24
+
+**Two observability blind-spot fixes and routine upstream pin rolls.**
+
+Both fixes came out of validating the 0.50.0 getting-started flow: the
+`[[trunk]]` gate's 403s — the exact scanner traffic the gate exists to
+shed — were invisible on `/metrics`, and four 0.49.0 admin endpoints
+reported as `endpoint="unknown"`. No protocol change (still `1`), CDR
+still v8, no new config keys. Drop-in upgrade; alerting can now key on
+`siphon_ai_invites_total{result="rejected_trunk"}`.
+
+### Changed
+
+- **siphon-rs pinned to `v2026.08.24`** (from `v2026.08.21`) — picks up
+  [sip-identity 0.3.0](https://github.com/thevoiceguy/siphon-rs/pull/124):
+  PASSporT **signing** behind a new `sign` feature
+  ([siphon-rs #123](https://github.com/thevoiceguy/siphon-rs/pull/123)),
+  the provider-side complement to the ES256 verification SiphonAI already
+  uses. SiphonAI does not enable the feature, so verification behaviour is
+  unchanged — this makes outbound STIR/SHAKEN signing (long demand-gated)
+  buildable against the current pin when it's picked up.
+- **forge-media pinned to `c277860cd123`** (from `1fe94a502efa`) — one
+  commit: aligns forge-media's own siphon-rs submodule to `v2026.08.24`,
+  keeping both pins on the same upstream revision (the media path sees
+  siphon-rs through that submodule).
+
 ### Fixed
 
 - **`[[trunk]]`-gate 403s now count in `siphon_ai_invites_total` as

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,7 +1122,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "forge-codecs"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1fe94a502efa#1fe94a502efa045fb4a8492266a32c1133ec17b6"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=c277860cd123#c277860cd123e3d7f9ed37d82503e73e5daddae2"
 dependencies = [
  "audiopus",
  "ezk-g722",
@@ -1134,7 +1134,7 @@ dependencies = [
 [[package]]
 name = "forge-core"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1fe94a502efa#1fe94a502efa045fb4a8492266a32c1133ec17b6"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=c277860cd123#c277860cd123e3d7f9ed37d82503e73e5daddae2"
 dependencies = [
  "chrono",
  "serde",
@@ -1149,7 +1149,7 @@ dependencies = [
 [[package]]
 name = "forge-dtmf"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1fe94a502efa#1fe94a502efa045fb4a8492266a32c1133ec17b6"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=c277860cd123#c277860cd123e3d7f9ed37d82503e73e5daddae2"
 dependencies = [
  "chrono",
  "forge-core",
@@ -1161,7 +1161,7 @@ dependencies = [
 [[package]]
 name = "forge-engine"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1fe94a502efa#1fe94a502efa045fb4a8492266a32c1133ec17b6"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=c277860cd123#c277860cd123e3d7f9ed37d82503e73e5daddae2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1191,7 +1191,7 @@ dependencies = [
 [[package]]
 name = "forge-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1fe94a502efa#1fe94a502efa045fb4a8492266a32c1133ec17b6"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=c277860cd123#c277860cd123e3d7f9ed37d82503e73e5daddae2"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -1204,7 +1204,7 @@ dependencies = [
 [[package]]
 name = "forge-injection"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1fe94a502efa#1fe94a502efa045fb4a8492266a32c1133ec17b6"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=c277860cd123#c277860cd123e3d7f9ed37d82503e73e5daddae2"
 dependencies = [
  "forge-core",
  "rubato",
@@ -1217,7 +1217,7 @@ dependencies = [
 [[package]]
 name = "forge-mixer"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1fe94a502efa#1fe94a502efa045fb4a8492266a32c1133ec17b6"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=c277860cd123#c277860cd123e3d7f9ed37d82503e73e5daddae2"
 dependencies = [
  "bytes",
  "dashmap 6.2.1",
@@ -1231,7 +1231,7 @@ dependencies = [
 [[package]]
 name = "forge-recorder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1fe94a502efa#1fe94a502efa045fb4a8492266a32c1133ec17b6"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=c277860cd123#c277860cd123e3d7f9ed37d82503e73e5daddae2"
 dependencies = [
  "bytes",
  "forge-core",
@@ -1245,7 +1245,7 @@ dependencies = [
 [[package]]
 name = "forge-resampler"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1fe94a502efa#1fe94a502efa045fb4a8492266a32c1133ec17b6"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=c277860cd123#c277860cd123e3d7f9ed37d82503e73e5daddae2"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -1254,7 +1254,7 @@ dependencies = [
 [[package]]
 name = "forge-rtp"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1fe94a502efa#1fe94a502efa045fb4a8492266a32c1133ec17b6"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=c277860cd123#c277860cd123e3d7f9ed37d82503e73e5daddae2"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm 0.11.0",
@@ -1279,14 +1279,14 @@ dependencies = [
 [[package]]
 name = "forge-sdp"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1fe94a502efa#1fe94a502efa045fb4a8492266a32c1133ec17b6"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=c277860cd123#c277860cd123e3d7f9ed37d82503e73e5daddae2"
 dependencies = [
  "base64 0.23.1",
  "chrono",
  "forge-core",
  "forge-rtp",
  "rand 0.10.1",
- "sip-sdp 0.3.1 (git+https://github.com/thevoiceguy/forge-media?rev=1fe94a502efa)",
+ "sip-sdp 0.3.1 (git+https://github.com/thevoiceguy/forge-media?rev=c277860cd123)",
  "smol_str",
  "thiserror 2.0.18",
 ]
@@ -1294,7 +1294,7 @@ dependencies = [
 [[package]]
 name = "forge-transcoder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1fe94a502efa#1fe94a502efa045fb4a8492266a32c1133ec17b6"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=c277860cd123#c277860cd123e3d7f9ed37d82503e73e5daddae2"
 dependencies = [
  "bytes",
  "forge-codecs",
@@ -1307,7 +1307,7 @@ dependencies = [
 [[package]]
 name = "forge-vad"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1fe94a502efa#1fe94a502efa045fb4a8492266a32c1133ec17b6"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=c277860cd123#c277860cd123e3d7f9ed37d82503e73e5daddae2"
 dependencies = [
  "forge-core",
  "thiserror 2.0.18",
@@ -3855,7 +3855,7 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 [[package]]
 name = "sip-auth"
 version = "0.4.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.21#e280e42fd01009c81cead1fd9455ace8e015e4bf"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24#718313a8b13dfd08cb5630302718928b8237d9a7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3878,7 +3878,7 @@ dependencies = [
 [[package]]
 name = "sip-core"
 version = "0.7.7"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.21#e280e42fd01009c81cead1fd9455ace8e015e4bf"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24#718313a8b13dfd08cb5630302718928b8237d9a7"
 dependencies = [
  "bytes",
  "httpdate",
@@ -3891,7 +3891,7 @@ dependencies = [
 [[package]]
 name = "sip-dialog"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.21#e280e42fd01009c81cead1fd9455ace8e015e4bf"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24#718313a8b13dfd08cb5630302718928b8237d9a7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3909,7 +3909,7 @@ dependencies = [
 [[package]]
 name = "sip-dns"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.21#e280e42fd01009c81cead1fd9455ace8e015e4bf"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24#718313a8b13dfd08cb5630302718928b8237d9a7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3923,7 +3923,7 @@ dependencies = [
 [[package]]
 name = "sip-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.21#e280e42fd01009c81cead1fd9455ace8e015e4bf"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24#718313a8b13dfd08cb5630302718928b8237d9a7"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -3933,8 +3933,8 @@ dependencies = [
 
 [[package]]
 name = "sip-identity"
-version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.21#e280e42fd01009c81cead1fd9455ace8e015e4bf"
+version = "0.3.0"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24#718313a8b13dfd08cb5630302718928b8237d9a7"
 dependencies = [
  "base64 0.22.1",
  "ring",
@@ -3947,7 +3947,7 @@ dependencies = [
 [[package]]
 name = "sip-observe"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.21#e280e42fd01009c81cead1fd9455ace8e015e4bf"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24#718313a8b13dfd08cb5630302718928b8237d9a7"
 dependencies = [
  "once_cell",
  "tracing",
@@ -3956,7 +3956,7 @@ dependencies = [
 [[package]]
 name = "sip-parse"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.21#e280e42fd01009c81cead1fd9455ace8e015e4bf"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24#718313a8b13dfd08cb5630302718928b8237d9a7"
 dependencies = [
  "bytes",
  "httpdate",
@@ -3970,7 +3970,7 @@ dependencies = [
 [[package]]
 name = "sip-ratelimit"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.21#e280e42fd01009c81cead1fd9455ace8e015e4bf"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24#718313a8b13dfd08cb5630302718928b8237d9a7"
 dependencies = [
  "dashmap 5.5.3",
  "parking_lot",
@@ -3981,7 +3981,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.21#e280e42fd01009c81cead1fd9455ace8e015e4bf"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24#718313a8b13dfd08cb5630302718928b8237d9a7"
 dependencies = [
  "nom 7.1.3",
  "smol_str",
@@ -3990,7 +3990,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=1fe94a502efa#1fe94a502efa045fb4a8492266a32c1133ec17b6"
+source = "git+https://github.com/thevoiceguy/forge-media?rev=c277860cd123#c277860cd123e3d7f9ed37d82503e73e5daddae2"
 dependencies = [
  "nom 7.1.3",
  "smol_str",
@@ -3999,7 +3999,7 @@ dependencies = [
 [[package]]
 name = "sip-transaction"
 version = "0.6.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.21#e280e42fd01009c81cead1fd9455ace8e015e4bf"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24#718313a8b13dfd08cb5630302718928b8237d9a7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4018,7 +4018,7 @@ dependencies = [
 [[package]]
 name = "sip-transport"
 version = "0.4.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.21#e280e42fd01009c81cead1fd9455ace8e015e4bf"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24#718313a8b13dfd08cb5630302718928b8237d9a7"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4039,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "sip-uac"
 version = "0.7.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.21#e280e42fd01009c81cead1fd9455ace8e015e4bf"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24#718313a8b13dfd08cb5630302718928b8237d9a7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4052,7 +4052,7 @@ dependencies = [
  "sip-dialog",
  "sip-dns",
  "sip-parse",
- "sip-sdp 0.3.1 (git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.21)",
+ "sip-sdp 0.3.1 (git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -4064,7 +4064,7 @@ dependencies = [
 [[package]]
 name = "sip-uas"
 version = "0.4.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.21#e280e42fd01009c81cead1fd9455ace8e015e4bf"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24#718313a8b13dfd08cb5630302718928b8237d9a7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4074,7 +4074,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.1 (git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.21)",
+ "sip-sdp 0.3.1 (git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -4084,7 +4084,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4133,7 +4133,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-admin-api-types"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -4141,7 +4141,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4157,7 +4157,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4179,7 +4179,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4196,7 +4196,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "regex",
  "serde",
@@ -4215,7 +4215,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4235,7 +4235,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.1 (git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.21)",
+ "sip-sdp 0.3.1 (git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24)",
  "sip-transaction",
  "sip-uac",
  "sip-uas",
@@ -4261,7 +4261,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "base64 0.22.1",
  "hmac 0.12.1",
@@ -4284,7 +4284,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4310,7 +4310,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4328,7 +4328,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4346,7 +4346,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4360,7 +4360,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "regex",
  "serde",
@@ -4372,7 +4372,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "schemars",
  "serde",
@@ -4382,7 +4382,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sightglass"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4397,7 +4397,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4425,7 +4425,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "base64 0.22.1",
  "rcgen",
@@ -4443,7 +4443,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "anyhow",
  "forge-engine",
@@ -4475,7 +4475,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.50.0"
+version = "0.50.1"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"
@@ -319,31 +319,31 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 #  `6fd432270bb8` = #67 dialog_manager share, siphon-ai #324;
 #  `fcaff011f9c6` = #65 invite_with_from, siphon-ai #316;
 #  `3a4fc312ade3` = #64 TLS-SNI-is-hostname, siphon-ai #312.)
-sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.21" }
-sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.21" }
-sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.21", features = ["tls"] }
-sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.21" }
-sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.21" }
-sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.21" }
-sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.21" }
-sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.21" }
-sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.21" }
+sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24" }
+sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24" }
+sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24", features = ["tls"] }
+sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24" }
+sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24" }
+sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24" }
+sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24" }
+sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24" }
+sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24" }
 # sip-sdp — the SAME sip-sdp sip-uac's SdpAnswerGenerator trait speaks
 # (distinct from forge-media's pinned sip-sdp). Used by the outbound
 # delayed-offer answer generator to hand the UAC a SessionDescription it
 # accepts. Must stay on the same siphon-rs rev as the rest below.
-sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.21" }
-sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.21" }
+sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24" }
+sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24" }
 # sip-observe — the transport-layer observability seam. We implement its
 # `TransportMetrics` trait in siphon-ai-telemetry and install it with
 # `set_transport_metrics`, which is the only way to see ingress
 # rate-limit drops: the hook is defaulted to a no-op upstream, so an
 # embedder that installs nothing (as we did until 0.48.11) silently gets
 # the `NoopTransportMetrics` fallback (siphon-ai #459).
-sip-observe     = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.21" }
+sip-observe     = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24" }
 # sip-identity — STIR/SHAKEN Identity-header parsing + PASSporT verification
 # (ES256 + X.509 chain validation). Consumed by the stir-shaken verifier crate.
-sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.21" }
+sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24" }
 
 # forge-media — RTP / codecs / SDP / DTMF / engine.
 #
@@ -475,20 +475,20 @@ sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v20
 # comment for the current rev.) Prior forge pins: forge 1c996ae5fb4f = #86
 # neural VAD; forge 3c59b5f6e464 = #82-#85 dependency migrations; forge
 # 5fa76fb38675 = #81.
-forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "1fe94a502efa" }
-forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "1fe94a502efa" }
-forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "1fe94a502efa", default-features = false, features = ["g722", "dtls", "opus", "neural-vad"] }
-forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "1fe94a502efa" }
-forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "1fe94a502efa" }
-forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "1fe94a502efa" }
-forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "1fe94a502efa" }
-forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "1fe94a502efa" }
+forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "c277860cd123" }
+forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "c277860cd123" }
+forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "c277860cd123", default-features = false, features = ["g722", "dtls", "opus", "neural-vad"] }
+forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "c277860cd123" }
+forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "c277860cd123" }
+forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "c277860cd123" }
+forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "c277860cd123" }
+forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "c277860cd123" }
 # Conference rooms (0.7.0): forge-mixer is the per-room AudioMixer;
 # forge-injection provides ToneGenerator (join/leave tones now, MOH
 # for park later). Deliberately NOT forge-conference — its DTMF
 # IVR/PIN/host-control layer is unused per DEV_PLAN_0.7.0.md §9.4.
-forge-mixer     = { git = "https://github.com/thevoiceguy/forge-media", rev = "1fe94a502efa" }
-forge-injection = { git = "https://github.com/thevoiceguy/forge-media", rev = "1fe94a502efa" }
+forge-mixer     = { git = "https://github.com/thevoiceguy/forge-media", rev = "c277860cd123" }
+forge-injection = { git = "https://github.com/thevoiceguy/forge-media", rev = "c277860cd123" }
 
 # hep-rs — HEP3 codec, transport, HepSink trait. Owned by the same
 # author as siphon-rs and forge-media; lives in its own repo.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.50.0.** Production-deployed against real carriers
+**Current release: v0.50.1.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged. Daemon upgrades are near-drop-in

--- a/test-harness/sipp-scenarios/run-all.sh
+++ b/test-harness/sipp-scenarios/run-all.sh
@@ -2292,7 +2292,9 @@ ws_url = "ws://127.0.0.1:$RIA_WS_PORT/"
 # A trunk that deliberately does not match the loopback SIPp runs on,
 # so the INVITE is rejected 403 — the premise of the case. Without any
 # [[trunk]] at all the daemon accepts from anywhere and the scenario
-# would fail at its `recv 403`.
+# would fail at its 'recv 403' step. (No backticks here — this heredoc
+# is unquoted so \$vars interpolate, and a backtick would run as a
+# command substitution.)
 [[trunk]]
 name = "nowhere"
 peer_addrs = ["192.0.2.1"]


### PR DESCRIPTION
Release-prep for **v0.50.1** per RELEASING.md: version bump + CHANGELOG cut + README marker, plus the upstream pin rolls.

## Upstream bumps

- **siphon-rs `v2026.08.21` → `v2026.08.24`** — [sip-identity 0.3.0](https://github.com/thevoiceguy/siphon-rs/pull/124): PASSporT **signing** behind a new `sign` feature ([#123](https://github.com/thevoiceguy/siphon-rs/pull/123)). SiphonAI doesn't enable the feature, so verification behaviour is unchanged; it makes outbound STIR/SHAKEN signing (demand-gated backlog) buildable against the current pin when picked up.
- **forge-media `1fe94a502efa` → `c277860cd123`** — one commit: aligns forge-media's siphon-rs submodule to the same `v2026.08.24`, keeping both pins on one upstream revision (the media path sees siphon-rs through that submodule).

## In the release (already on main)

- #566 — `siphon_ai_invites_total{result="rejected_trunk"}` for `[[trunk]]`-gate 403s (#564)
- #567 — `STATIC_ROUTES` table fixing `endpoint="unknown"` on four admin endpoints (#565)

No protocol change (still `1`), CDR still v8, no new config keys.

## Verification (per CLAUDE.md §7.5)

- `cargo test --workspace` — 60 suites, all green on the new pins
- `cargo clippy --workspace --all-targets -- -D warnings` + fmt clean
- Full SIPp suite: **43/43 scenarios passed**, including the new `trunk_403` phase
- `check-version-consistency.py` (plain and `--tag v0.50.1`) and `extract-changelog.py 0.50.1` all pass

Drive-by: fixed a backtick in `run-all.sh`'s `rejected_invite_ack` heredoc comment that executed as a command substitution (`recv: command not found` noise on every run since #500).

After merge: tag `v0.50.1` on the merge commit and push to trigger the release pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Gm9Cizujd8LBMzrpDx9LU