### PR TITLE
chore(deps): pin forge-media by tag v2026.08.24 (first tagged forge release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **forge-media pinned by tag: `v2026.08.24`** (was `rev = "c277860cd123"`) —
+  forge-media's first tagged release under its new
+  [RELEASING.md](https://github.com/thevoiceguy/forge-media/blob/main/RELEASING.md)
+  (the siphon-rs model, adopted in
+  [forge-media #131](https://github.com/thevoiceguy/forge-media/pull/131)).
+  Both upstream pins now read as tags, and this pair is self-consistent by
+  construction: forge-media `v2026.08.24` embeds siphon-rs `v2026.08.24`,
+  the same tag `[workspace.dependencies]` pins directly. Content over the
+  old rev: forge-webrtc 0.4.0's G.711 negotiation
+  ([forge-media #130](https://github.com/thevoiceguy/forge-media/pull/130))
+  and crate-version stamps (forge-ice 0.3.0, forge-rtp 0.3.0) — none of
+  which siphon-ai compiles today (forge-webrtc is not yet a dependency;
+  the version bumps are manifest-only for the crates we use), so no
+  behaviour change.
+
 ## [0.50.1] - 2026-08-24
 
 **Two observability blind-spot fixes and routine upstream pin rolls.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,7 +1122,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "forge-codecs"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=c277860cd123#c277860cd123e3d7f9ed37d82503e73e5daddae2"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24#6d6bf61183ee4a38dffb82bd52e58ef3ec77371c"
 dependencies = [
  "audiopus",
  "ezk-g722",
@@ -1134,7 +1134,7 @@ dependencies = [
 [[package]]
 name = "forge-core"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=c277860cd123#c277860cd123e3d7f9ed37d82503e73e5daddae2"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24#6d6bf61183ee4a38dffb82bd52e58ef3ec77371c"
 dependencies = [
  "chrono",
  "serde",
@@ -1149,7 +1149,7 @@ dependencies = [
 [[package]]
 name = "forge-dtmf"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=c277860cd123#c277860cd123e3d7f9ed37d82503e73e5daddae2"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24#6d6bf61183ee4a38dffb82bd52e58ef3ec77371c"
 dependencies = [
  "chrono",
  "forge-core",
@@ -1161,7 +1161,7 @@ dependencies = [
 [[package]]
 name = "forge-engine"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=c277860cd123#c277860cd123e3d7f9ed37d82503e73e5daddae2"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24#6d6bf61183ee4a38dffb82bd52e58ef3ec77371c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1191,7 +1191,7 @@ dependencies = [
 [[package]]
 name = "forge-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=c277860cd123#c277860cd123e3d7f9ed37d82503e73e5daddae2"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24#6d6bf61183ee4a38dffb82bd52e58ef3ec77371c"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -1204,7 +1204,7 @@ dependencies = [
 [[package]]
 name = "forge-injection"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=c277860cd123#c277860cd123e3d7f9ed37d82503e73e5daddae2"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24#6d6bf61183ee4a38dffb82bd52e58ef3ec77371c"
 dependencies = [
  "forge-core",
  "rubato",
@@ -1217,7 +1217,7 @@ dependencies = [
 [[package]]
 name = "forge-mixer"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=c277860cd123#c277860cd123e3d7f9ed37d82503e73e5daddae2"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24#6d6bf61183ee4a38dffb82bd52e58ef3ec77371c"
 dependencies = [
  "bytes",
  "dashmap 6.2.1",
@@ -1231,7 +1231,7 @@ dependencies = [
 [[package]]
 name = "forge-recorder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=c277860cd123#c277860cd123e3d7f9ed37d82503e73e5daddae2"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24#6d6bf61183ee4a38dffb82bd52e58ef3ec77371c"
 dependencies = [
  "bytes",
  "forge-core",
@@ -1245,7 +1245,7 @@ dependencies = [
 [[package]]
 name = "forge-resampler"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=c277860cd123#c277860cd123e3d7f9ed37d82503e73e5daddae2"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24#6d6bf61183ee4a38dffb82bd52e58ef3ec77371c"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -1253,8 +1253,8 @@ dependencies = [
 
 [[package]]
 name = "forge-rtp"
-version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=c277860cd123#c277860cd123e3d7f9ed37d82503e73e5daddae2"
+version = "0.3.0"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24#6d6bf61183ee4a38dffb82bd52e58ef3ec77371c"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm 0.11.0",
@@ -1279,14 +1279,14 @@ dependencies = [
 [[package]]
 name = "forge-sdp"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=c277860cd123#c277860cd123e3d7f9ed37d82503e73e5daddae2"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24#6d6bf61183ee4a38dffb82bd52e58ef3ec77371c"
 dependencies = [
  "base64 0.23.1",
  "chrono",
  "forge-core",
  "forge-rtp",
  "rand 0.10.1",
- "sip-sdp 0.3.1 (git+https://github.com/thevoiceguy/forge-media?rev=c277860cd123)",
+ "sip-sdp 0.3.1 (git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24)",
  "smol_str",
  "thiserror 2.0.18",
 ]
@@ -1294,7 +1294,7 @@ dependencies = [
 [[package]]
 name = "forge-transcoder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=c277860cd123#c277860cd123e3d7f9ed37d82503e73e5daddae2"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24#6d6bf61183ee4a38dffb82bd52e58ef3ec77371c"
 dependencies = [
  "bytes",
  "forge-codecs",
@@ -1307,7 +1307,7 @@ dependencies = [
 [[package]]
 name = "forge-vad"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=c277860cd123#c277860cd123e3d7f9ed37d82503e73e5daddae2"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24#6d6bf61183ee4a38dffb82bd52e58ef3ec77371c"
 dependencies = [
  "forge-core",
  "thiserror 2.0.18",
@@ -3981,7 +3981,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24#718313a8b13dfd08cb5630302718928b8237d9a7"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24#6d6bf61183ee4a38dffb82bd52e58ef3ec77371c"
 dependencies = [
  "nom 7.1.3",
  "smol_str",
@@ -3990,7 +3990,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/forge-media?rev=c277860cd123#c277860cd123e3d7f9ed37d82503e73e5daddae2"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24#718313a8b13dfd08cb5630302718928b8237d9a7"
 dependencies = [
  "nom 7.1.3",
  "smol_str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -475,20 +475,20 @@ sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v20
 # comment for the current rev.) Prior forge pins: forge 1c996ae5fb4f = #86
 # neural VAD; forge 3c59b5f6e464 = #82-#85 dependency migrations; forge
 # 5fa76fb38675 = #81.
-forge-core    = { git = "https://github.com/thevoiceguy/forge-media", rev = "c277860cd123" }
-forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "c277860cd123" }
-forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", rev = "c277860cd123", default-features = false, features = ["g722", "dtls", "opus", "neural-vad"] }
-forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", rev = "c277860cd123" }
-forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", rev = "c277860cd123" }
-forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", rev = "c277860cd123" }
-forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", rev = "c277860cd123" }
-forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", rev = "c277860cd123" }
+forge-core    = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.24" }
+forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.24" }
+forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.24", default-features = false, features = ["g722", "dtls", "opus", "neural-vad"] }
+forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.24" }
+forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.24" }
+forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.24" }
+forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.24" }
+forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.24" }
 # Conference rooms (0.7.0): forge-mixer is the per-room AudioMixer;
 # forge-injection provides ToneGenerator (join/leave tones now, MOH
 # for park later). Deliberately NOT forge-conference — its DTMF
 # IVR/PIN/host-control layer is unused per DEV_PLAN_0.7.0.md §9.4.
-forge-mixer     = { git = "https://github.com/thevoiceguy/forge-media", rev = "c277860cd123" }
-forge-injection = { git = "https://github.com/thevoiceguy/forge-media", rev = "c277860cd123" }
+forge-mixer     = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.24" }
+forge-injection = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.24" }
 
 # hep-rs — HEP3 codec, transport, HepSink trait. Owned by the same
 # author as siphon-rs and forge-media; lives in its own repo.


### PR DESCRIPTION
forge-media adopted the siphon-rs release model ([forge-media #131](https://github.com/thevoiceguy/forge-media/pull/131)) and cut its first tag, [v2026.08.24](https://github.com/thevoiceguy/forge-media/releases/tag/v2026.08.24). This switches our forge pins from a raw SHA to that tag — both upstream pins in the workspace now read as tags, and the pair is self-consistent by construction: forge-media `v2026.08.24` **embeds** siphon-rs `v2026.08.24`, the same tag we pin directly (the submodule-alignment class of drift from #405/#406 is now checkable at a glance).

Content over the old rev (`c277860cd123`): forge-webrtc 0.4.0's G.711 negotiation ([forge-media #130](https://github.com/thevoiceguy/forge-media/pull/130)) and the audit version stamps (forge-ice 0.3.0, forge-rtp 0.3.0). **No behaviour change for siphon-ai** — forge-webrtc is not yet a dependency, and for the forge crates we do use the delta is manifest-only.

## Verification (CLAUDE.md §7.5)

- `cargo test --workspace` — all green on the new pin
- clippy `-D warnings` + fmt clean
- Full SIPp suite: **43/43 scenarios passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Gm9Cizujd8LBMzrpDx9LU