### PR TITLE
feat(sip): SIP-over-WebSocket listeners (RFC 7118) — WebRTC plan Phase 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **SIP over WebSocket listeners (RFC 7118)** — Phase 1 of
+  `docs/design/DEV_PLAN_WebRTC.md`. `[sip].transports` accepts `"ws"`
+  and `"wss"`, each with its own listener block: `[sip.ws]` /
+  `[sip.wss]` (`listen`, `cert`/`key` for WSS, `allowed_origins`).
+  Upgrades must offer the `sip` subprotocol; a non-empty
+  `allowed_origins` refuses unlisted (or absent) `Origin`s `403` at
+  the upgrade, pinning which pages may open signalling (browsers
+  always send it; `[sip.auth]` remains the real authentication).
+  Replies and in-dialog requests to a WS client route down the
+  connection the client established — browser Via/Contacts are
+  unroutable, so there is deliberately no dial-back fallback. Off
+  unless configured; the WSS cert is deliberately independent of
+  `[sip.tls]` (browsers must trust it) and rotating it wants a
+  restart. The signalling suite gains a `ws_signaling` phase
+  (`ws_sip_call.py` — SIPp can't speak RFC 7118): a full
+  INVITE/ACK/BYE call over one WS connection, origin-refusal
+  assertions, and the settle-to-zero check. Verified end-to-end:
+  OPTIONS and a full call answered over WS, wrong/absent origin
+  refused, teardown clean. siphon-rs pinned to `v2026.08.24.1`
+  (sip-transport 0.5.0: `WsAcceptPolicy` + WS idle timeout,
+  [siphon-rs #125](https://github.com/thevoiceguy/siphon-rs/pull/125));
+  the `ws` feature joins `tls` on the sip-transport dependency.
+
 - **RTP port-pool gauges + a teardown-soak harness phase** (Phase 0 of
   `docs/design/DEV_PLAN_WebRTC.md`). Two new gauges,
   `siphon_ai_rtp_port_pairs_allocated` and `_capacity`, published every

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3855,7 +3855,7 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 [[package]]
 name = "sip-auth"
 version = "0.4.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24#718313a8b13dfd08cb5630302718928b8237d9a7"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24.1#77d000287049afd4fbb7e92af8602ba4bad5a110"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3878,7 +3878,7 @@ dependencies = [
 [[package]]
 name = "sip-core"
 version = "0.7.7"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24#718313a8b13dfd08cb5630302718928b8237d9a7"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24.1#77d000287049afd4fbb7e92af8602ba4bad5a110"
 dependencies = [
  "bytes",
  "httpdate",
@@ -3891,7 +3891,7 @@ dependencies = [
 [[package]]
 name = "sip-dialog"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24#718313a8b13dfd08cb5630302718928b8237d9a7"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24.1#77d000287049afd4fbb7e92af8602ba4bad5a110"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3909,7 +3909,7 @@ dependencies = [
 [[package]]
 name = "sip-dns"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24#718313a8b13dfd08cb5630302718928b8237d9a7"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24.1#77d000287049afd4fbb7e92af8602ba4bad5a110"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3923,7 +3923,7 @@ dependencies = [
 [[package]]
 name = "sip-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24#718313a8b13dfd08cb5630302718928b8237d9a7"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24.1#77d000287049afd4fbb7e92af8602ba4bad5a110"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -3934,7 +3934,7 @@ dependencies = [
 [[package]]
 name = "sip-identity"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24#718313a8b13dfd08cb5630302718928b8237d9a7"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24.1#77d000287049afd4fbb7e92af8602ba4bad5a110"
 dependencies = [
  "base64 0.22.1",
  "ring",
@@ -3947,7 +3947,7 @@ dependencies = [
 [[package]]
 name = "sip-observe"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24#718313a8b13dfd08cb5630302718928b8237d9a7"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24.1#77d000287049afd4fbb7e92af8602ba4bad5a110"
 dependencies = [
  "once_cell",
  "tracing",
@@ -3956,7 +3956,7 @@ dependencies = [
 [[package]]
 name = "sip-parse"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24#718313a8b13dfd08cb5630302718928b8237d9a7"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24.1#77d000287049afd4fbb7e92af8602ba4bad5a110"
 dependencies = [
  "bytes",
  "httpdate",
@@ -3970,7 +3970,7 @@ dependencies = [
 [[package]]
 name = "sip-ratelimit"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24#718313a8b13dfd08cb5630302718928b8237d9a7"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24.1#77d000287049afd4fbb7e92af8602ba4bad5a110"
 dependencies = [
  "dashmap 5.5.3",
  "parking_lot",
@@ -3990,7 +3990,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24#718313a8b13dfd08cb5630302718928b8237d9a7"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24.1#77d000287049afd4fbb7e92af8602ba4bad5a110"
 dependencies = [
  "nom 7.1.3",
  "smol_str",
@@ -3999,7 +3999,7 @@ dependencies = [
 [[package]]
 name = "sip-transaction"
 version = "0.6.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24#718313a8b13dfd08cb5630302718928b8237d9a7"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24.1#77d000287049afd4fbb7e92af8602ba4bad5a110"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4017,13 +4017,14 @@ dependencies = [
 
 [[package]]
 name = "sip-transport"
-version = "0.4.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24#718313a8b13dfd08cb5630302718928b8237d9a7"
+version = "0.5.0"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24.1#77d000287049afd4fbb7e92af8602ba4bad5a110"
 dependencies = [
  "anyhow",
  "arc-swap",
  "bytes",
  "dashmap 5.5.3",
+ "futures-util",
  "memchr",
  "rustls",
  "rustls-pki-types",
@@ -4033,13 +4034,14 @@ dependencies = [
  "socket2 0.5.10",
  "tokio",
  "tokio-rustls",
+ "tokio-tungstenite 0.21.0",
  "tracing",
 ]
 
 [[package]]
 name = "sip-uac"
 version = "0.7.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24#718313a8b13dfd08cb5630302718928b8237d9a7"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24.1#77d000287049afd4fbb7e92af8602ba4bad5a110"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4052,7 +4054,7 @@ dependencies = [
  "sip-dialog",
  "sip-dns",
  "sip-parse",
- "sip-sdp 0.3.1 (git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24)",
+ "sip-sdp 0.3.1 (git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24.1)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -4064,7 +4066,7 @@ dependencies = [
 [[package]]
 name = "sip-uas"
 version = "0.4.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24#718313a8b13dfd08cb5630302718928b8237d9a7"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24.1#77d000287049afd4fbb7e92af8602ba4bad5a110"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4074,7 +4076,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.1 (git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24)",
+ "sip-sdp 0.3.1 (git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24.1)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -4172,7 +4174,7 @@ dependencies = [
  "siphon-ai-security",
  "thiserror 1.0.69",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.24.0",
  "tracing",
  "webpki-roots 0.26.11",
 ]
@@ -4235,7 +4237,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.1 (git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24)",
+ "sip-sdp 0.3.1 (git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.24.1)",
  "sip-transaction",
  "sip-uac",
  "sip-uas",
@@ -4254,7 +4256,7 @@ dependencies = [
  "siphon-ai-webhooks",
  "thiserror 1.0.69",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.24.0",
  "tracing",
  "uuid",
 ]
@@ -4320,7 +4322,7 @@ dependencies = [
  "serde_json",
  "siphon-ai-bridge",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.24.0",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -5039,6 +5041,18 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.21.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
@@ -5049,7 +5063,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite",
+ "tungstenite 0.24.0",
  "webpki-roots 0.26.11",
 ]
 
@@ -5510,6 +5524,25 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.6",
+ "sha1 0.10.6",
+ "thiserror 1.0.69",
+ "url",
+ "utf-8",
+]
 
 [[package]]
 name = "tungstenite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -319,31 +319,31 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 #  `6fd432270bb8` = #67 dialog_manager share, siphon-ai #324;
 #  `fcaff011f9c6` = #65 invite_with_from, siphon-ai #316;
 #  `3a4fc312ade3` = #64 TLS-SNI-is-hostname, siphon-ai #312.)
-sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24" }
-sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24" }
-sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24", features = ["tls"] }
-sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24" }
-sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24" }
-sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24" }
-sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24" }
-sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24" }
-sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24" }
+sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24.1" }
+sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24.1" }
+sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24.1", features = ["tls", "ws"] }
+sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24.1" }
+sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24.1" }
+sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24.1" }
+sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24.1" }
+sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24.1" }
+sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24.1" }
 # sip-sdp — the SAME sip-sdp sip-uac's SdpAnswerGenerator trait speaks
 # (distinct from forge-media's pinned sip-sdp). Used by the outbound
 # delayed-offer answer generator to hand the UAC a SessionDescription it
 # accepts. Must stay on the same siphon-rs rev as the rest below.
-sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24" }
-sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24" }
+sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24.1" }
+sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24.1" }
 # sip-observe — the transport-layer observability seam. We implement its
 # `TransportMetrics` trait in siphon-ai-telemetry and install it with
 # `set_transport_metrics`, which is the only way to see ingress
 # rate-limit drops: the hook is defaulted to a no-op upstream, so an
 # embedder that installs nothing (as we did until 0.48.11) silently gets
 # the `NoopTransportMetrics` fallback (siphon-ai #459).
-sip-observe     = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24" }
+sip-observe     = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24.1" }
 # sip-identity — STIR/SHAKEN Identity-header parsing + PASSporT verification
 # (ES256 + X.509 chain validation). Consumed by the stir-shaken verifier crate.
-sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24" }
+sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.24.1" }
 
 # forge-media — RTP / codecs / SDP / DTMF / engine.
 #

--- a/bins/siphon-ai/src/inspect.rs
+++ b/bins/siphon-ai/src/inspect.rs
@@ -70,6 +70,8 @@ fn transport_str(t: &SipTransport) -> &'static str {
         SipTransport::Udp => "udp",
         SipTransport::Tcp => "tcp",
         SipTransport::Tls => "tls",
+        SipTransport::Ws => "ws",
+        SipTransport::Wss => "wss",
     }
 }
 

--- a/bins/siphon-ai/src/main.rs
+++ b/bins/siphon-ai/src/main.rs
@@ -452,6 +452,8 @@ fn print_check_summary(path: &Path, config: &Config) {
             siphon_ai_config::SipTransport::Udp => "udp",
             siphon_ai_config::SipTransport::Tcp => "tcp",
             siphon_ai_config::SipTransport::Tls => "tls",
+            siphon_ai_config::SipTransport::Ws => "ws",
+            siphon_ai_config::SipTransport::Wss => "wss",
         })
         .collect::<Vec<_>>()
         .join(", ");

--- a/bins/siphon-ai/src/registration.rs
+++ b/bins/siphon-ai/src/registration.rs
@@ -527,6 +527,10 @@ fn build_contact_uri(username: &str, addr: &str, transport: SipTransport) -> Str
         SipTransport::Udp => "udp",
         SipTransport::Tcp => "tcp",
         SipTransport::Tls => "tls",
+        // Unreachable today: [[register]].transport rejects ws/wss at
+        // load (client-side WS registration is not supported — browsers
+        // register TO us). RFC 7118 §5.4 token, kept for exhaustiveness.
+        SipTransport::Ws | SipTransport::Wss => "ws",
     };
     format!("sip:{username}@{addr};transport={transport_param}")
 }

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -846,6 +846,22 @@ impl Runtime {
                 _ => None,
             };
 
+        // WSS listener TLS (`[sip.wss]`, RFC 7118). Same
+        // load-at-startup posture as `[sip.tls]` — a bad cert/key
+        // fails before any listener accepts. Held in an ArcSwap for
+        // shape-parity with the other listeners, but not yet wired to
+        // the SIGHUP reloader: rotating the WSS cert wants a restart
+        // (documented in CONFIG.md; the browser-facing cert is
+        // typically ACME-managed, where a restart is the norm).
+        let wss_server_config: Option<Arc<arc_swap::ArcSwap<tokio_rustls::rustls::ServerConfig>>> =
+            match sip.wss.as_ref() {
+                Some(wss) => {
+                    let initial = load_wss_server_config(wss)?;
+                    Some(Arc::new(arc_swap::ArcSwap::from(initial)))
+                }
+                None => None,
+            };
+
         // The SIGHUP handler (config reload + TLS cert reload) is
         // spawned *after* the outbound service is built (it needs the
         // gateway-reload handle). The TLS swap handle is consumed by the
@@ -1006,6 +1022,7 @@ impl Runtime {
             Arc::clone(&transaction_mgr),
             Arc::clone(&uas),
             tls_server_config,
+            wss_server_config,
             &tcp_client_pool,
             &tls_client_pool,
         )
@@ -2047,6 +2064,36 @@ fn build_tls_client_config(extra_ca: Option<&std::path::Path>) -> Result<Arc<Tls
 /// `[sip.tls]`. Failure here is fatal — operators who set
 /// `transports = ["tls"]` expect SIPS to actually work, not to
 /// silently degrade to cleartext.
+/// Load the `[sip.wss]` cert/key into a rustls `ServerConfig` — the
+/// browser-facing WSS listener's identity, independent of `[sip.tls]`
+/// (see `RawSipWss::cert`).
+pub(crate) fn load_wss_server_config(
+    wss: &siphon_ai_config::SipWssConfig,
+) -> Result<Arc<tokio_rustls::rustls::ServerConfig>> {
+    let cert = wss
+        .cert_path
+        .to_str()
+        .ok_or_else(|| anyhow!("[sip.wss].cert path is not valid UTF-8"))?;
+    let key = wss
+        .key_path
+        .to_str()
+        .ok_or_else(|| anyhow!("[sip.wss].key path is not valid UTF-8"))?;
+    let cfg = load_rustls_server_config(cert, key).with_context(|| {
+        format!(
+            "load WSS cert={} key={}",
+            wss.cert_path.display(),
+            wss.key_path.display()
+        )
+    })?;
+    info!(
+        cert = %wss.cert_path.display(),
+        key = %wss.key_path.display(),
+        listen = %wss.listen_addr,
+        "WSS (SIP over WebSocket) server config loaded"
+    );
+    Ok(cfg)
+}
+
 pub(crate) fn load_sip_tls_server_config(
     tls: &SipTlsConfig,
 ) -> Result<Arc<tokio_rustls::rustls::ServerConfig>> {
@@ -2895,6 +2942,7 @@ async fn spawn_listeners(
     transaction_mgr: Arc<TransactionManager>,
     uas: Arc<IntegratedUAS>,
     tls_server_config: Option<Arc<arc_swap::ArcSwap<tokio_rustls::rustls::ServerConfig>>>,
+    wss_server_config: Option<Arc<arc_swap::ArcSwap<tokio_rustls::rustls::ServerConfig>>>,
     tcp_client_pool: &ConnectionPool,
     tls_client_pool: &TlsPool,
 ) -> Vec<JoinHandle<()>> {
@@ -2960,6 +3008,56 @@ async fn spawn_listeners(
                 error!(
                     "TLS transport enabled but no [sip.tls] config / server config available; \
                      SIPS connections will be refused"
+                );
+            }
+        }
+    }
+
+    // WS / WSS listeners (RFC 7118) — each on its own bind, since
+    // browsers connect to a web-shaped port, not the SIP port. The
+    // Origin allow-list is enforced upstream at the upgrade
+    // (sip-transport WsAcceptPolicy); everything after the upgrade —
+    // rate limiting, HEP capture, idle timeout, the reply-down-the-
+    // same-connection routing that unroutable browser Contacts
+    // depend on — is the same machinery as TCP/TLS.
+    if let Some(ws) = sip.ws.as_ref() {
+        let bind = ws.listen_addr.to_string();
+        let policy = sip_transport::WsAcceptPolicy {
+            allowed_origins: ws.allowed_origins.clone(),
+        };
+        let tx = packet_tx.clone();
+        handles.push(tokio::spawn(async move {
+            if let Err(e) = sip_transport::run_ws_with_policy(&bind, policy, tx).await {
+                error!(error = %e, "WS listener exited");
+            }
+        }));
+    }
+    if let Some(wss) = sip.wss.as_ref() {
+        match &wss_server_config {
+            Some(swappable) => {
+                let bind = wss.listen_addr.to_string();
+                let policy = sip_transport::WsAcceptPolicy {
+                    allowed_origins: wss.allowed_origins.clone(),
+                };
+                let swappable = Arc::clone(swappable);
+                let tx = packet_tx.clone();
+                handles.push(tokio::spawn(async move {
+                    if let Err(e) = sip_transport::run_wss_with_swappable_config_and_policy(
+                        &bind, swappable, policy, tx,
+                    )
+                    .await
+                    {
+                        error!(error = %e, "WSS listener exited");
+                    }
+                }));
+            }
+            None => {
+                // Startup loads the cert whenever [sip.wss] compiles,
+                // so this arm is unreachable without a code change —
+                // be loud if that contract ever breaks.
+                error!(
+                    "WSS transport enabled but no server config available; \
+                     browser connections will be refused"
                 );
             }
         }
@@ -3182,6 +3280,30 @@ impl TransportDispatcher for MultiTransportDispatcher {
                     }
                     _ => unreachable!(),
                 },
+            },
+            // WS/WSS (RFC 7118): replies and in-dialog requests go down
+            // the connection the client established, and ONLY that
+            // connection — a browser's Via/Contact addresses are
+            // unroutable, so there is no client-originate fallback. A
+            // missing writer means the client's connection is gone;
+            // per RFC 7118 §5.2 the request fails rather than being
+            // dialed elsewhere.
+            TxTransportKind::Ws | TxTransportKind::Wss => match ctx.stream() {
+                Some(writer) => {
+                    let target = match ctx.transport() {
+                        TxTransportKind::Ws => sip_transport::TransportKind::Ws,
+                        TxTransportKind::Wss => sip_transport::TransportKind::Wss,
+                        _ => unreachable!(),
+                    };
+                    send_stream(target, writer, payload)
+                        .await
+                        .with_context(|| format!("send over websocket to {}", ctx.peer()))
+                }
+                None => Err(anyhow!(
+                    "websocket peer {} has no live connection (browser clients \
+                     cannot be dialed back; they must reconnect and re-REGISTER)",
+                    ctx.peer()
+                )),
             },
             other => Err(anyhow!(
                 "transport {other:?} is not enabled in this build (peer={})",

--- a/crates/config/src/compile.rs
+++ b/crates/config/src/compile.rs
@@ -639,6 +639,12 @@ pub struct SipConfig {
     /// the webpki roots when verifying OUTGOING TLS connections
     /// (gateways / registrations with `transport = "tls"`).
     pub tls_client_extra_ca: Option<PathBuf>,
+    /// `Some` when `[sip.ws]` is supplied AND `ws` is in the
+    /// transports list (RFC 7118).
+    pub ws: Option<SipWsConfig>,
+    /// `Some` when `[sip.wss]` is supplied AND `wss` is in the
+    /// transports list.
+    pub wss: Option<SipWssConfig>,
     /// RFC 4028 Min-SE for the UAS (`[sip].min_session_expires_secs`).
     /// Defaults to 90 (RFC minimum).
     pub min_session_expires: Duration,
@@ -759,19 +765,47 @@ pub enum SipTransport {
     Udp,
     Tcp,
     Tls,
+    /// SIP over WebSocket (RFC 7118). Lab use — browsers require
+    /// secure contexts.
+    Ws,
+    /// SIP over secure WebSocket (RFC 7118).
+    Wss,
 }
 
 impl SipTransport {
     /// The `;transport=` URI parameter for a Request-URI using this
     /// transport. Empty for UDP — the RFC 3263 default; emitting it
-    /// explicitly would only churn byte-identical configs.
+    /// explicitly would only churn byte-identical configs. Both WS
+    /// variants use `ws` (RFC 7118 §5.4 — security is signalled by
+    /// the SIPS scheme, not the transport token).
     pub fn uri_param(&self) -> &'static str {
         match self {
             SipTransport::Udp => "",
             SipTransport::Tcp => ";transport=tcp",
             SipTransport::Tls => ";transport=tls",
+            SipTransport::Ws | SipTransport::Wss => ";transport=ws",
         }
     }
+}
+
+/// Compiled `[sip.ws]` — present only when `transports` includes
+/// `"ws"`.
+#[derive(Debug, Clone)]
+pub struct SipWsConfig {
+    pub listen_addr: SocketAddr,
+    /// `Origin` allow-list for the WebSocket upgrade; empty = no
+    /// check. See `RawSipWs::allowed_origins`.
+    pub allowed_origins: Vec<String>,
+}
+
+/// Compiled `[sip.wss]` — present only when `transports` includes
+/// `"wss"`.
+#[derive(Debug, Clone)]
+pub struct SipWssConfig {
+    pub listen_addr: SocketAddr,
+    pub cert_path: PathBuf,
+    pub key_path: PathBuf,
+    pub allowed_origins: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -820,8 +854,37 @@ pub enum CompileError {
         max: u32,
     },
 
-    #[error("[sip].transports has unknown entry {0:?}; expected udp / tcp / tls")]
+    #[error("[sip].transports has unknown entry {0:?}; expected udp / tcp / tls / ws / wss")]
     UnknownTransport(String),
+
+    #[error("[sip.ws].listen is required when transports includes \"ws\"")]
+    SipWsListenRequired,
+
+    #[error("[sip.ws].listen {0:?} is not a valid socket address: {1}")]
+    BadSipWsListen(String, std::net::AddrParseError),
+
+    #[error("[sip.ws] is configured but transports does not include \"ws\"")]
+    SipWsConfiguredButNotEnabled,
+
+    #[error("[sip.wss].listen is required when transports includes \"wss\"")]
+    SipWssListenRequired,
+
+    #[error("[sip.wss].listen {0:?} is not a valid socket address: {1}")]
+    BadSipWssListen(String, std::net::AddrParseError),
+
+    #[error("[sip.wss].cert is required when transports includes \"wss\"")]
+    SipWssCertRequired,
+
+    #[error("[sip.wss].key is required when transports includes \"wss\"")]
+    SipWssKeyRequired,
+
+    #[error("[sip.wss] is configured but transports does not include \"wss\"")]
+    SipWssConfiguredButNotEnabled,
+
+    #[error(
+        "{0}.allowed_origins contains an empty entry, which can never match a real Origin header"
+    )]
+    EmptyAllowedOrigin(&'static str),
 
     #[error("[sip.tls].cert is required when transports includes \"tls\"")]
     SipTlsCertRequired,
@@ -1645,6 +1708,8 @@ fn compile_sip(raw: RawSip) -> Result<SipConfig, CompileError> {
             "udp" => SipTransport::Udp,
             "tcp" => SipTransport::Tcp,
             "tls" => SipTransport::Tls,
+            "ws" => SipTransport::Ws,
+            "wss" => SipTransport::Wss,
             _ => return Err(CompileError::UnknownTransport(name.clone())),
         };
         if !transports.contains(&t) {
@@ -1654,6 +1719,9 @@ fn compile_sip(raw: RawSip) -> Result<SipConfig, CompileError> {
 
     let tls_enabled = transports.contains(&SipTransport::Tls);
     let tls = compile_sip_tls(raw.tls, tls_enabled, &listen_addr)?;
+
+    let ws = compile_sip_ws(raw.ws, transports.contains(&SipTransport::Ws))?;
+    let wss = compile_sip_wss(raw.wss, transports.contains(&SipTransport::Wss))?;
 
     // Client-side roots are independent of the TLS *listener* — a
     // UDP-only daemon can still dial a TLS trunk. Validate the path
@@ -1706,6 +1774,8 @@ fn compile_sip(raw: RawSip) -> Result<SipConfig, CompileError> {
         contact: raw.contact,
         tls,
         tls_client_extra_ca,
+        ws,
+        wss,
         call_progress,
         min_session_expires,
         preferred_session_expires,
@@ -1908,6 +1978,76 @@ fn compile_sip_tls(
         cert_path: PathBuf::from(cert_path),
         key_path: PathBuf::from(key_path),
     }))
+}
+
+fn compile_sip_ws(
+    raw: crate::raw::RawSipWs,
+    enabled: bool,
+) -> Result<Option<SipWsConfig>, CompileError> {
+    let has_any_field = raw.listen.is_some() || !raw.allowed_origins.is_empty();
+    if !enabled {
+        if has_any_field {
+            // Same posture as [sip.tls]: a configured-but-unenabled
+            // block is almost always a typo — fail loud rather than
+            // silently never listening.
+            return Err(CompileError::SipWsConfiguredButNotEnabled);
+        }
+        return Ok(None);
+    }
+    let listen = raw.listen.ok_or(CompileError::SipWsListenRequired)?;
+    let listen_addr = listen
+        .parse()
+        .map_err(|e| CompileError::BadSipWsListen(listen, e))?;
+    Ok(Some(SipWsConfig {
+        listen_addr,
+        allowed_origins: validate_origins(raw.allowed_origins, "[sip.ws]")?,
+    }))
+}
+
+fn compile_sip_wss(
+    raw: crate::raw::RawSipWss,
+    enabled: bool,
+) -> Result<Option<SipWssConfig>, CompileError> {
+    let has_any_field = raw.listen.is_some()
+        || raw.cert.is_some()
+        || raw.key.is_some()
+        || !raw.allowed_origins.is_empty();
+    if !enabled {
+        if has_any_field {
+            return Err(CompileError::SipWssConfiguredButNotEnabled);
+        }
+        return Ok(None);
+    }
+    let listen = raw.listen.ok_or(CompileError::SipWssListenRequired)?;
+    let listen_addr = listen
+        .parse()
+        .map_err(|e| CompileError::BadSipWssListen(listen, e))?;
+    let cert = raw.cert.filter(|c| !c.is_empty());
+    let key = raw.key.filter(|k| !k.is_empty());
+    let cert_path = cert.ok_or(CompileError::SipWssCertRequired)?;
+    let key_path = key.ok_or(CompileError::SipWssKeyRequired)?;
+    Ok(Some(SipWssConfig {
+        listen_addr,
+        cert_path: PathBuf::from(cert_path),
+        key_path: PathBuf::from(key_path),
+        allowed_origins: validate_origins(raw.allowed_origins, "[sip.wss]")?,
+    }))
+}
+
+/// An allow-list entry that is empty or whitespace can never match a
+/// real `Origin` header — it silently turns the allow-list into
+/// "refuse every browser", which reads as an outage, not a typo. Fail
+/// loud at load per CLAUDE.md §4.6.
+fn validate_origins(
+    origins: Vec<String>,
+    block: &'static str,
+) -> Result<Vec<String>, CompileError> {
+    for o in &origins {
+        if o.trim().is_empty() {
+            return Err(CompileError::EmptyAllowedOrigin(block));
+        }
+    }
+    Ok(origins)
 }
 
 fn compile_node(raw: RawNode, sip: &SipConfig) -> Result<NodeConfig, CompileError> {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -39,8 +39,8 @@ pub use compile::{
     Config, Gateway, GatewayCredentials, HepConfig, MediaConfig, NodeConfig, ObservabilityConfig,
     OtlpConfig, OutboundConfig, ParkConfig, ParkTimeoutAction, QualityConfig, QualityFileConfig,
     QualityWebhookConfig, RegisterConfig, SecurityConfig, ShutdownConfig, SipAdmissionConfig,
-    SipAuthConfig, SipAuthUser, SipConfig, SipTlsConfig, SipTransport, TrunkCidr,
-    TrunkCidrParseError, TrunkConfig, WebhooksConfig,
+    SipAuthConfig, SipAuthUser, SipConfig, SipTlsConfig, SipTransport, SipWsConfig, SipWssConfig,
+    TrunkCidr, TrunkCidrParseError, TrunkConfig, WebhooksConfig,
 };
 pub use env::{expand, expand_cow, EnvError, EnvSource, ProcessEnv};
 pub use raw::{

--- a/crates/config/src/raw.rs
+++ b/crates/config/src/raw.rs
@@ -185,10 +185,11 @@ pub struct RawNode {
 pub struct RawSip {
     /// `host:port` to bind UDP / TCP on. Required.
     pub listen: String,
-    /// Transports to enable on `listen`. Default: `["udp"]`. Valid
-    /// entries: `udp`, `tcp`, `tls`. `tls` requires `[sip.tls]` to
-    /// be configured (cert/key); compile-time validation enforces
-    /// that.
+    /// Transports to enable. Default: `["udp"]`. Valid entries:
+    /// `udp`, `tcp`, `tls`, `ws`, `wss`. `udp`/`tcp` bind `listen`;
+    /// `tls` requires `[sip.tls]` (cert/key), `ws` requires
+    /// `[sip.ws]` and `wss` requires `[sip.wss]` — each on its own
+    /// listen address. Compile-time validation enforces all of it.
     #[serde(default = "default_transports")]
     pub transports: Vec<String>,
     /// Product token for the `Server` header on responses this daemon
@@ -213,6 +214,16 @@ pub struct RawSip {
     /// the server side. Unset = the bundled webpki roots only.
     #[serde(default)]
     pub tls_client: RawSipTlsClient,
+    /// SIP-over-WebSocket listener sub-block (RFC 7118). Required
+    /// when `transports` includes `"ws"`. Plain WS is for lab use —
+    /// browsers require secure contexts, so production browser
+    /// clients need `[sip.wss]`.
+    #[serde(default)]
+    pub ws: RawSipWs,
+    /// SIP over secure WebSocket listener sub-block (RFC 7118).
+    /// Required when `transports` includes `"wss"`.
+    #[serde(default)]
+    pub wss: RawSipWss,
     /// Call-progress sub-block — how the UAS responds to inbound
     /// INVITEs before the 2xx. Unset = `mode = "instant_answer"`
     /// (v0.1.0 behaviour).
@@ -410,6 +421,51 @@ pub struct RawSipTls {
     /// PEM-encoded private key (path on disk). Required.
     #[serde(default)]
     pub key: Option<String>,
+}
+
+/// `[sip.ws]` — SIP-over-WebSocket listener (RFC 7118). Read only when
+/// `[sip].transports` includes `"ws"`.
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawSipWs {
+    /// `host:port` to bind the WS listener on. Required when the
+    /// transport is enabled — RFC 7118 has no SIP-specific default
+    /// port, and squatting 80 would collide with any co-hosted HTTP.
+    #[serde(default)]
+    pub listen: Option<String>,
+    /// Allowed `Origin` header values for the WebSocket upgrade,
+    /// compared case-insensitively against the full serialized origin
+    /// (e.g. `https://ops.example.com`). Empty (default) = no check.
+    /// Non-empty = upgrades whose `Origin` is absent or unlisted are
+    /// refused `403` — browsers always send it, so this pins which
+    /// pages may open signalling; non-browser clients can forge it,
+    /// which is why `[sip.auth]` stays the real authentication.
+    #[serde(default)]
+    pub allowed_origins: Vec<String>,
+}
+
+/// `[sip.wss]` — SIP over secure WebSocket (RFC 7118). Read only when
+/// `[sip].transports` includes `"wss"`.
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawSipWss {
+    /// `host:port` to bind the WSS listener on. Required when the
+    /// transport is enabled.
+    #[serde(default)]
+    pub listen: Option<String>,
+    /// PEM-encoded certificate chain (path on disk). Required —
+    /// deliberately not inherited from `[sip.tls]`: a WSS cert is
+    /// typically a public web PKI cert the browser must trust, while
+    /// the SIP TLS cert may be private-CA. Point both at the same
+    /// files if they genuinely share one.
+    #[serde(default)]
+    pub cert: Option<String>,
+    /// PEM-encoded private key (path on disk). Required.
+    #[serde(default)]
+    pub key: Option<String>,
+    /// Same as `[sip.ws].allowed_origins`.
+    #[serde(default)]
+    pub allowed_origins: Vec<String>,
 }
 
 /// `[sip.tls_client]` — verification roots for outgoing TLS.

--- a/crates/config/tests/load.rs
+++ b/crates/config/tests/load.rs
@@ -3323,3 +3323,97 @@ fn reserved_outbound_calls_validates_against_forge_default_pool() {
     let err = load_from_str_with_env(&too_big, &MapEnv::new([])).unwrap_err();
     assert!(matches!(err, LoadError::Compile(_)), "got {err:?}");
 }
+
+// ─── SIP over WebSocket (RFC 7118) config ───────────────────────
+
+/// Minimal TOML with the given `[sip]` fragment spliced in.
+fn ws_toml(sip_extra: &str) -> String {
+    format!(
+        r#"
+[sip]
+listen = "127.0.0.1:5060"
+{sip_extra}
+
+[bridge]
+ws_url = "ws://127.0.0.1:8765/"
+
+[[route]]
+name = "default"
+[route.match]
+any = true
+"#
+    )
+}
+
+#[test]
+fn ws_transport_compiles_with_listener_and_origins() {
+    let toml = ws_toml(
+        r#"transports = ["udp", "ws"]
+[sip.ws]
+listen = "127.0.0.1:5082"
+allowed_origins = ["https://ops.example.com"]"#,
+    );
+    let cfg = load_from_str_with_env(&toml, &MapEnv::new([])).expect("compiles");
+    assert!(cfg.sip.transports.contains(&SipTransport::Ws));
+    let ws = cfg.sip.ws.expect("ws config present");
+    assert_eq!(ws.listen_addr.port(), 5082);
+    assert_eq!(ws.allowed_origins, vec!["https://ops.example.com"]);
+    assert!(cfg.sip.wss.is_none());
+}
+
+#[test]
+fn ws_transport_requires_a_listen_address() {
+    let toml = ws_toml(r#"transports = ["udp", "ws"]"#);
+    let err = load_from_str_with_env(&toml, &MapEnv::new([])).unwrap_err();
+    assert!(
+        format!("{err}").contains("[sip.ws].listen"),
+        "expected [sip.ws].listen error, got {err}"
+    );
+}
+
+#[test]
+fn ws_block_without_ws_transport_fails_loud() {
+    // Same typo-posture as [sip.tls]: a configured-but-unenabled
+    // block would silently never listen.
+    let toml = ws_toml(
+        r#"transports = ["udp"]
+[sip.ws]
+listen = "127.0.0.1:5082""#,
+    );
+    let err = load_from_str_with_env(&toml, &MapEnv::new([])).unwrap_err();
+    assert!(
+        format!("{err}").contains("does not include \"ws\""),
+        "expected configured-but-not-enabled error, got {err}"
+    );
+}
+
+#[test]
+fn wss_transport_requires_cert_and_key() {
+    let toml = ws_toml(
+        r#"transports = ["udp", "wss"]
+[sip.wss]
+listen = "127.0.0.1:8443""#,
+    );
+    let err = load_from_str_with_env(&toml, &MapEnv::new([])).unwrap_err();
+    assert!(
+        format!("{err}").contains("[sip.wss].cert"),
+        "expected [sip.wss].cert error, got {err}"
+    );
+}
+
+#[test]
+fn empty_allowed_origin_fails_loud() {
+    // An empty entry can never match a real Origin header — the
+    // allow-list silently becomes "refuse every browser".
+    let toml = ws_toml(
+        r#"transports = ["udp", "ws"]
+[sip.ws]
+listen = "127.0.0.1:5082"
+allowed_origins = ["https://ops.example.com", " "]"#,
+    );
+    let err = load_from_str_with_env(&toml, &MapEnv::new([])).unwrap_err();
+    assert!(
+        format!("{err}").contains("allowed_origins"),
+        "expected empty-origin error, got {err}"
+    );
+}

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -89,7 +89,7 @@ credentials. Resolved secret values are never logged.
 | Field        | Type             | Default    | Notes |
 |--------------|------------------|------------|-------|
 | `listen`     | `host:port`      | required   | UDP/TCP bind. UDP and TCP share this port. **A `[[register]]` block requires a fixed port here** — the Contact a registrar routes calls back through is built from this port, and `:0` (ephemeral) cannot be advertised, since the kernel only picks the real port at bind time. Config load refuses that combination rather than leaving one registration dead on an otherwise healthy daemon. |
-| `transports` | `["udp","tcp","tls"]` | `["udp"]` | Subset enabled. `"tls"` requires `[sip.tls]`. |
+| `transports` | `["udp","tcp","tls","ws","wss"]` | `["udp"]` | Subset enabled. `"tls"` requires `[sip.tls]`; `"ws"` requires `[sip.ws]` and `"wss"` requires `[sip.wss]` (RFC 7118, each on its own listen address). |
 | `user_agent` | string           | `siphon-ai/<version>` | Product token this daemon stamps on the `Server` header of its responses and the `User-Agent` of the requests it originates (REGISTER, INVITE, REFER, BYE) — set it to brand the node (`"Acme Voice Bridge/2.1"`), leave it unset for the product and its own version (`siphon-ai/<version>`, e.g. `siphon-ai/0.49.7`). Until the releases carrying [#539](https://github.com/thevoiceguy/siphon-ai/issues/539) this key was documented but wired to nothing at all — responses read `siphon-rs/0.1.0`, then `sip-uas/<version>`, and requests `sip-uac/<version>`, whatever was configured here. Restart-required. |
 | `contact`    | string           | derived    | Override the `Contact` URI; otherwise built from `[node].public_address` + the bound port. |
 | `allow_delayed_offer` | bool    | `true`     | Accept an inbound INVITE with **no SDP** (RFC 3264 delayed offer): SiphonAI offers in the 200 OK and reads the peer's answer from the ACK. Needed for CUCM trunks/phones without a forced MTP. `false` rejects an offerless INVITE with `488`. Early-offer INVITEs are unaffected either way. |
@@ -149,6 +149,24 @@ credentials. Resolved secret values are never logged.
 > `[[register]]` blocks with `transport = "tls"` — verify the peer
 > against the client roots below and need no `[sip.tls]` at all: a
 > UDP-only daemon can still dial a TLS trunk.
+
+### `[sip.ws]` / `[sip.wss]` — SIP over WebSocket (RFC 7118)
+
+| Field             | Type          | Default  | Notes |
+|-------------------|---------------|----------|-------|
+| `listen`          | `host:port`   | required | Where the WS/WSS listener binds — its own address, not the SIP port (browsers connect to a web-shaped port). |
+| `cert` / `key`    | path          | required (`[sip.wss]` only) | PEM cert chain + private key. **Deliberately not inherited from `[sip.tls]`**: the WSS cert must be one browsers trust (public web PKI), while the SIP TLS cert may be private-CA. Point both at the same files if they genuinely share one. Rotating the WSS cert wants a **restart** (not yet on the SIGHUP reload path). |
+| `allowed_origins` | array[string] | `[]`     | `Origin` allow-list for the WebSocket upgrade, matched case-insensitively against the full serialized origin (e.g. `https://ops.example.com`). Empty = no check. Non-empty = upgrades with an absent or unlisted `Origin` are refused `403` before subprotocol selection — browsers always send it, so this pins which pages may open signalling to the daemon. Non-browser clients can forge the header; `[sip.auth]` remains the real authentication. An empty/whitespace entry fails at load (it could never match, silently refusing every browser). |
+
+Upgrades must offer the `sip` WebSocket subprotocol (RFC 7118 §4) or
+they are refused. Replies and in-dialog requests to a WS client go
+back down the connection the client established — a browser's
+Via/Contact addresses are unroutable, so if the connection is gone the
+request fails; the client reconnects and re-REGISTERs. Plain `ws` is
+for lab use: browsers require secure contexts, so production browser
+clients need `[sip.wss]`. Client-side WS — `[[gateway]]` /
+`[[register]]` with `transport = "ws"` — is **not** supported;
+browsers register to us, not the reverse.
 
 ### `[sip.tls_client]` (0.6.2+)
 

--- a/test-harness/sipp-scenarios/run-all.sh
+++ b/test-harness/sipp-scenarios/run-all.sh
@@ -2890,6 +2890,100 @@ fi
 ts_cleanup
 trap - EXIT
 
+# ─── Always-on auxiliary phase: ws_signaling ──────────────────────
+# SIP over WebSocket (RFC 7118, DEV_PLAN_WebRTC.md Phase 1). SIPp
+# cannot speak WS, so ws_sip_call.py (python websockets, from the
+# echo-ws venv) is the client: one full INVITE/ACK/BYE call over a
+# single WS connection with the `sip` subprotocol and an allowed
+# Origin, then an assertion that a wrong (and an absent) Origin is
+# refused 403 at the upgrade, then the usual settle-to-zero check.
+echo
+echo "─── auxiliary phase: ws_signaling ─────────────────────"
+WSP_DAEMON_LOG=$(mktemp -t siphon-ai-wsp.XXXXXX.log)
+WSP_CONFIG=$(mktemp -t siphon-ai-wsp.XXXXXX.toml)
+WSP_WS_PORT=5083
+cat >"$WSP_CONFIG" <<EOF
+[node]
+id = "siphon-ai-sipp-wsp"
+[sip]
+listen = "127.0.0.1:$DAEMON_PORT"
+transports = ["udp", "ws"]
+[sip.ws]
+listen = "127.0.0.1:$WSP_WS_PORT"
+allowed_origins = ["https://ops.example.com"]
+[media]
+codecs = ["pcmu"]
+# The WS caller never sends RTP; give the watchdog room for the 1s
+# call so teardown is BYE-driven, not watchdog-driven.
+inactivity_timeout_secs = 30
+[bridge]
+ws_url = "ws://127.0.0.1:$ECHO_WS_PORT/"
+[observability]
+enabled = true
+http_listen = "127.0.0.1:$AUX_OBS_PORT"
+[[route]]
+name = "default"
+[route.match]
+any = true
+EOF
+
+RUST_LOG=siphon_ai=info "$DAEMON_BIN" --config "$WSP_CONFIG" \
+    >"$WSP_DAEMON_LOG" 2>&1 &
+WSP_DAEMON_PID=$!
+wsp_cleanup() {
+    kill "$WSP_DAEMON_PID" 2>/dev/null || true
+    wait "$WSP_DAEMON_PID" 2>/dev/null || true
+}
+trap wsp_cleanup EXIT
+sleep 1.2
+
+WSP_PYTHON="$REPO_ROOT/examples/echo-ws-server-python/.venv/bin/python"
+[[ -x "$WSP_PYTHON" ]] || WSP_PYTHON=python3
+
+total=$((total + 2))
+echo "─── ws_sip_call ──────────────────────────────────────"
+if WS_URL="ws://127.0.0.1:$WSP_WS_PORT" "$WSP_PYTHON" \
+    "$SCRIPT_DIR/ws_sip_call.py" call >/dev/null 2>&1; then
+    echo "  OK"
+else
+    echo "  FAIL (daemon: $WSP_DAEMON_LOG)"
+    failures=$((failures + 1))
+fi
+echo "─── ws_origin_refused ────────────────────────────────"
+if WS_URL="ws://127.0.0.1:$WSP_WS_PORT" "$WSP_PYTHON" \
+    "$SCRIPT_DIR/ws_sip_call.py" refused >/dev/null 2>&1; then
+    echo "  OK"
+else
+    echo "  FAIL (daemon: $WSP_DAEMON_LOG)"
+    failures=$((failures + 1))
+fi
+
+total=$((total + 1))
+echo "─── ws_signaling_settles_to_zero ─────────────────────"
+wsp_ok=0
+wsp_deadline=$((SECONDS + 20))
+while (( SECONDS < wsp_deadline )); do
+    wsp_state=$(curl -s "http://127.0.0.1:$AUX_OBS_PORT/metrics" | awk '
+        BEGIN { c = "?"; p = "?" }
+        /^siphon_ai_calls_active /            { c = $2 }
+        /^siphon_ai_rtp_port_pairs_allocated /{ p = $2 }
+        END { printf "calls=%s port_pairs=%s", c, p }')
+    if [[ "$wsp_state" == "calls=0 port_pairs=0" ]]; then
+        wsp_ok=1
+        break
+    fi
+    sleep 2
+done
+if (( wsp_ok )); then
+    echo "  OK"
+else
+    echo "  FAIL (stuck at: $wsp_state; daemon: $WSP_DAEMON_LOG)"
+    failures=$((failures + 1))
+fi
+
+wsp_cleanup
+trap - EXIT
+
 # ─── Always-on auxiliary phase: graceful drain ────────────────────
 # Exercises the 0.17.0 SIGTERM drain end-to-end (DESIGN_GRACEFUL_SHUTDOWN
 # §5):

--- a/test-harness/sipp-scenarios/ws_sip_call.py
+++ b/test-harness/sipp-scenarios/ws_sip_call.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""SIP-over-WebSocket (RFC 7118) signalling probe for run-all.sh.
+
+SIPp cannot speak RFC 7118, so this is the suite's WS client
+(DEV_PLAN_WebRTC.md Phase 1 §3.3). Uses the `websockets` package the
+echo-ws-server venv already carries.
+
+Modes:
+  call     INVITE -> 100/200 -> ACK -> hold 1s -> BYE -> 200, all over
+           one WS connection with the `sip` subprotocol and an allowed
+           Origin. Exits 0 and prints CALL-OK on success. The SDP
+           offers classic RTP/AVP PCMU; no RTP is actually sent, so
+           run the daemon with the media watchdog generous or off.
+  refused  Assert the upgrade is REFUSED for (a) a wrong Origin and
+           (b) no Origin, when the daemon has an allow-list. Exits 0
+           and prints REFUSED-OK when both are rejected.
+
+Env: WS_URL (default ws://127.0.0.1:5082), WS_ORIGIN (the allowed
+origin, default https://ops.example.com).
+"""
+
+import asyncio
+import os
+import sys
+
+import websockets
+
+WS_URL = os.environ.get("WS_URL", "ws://127.0.0.1:5082")
+ORIGIN = os.environ.get("WS_ORIGIN", "https://ops.example.com")
+CALL_ID = "ws-call-1@browser.invalid"
+
+
+def sdp(port=6000):
+    return (
+        "v=0\r\no=browser 1 1 IN IP4 127.0.0.1\r\ns=-\r\n"
+        "c=IN IP4 127.0.0.1\r\nt=0 0\r\n"
+        f"m=audio {port} RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\n"
+    )
+
+
+def msg(method, cseq, extra="", body=""):
+    m = (
+        f"{method} sip:1000@127.0.0.1 SIP/2.0\r\n"
+        f"Via: SIP/2.0/WS browser.invalid;branch=z9hG4bK-{method.lower()}-{cseq}\r\n"
+        "Max-Forwards: 70\r\n"
+        "From: <sip:browser@browser.invalid>;tag=bt1\r\n"
+        f"To: <sip:1000@127.0.0.1>{extra}\r\n"
+        f"Call-ID: {CALL_ID}\r\n"
+        f"CSeq: {cseq} {method}\r\n"
+        "Contact: <sip:browser@browser.invalid;transport=ws>\r\n"
+    )
+    if body:
+        m += f"Content-Type: application/sdp\r\nContent-Length: {len(body)}\r\n\r\n{body}"
+    else:
+        m += "Content-Length: 0\r\n\r\n"
+    return m.encode()
+
+
+async def recv_status(ws, want, timeout=8):
+    while True:
+        r = await asyncio.wait_for(ws.recv(), timeout=timeout)
+        if isinstance(r, bytes):
+            r = r.decode(errors="replace")
+        line = r.splitlines()[0]
+        print("<", line)
+        code = line.split(" ", 2)[1]
+        if code == want:
+            return r
+        if not code.startswith("1"):
+            raise SystemExit(f"expected {want}, got {line}")
+
+
+async def call():
+    async with websockets.connect(
+        WS_URL, subprotocols=["sip"], additional_headers={"Origin": ORIGIN}
+    ) as ws:
+        assert ws.subprotocol == "sip", f"subprotocol {ws.subprotocol!r}"
+        await ws.send(msg("INVITE", 1, body=sdp()))
+        ok = await recv_status(ws, "200")
+        to_line = next(l for l in ok.splitlines() if l.lower().startswith("to:"))
+        tag = to_line.split("tag=", 1)[1].split(";")[0].strip()
+        await ws.send(msg("ACK", 1, extra=f";tag={tag}"))
+        await asyncio.sleep(1)
+        await ws.send(msg("BYE", 2, extra=f";tag={tag}"))
+        await recv_status(ws, "200")
+        print("CALL-OK")
+
+
+async def assert_refused(origin):
+    kw = {"subprotocols": ["sip"]}
+    if origin is not None:
+        kw["additional_headers"] = {"Origin": origin}
+    try:
+        async with websockets.connect(WS_URL, **kw):
+            raise SystemExit(f"upgrade with origin={origin!r} was NOT refused")
+    except websockets.exceptions.InvalidStatus as e:
+        code = e.response.status_code
+        if code != 403:
+            raise SystemExit(f"origin={origin!r}: expected 403, got {code}")
+        print(f"refused as expected (403) origin={origin!r}")
+
+
+async def refused():
+    await assert_refused("https://evil.example.net")
+    await assert_refused(None)
+    print("REFUSED-OK")
+
+
+mode = sys.argv[1] if len(sys.argv) > 1 else "call"
+asyncio.run({"call": call, "refused": refused}[mode]())


### PR DESCRIPTION
Enables the WS/WSS SIP transports — the piece the runtime doc has called "deferred until we have a deployment that needs it." The deployment is `DEV_PLAN_WebRTC.md` (Phase 1, §3.1–3.2).

## Config surface

- `[sip].transports` accepts `"ws"` / `"wss"`, each requiring its own block: **`[sip.ws]` / `[sip.wss]`** (`listen`, `cert`/`key` for WSS, `allowed_origins`). Same fail-loud posture as `[sip.tls]`: a configured-but-unenabled block is a load error, as is an empty `allowed_origins` entry (it could never match a real `Origin` and would silently refuse every browser).
- The WSS cert is **deliberately independent of `[sip.tls]`** — browsers must trust it (public web PKI), while the SIP TLS cert may be private-CA. Restart to rotate (not on the SIGHUP path yet; documented).
- `[[gateway]]`/`[[register]]` still reject `ws` — client-side WS is out of scope; browsers register to us.

## The bug the first-ever WS request found

`MultiTransportDispatcher` had a catch-all that errored any non-UDP/TCP/TLS send — so the very first OPTIONS over WS parsed, dispatched, and then its `200 OK` silently died in the response path. New `Ws | Wss` arms route replies (and in-dialog requests) down the connection the client established, **and only that connection** — a browser's Via/Contact addresses are unroutable, so there is deliberately no dial-back fallback (RFC 7118 §5.2): no connection ⇒ the request fails and the client re-REGISTERs on reconnect.

## Testing

- **`ws_signaling` harness phase** + `ws_sip_call.py` (SIPp cannot speak RFC 7118; python `websockets` from the echo venv is the suite's WS client per plan §3.3): a full INVITE → 100/200 → ACK → BYE → 200 call over one WS connection with the `sip` subprotocol and an allowed Origin; wrong-Origin and absent-Origin refused `403` at the upgrade; then the settle-to-zero check. **Suite: 59/59** (was 56).
- 5 new config load tests (listen required, cert/key required, configured-but-unenabled, empty origin, happy path).
- Verified live by hand as well: OPTIONS answered over WS; the full call with clean teardown (`calls_active`/`rtp_port_pairs_allocated` back to 0, `invites_total{result="accepted"} 1`).

## Upstream

Pins siphon-rs **v2026.08.24.1** (sip-transport 0.5.0 — `WsAcceptPolicy` Origin allow-list + WS two-phase idle timeout, [siphon-rs #125](https://github.com/thevoiceguy/siphon-rs/pull/125)); the `ws` feature joins `tls` on the sip-transport dependency.

Toward the Phase 1 exit criteria, this delivers the transport + a WS client placing a call end-to-end. Still open for Phase 1: registrar acceptance (SIP.js REGISTERs — siphon-ai doesn't serve REGISTER yet) and Homer visibility confirmation (HEP emission on WS is already wired upstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Gm9Cizujd8LBMzrpDx9LU