### PR TITLE
feat(webrtc): the media leg's lifecycle and audio path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The WebRTC media leg's lifecycle and audio path** (`crates/webrtc-glue`,
+  Phase 2 §4.2–4.3 of `docs/design/DEV_PLAN_WebRTC.md`). `WebRtcLeg`
+  answers a browser offer with **complete gathering before the answer**
+  (v1 does no SIP trickle, so both ends gather fully before signalling
+  — bounded, because a black-holing STUN server must degrade the
+  candidate list rather than stall a call), then exposes connect and
+  teardown on the `[webrtc].setup_timeout` budget. `InboundAudio` /
+  `OutboundAudio` convert between SRTP and the bridge's fixed 20 ms
+  PCM16LE frames, reusing the **same** `Reframer` / `pack_pcm16_le` as
+  the classic tap so the frame contract cannot drift between leg types,
+  and forge-rtp's `JitterBuffer` rather than a bespoke reorder queue.
+
+  Two things this pinned down that the plan had sketched differently:
+  **no resampler is needed** — libopus decodes 48 kHz straight to the
+  bridge's 16 kHz, exactly as the classic Opus path already relies on,
+  so a browser leg hands the bridge the same PCM rate a classic Opus
+  call does; and Opus's **RTP timestamp advances at 48 kHz even when
+  decoding at 16 kHz** (RFC 7587 §4.1), so a 20 ms frame is 320 samples
+  but 960 timestamp units — the increment comes from forge-webrtc's
+  `samples_per_20ms()` and never from the PCM length, because deriving
+  it from the frame would run the clock at a third of real time and
+  slowly starve the browser's jitter buffer.
+
+  Not yet wired into the acceptor — that is the next step, and the
+  reason this lands as a self-contained, separately-tested unit.
+
+### Changed
+
+- **forge-media pinned to `v2026.08.25`** (from `v2026.08.24`) —
+  forge-rtp 0.3.1, whose `JitterBuffer::pop` no longer aborts the
+  process on a reordered RTP packet
+  ([forge-media #132](https://github.com/thevoiceguy/forge-media/pull/132)).
+  Found building the leg above, which is that buffer's first consumer;
+  nothing released used it, so no shipped siphon-ai was affected.
+
+### Added
+
 - **`crates/webrtc-glue` + `[webrtc]` config** — the foundation of
   Phase 2 in `docs/design/DEV_PLAN_WebRTC.md`, and the answer to that
   plan's top risk. The new crate holds the §4.1 leg-selection rule

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,7 +1122,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "forge-codecs"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24#6d6bf61183ee4a38dffb82bd52e58ef3ec77371c"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.25#dd122123548ccc06838fe442acb8a5d508de3bc1"
 dependencies = [
  "audiopus",
  "ezk-g722",
@@ -1134,7 +1134,7 @@ dependencies = [
 [[package]]
 name = "forge-core"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24#6d6bf61183ee4a38dffb82bd52e58ef3ec77371c"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.25#dd122123548ccc06838fe442acb8a5d508de3bc1"
 dependencies = [
  "chrono",
  "serde",
@@ -1149,7 +1149,7 @@ dependencies = [
 [[package]]
 name = "forge-dtmf"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24#6d6bf61183ee4a38dffb82bd52e58ef3ec77371c"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.25#dd122123548ccc06838fe442acb8a5d508de3bc1"
 dependencies = [
  "chrono",
  "forge-core",
@@ -1161,7 +1161,7 @@ dependencies = [
 [[package]]
 name = "forge-engine"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24#6d6bf61183ee4a38dffb82bd52e58ef3ec77371c"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.25#dd122123548ccc06838fe442acb8a5d508de3bc1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1191,7 +1191,7 @@ dependencies = [
 [[package]]
 name = "forge-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24#6d6bf61183ee4a38dffb82bd52e58ef3ec77371c"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.25#dd122123548ccc06838fe442acb8a5d508de3bc1"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -1204,7 +1204,7 @@ dependencies = [
 [[package]]
 name = "forge-ice"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24#6d6bf61183ee4a38dffb82bd52e58ef3ec77371c"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.25#dd122123548ccc06838fe442acb8a5d508de3bc1"
 dependencies = [
  "bytes",
  "forge-core",
@@ -1226,7 +1226,7 @@ dependencies = [
 [[package]]
 name = "forge-injection"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24#6d6bf61183ee4a38dffb82bd52e58ef3ec77371c"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.25#dd122123548ccc06838fe442acb8a5d508de3bc1"
 dependencies = [
  "forge-core",
  "rubato",
@@ -1239,7 +1239,7 @@ dependencies = [
 [[package]]
 name = "forge-mixer"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24#6d6bf61183ee4a38dffb82bd52e58ef3ec77371c"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.25#dd122123548ccc06838fe442acb8a5d508de3bc1"
 dependencies = [
  "bytes",
  "dashmap 6.2.1",
@@ -1253,7 +1253,7 @@ dependencies = [
 [[package]]
 name = "forge-recorder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24#6d6bf61183ee4a38dffb82bd52e58ef3ec77371c"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.25#dd122123548ccc06838fe442acb8a5d508de3bc1"
 dependencies = [
  "bytes",
  "forge-core",
@@ -1267,7 +1267,7 @@ dependencies = [
 [[package]]
 name = "forge-resampler"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24#6d6bf61183ee4a38dffb82bd52e58ef3ec77371c"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.25#dd122123548ccc06838fe442acb8a5d508de3bc1"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -1275,8 +1275,8 @@ dependencies = [
 
 [[package]]
 name = "forge-rtp"
-version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24#6d6bf61183ee4a38dffb82bd52e58ef3ec77371c"
+version = "0.3.1"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.25#dd122123548ccc06838fe442acb8a5d508de3bc1"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm 0.11.0",
@@ -1301,7 +1301,7 @@ dependencies = [
 [[package]]
 name = "forge-sdp"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24#6d6bf61183ee4a38dffb82bd52e58ef3ec77371c"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.25#dd122123548ccc06838fe442acb8a5d508de3bc1"
 dependencies = [
  "base64 0.23.1",
  "chrono",
@@ -1309,7 +1309,7 @@ dependencies = [
  "forge-ice",
  "forge-rtp",
  "rand 0.10.1",
- "sip-sdp 0.3.1 (git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24)",
+ "sip-sdp 0.3.1 (git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.25)",
  "smol_str",
  "thiserror 2.0.18",
 ]
@@ -1317,7 +1317,7 @@ dependencies = [
 [[package]]
 name = "forge-transcoder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24#6d6bf61183ee4a38dffb82bd52e58ef3ec77371c"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.25#dd122123548ccc06838fe442acb8a5d508de3bc1"
 dependencies = [
  "bytes",
  "forge-codecs",
@@ -1330,7 +1330,7 @@ dependencies = [
 [[package]]
 name = "forge-vad"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24#6d6bf61183ee4a38dffb82bd52e58ef3ec77371c"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.25#dd122123548ccc06838fe442acb8a5d508de3bc1"
 dependencies = [
  "forge-core",
  "thiserror 2.0.18",
@@ -1340,7 +1340,7 @@ dependencies = [
 [[package]]
 name = "forge-webrtc"
 version = "0.4.0"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24#6d6bf61183ee4a38dffb82bd52e58ef3ec77371c"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.25#dd122123548ccc06838fe442acb8a5d508de3bc1"
 dependencies = [
  "bytes",
  "dashmap 6.2.1",
@@ -4055,7 +4055,7 @@ dependencies = [
 [[package]]
 name = "sip-sdp"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.24#6d6bf61183ee4a38dffb82bd52e58ef3ec77371c"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.25#dd122123548ccc06838fe442acb8a5d508de3bc1"
 dependencies = [
  "nom 7.1.3",
  "smol_str",
@@ -4570,10 +4570,14 @@ dependencies = [
 name = "siphon-ai-webrtc-glue"
 version = "0.50.1"
 dependencies = [
+ "bytes",
+ "forge-codecs",
  "forge-core",
  "forge-ice",
+ "forge-rtp",
  "forge-sdp",
  "forge-webrtc",
+ "siphon-ai-bridge",
  "thiserror 1.0.69",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -478,25 +478,25 @@ sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v20
 # comment for the current rev.) Prior forge pins: forge 1c996ae5fb4f = #86
 # neural VAD; forge 3c59b5f6e464 = #82-#85 dependency migrations; forge
 # 5fa76fb38675 = #81.
-forge-core    = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.24" }
-forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.24" }
-forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.24", default-features = false, features = ["g722", "dtls", "opus", "neural-vad"] }
-forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.24" }
-forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.24" }
-forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.24" }
-forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.24" }
-forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.24" }
+forge-core    = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.25" }
+forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.25" }
+forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.25", default-features = false, features = ["g722", "dtls", "opus", "neural-vad"] }
+forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.25" }
+forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.25" }
+forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.25" }
+forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.25" }
+forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.25" }
 # WebRTC leg (DEV_PLAN_WebRTC.md Phase 2). Only reachable through
 # siphon-ai-webrtc-glue, which the daemon pulls in behind its
 # `webrtc` feature — a default build links neither.
-forge-webrtc  = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.24" }
-forge-ice     = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.24" }
+forge-webrtc  = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.25" }
+forge-ice     = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.25" }
 # Conference rooms (0.7.0): forge-mixer is the per-room AudioMixer;
 # forge-injection provides ToneGenerator (join/leave tones now, MOH
 # for park later). Deliberately NOT forge-conference — its DTMF
 # IVR/PIN/host-control layer is unused per DEV_PLAN_0.7.0.md §9.4.
-forge-mixer     = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.24" }
-forge-injection = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.24" }
+forge-mixer     = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.25" }
+forge-injection = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.25" }
 
 # hep-rs — HEP3 codec, transport, HepSink trait. Owned by the same
 # author as siphon-rs and forge-media; lives in its own repo.

--- a/crates/webrtc-glue/Cargo.toml
+++ b/crates/webrtc-glue/Cargo.toml
@@ -14,8 +14,25 @@ forge-sdp.workspace = true
 forge-webrtc.workspace = true
 forge-ice.workspace = true
 forge-core.workspace = true
+# Decode/encode for the leg's own audio path: forge-webrtc hands over
+# codec-encoded RTP, not PCM.
+forge-codecs.workspace = true
+# Reorder/dedupe inbound RTP with forge's buffer rather than a bespoke
+# one (CLAUDE.md §4.8).
+forge-rtp.workspace = true
+# The SAME framing helpers the classic tap uses, so the 20 ms PCM16LE
+# contract cannot drift between leg types.
+siphon-ai-bridge.workspace = true
+bytes.workspace = true
+tokio.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+
+[features]
+default = ["opus"]
+# Opus on the browser leg. Off leaves G.711 only, which every browser
+# also implements (RFC 7874 §3).
+opus = ["forge-codecs/opus"]
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/webrtc-glue/src/audio.rs
+++ b/crates/webrtc-glue/src/audio.rs
@@ -1,0 +1,379 @@
+//! The browser leg's audio path: SRTP ⇄ the bridge's PCM16LE frames
+//! (`DEV_PLAN_WebRTC.md` §4.3).
+//!
+//! forge-webrtc hands over RTP that is authenticated, decrypted and
+//! parsed — but still **codec-encoded**, with no jitter buffer and no
+//! depacketization. Everything between that and the WS bridge's fixed
+//! 20 ms PCM16LE frames lives here:
+//!
+//! ```text
+//!   inbound   RtpPacket ─► JitterBuffer ─► decode ─► Reframer ─► PCM16LE bytes
+//!   outbound  PCM16LE bytes ─► i16 ─► encode ─► AudioSender::send_audio
+//! ```
+//!
+//! Two deliberate reuses keep this leg honest against the classic one:
+//! the **same** `Reframer` / `pack_pcm16_le` the classic tap uses (so
+//! the frame contract cannot drift between leg types), and forge-rtp's
+//! **`JitterBuffer`** rather than a bespoke reorder queue (CLAUDE.md
+//! §4.8 — forge already solved this for the classic path).
+//!
+//! # The RTP-clock trap
+//!
+//! Opus decodes to whatever rate we ask for (16 kHz here, matching the
+//! classic path), but its **RTP timestamp always advances at 48 kHz**
+//! regardless — RFC 7587 §4.1. So a 20 ms frame is 320 PCM samples and
+//! 960 timestamp units. Passing the PCM length as the timestamp
+//! increment would make our clock run at a third of real time and the
+//! browser's jitter buffer would slowly starve. [`OutboundAudio`]
+//! therefore takes the increment from forge-webrtc's
+//! `AudioSender::samples_per_20ms()` and never from the PCM frame.
+
+use bytes::Bytes;
+use forge_codecs::{g711::G711ALaw, g711::G711MuLaw, AudioCodec as CodecTrait};
+use forge_core::AudioCodec;
+use forge_rtp::{jitter::JitterBuffer, RtpPacket};
+use forge_webrtc::AudioSender;
+use siphon_ai_bridge::audio::{pack_pcm16_le, unpack_pcm16_le, Reframer};
+use std::time::Duration;
+use tracing::{debug, warn};
+
+use crate::{Result, WebRtcGlueError};
+
+/// Jitter-buffer target depth. Browser paths are lossier and jitterier
+/// than SIP trunks, but this leg feeds a speech pipeline, so latency is
+/// as real a cost as reordering: 60 ms (three frames) absorbs ordinary
+/// internet jitter while staying well inside a conversational budget.
+pub const JITTER_TARGET: Duration = Duration::from_millis(60);
+
+/// Build the codec for one direction at `rate`.
+///
+/// One instance per direction per call: `AudioCodec::encode`/`decode`
+/// take `&mut self`, and sharing would need a lock on the audio path
+/// (CLAUDE.md §4.3 forbids that).
+fn codec_for(codec: AudioCodec, rate: u32) -> Result<Box<dyn CodecTrait>> {
+    match codec {
+        AudioCodec::PCMU => Ok(Box::new(G711MuLaw::new(rate))),
+        AudioCodec::PCMA => Ok(Box::new(G711ALaw::new(rate))),
+        AudioCodec::Opus => {
+            #[cfg(feature = "opus")]
+            {
+                let cfg = forge_codecs::opus::OpusConfig {
+                    // Decode straight to the bridge rate — libopus does
+                    // 48↔16 and stereo→mono internally, which is how the
+                    // classic Opus path already works.
+                    sample_rate: rate,
+                    channels: 1,
+                    ..forge_codecs::opus::OpusConfig::voip()
+                };
+                forge_codecs::opus::OpusCodec::with_config(cfg)
+                    .map(|c| Box::new(c) as Box<dyn CodecTrait>)
+                    .map_err(|e| WebRtcGlueError::Codec(e.to_string()))
+            }
+            #[cfg(not(feature = "opus"))]
+            {
+                let _ = rate;
+                Err(WebRtcGlueError::Codec(
+                    "Opus was negotiated but this build has no Opus codec \
+                     (enable the `opus` feature)"
+                        .into(),
+                ))
+            }
+        }
+        other => Err(WebRtcGlueError::Codec(format!(
+            "{other:?} is not a WebRTC leg codec"
+        ))),
+    }
+}
+
+/// Browser → bridge. Feed it RTP; take PCM16LE frames of exactly the
+/// bridge's 20 ms size.
+pub struct InboundAudio {
+    codec: Box<dyn CodecTrait>,
+    jitter: JitterBuffer,
+    reframer: Reframer,
+    payload_type: u8,
+    /// Packets whose payload type is not the negotiated one (a browser
+    /// sending DTMF or comfort noise on the same stream). Counted, not
+    /// decoded — feeding telephone-event bytes to a speech codec would
+    /// produce noise.
+    pub other_payload_packets: u64,
+    /// Payloads the codec refused. A decode failure is per-packet and
+    /// recoverable; killing the call over one is worse than a click.
+    pub decode_errors: u64,
+}
+
+impl InboundAudio {
+    pub fn new(codec: AudioCodec, payload_type: u8, bridge_rate: u32) -> Result<Self> {
+        Ok(Self {
+            codec: codec_for(codec, bridge_rate)?,
+            jitter: JitterBuffer::new(JITTER_TARGET),
+            reframer: Reframer::new(bridge_rate)
+                .map_err(|e| WebRtcGlueError::Codec(e.to_string()))?,
+            payload_type,
+            other_payload_packets: 0,
+            decode_errors: 0,
+        })
+    }
+
+    /// Accept one inbound packet. Reordering and duplicate suppression
+    /// are the jitter buffer's job; nothing is decoded yet.
+    pub fn push(&mut self, packet: &RtpPacket) {
+        if packet.header.payload_type() != self.payload_type {
+            self.other_payload_packets += 1;
+            return;
+        }
+        self.jitter.push(
+            packet.header.sequence_number,
+            packet.header.timestamp,
+            packet.payload.to_vec(),
+        );
+    }
+
+    /// Drain whatever the jitter buffer will release, decode it, and
+    /// return the complete 20 ms PCM16LE frames that fall out.
+    ///
+    /// **Call this on a 20 ms tick, not on packet arrival.** The
+    /// buffer releases a packet only once it has been held for
+    /// [`JITTER_TARGET`], which is exactly how arrival jitter is
+    /// converted into the steady cadence the bridge expects — the
+    /// same shape as the classic tap's pacing tick. Draining only when
+    /// a packet arrives would hand the jitter straight through and,
+    /// on a quiet stream, stall until the next packet.
+    ///
+    /// Returns frames in the shape `caller_audio_tx` wants, so the
+    /// caller's send loop is identical to the classic tap's.
+    pub fn drain(&mut self) -> Vec<Vec<u8>> {
+        let mut frames = Vec::new();
+        while let Some(payload) = self.jitter.pop() {
+            match self.codec.decode(&payload) {
+                Ok(samples) => self.reframer.push(&samples),
+                Err(e) => {
+                    self.decode_errors += 1;
+                    // One bad packet is a click, not a dropped call.
+                    debug!(error = %e, "WebRTC leg: dropping undecodable payload");
+                    continue;
+                }
+            }
+            while let Some(frame) = self.reframer.pop_frame() {
+                frames.push(pack_pcm16_le(&frame));
+            }
+        }
+        frames
+    }
+
+    /// Jitter-buffer depth, for the setup watchdog and metrics.
+    pub fn buffered_packets(&self) -> usize {
+        self.jitter.size()
+    }
+}
+
+/// Bridge → browser. Feed it the WS server's PCM16LE frames; it
+/// encodes and sends them as SRTP.
+pub struct OutboundAudio {
+    codec: Box<dyn CodecTrait>,
+    sender: AudioSender,
+    /// Timestamp units per 20 ms **at the codec's RTP clock** — 960 for
+    /// Opus (48 kHz clock even when decoding at 16 kHz, RFC 7587 §4.1),
+    /// 160 for G.711. Taken from forge-webrtc, never derived from the
+    /// PCM frame length; see the module docs.
+    samples_per_frame: u32,
+    /// Frames the codec refused to encode.
+    pub encode_errors: u64,
+}
+
+impl OutboundAudio {
+    pub fn new(codec: AudioCodec, sender: AudioSender, bridge_rate: u32) -> Result<Self> {
+        let samples_per_frame = sender.samples_per_20ms();
+        Ok(Self {
+            codec: codec_for(codec, bridge_rate)?,
+            sender,
+            samples_per_frame,
+            encode_errors: 0,
+        })
+    }
+
+    /// Encode and transmit one 20 ms PCM16LE frame from the bridge.
+    ///
+    /// The frame is exactly the size the WS contract already enforces
+    /// (`conn.rs` rejects anything else before it reaches a leg), so a
+    /// wrong size here is a bug rather than a peer's fault — hence the
+    /// hard error rather than a silent drop.
+    pub async fn send_frame(&mut self, pcm16le: &[u8]) -> Result<()> {
+        let samples =
+            unpack_pcm16_le(pcm16le).map_err(|e| WebRtcGlueError::Codec(e.to_string()))?;
+        let encoded = match self.codec.encode(&samples) {
+            Ok(e) => e,
+            Err(e) => {
+                self.encode_errors += 1;
+                warn!(error = %e, "WebRTC leg: dropping unencodable frame");
+                return Ok(());
+            }
+        };
+        self.sender
+            .send_audio(Bytes::from(encoded), self.samples_per_frame)
+            .await
+            .map_err(|e| WebRtcGlueError::Send(e.to_string()))
+    }
+
+    /// Timestamp units this leg advances per 20 ms frame.
+    pub fn samples_per_frame(&self) -> u32 {
+        self.samples_per_frame
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use forge_rtp::{RtpHeader, RtpPacket};
+
+    fn g711_packet(seq: u16, ts: u32, pt: u8, payload: Vec<u8>) -> RtpPacket {
+        let header = RtpHeader {
+            version_flags: 0x80,     // V=2, no padding/extension/CSRC
+            marker_payload_type: pt, // marker clear
+            sequence_number: seq,
+            timestamp: ts,
+            ssrc: 0x1234_5678,
+        };
+        RtpPacket {
+            header,
+            csrc_list: vec![],
+            extension: None,
+            payload: Bytes::from(payload),
+            padding_len: 0,
+        }
+    }
+
+    /// The buffer is wall-clock gated, so a test must wait out
+    /// [`JITTER_TARGET`] before draining — exactly as the real leg's
+    /// 20 ms tick does.
+    async fn settle() {
+        tokio::time::sleep(JITTER_TARGET + Duration::from_millis(20)).await;
+    }
+
+    /// 20 ms of µ-law is 160 bytes → exactly one 8 kHz bridge frame of
+    /// 160 samples = 320 bytes PCM16LE.
+    #[tokio::test]
+    async fn g711_packets_become_exact_bridge_frames() {
+        let mut inbound = InboundAudio::new(AudioCodec::PCMU, 0, 8_000).expect("codec");
+        for i in 0..4u16 {
+            inbound.push(&g711_packet(i, u32::from(i) * 160, 0, vec![0xffu8; 160]));
+        }
+        settle().await;
+        let frames = inbound.drain();
+        assert!(!frames.is_empty(), "some frames must be released");
+        for f in &frames {
+            assert_eq!(f.len(), 320, "20 ms @ 8 kHz PCM16LE");
+        }
+        assert_eq!(inbound.decode_errors, 0);
+    }
+
+    /// A browser sends telephone-event on the same stream. Those bytes
+    /// are not speech and must never reach the decoder.
+    #[test]
+    fn foreign_payload_types_are_counted_not_decoded() {
+        let mut inbound = InboundAudio::new(AudioCodec::PCMU, 0, 8_000).expect("codec");
+        inbound.push(&g711_packet(1, 160, 101, vec![0x00, 0x0a, 0x00, 0xa0]));
+        assert_eq!(inbound.other_payload_packets, 1);
+        assert_eq!(inbound.buffered_packets(), 0, "nothing was buffered");
+        assert!(inbound.drain().is_empty());
+    }
+
+    /// Out-of-order arrival is the jitter buffer's job: 1, 3, 2 on the
+    /// wire must reach the bridge as 1, 2, 3.
+    ///
+    /// Note what "late" means here — the buffer takes its baseline from
+    /// the first packet it sees, so a packet *preceding* that baseline
+    /// is late by definition and is dropped rather than resequenced
+    /// (the case below). Real reordering happens after the stream is
+    /// established, which is what this covers.
+    #[tokio::test]
+    async fn reordered_packets_are_resequenced() {
+        let mut inbound = InboundAudio::new(AudioCodec::PCMU, 0, 8_000).expect("codec");
+        // Constant payloads: after µ-law decode each frame is a
+        // constant sample value, so release order is observable.
+        inbound.push(&g711_packet(1, 160, 0, vec![0x01u8; 160]));
+        inbound.push(&g711_packet(3, 480, 0, vec![0x03u8; 160])); // early
+        inbound.push(&g711_packet(2, 320, 0, vec![0x02u8; 160])); // fills the hole
+        settle().await;
+
+        let frames = inbound.drain();
+        assert_eq!(frames.len(), 3, "all three released");
+        let order: Vec<i16> = frames.iter().map(|f| decode_first_sample(f)).collect();
+        assert_eq!(
+            order,
+            vec![
+                forge_codecs::g711::decode_ulaw(0x01),
+                forge_codecs::g711::decode_ulaw(0x02),
+                forge_codecs::g711::decode_ulaw(0x03),
+            ],
+            "sequence order, not arrival order"
+        );
+        assert_eq!(inbound.decode_errors, 0);
+    }
+
+    /// A packet arriving *behind* the stream's baseline is late, not
+    /// reorderable: its playout moment never existed, so it is dropped
+    /// rather than replayed out of position. Before forge-media #132
+    /// this exact shape aborted the process with a stack overflow.
+    #[tokio::test]
+    async fn a_packet_behind_the_baseline_is_dropped_not_replayed() {
+        let mut inbound = InboundAudio::new(AudioCodec::PCMU, 0, 8_000).expect("codec");
+        inbound.push(&g711_packet(2, 320, 0, vec![0x02u8; 160]));
+        inbound.push(&g711_packet(1, 160, 0, vec![0x01u8; 160]));
+        settle().await;
+        let frames = inbound.drain();
+        assert_eq!(frames.len(), 1, "only the baseline packet plays");
+        assert_eq!(
+            decode_first_sample(&frames[0]),
+            forge_codecs::g711::decode_ulaw(0x02)
+        );
+    }
+
+    /// First PCM16LE sample of a frame, as i16.
+    fn decode_first_sample(frame: &[u8]) -> i16 {
+        i16::from_le_bytes([frame[0], frame[1]])
+    }
+
+    /// A gap the sender never fills must not wedge the stream: the
+    /// buffer steps over the hole once the wait exceeds its max delay
+    /// (3× the target), so audio keeps flowing.
+    #[tokio::test]
+    async fn a_permanent_gap_does_not_wedge_the_stream() {
+        let mut inbound = InboundAudio::new(AudioCodec::PCMU, 0, 8_000).expect("codec");
+        inbound.push(&g711_packet(1, 160, 0, vec![0x01u8; 160]));
+        settle().await;
+        assert_eq!(inbound.drain().len(), 1);
+
+        // seq 2 is lost forever; 3 and 4 arrive behind it.
+        inbound.push(&g711_packet(3, 480, 0, vec![0x03u8; 160]));
+        inbound.push(&g711_packet(4, 640, 0, vec![0x04u8; 160]));
+        tokio::time::sleep(JITTER_TARGET * 3 + Duration::from_millis(40)).await;
+
+        let frames = inbound.drain();
+        assert_eq!(frames.len(), 2, "the stream continues past the hole");
+        assert_eq!(
+            decode_first_sample(&frames[0]),
+            forge_codecs::g711::decode_ulaw(0x03),
+            "resumes at the first packet after the gap"
+        );
+    }
+
+    #[test]
+    fn unsupported_bridge_rate_is_refused_before_audio_flows() {
+        // 44.1 kHz is not in the bridge's fixed 8/16 kHz contract.
+        let err = match InboundAudio::new(AudioCodec::PCMU, 0, 44_100) {
+            Err(e) => e,
+            Ok(_) => panic!("44.1 kHz is outside the bridge's 8/16 kHz contract"),
+        };
+        assert!(matches!(err, WebRtcGlueError::Codec(_)), "{err:?}");
+    }
+
+    #[test]
+    fn g722_is_not_a_webrtc_leg_codec() {
+        let err = match InboundAudio::new(AudioCodec::G722, 9, 16_000) {
+            Err(e) => e,
+            Ok(_) => panic!("G.722 is not a WebRTC leg codec"),
+        };
+        assert!(matches!(err, WebRtcGlueError::Codec(_)), "{err:?}");
+    }
+}

--- a/crates/webrtc-glue/src/leg.rs
+++ b/crates/webrtc-glue/src/leg.rs
@@ -1,0 +1,259 @@
+//! The browser's media leg: answer, connect, tear down.
+//!
+//! Wraps forge-webrtc's `PeerConnection` in the shape siphon-ai's call
+//! machinery wants — an offer goes in, an answer comes out, and the
+//! caller learns when media may flow (`DEV_PLAN_WebRTC.md` §4.2).
+//!
+//! # Complete gathering before the answer
+//!
+//! v1 does **no SIP trickle** (§4.2). Instead both ends gather fully
+//! before signalling: SIP.js waits for its own gathering before
+//! sending the INVITE — which is why the captured Chrome offer already
+//! carries its candidates — and [`WebRtcLeg::answer`] waits for
+//! `GatheringComplete` before building the answer, so the SDP the
+//! browser receives is final. On a host-candidate-only server that is
+//! milliseconds; with STUN it is one round trip, which is why the wait
+//! is bounded rather than unconditional: a STUN server that black-holes
+//! must not stall a call, and the host candidates already gathered are
+//! a perfectly good answer.
+
+use std::time::Duration;
+
+use forge_core::AudioCodec;
+use forge_webrtc::{ConnectionState, PeerConnection, PeerEvent};
+use tokio::sync::mpsc;
+use tracing::{debug, warn};
+
+use crate::{Result, WebRtcGlueError, WebRtcSettings};
+
+/// How long [`WebRtcLeg::answer`] waits for candidate gathering before
+/// answering with what it has. Host candidates are immediate; this
+/// budget exists for the STUN round trip, and expiring is a
+/// degradation (fewer candidates), not a failure.
+pub const GATHER_BUDGET: Duration = Duration::from_secs(2);
+
+/// A leg that has answered and is establishing ICE/DTLS.
+pub struct WebRtcLeg {
+    peer: PeerConnection,
+    codec: AudioCodec,
+    payload_type: u8,
+}
+
+/// What [`WebRtcLeg::answer`] produces: the leg, the SDP to put in the
+/// 200 OK, and the peer's event stream (candidates already gathered,
+/// so what remains is state changes and media).
+pub struct Answered {
+    pub leg: WebRtcLeg,
+    pub answer_sdp: String,
+    pub events: mpsc::Receiver<PeerEvent>,
+}
+
+impl WebRtcLeg {
+    /// Answer a browser's offer.
+    ///
+    /// Applies the remote description, waits (bounded) for local
+    /// gathering, and produces the final answer SDP.
+    pub async fn answer(offer_sdp: &str, settings: &WebRtcSettings) -> Result<Answered> {
+        Self::answer_with_gather_budget(offer_sdp, settings, GATHER_BUDGET).await
+    }
+
+    /// [`answer`](Self::answer) with an explicit gather budget — tests
+    /// use a short one.
+    pub async fn answer_with_gather_budget(
+        offer_sdp: &str,
+        settings: &WebRtcSettings,
+        gather_budget: Duration,
+    ) -> Result<Answered> {
+        let mut peer = PeerConnection::with_config(settings.peer_config())
+            .await
+            .map_err(|e| WebRtcGlueError::Setup(e.to_string()))?;
+
+        // Applying the offer is what starts the transport (and so
+        // gathering), so the events receiver must be taken after it.
+        peer.set_remote_offer(offer_sdp)
+            .await
+            .map_err(|e| WebRtcGlueError::Offer(e.to_string()))?;
+        let mut events = peer
+            .take_events()
+            .ok_or_else(|| WebRtcGlueError::Setup("peer event stream already taken".into()))?;
+
+        // Drain candidate events until gathering finishes or the budget
+        // expires. Candidates are inlined into the answer by
+        // forge-webrtc, so nothing is lost by consuming the events —
+        // and consuming them keeps the bounded channel from filling
+        // while we wait.
+        let gathered = wait_for_gathering(&mut events, gather_budget).await;
+        if !gathered {
+            warn!(
+                budget_ms = gather_budget.as_millis(),
+                "ICE gathering did not complete in time; answering with the \
+                 candidates gathered so far"
+            );
+        }
+
+        let answer_sdp = peer
+            .create_answer()
+            .await
+            .map_err(|e| WebRtcGlueError::Answer(e.to_string()))?;
+        let (codec, payload_type) = peer.negotiated_codec();
+        debug!(
+            connection_id = peer.connection_id(),
+            ?codec,
+            payload_type,
+            gathered,
+            "WebRTC leg answered"
+        );
+
+        Ok(Answered {
+            leg: WebRtcLeg {
+                peer,
+                codec,
+                payload_type,
+            },
+            answer_sdp,
+            events,
+        })
+    }
+
+    /// Wait for ICE + DTLS. This is the `[webrtc].setup_timeout`
+    /// budget: a browser that signalled but never completes media must
+    /// not hold a call slot (§4.4).
+    pub async fn wait_connected(&self, timeout: Duration) -> Result<()> {
+        self.peer
+            .wait_connected(timeout)
+            .await
+            .map_err(|e| WebRtcGlueError::Connect(e.to_string()))
+    }
+
+    /// The negotiated codec and the payload type the browser expects.
+    pub fn codec(&self) -> (AudioCodec, u8) {
+        (self.codec, self.payload_type)
+    }
+
+    /// The PCM rate the WS bridge will see for this leg.
+    ///
+    /// **Not** the codec's RTP clock. Opus signals a 48 kHz clock on
+    /// the wire but libopus decodes straight to the rate we ask for,
+    /// so the bridge sees 16 kHz — exactly what a classic Opus call
+    /// already delivers (`media-glue::sdp::Codec::audio_sample_rate`).
+    /// Keeping the two paths on the same number is what lets a browser
+    /// leg reuse the bridge's fixed 8/16 kHz frame contract untouched.
+    pub fn bridge_sample_rate(&self) -> u32 {
+        match self.codec {
+            AudioCodec::Opus => 16_000,
+            _ => 8_000,
+        }
+    }
+
+    /// Current transport state.
+    pub fn state(&self) -> ConnectionState {
+        self.peer.get_state()
+    }
+
+    /// Stable id for logs/metrics.
+    pub fn connection_id(&self) -> &str {
+        self.peer.connection_id()
+    }
+
+    /// Borrow the peer connection (audio handles, renegotiation).
+    pub fn peer(&self) -> &PeerConnection {
+        &self.peer
+    }
+
+    /// Mutable borrow, for re-offer / rollback (hold, §4.2).
+    pub fn peer_mut(&mut self) -> &mut PeerConnection {
+        &mut self.peer
+    }
+
+    /// Close the transport. Idempotent.
+    pub fn close(&mut self) {
+        self.peer.close();
+    }
+}
+
+/// Consume events until `GatheringComplete`. Returns whether it
+/// arrived within the budget.
+async fn wait_for_gathering(events: &mut mpsc::Receiver<PeerEvent>, budget: Duration) -> bool {
+    let deadline = tokio::time::Instant::now() + budget;
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            return false;
+        }
+        match tokio::time::timeout(remaining, events.recv()).await {
+            Ok(Some(PeerEvent::GatheringComplete)) => return true,
+            // Candidates are inlined into the answer by forge-webrtc;
+            // draining them here just keeps the channel clear.
+            Ok(Some(_)) => continue,
+            // Transport gone before we answered — let the answer
+            // attempt produce the real error.
+            Ok(None) => return false,
+            Err(_) => return false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CHROME_OFFER: &str = include_str!("../fixtures/chrome-offer.sdp");
+
+    #[tokio::test]
+    async fn answers_the_real_chrome_offer_with_gathered_candidates() {
+        let Answered {
+            leg, answer_sdp, ..
+        } = WebRtcLeg::answer(CHROME_OFFER, &WebRtcSettings::default())
+            .await
+            .expect("answer");
+
+        assert!(answer_sdp.contains("a=setup:active"), "{answer_sdp}");
+        assert!(
+            answer_sdp.contains("a=candidate:"),
+            "complete-gathering-before-answer means the answer carries \
+             our candidates: {answer_sdp}"
+        );
+        // Opus by default → the bridge sees 16 kHz, same as a classic
+        // Opus call.
+        assert_eq!(leg.codec().0, AudioCodec::Opus);
+        assert_eq!(leg.bridge_sample_rate(), 16_000);
+    }
+
+    #[tokio::test]
+    async fn g711_leg_reports_the_8k_bridge_rate() {
+        let settings = WebRtcSettings {
+            prefer_g711: true,
+            ..Default::default()
+        };
+        let Answered { leg, .. } = WebRtcLeg::answer(CHROME_OFFER, &settings)
+            .await
+            .expect("answer");
+        assert_eq!(leg.codec(), (AudioCodec::PCMU, 0));
+        assert_eq!(leg.bridge_sample_rate(), 8_000);
+    }
+
+    /// A gather budget that expires must still produce an answer —
+    /// degraded (fewer candidates), never a failed call.
+    #[tokio::test]
+    async fn expired_gather_budget_still_answers() {
+        let Answered { answer_sdp, .. } = WebRtcLeg::answer_with_gather_budget(
+            CHROME_OFFER,
+            &WebRtcSettings::default(),
+            Duration::from_millis(0),
+        )
+        .await
+        .expect("answer even when gathering did not finish");
+        assert!(answer_sdp.contains("a=ice-ufrag:"), "{answer_sdp}");
+    }
+
+    #[tokio::test]
+    async fn a_non_webrtc_offer_is_refused() {
+        let plain = "v=0\r\no=- 1 1 IN IP4 192.0.2.1\r\ns=-\r\nc=IN IP4 192.0.2.1\r\n\
+t=0 0\r\nm=audio 9000 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\n";
+        let err = match WebRtcLeg::answer(plain, &WebRtcSettings::default()).await {
+            Err(e) => e,
+            Ok(_) => panic!("a plain RTP offer has no ICE/fingerprint to build a leg from"),
+        };
+        assert!(matches!(err, WebRtcGlueError::Offer(_)), "{err:?}");
+    }
+}

--- a/crates/webrtc-glue/src/lib.rs
+++ b/crates/webrtc-glue/src/lib.rs
@@ -29,8 +29,38 @@
 //! Nothing here is reachable from a default build: the daemon depends
 //! on this crate behind its `webrtc` feature.
 
+pub mod audio;
 pub mod detect;
+pub mod leg;
 pub mod settings;
 
+pub use audio::{InboundAudio, OutboundAudio};
 pub use detect::{inspect, is_webrtc_offer, OfferShape};
+pub use leg::{Answered, WebRtcLeg};
 pub use settings::{SettingsError, WebRtcSettings};
+
+/// What can go wrong building or running a browser media leg.
+#[derive(Debug, thiserror::Error)]
+pub enum WebRtcGlueError {
+    /// The peer connection could not be created (certificate, socket).
+    #[error("WebRTC setup failed: {0}")]
+    Setup(String),
+    /// The browser's offer was not applicable — malformed, or missing
+    /// the ICE/DTLS material a leg needs.
+    #[error("WebRTC offer rejected: {0}")]
+    Offer(String),
+    /// No answer could be produced (typically no codec in common).
+    #[error("WebRTC answer failed: {0}")]
+    Answer(String),
+    /// ICE or DTLS did not complete within the setup budget.
+    #[error("WebRTC connect failed: {0}")]
+    Connect(String),
+    /// Codec construction, decode, or an unsupported bridge rate.
+    #[error("WebRTC codec error: {0}")]
+    Codec(String),
+    /// The transport refused an outbound frame.
+    #[error("WebRTC send failed: {0}")]
+    Send(String),
+}
+
+pub type Result<T> = std::result::Result<T, WebRtcGlueError>;


### PR DESCRIPTION
Phase 2 §4.2–4.3 of `DEV_PLAN_WebRTC.md`, as a **self-contained unit** — the acceptor wiring follows separately, so lifecycle bugs can't hide inside a large integration diff (the acceptor assumes a forge `MediaSession` pervasively; that's a real refactor and deserves its own review).

## What's here

- **`leg.rs`** — `WebRtcLeg::answer` does **complete-gathering-before-answer** (v1 has no SIP trickle, so both ends gather fully before signalling — which is also why the captured Chrome offer already carries its candidates). The wait is *bounded*: a black-holing STUN server must degrade the candidate list, never stall a call. Plus connect on the `[webrtc].setup_timeout` budget, state, and teardown.
- **`audio.rs`** — SRTP ⇄ the bridge's fixed 20 ms PCM16LE frames, reusing the **same** `Reframer` / `pack_pcm16_le` as the classic tap (so the frame contract cannot drift between leg types) and forge-rtp's `JitterBuffer` instead of writing a fourth reorder queue (§4.8). Foreign payload types — a browser's DTMF/comfort noise on the same stream — are counted, never fed to the speech codec; a decode failure is a click, not a dropped call.

## Two facts this nailed down that the plan sketched differently

1. **No resampler is needed.** §4.3 describes "decode Opus 48 kHz → forge-resampler → bridge rate", but libopus decodes *straight* to the rate you ask for, which is exactly how the classic Opus path already works. A browser leg therefore hands the bridge the same 16 kHz PCM a classic Opus call does. (I pinned `forge-resampler`, discovered this, and removed it.)
2. **Opus's RTP timestamp advances at 48 kHz even when decoding at 16 kHz** (RFC 7587 §4.1) — a 20 ms frame is 320 PCM samples but **960 timestamp units**. The increment comes from forge-webrtc's `samples_per_20ms()` and never from the PCM length; deriving it from the frame would run our clock at a third of real time and slowly starve the browser's jitter buffer.

Also documented: `drain()` must be called on a **20 ms tick, not on packet arrival** — the buffer is wall-clock gated, which is precisely how arrival jitter becomes the steady cadence the bridge expects.

## Upstream

Pins forge-media **v2026.08.25** for forge-rtp 0.3.1 ([#132](https://github.com/thevoiceguy/forge-media/pull/132)) — the jitter buffer used to abort the process on a single reordered packet. This leg is that buffer's first consumer, which is how it surfaced.

## Verification

26 crate tests (resequencing, late-packet-behind-baseline drop, permanent gap, exact frame sizes, foreign payload types, real Chrome offer end-to-end); workspace tests + clippy `-D warnings` clean **with and without** the `webrtc` feature; SIPp **60/60**.

*(An earlier suite run showed 3 unrelated failures — that was the disk hitting 0 bytes free, not the forge bump. Cleaned, re-ran, 60/60.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Gm9Cizujd8LBMzrpDx9LU