### PR TITLE
fix(lab): gen-cert.sh works on a fresh clone

### DIFF
--- a/examples/browser-sip/gen-cert.sh
+++ b/examples/browser-sip/gen-cert.sh
@@ -9,7 +9,13 @@
 # Output: certs/wss-cert.pem + certs/wss-key.pem, SANs for
 # localhost / 127.0.0.1 — matching lab.toml's [sip.wss] block.
 set -euo pipefail
-cd "$(dirname "$0")/certs"
+# `certs/` is gitignored (it holds a private key), so on a fresh clone
+# it does not exist yet — creating it is this script's job, not the
+# reader's. Found by the first CI run of the browser-interop workflow,
+# but it fails for anyone following the README on a new checkout too.
+CERTS="$(dirname "$0")/certs"
+mkdir -p "$CERTS"
+cd "$CERTS"
 
 if command -v mkcert >/dev/null 2>&1; then
     mkcert -install >/dev/null


### PR DESCRIPTION
The `browser interop` nightly (#586) failed on its very first run, before any browser started:

```
gen-cert.sh: line 12: cd: examples/browser-sip/certs: No such file or directory
```

`examples/browser-sip/certs/` is gitignored — it holds a private key — so it does not exist on a fresh checkout, and the script assumed it did. Creating it is the script's job.

**This is not a CI-only bug.** Anyone following `examples/browser-sip/README.md` on a new clone hits it at the first step; CI is simply the first fresh clone this repo has had in a while.

Verified by moving the local `certs/` aside and running the script from nothing.

Once this lands I'll re-dispatch the interop workflow — WebKit still hasn't run anywhere, on CI or locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ozxii7NcpDfquGXaegkTU