### PR TITLE
feat(telemetry): the daemon can log as JSON, so fields survive leaving the box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The daemon can emit its logs as JSON** — `--log-format json`, or
+  `SIPHON_AI_LOG_FORMAT=json` for a systemd unit (#588). One object per
+  line, the event's own fields flattened to the top level and the current
+  span's fields under `span`, which is where `call_id` lives.
+
+  The point is what happens when logs leave the box. The daemon attaches a
+  lot of structure to its events — `call_id`, `route`, `from_user`,
+  `request_uri_user`, `register_source` — and in text form every one of
+  those is a substring that a shipper has to regex back apart, badly, and
+  that silently stops carrying a field the day a call site gains one. As
+  keys they land as queryable fields in Cloud Logging / Loki / Elastic and
+  survive new call sites without anyone touching a regex.
+
+  **`text` remains the default and its output is unchanged**, byte for
+  byte — it is the right thing for `journalctl` on one node, and the
+  shipped fail2ban filter's `<HOST>` extractor string-matches it.
+  Switching a node to `json` breaks that regex silently (bans stop, the
+  jail still looks healthy), which is called out in both
+  `docs/CONFIG.md` → *CLI flags & environment* (a new section covering
+  `--config` / `--log` / `--log-format` and their env twins) and the
+  `docs/OPERATIONS.md` quick-reference table.
+
+  Format and filter stay orthogonal: `--log-format` never changes which
+  events are emitted, and `PUT /admin/v1/log` never changes how they are
+  rendered. The `check` / `print-config` / `route-test` reports are
+  written straight to stdout, not through `tracing`, so they stay
+  human-readable in both modes.
+
 - **Three real browsers now call the daemon every night and have to
   prove audio in both directions** (`DEV_PLAN_WebRTC.md` §5, item 2).
   `test-harness/browser/` is a Playwright harness — Chromium, Firefox

--- a/bins/siphon-ai/src/main.rs
+++ b/bins/siphon-ai/src/main.rs
@@ -37,6 +37,14 @@ struct Cli {
     #[arg(long, env = "SIPHON_AI_LOG", global = true)]
     log: Option<String>,
 
+    /// Log output format: `text` (human-readable, the default) or
+    /// `json` (one JSON object per line, for a log shipper). Orthogonal
+    /// to `--log`, which selects *what* is logged, not how it is
+    /// rendered.
+    #[arg(long = "log-format", env = "SIPHON_AI_LOG_FORMAT", value_enum,
+          default_value_t = LogFormat::Text, global = true)]
+    log_format: LogFormat,
+
     #[command(subcommand)]
     command: Option<Command>,
 }
@@ -140,6 +148,27 @@ enum PrintFormat {
     Json,
 }
 
+/// How the daemon renders log events (`--log-format`).
+///
+/// This picks the *formatter*, never the filter — `--log` /
+/// `SIPHON_AI_LOG` still decide which events are emitted, and
+/// `PUT /admin/v1/log` still retunes that at runtime. It also does not
+/// touch the read-only subcommands' report output: `check`,
+/// `print-config` and `route-test` write their summaries straight to
+/// stdout, not through `tracing`, so those stay human-readable in both
+/// modes. What the flag *does* change for a subcommand is the
+/// rendering of the load-time `warn!`s it surfaces.
+#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+enum LogFormat {
+    /// The default: one human-readable line per event, ANSI-coloured
+    /// when stdout is a terminal.
+    Text,
+    /// One JSON object per line, event fields flattened to the top
+    /// level. For OpenTelemetry Collector / Fluent Bit / Vector /
+    /// Promtail — anything that indexes fields rather than text.
+    Json,
+}
+
 /// The config path, from `--config` or `$SIPHON_AI_CONFIG`. A clap
 /// `global` arg can't be `required`, so enforce presence here.
 fn config_path(cli: &Cli) -> Result<PathBuf> {
@@ -171,7 +200,7 @@ async fn main() -> Result<()> {
     // SRTP-key-in-cleartext footgun); without a subscriber those are
     // silently dropped and the preflight is less informative than a real
     // boot.
-    let (log_filter, otel_activation) = init_tracing(cli.log.as_deref());
+    let (log_filter, otel_activation) = init_tracing(cli.log.as_deref(), cli.log_format);
 
     // Read-only subcommands dispatch here and exit — no socket binding,
     // no runtime (but tracing is live, so config warnings show).
@@ -620,7 +649,10 @@ const DEFAULT_LOG_FILTER: &str = "warn,\
 /// shorthand `tracing_subscriber::fmt()` builder, because the
 /// shorthand doesn't expose a reload handle. The layered form is
 /// the canonical way to make `EnvFilter` mutable at runtime.
-fn init_tracing(cli_filter: Option<&str>) -> (LogFilterHandle, OtelActivation) {
+fn init_tracing(
+    cli_filter: Option<&str>,
+    log_format: LogFormat,
+) -> (LogFilterHandle, OtelActivation) {
     const DEFAULT: &str = DEFAULT_LOG_FILTER;
 
     let env_filter = match cli_filter {
@@ -649,18 +681,55 @@ fn init_tracing(cli_filter: Option<&str>) -> (LogFilterHandle, OtelActivation) {
     let otel_layer = tracing_opentelemetry::layer()
         .with_tracer(siphon_ai::otel::LazyGlobalTracer::default())
         .with_filter(otel_filter);
-    // `fmt::layer()` defaults to ANSI on regardless of stdout type
-    // — unlike the higher-level `fmt::Subscriber::builder()` which
-    // does tty auto-detection. Without the explicit `with_ansi`
-    // call, every log line under systemd lands in journald with
-    // embedded `\x1b[..m` escape sequences. That's harmless to
-    // human readers (journalctl strips them on display) but breaks
-    // every downstream consumer that does string matching against
-    // the journal — most importantly the fail2ban `<HOST>` extractor
-    // for our trunk-rejection regex, which silently never matches.
-    let fmt_layer = tracing_subscriber::fmt::layer()
-        .with_target(true)
-        .with_ansi(std::io::IsTerminal::is_terminal(&std::io::stdout()));
+    // The formatting layer, `text` (default) or `json`. The two arms
+    // have different types, so both are boxed into one
+    // `Box<dyn Layer<_>>` before joining the registry.
+    //
+    // `text` is deliberately the default and is byte-for-byte what the
+    // daemon has always emitted: it is the right output for
+    // `journalctl` on one node, and — see the `with_ansi` note below
+    // — for the fail2ban regex that reads the journal. `json` is for
+    // the case a text line cannot serve: a shipper that indexes
+    // *fields*, where `call_id` / `route` / `from_user` should arrive
+    // as queryable keys instead of substrings some regex has to pick
+    // back out (and silently stops picking out the day a call site
+    // gains a field).
+    let fmt_layer: Box<dyn tracing_subscriber::Layer<_> + Send + Sync> = match log_format {
+        // `fmt::layer()` defaults to ANSI on regardless of stdout type
+        // — unlike the higher-level `fmt::Subscriber::builder()` which
+        // does tty auto-detection. Without the explicit `with_ansi`
+        // call, every log line under systemd lands in journald with
+        // embedded `\x1b[..m` escape sequences. That's harmless to
+        // human readers (journalctl strips them on display) but breaks
+        // every downstream consumer that does string matching against
+        // the journal — most importantly the fail2ban `<HOST>` extractor
+        // for our trunk-rejection regex, which silently never matches.
+        LogFormat::Text => Box::new(
+            tracing_subscriber::fmt::layer()
+                .with_target(true)
+                .with_ansi(std::io::IsTerminal::is_terminal(&std::io::stdout())),
+        ),
+        // No `with_ansi` here on purpose rather than `with_ansi(false)`:
+        // the JSON writer never emits escape sequences, so passing the
+        // flag would only suggest it might.
+        //
+        // `flatten_event` puts the event's own fields at the top level
+        // instead of nesting them under `fields`, which is what a
+        // collector can index without a transform. `with_current_span`
+        // keeps the innermost span's fields — that is where `call_id`
+        // lives, since every per-call function is `#[instrument(fields(call_id))]`.
+        // `with_span_list(false)` drops the full ancestor chain, which
+        // would repeat those same fields on every line and put no bound
+        // on line size.
+        LogFormat::Json => Box::new(
+            tracing_subscriber::fmt::layer()
+                .json()
+                .flatten_event(true)
+                .with_current_span(true)
+                .with_span_list(false)
+                .with_target(true),
+        ),
+    };
     // `try_init` so tests that initialise the subscriber separately
     // don't crash this process; the second init is a noop. The
     // reload handle works either way because the layer is part of
@@ -796,6 +865,112 @@ mod tests {
             out.contains("boom"),
             "an unlisted dependency must not be silently muted; got {out:?}"
         );
+    }
+
+    /// Render one event inside a `call_id`-bearing span through the
+    /// same JSON formatter `--log-format json` installs, and return the
+    /// line. Mirrors the real layer's configuration exactly — a copy
+    /// that drifted would prove nothing.
+    fn json_line(emit: impl FnOnce()) -> serde_json::Value {
+        use tracing_subscriber::layer::SubscriberExt;
+
+        let buf = Buffer::default();
+        let layer = tracing_subscriber::fmt::layer()
+            .json()
+            .flatten_event(true)
+            .with_current_span(true)
+            .with_span_list(false)
+            .with_target(true)
+            .with_writer(buf.clone());
+        let subscriber = tracing_subscriber::registry()
+            .with(EnvFilter::try_new("info").expect("directive parses"))
+            .with(layer);
+        tracing::subscriber::with_default(subscriber, emit);
+        let out = buf.contents();
+        serde_json::from_str(out.trim()).unwrap_or_else(|e| panic!("not JSON: {e}: {out:?}"))
+    }
+
+    /// The point of the whole flag (#588): under `json`, a field a
+    /// call site attached is a *key*, not a substring of the message
+    /// that a shipper has to regex back out.
+    #[test]
+    fn json_format_promotes_event_fields_to_top_level_keys() {
+        let line = json_line(|| {
+            tracing::info!(target: "siphon_ai::call", from = "sip:alice@pbx", "received invite");
+        });
+        assert_eq!(
+            line["fields"],
+            serde_json::Value::Null,
+            "flatten_event(true) should leave no `fields` nesting: {line}"
+        );
+        assert_eq!(
+            line["from"], "sip:alice@pbx",
+            "event field must be a top-level key: {line}"
+        );
+        assert_eq!(line["message"], "received invite", "{line}");
+        assert_eq!(line["target"], "siphon_ai::call", "{line}");
+        assert_eq!(line["level"], "INFO", "{line}");
+    }
+
+    /// `call_id` lives on the span, not the event — every per-call
+    /// function is `#[instrument(fields(call_id = ...))]`. It reaches
+    /// the line via `with_current_span(true)`, and the acceptance
+    /// criterion is that it is queryable rather than buried in text.
+    #[test]
+    fn json_format_carries_call_id_from_the_current_span() {
+        let line = json_line(|| {
+            let span = tracing::info_span!("handle_invite", call_id = "abc123@pbx");
+            let _g = span.enter();
+            tracing::info!("call answered");
+        });
+        assert_eq!(
+            line["span"]["call_id"], "abc123@pbx",
+            "the current span's call_id must ride along: {line}"
+        );
+        // `with_span_list(false)`: the ancestor chain is not repeated.
+        assert_eq!(
+            line["spans"],
+            serde_json::Value::Null,
+            "span list should stay off so line size is bounded: {line}"
+        );
+    }
+
+    /// The default must not move. Existing operators read this in
+    /// `journalctl`, and the fail2ban `<HOST>` extractor string-matches
+    /// it — a silent switch to JSON would break bans, not just eyes.
+    #[test]
+    fn text_is_the_default_log_format() {
+        use clap::Parser as _;
+        let cli = super::Cli::parse_from(["siphon-ai", "--config", "/dev/null"]);
+        assert_eq!(cli.log_format, super::LogFormat::Text);
+    }
+
+    /// `--log-format` is `global = true`, so it parses on either side
+    /// of a subcommand — same ergonomics as `--config` / `--log`.
+    #[test]
+    fn log_format_parses_before_and_after_a_subcommand() {
+        use clap::Parser as _;
+        for argv in [
+            vec![
+                "siphon-ai",
+                "--log-format",
+                "json",
+                "check",
+                "--config",
+                "x",
+            ],
+            vec![
+                "siphon-ai",
+                "check",
+                "--config",
+                "x",
+                "--log-format",
+                "json",
+            ],
+        ] {
+            let cli = super::Cli::parse_from(&argv);
+            assert_eq!(cli.log_format, super::LogFormat::Json, "argv: {argv:?}");
+        }
     }
 
     /// The floor is a floor, not a ceiling: first-party crates still

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -5,6 +5,79 @@ on the daemon binary. TOML is the only supported format (CLAUDE.md §4.6); all
 validation runs at config load time, not first-use, so a bad config fails
 loudly at startup instead of mid-call.
 
+## CLI flags & environment
+
+Everything that shapes a *run* lives in the TOML file; the handful of things
+that shape the *process* — which file to read, and how the daemon logs — are
+flags. All three are `global`, so they parse on either side of a subcommand
+(`siphon-ai --config X check` and `siphon-ai check --config X` are the same
+command), and each has an environment twin for systemd units and containers.
+
+| Flag | Env | Default | What it does |
+|---|---|---|---|
+| `--config <PATH>` | `SIPHON_AI_CONFIG` | none (required) | The TOML file. Required by the daemon and by every subcommand except `decrypt-recording`. |
+| `--log <DIRECTIVE>` | `SIPHON_AI_LOG` | `RUST_LOG`, else the built-in default | The `tracing` filter — *which* events are emitted (`siphon_ai=debug,siphon=info`). Precedence is **replace, not merge**: the value you supply is the whole directive, so narrowing to one target (`siphon_ai_core=debug`) also drops the built-in `warn` floor and mutes everything else. Prefix it with `warn,` to keep the floor. Retunable at runtime without a restart via `PUT /admin/v1/log`. |
+| `--log-format <text\|json>` | `SIPHON_AI_LOG_FORMAT` | `text` | *How* those events are rendered. See below. |
+
+### `--log-format` (0.51.0)
+
+`text` — the default, and unchanged from every prior release — is one
+human-readable line per event, ANSI-coloured only when stdout is a terminal.
+It is the right output for reading `journalctl` on one node.
+
+`json` emits **one JSON object per line**, with the event's own fields
+flattened to the top level and the current span's fields under `span`:
+
+```console
+$ siphon-ai --config /etc/siphon-ai/config.toml --log-format json
+{"timestamp":"2026-09-02T17:09:39.164893Z","level":"INFO","message":"configuration compiled","node_id":"siphon-ai-local","sip_listen":"127.0.0.1:5070","routes":1,"target":"siphon_ai"}
+```
+
+Use it when the logs leave the box. The daemon attaches a lot of structure to
+its events — `call_id`, `route`, `from_user`, `request_uri_user`,
+`register_source` — and in `text` mode every one of those is a substring
+inside a line, which a shipper (OpenTelemetry Collector, Fluent Bit, Vector,
+Promtail) then has to regex back apart. In `json` mode they are keys, so they
+land as queryable fields in Cloud Logging / Loki / Elastic, and a field added
+at a new call site appears downstream without anyone updating a regex.
+
+`call_id` is a **span** field — every per-call function is instrumented with
+it — so it arrives as `span.call_id`, not at the top level:
+
+```console
+$ journalctl -o cat -u siphon-ai | jq -r 'select(.span.call_id) | "\(.span.call_id) \(.message)"'
+```
+
+Notes:
+
+- **Switching to `json` breaks anything that string-matches the journal.**
+  Most importantly the shipped `fail2ban` filter
+  (`docs/SECURITY_FAIL2BAN.md`), whose `<HOST>` extractor is written against
+  the text line and will silently stop matching — bans quietly stop happening
+  while the jail still looks healthy. If you run both, either keep `text` or
+  rewrite `contrib/fail2ban/filter.d/siphon-ai.conf` against the JSON shape
+  first.
+- **Format and filter are orthogonal.** `--log-format` never changes which
+  events are emitted, and `PUT /admin/v1/log` never changes how they are
+  rendered.
+- **The read-only subcommands' reports are unaffected.** `check`,
+  `print-config` and `route-test` write their summaries straight to stdout,
+  not through `tracing`, so those stay human-readable (and `print-config
+  --format json` stays the way to get *config* as JSON). What the flag does
+  change for a subcommand is how the load-time warnings it surfaces are
+  rendered.
+- **A fatal startup error still goes to stderr as plain text** — it is the
+  process's exit report, not a log record. Everything emitted during a call is
+  JSON.
+
+Under systemd, set it in the unit's environment file rather than the
+`ExecStart` line:
+
+```ini
+# /etc/siphon-ai/env
+SIPHON_AI_LOG_FORMAT=json
+```
+
 ## Secrets & variable expansion
 
 `${...}` references in any string value are expanded before TOML parsing, in a

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -14,7 +14,7 @@ evidence and flags any gaps.
 
 | Source                              | What's there                                                                           |
 |-------------------------------------|----------------------------------------------------------------------------------------|
-| Daemon log (stdout / journald)      | Lifecycle events, state transitions, errors, registration drive output                 |
+| Daemon log (stdout / journald)      | Lifecycle events, state transitions, errors, registration drive output. Human-readable text by default; `--log-format json` / `SIPHON_AI_LOG_FORMAT=json` (0.51.0) emits one JSON object per line instead, so `call_id` / `route` / `from_user` reach a shipper as queryable fields rather than substrings — see `docs/CONFIG.md` → *CLI flags & environment*. **Switching to `json` breaks the fail2ban journal regex** (`docs/SECURITY_FAIL2BAN.md`). |
 | `tracing` spans                     | Per-call latency between `on_invite` → `on_matched` → `accept_inbound` → `start_session`. With `[observability.otlp]` (0.22.0) these export as one OTLP trace per call (root carries the SIP `Call-ID`, direction, from/to) to Tempo / Jaeger — and the trace context propagates to the developer's WS server via `traceparent` on the WS upgrade + `start.trace_context` (0.23.0), so a server that continues it appears in the same waterfall. |
 | Homer UI (`http://.../`)            | SIP call flow + RTCP + CDR + log chunks correlated by SIP `Call-ID`                    |
 | Prometheus `/metrics`               | Counters / histograms; `siphon_ai_*` for app-level, `forge_*` for media, `heplify_*` for collector  |


### PR DESCRIPTION
Closes #588.

## The problem

The daemon installed one formatter, a plain human-readable one. Every field it works hard to attach — `call_id`, `route`, `from_user`, `request_uri_user`, `register_source`, and the span around them — ended up a substring inside one text line. Right for `journalctl` on one node; wrong the moment the logs leave the box, where a shipper has to regex them back apart and a new call-site field silently stops arriving until someone updates the regex.

## What this adds

`--log-format <text|json>`, env `SIPHON_AI_LOG_FORMAT`, `global = true`, default `text`.

The JSON arm is `.json().flatten_event(true).with_current_span(true).with_span_list(false).with_target(true)` — event fields at the top level (what a collector indexes without a transform), the innermost span's fields under `span` (where `call_id` lives), no ancestor chain (bounded line size). The two arms have different types, so both are boxed into one `Box<dyn Layer<_>>` before joining the registry. `with_ansi` is simply absent in the JSON arm rather than passed `false` — the JSON writer emits no escapes, so naming the flag would only suggest it might.

```console
$ siphon-ai --config … --log-format json
{"timestamp":"2026-09-02T17:09:39.164893Z","level":"INFO","message":"configuration compiled","node_id":"siphon-ai-local","sip_listen":"127.0.0.1:5070","routes":1,"target":"siphon_ai"}
```

## The default did not move

Verified, not assumed: captured a full startup→SIGTERM→teardown run from this branch's binary and from the pre-change binary and diffed them. Identical except one measured `elapsed_secs` value.

That matters for more than eyes — the shipped fail2ban filter's `<HOST>` extractor string-matches the text line, so a node switched to `json` **stops banning while the jail still looks healthy**. Called out in `docs/CONFIG.md` and the `docs/OPERATIONS.md` table rather than left as a trap.

## Decisions the issue asked to be explicit about

- **`check` / `print-config` / `route-test` reports are unaffected.** They write summaries straight to stdout, not through `tracing`, so they stay human-readable in both modes and `print-config --format json` remains the way to get *config* as JSON. What the flag does change for a subcommand is how the load-time `warn!`s it surfaces are rendered — which is the point of initialising tracing before those subcommands run.
- **`ErrorRingLayer` and `PUT /admin/v1/log` are untouched.** The ring is a separate layer on the same registry; the log endpoint operates on the reloadable global `EnvFilter`. Format and filter are orthogonal in both directions.
- **A fatal startup error still reaches stderr as plain text** — it is `main`'s exit report via `anyhow`, not a log record. Unchanged behaviour; noted in the docs so nobody is surprised that one line does not parse.

## Verification

- 4 new unit tests: event fields become top-level keys with no `fields` nesting; `call_id` rides along from the current span and the span *list* stays off; `text` is the parsed default; the flag parses on both sides of a subcommand.
- End to end against a real daemon run: `jq -c . out.json` parses **every** line of a full startup→ready→SIGTERM→drain→teardown cycle.
- `cargo clippy -p siphon-ai --all-targets -- -D warnings` clean, `cargo fmt --all` clean, `check-doc-links.py` and `check-version-consistency.py` pass.

## Docs

`docs/CONFIG.md` gains a **CLI flags & environment** section — none of `--config`, `--log`, or `--log-format` had been documented there before, and `--log`'s replace-not-merge precedence (which drops the `warn` floor) is a real trap worth writing down. `docs/OPERATIONS.md`'s quick-reference "Daemon log" row gains the flag and the fail2ban caveat.

Docs pre-stamp this as 0.51.0, matching the CDR v9 work already on `main`.

## Sibling

This makes the *stdout* path structured. It does not give records trace context — that is #589, implemented separately and stacked on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186W8dhfvFie93qXueyaKDk