### PR TITLE
chore(deps): bump forge-media v2026.08.26 → v2026.09.02

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **forge-media pin `v2026.08.26` → `v2026.09.02`** — a routine roll-up.
+  Nothing in it was asked for by this project and nothing in it changes
+  this daemon's behaviour; the bump is to stop the pin drifting.
+
+  Three tags passed (`v2026.09.01` was superseded untagged by
+  `v2026.09.01.1`). Across the whole range only three files we build
+  changed. **forge-engine** gives `MediaSession` a dynamic payload-type
+  map — a B2BUA learns the far leg's negotiated payload types only when
+  its SDP answer arrives, and a re-INVITE can change them mid-call — held
+  in an `AtomicU32` so the per-packet forwarding path stays lock-free.
+  It is additive: every constructor seeds it from the frozen
+  `transcoding_config.payload_type_map` the forwarding path already read,
+  so a consumer that never calls the setter behaves identically, and we
+  have no leg whose payload types arrive late. **forge-sdp** moves its
+  `sip-sdp` dependency from a submodule-relative path to
+  `tag = "v2026.08.25"` — the same tag this workspace pins every other
+  `sip-*` crate to, so the lock still holds exactly one `sip-sdp`
+  (verified; differing tags would have linked two copies of the SDP
+  negotiator).
+
+  Everything else in the range is **forge-conference** — DTMF dial-out,
+  PIN auth, wait-for-moderator, an 80 ms RFC 2833 duplicate window. We
+  do not depend on that crate (our conferencing is forge-mixer), and the
+  dedup lives in `forge-conference`, not `forge-dtmf`, so this daemon's
+  DTMF path is untouched.
+
+  **siphon-rs is deliberately not bumped**: its newest tag is still
+  `v2026.08.25`, which we already pin — and which is the tag this forge
+  release records in `external/siphon-rs`, so the embedded pair matches.
+
+  Verified with the full workspace suite, a `--features webrtc` build,
+  and all 60 SIPp signaling scenarios.
+
 ### Added
 
 - **The daemon can emit its logs as JSON** — `--log-format json`, or

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,7 +1122,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "forge-codecs"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.26#38d31061cf622ebdbc4eeb69231c97d224865096"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.09.02#d6d53e99b835c5095e3a0e11d39bd6677c494742"
 dependencies = [
  "audiopus",
  "ezk-g722",
@@ -1134,7 +1134,7 @@ dependencies = [
 [[package]]
 name = "forge-core"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.26#38d31061cf622ebdbc4eeb69231c97d224865096"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.09.02#d6d53e99b835c5095e3a0e11d39bd6677c494742"
 dependencies = [
  "chrono",
  "serde",
@@ -1149,7 +1149,7 @@ dependencies = [
 [[package]]
 name = "forge-dtmf"
 version = "0.2.1"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.26#38d31061cf622ebdbc4eeb69231c97d224865096"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.09.02#d6d53e99b835c5095e3a0e11d39bd6677c494742"
 dependencies = [
  "chrono",
  "forge-core",
@@ -1161,7 +1161,7 @@ dependencies = [
 [[package]]
 name = "forge-engine"
 version = "0.5.1"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.26#38d31061cf622ebdbc4eeb69231c97d224865096"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.09.02#d6d53e99b835c5095e3a0e11d39bd6677c494742"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1191,7 +1191,7 @@ dependencies = [
 [[package]]
 name = "forge-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.26#38d31061cf622ebdbc4eeb69231c97d224865096"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.09.02#d6d53e99b835c5095e3a0e11d39bd6677c494742"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -1204,7 +1204,7 @@ dependencies = [
 [[package]]
 name = "forge-ice"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.26#38d31061cf622ebdbc4eeb69231c97d224865096"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.09.02#d6d53e99b835c5095e3a0e11d39bd6677c494742"
 dependencies = [
  "bytes",
  "forge-core",
@@ -1226,7 +1226,7 @@ dependencies = [
 [[package]]
 name = "forge-injection"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.26#38d31061cf622ebdbc4eeb69231c97d224865096"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.09.02#d6d53e99b835c5095e3a0e11d39bd6677c494742"
 dependencies = [
  "forge-core",
  "rubato",
@@ -1239,7 +1239,7 @@ dependencies = [
 [[package]]
 name = "forge-mixer"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.26#38d31061cf622ebdbc4eeb69231c97d224865096"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.09.02#d6d53e99b835c5095e3a0e11d39bd6677c494742"
 dependencies = [
  "bytes",
  "dashmap 6.2.1",
@@ -1253,7 +1253,7 @@ dependencies = [
 [[package]]
 name = "forge-recorder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.26#38d31061cf622ebdbc4eeb69231c97d224865096"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.09.02#d6d53e99b835c5095e3a0e11d39bd6677c494742"
 dependencies = [
  "bytes",
  "forge-core",
@@ -1267,7 +1267,7 @@ dependencies = [
 [[package]]
 name = "forge-resampler"
 version = "0.1.1"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.26#38d31061cf622ebdbc4eeb69231c97d224865096"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.09.02#d6d53e99b835c5095e3a0e11d39bd6677c494742"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -1276,7 +1276,7 @@ dependencies = [
 [[package]]
 name = "forge-rtp"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.26#38d31061cf622ebdbc4eeb69231c97d224865096"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.09.02#d6d53e99b835c5095e3a0e11d39bd6677c494742"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm 0.11.0",
@@ -1301,7 +1301,7 @@ dependencies = [
 [[package]]
 name = "forge-sdp"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.26#38d31061cf622ebdbc4eeb69231c97d224865096"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.09.02#d6d53e99b835c5095e3a0e11d39bd6677c494742"
 dependencies = [
  "base64 0.23.1",
  "chrono",
@@ -1309,7 +1309,7 @@ dependencies = [
  "forge-ice",
  "forge-rtp",
  "rand 0.10.1",
- "sip-sdp 0.3.1 (git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.26)",
+ "sip-sdp",
  "smol_str",
  "thiserror 2.0.18",
 ]
@@ -1317,7 +1317,7 @@ dependencies = [
 [[package]]
 name = "forge-transcoder"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.26#38d31061cf622ebdbc4eeb69231c97d224865096"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.09.02#d6d53e99b835c5095e3a0e11d39bd6677c494742"
 dependencies = [
  "bytes",
  "forge-codecs",
@@ -1330,7 +1330,7 @@ dependencies = [
 [[package]]
 name = "forge-vad"
 version = "0.2.0"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.26#38d31061cf622ebdbc4eeb69231c97d224865096"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.09.02#d6d53e99b835c5095e3a0e11d39bd6677c494742"
 dependencies = [
  "forge-core",
  "thiserror 2.0.18",
@@ -1340,7 +1340,7 @@ dependencies = [
 [[package]]
 name = "forge-webrtc"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.26#38d31061cf622ebdbc4eeb69231c97d224865096"
+source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.09.02#d6d53e99b835c5095e3a0e11d39bd6677c494742"
 dependencies = [
  "bytes",
  "dashmap 6.2.1",
@@ -4062,15 +4062,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sip-sdp"
-version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/forge-media?tag=v2026.08.26#38d31061cf622ebdbc4eeb69231c97d224865096"
-dependencies = [
- "nom 7.1.3",
- "smol_str",
-]
-
-[[package]]
 name = "sip-transaction"
 version = "0.6.0"
 source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.25#74bf30e58c256726d365e3885d19d4b5f1162ebf"
@@ -4128,7 +4119,7 @@ dependencies = [
  "sip-dialog",
  "sip-dns",
  "sip-parse",
- "sip-sdp 0.3.1 (git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.25)",
+ "sip-sdp",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -4150,7 +4141,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.1 (git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.25)",
+ "sip-sdp",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -4313,7 +4304,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp 0.3.1 (git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.25)",
+ "sip-sdp",
  "sip-transaction",
  "sip-uac",
  "sip-uas",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -357,7 +357,44 @@ sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v20
 # upstream gate at https://github.com/thevoiceguy/forge-media/pull/39.
 #
 # forge-media is pinned to a **release tag** (RELEASING.md, adopted
-# 2026-08-24). Bumped 2026-08-26 **v2026.08.25 → v2026.08.26** for
+# 2026-08-24). Bumped 2026-09-02 **v2026.08.26 → v2026.09.02**, a
+# routine roll-up: nothing in it was asked for by this project, and
+# nothing in it changes our behaviour.
+#
+# Three tags passed (v2026.09.01 was superseded untagged by v2026.09.01.1).
+# Per-crate audit over the whole range — only three files we build changed:
+#
+#  * **forge-engine** `session.rs` + `forwarding.rs`: `MediaSession` gains a
+#    dynamic payload-type map (`payload_type_map()` /
+#    `set_payload_type_map()`), because a B2BUA learns the far leg's
+#    negotiated PTs only when its SDP answer arrives and a re-INVITE can
+#    change them mid-call. Held in an `AtomicU32` so the per-packet
+#    forwarding path stays lock-free. **Additive**: all three constructors
+#    seed it from `config.transcoding_config.payload_type_map`, the frozen
+#    value the forwarding path read before, so a consumer that never calls
+#    the setter — us — behaves identically. `to_transcoder_codec` also
+#    became `pub`. First consumer is FCP, not this daemon; we have no
+#    B2BUA leg whose PTs arrive late.
+#  * **forge-sdp** `Cargo.toml`: `sip-sdp` moves from a submodule-relative
+#    path to `git … tag = "v2026.08.25"`. That is the *same* tag this
+#    workspace pins every other `sip-*` crate to, so cargo unifies them and
+#    the lock still holds exactly one `sip-sdp`. Had the tags differed we
+#    would have linked two copies of the SDP negotiator — worth re-checking
+#    on any future forge bump that lands before ours.
+#
+# Everything else in the range is **forge-conference** (DTMF dial-out, PIN
+# auth, wait-for-moderator, and an 80 ms RFC 2833 duplicate window). We do
+# not depend on that crate — our conferencing is forge-mixer — and the
+# dedup lives in `forge-conference/dtmf_commands.rs`, not `forge-dtmf`, so
+# this daemon's DTMF path is untouched. No crate version was bumped in the
+# range; forge-engine's new public API arguably owed a minor bump, raised
+# upstream rather than worked around here.
+#
+# siphon-rs is deliberately NOT bumped alongside: its newest tag is still
+# **v2026.08.25**, which we already pin — and which is the tag this forge
+# release records in `external/siphon-rs`, so the embedded pair matches.
+#
+# (Prior: 2026-08-26 **v2026.08.25 → v2026.08.26** for
 # forge-media #134, which this project asked for: `TransportConfig::
 # local_port` lets a WebRTC leg bind its one socket (BUNDLE + rtcp-mux)
 # inside `[media].rtp_port_range` instead of an ephemeral port, and
@@ -370,7 +407,7 @@ sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v20
 # for exhaustive `TransportConfig` literals; we build ours with
 # `..Default::default()`, and `local_port: 0` preserves the old bind
 # behaviour for every other consumer. forge-engine 0.5.0 → 0.5.1 is
-# additive. Nothing else in the workspace changed between the two tags.
+# additive. Nothing else in the workspace changed between the two tags.)
 #
 # (Prior: 2026-08-23 rev pin 1fe94a502efa = nine commits, of which
 # **three were filed from this project** and two more reach our build.)
@@ -493,25 +530,25 @@ sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v20
 # comment for the current rev.) Prior forge pins: forge 1c996ae5fb4f = #86
 # neural VAD; forge 3c59b5f6e464 = #82-#85 dependency migrations; forge
 # 5fa76fb38675 = #81.
-forge-core    = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.26" }
-forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.26" }
-forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.26", default-features = false, features = ["g722", "dtls", "opus", "neural-vad"] }
-forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.26" }
-forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.26" }
-forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.26" }
-forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.26" }
-forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.26" }
+forge-core    = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.09.02" }
+forge-rtp     = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.09.02" }
+forge-engine  = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.09.02", default-features = false, features = ["g722", "dtls", "opus", "neural-vad"] }
+forge-codecs  = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.09.02" }
+forge-sdp     = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.09.02" }
+forge-dtmf    = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.09.02" }
+forge-vad     = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.09.02" }
+forge-hep     = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.09.02" }
 # WebRTC leg (DEV_PLAN_WebRTC.md Phase 2). Only reachable through
 # siphon-ai-webrtc-glue, which the daemon pulls in behind its
 # `webrtc` feature — a default build links neither.
-forge-webrtc  = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.26" }
-forge-ice     = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.26" }
+forge-webrtc  = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.09.02" }
+forge-ice     = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.09.02" }
 # Conference rooms (0.7.0): forge-mixer is the per-room AudioMixer;
 # forge-injection provides ToneGenerator (join/leave tones now, MOH
 # for park later). Deliberately NOT forge-conference — its DTMF
 # IVR/PIN/host-control layer is unused per DEV_PLAN_0.7.0.md §9.4.
-forge-mixer     = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.26" }
-forge-injection = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.08.26" }
+forge-mixer     = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.09.02" }
+forge-injection = { git = "https://github.com/thevoiceguy/forge-media", tag = "v2026.09.02" }
 
 # hep-rs — HEP3 codec, transport, HepSink trait. Owned by the same
 # author as siphon-rs and forge-media; lives in its own repo.


### PR DESCRIPTION
Routine pin roll-up. **Nothing in this range was asked for by this project, and nothing in it changes this daemon's behaviour** — the bump is to stop the pin drifting three tags behind.

**siphon-rs is not bumped.** Its newest tag is still `v2026.08.25`, which we already pin — and which is the tag this forge release records in `external/siphon-rs`, so the embedded pair matches.

## Per-crate audit

Three tags passed (`v2026.09.01` was superseded untagged by `v2026.09.01.1`). Across the whole range, `git diff v2026.08.26 v2026.09.02` touches ten files, of which **three are in crates we build**:

| Crate | Change | Effect on us |
|---|---|---|
| `forge-engine` | `session.rs` (+147), `forwarding.rs` (2 lines) — dynamic payload-type map | Additive; none |
| `forge-sdp` | `Cargo.toml` — `sip-sdp` path → git tag | None, after the check below |
| `forge-conference` | DTMF dial-out, PIN auth, wait-for-moderator, RFC 2833 dedup | **Not a dependency** |

**forge-engine.** `MediaSession` gains `payload_type_map()` / `set_payload_type_map()`. The map was frozen at session creation, but a B2BUA learns the far leg's negotiated payload types only when that leg's SDP answer arrives, and a re-INVITE can change them mid-call — a dynamic PT (Opus at 96 rather than 111) previously resolved to nothing in the forwarding path and silently disabled transcoding. Held in an `AtomicU32` so the per-packet path stays lock-free. Additive for us: all three constructors seed it from `config.transcoding_config.payload_type_map`, the exact frozen value `forwarding.rs` read before, so a consumer that never calls the setter behaves identically. We have no leg whose payload types arrive late; first consumer is FCP.

**forge-sdp.** `sip-sdp` moves from `path = "../../external/siphon-rs/crates/sip-sdp"` to `git … tag = "v2026.08.25"`. That is the same tag this workspace pins every other `sip-*` crate to, so cargo unifies them — verified in the lock:

```
name = "sip-sdp"
source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.25#74bf30e5..."
```

one entry, one siphon-rs source across the whole lock. Had the tags differed we would have linked **two copies of the SDP negotiator** — the negotiator our media path actually runs. Worth re-checking on any future forge bump that lands ahead of a siphon-rs bump of ours; noted in the `Cargo.toml` comment.

**forge-conference** is the bulk of the diff and is not in our dependency list — our conferencing is forge-mixer. The RFC 2833 dedup that the release notes mention lives in `forge-conference/src/dtmf_commands.rs`, **not** `forge-dtmf`, so this daemon's DTMF path is untouched. That was the one item in the notes that could have been a silent behaviour change for us, so it is worth stating explicitly.

## Verification

- `cargo test --workspace` — exit 0, no failures
- `cargo build -p siphon-ai --features webrtc` — forge-webrtc / forge-ice compile at the new tag
- `cargo clippy --workspace --all-targets -- -D warnings` — clean; `cargo fmt --all --check` — clean
- **All 60 SIPp signaling scenarios pass** (`AUX_OBS_PORT=9591 ./run-all.sh`), including the media, teardown-soak, WS-signaling, registrar and graceful-drain phases

`test-harness/hep-collector-stub/` is named in CLAUDE.md §7.5's bump checklist but has never contained anything but a `.gitkeep` — there are no HEP stub tests to run. Flagging rather than quietly skipping.

## One upstream nit

No crate version was bumped anywhere in the range, but `forge-engine` gained public API (`payload_type_map`, `set_payload_type_map`, and `to_transcoder_codec` becoming `pub`) while staying at `0.5.1`. Additive public API owes a minor bump under the per-crate SemVer rule forge adopted in its RELEASING.md. Nothing to work around here — raising it upstream rather than papering over it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186W8dhfvFie93qXueyaKDk