### PR TITLE
docs: the RUST_LOG examples were muting the warnings they exist to surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,8 +226,11 @@ cargo fmt --all
 # Run the daemon locally with example config
 cargo run -p siphon-ai -- --config configs/local-dev.toml
 
-# Run with verbose tracing
-RUST_LOG=siphon_ai=debug,siphon=info,forge=info cargo run -p siphon-ai -- --config configs/local-dev.toml
+# Run with verbose tracing. Keep the leading `warn,` — RUST_LOG replaces the
+# built-in filter rather than merging with it, so a directive that only names
+# targets drops the default `warn` floor and mutes every crate it doesn't
+# name (an unreachable HEP or OTLP collector goes silent that way).
+RUST_LOG=warn,siphon_ai=debug,siphon=info,forge=info cargo run -p siphon-ai -- --config configs/local-dev.toml
 
 # Bring up the full local stack (siphond as fake PBX + SiphonAI + echo WS + Homer)
 docker compose -f docker/compose.yaml up

--- a/docs/REGISTRATION.md
+++ b/docs/REGISTRATION.md
@@ -242,8 +242,12 @@ INFO drive{name=cucm-main server=10.10.0.50:5060}: registration succeeded grante
 WARN drive{name=cucm-main server=10.10.0.50:5060}: registration failed; will retry after backoff outcome="auth_failed" error="401 Unauthorized" backoff_secs=5
 ```
 
-Filter with `RUST_LOG=siphon_ai::registration=debug` for the per-attempt
-detail (sleep deltas, transition events).
+Filter with `RUST_LOG=warn,siphon_ai::registration=debug` for the per-attempt
+detail (sleep deltas, transition events). Keep the leading `warn,`: the
+directive **replaces** the built-in filter rather than merging with it, so
+naming only this target would mute every other crate — including the
+upstream SIP-stack warnings that explain several rows of the
+troubleshooting table below. See `docs/CONFIG.md` §`--log`.
 
 ## Vendor notes
 
@@ -315,7 +319,7 @@ on every registered node and could not be alerted on (issue #486).
 |---|---|---|
 | `siphon_ai_register_state{state="pending"}` stays at 1 forever | First REGISTER never gets a response | Packet capture on the registrar's IP; firewall on `[sip].listen` |
 | `outcome="transport_error"` and the error is `Timer F expired` | Daemon sent REGISTER but no response arrived in 32s | Verify the registrar received it (PBX trace logs); confirm response source IP/port matches the daemon's `[sip].listen` |
-| `outcome="auth_failed"` after one attempt | Wrong `password` or `realm` | Compare the digest challenge details in tracing (`RUST_LOG=sip_auth=debug`) against the PBX config |
+| `outcome="auth_failed"` after one attempt | Wrong `password` or `realm` | Compare the digest challenge details in tracing (`RUST_LOG=warn,sip_auth=debug`) against the PBX config |
 | Refresh hits `transport_error` after a long-running success | Registrar restarted and lost our binding; or NAT mapping expired | The exponential backoff will retry; if it persists, shorten `expires_secs` so refresh runs more often |
 | Inbound INVITEs from the PBX get `register_source = "trunk"` instead of the registration name | Source IP/port doesn't match what `[[register]].server`/`port` resolved to | Confirm the PBX sends INVITEs from the same address it accepts REGISTERs on |
 | `siphon_ai_notify_total{result="ignored"}` climbs at the REGISTER rate | The registrar pushes MWI after each REGISTER — normal, absorbed | Nothing to do; see [MWI pushes](#mwi-pushes-from-the-registrar). Only `result="bad_event"` is actionable |


### PR DESCRIPTION
Addresses the first item of #597 — the cheap one that is worth doing regardless of how the rest of that issue lands.

## The problem

A supplied `RUST_LOG` / `--log` / `SIPHON_AI_LOG` **replaces** the built-in filter rather than merging with it. So a directive that only names targets drops `DEFAULT_LOG_FILTER`'s `warn` floor and mutes every crate it does not name. Every filter example in these two files did exactly that.

That floor is not decoration. `bins/siphon-ai/src/main.rs` records why it was added:

> `hep_rs`'s "collector unreachable" warning (#460) and `sip_uac`'s registration-auth warnings both went from **zero** log lines in three days to firing normally once the floor was in place.

The examples were therefore teaching the shape that caused #460.

## What changed

| File | Before | After |
|---|---|---|
| `CLAUDE.md:230` | `RUST_LOG=siphon_ai=debug,siphon=info,forge=info` | `RUST_LOG=warn,…`, with a comment explaining the prefix |
| `docs/REGISTRATION.md:245` | `RUST_LOG=siphon_ai::registration=debug` | `RUST_LOG=warn,…`, with the reason and a pointer to `docs/CONFIG.md` §`--log` |
| `docs/REGISTRATION.md:322` | `RUST_LOG=sip_auth=debug` | `RUST_LOG=warn,sip_auth=debug` |

The third was found by sweeping rather than from the issue text. It is the `outcome="auth_failed"` row of the troubleshooting table, so following it verbatim leaves an operator diagnosing a registration failure with every other crate's warnings switched off — while sitting a few lines under a sample log block whose whole point is a `WARN` line.

## How it was found

Soaking the OTLP log export (#589 / #592) at 200 concurrent with the collector killed: the daemon logged **nothing** about the outage for 46 minutes, because the run used `--log siphon_ai=info,siphon=info,forge=info` — a filter shaped exactly like the CLAUDE.md example. Under the default filter the same outage produces `BatchLogProcessor.ExportError` within seconds. Details in `test-harness/load/RESULTS-0.51.0-otlp-logs.md` §6.

Per #596 that log line is currently the *only* signal a collector is down, since no metric moves — so silencing it is not cosmetic.

## Deliberately not touched

- **`docs/CONFIG.md`** — it already documents this correctly ("*naming one target … also drops the built-in `warn` floor and mutes everything else. Prefix it with `warn,` to keep the floor*"). The docs were right; the examples contradicted them.
- **`test-harness/` and `examples/` scripts** — ~35 `RUST_LOG=siphon_ai=info` invocations. Quietness there may well be deliberate and changing it would alter harness output; that is a separate decision, still open under #597.
- **`RESULTS-0.51.0-otlp-logs.md`** — it records the floorless filter as what was actually run. That is a historical record, and the missing floor is the finding.

Docs only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014JspgWG2zEdURw8FVpUq3U
