### PR TITLE
feat(sip): mutual TLS on the trunk — verify the caller's certificate and route on it (siphon-rs #129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Mutual TLS on the SIP trunk: verify who is calling, and route on it**
+  (siphon-rs [#129](https://github.com/thevoiceguy/siphon-rs/issues/129) /
+  [#130](https://github.com/thevoiceguy/siphon-rs/pull/130), pin `v2026.08.25` →
+  `v2026.09.03`). Until now a TLS trunk was encrypted but anonymous: the listener never
+  asked for a client certificate, so nothing distinguished a partner node from anyone who
+  found port 5061, and the only handles for a route were what the INVITE *claimed* about
+  itself. Now:
+  - **`[sip.tls].client_ca` + `client_auth = "optional" | "required"`** make the TLS
+    listener request a client certificate and verify it against a PEM CA bundle.
+    `required` fails the handshake for a peer with no certificate — it never sends a SIP
+    message; `optional` admits such a peer (no identity) while still refusing a
+    certificate that does not chain, so a fleet can roll certificates out before the
+    switch is thrown. Both halves must be set together; the bundle must exist at load;
+    the mode is validated at load; all three by `siphon-ai check`. Applies to the SIP TLS
+    listener only (browsers on `[sip.wss]` do not present client certificates).
+  - **`[sip.tls_client].client_cert` + `client_key`** present a certificate on every
+    outgoing TLS connection to a peer that asks — mutual TLS *toward* a trunk. Key must
+    be `0600`, as the listener key already is.
+  - **`peer_cert_san` route match key** (`docs/DIALPLAN.md` §4.6): matches when any name
+    the verified certificate asserts — URI SANs (where RFC 5922 puts a SIP identity), DNS,
+    IP, e-mail SANs, then the CN — satisfies the predicate. A call with no verified
+    certificate has no candidate names and can never match it, so a `.*` regex cannot
+    admit an unauthenticated caller the way it can for an absent header. A dialplan naming
+    the key on a daemon whose listener never asks for a certificate is **refused at load**,
+    naming the route — such a route could never fire. `siphon-ai route-test
+    --peer-cert-san <name>` (repeatable) models it offline.
+  - **Observability**: every INVITE on a verified connection logs `peer_identity` (subject
+    + SANs) and the SHA-256 fingerprint at `info` with the peer address, and the routed /
+    no-match lines carry `peer_cert_names`; new counter
+    `siphon_ai_tls_peer_identity_total{result="verified"|"none"}` per INVITE on TLS/WSS
+    (documented in DEPLOY.md, with the rollout recipe); `GET /admin/v1/calls` rows gain
+    an optional `peer_identity` field (additive — absent for every call that presented
+    none, so existing rows are byte-identical); `print-config` shows `tls_client_auth` and
+    `tls_client_identity` under `sip`.
+  - **Not in this release**: the identity is not yet on the CDR (would be v10) and
+    `[sip.admission]` / `[[trunk]]` do not consult it — routing is the authorization
+    point for now; the default route (or the absence of one → 404) is where an
+    unrecognized certificate ends up.
+
 ### Changed
 
 - **forge-media pin `v2026.08.26` → `v2026.09.02`** — a routine roll-up.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,6 +856,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1309,7 +1362,7 @@ dependencies = [
  "forge-ice",
  "forge-rtp",
  "rand 0.10.1",
- "sip-sdp",
+ "sip-sdp 0.3.1 (git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.25)",
  "smol_str",
  "thiserror 2.0.18",
 ]
@@ -2672,6 +2725,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3528,6 +3590,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3920,7 +3991,7 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 [[package]]
 name = "sip-auth"
 version = "0.4.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.25#74bf30e58c256726d365e3885d19d4b5f1162ebf"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.09.03#0bed4fd3d9a3c99da4860effd61402a30f0c4842"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3943,7 +4014,7 @@ dependencies = [
 [[package]]
 name = "sip-core"
 version = "0.7.7"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.25#74bf30e58c256726d365e3885d19d4b5f1162ebf"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.09.03#0bed4fd3d9a3c99da4860effd61402a30f0c4842"
 dependencies = [
  "bytes",
  "httpdate",
@@ -3956,7 +4027,7 @@ dependencies = [
 [[package]]
 name = "sip-dialog"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.25#74bf30e58c256726d365e3885d19d4b5f1162ebf"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.09.03#0bed4fd3d9a3c99da4860effd61402a30f0c4842"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3974,7 +4045,7 @@ dependencies = [
 [[package]]
 name = "sip-dns"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.25#74bf30e58c256726d365e3885d19d4b5f1162ebf"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.09.03#0bed4fd3d9a3c99da4860effd61402a30f0c4842"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3988,7 +4059,7 @@ dependencies = [
 [[package]]
 name = "sip-hep"
 version = "0.0.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.25#74bf30e58c256726d365e3885d19d4b5f1162ebf"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.09.03#0bed4fd3d9a3c99da4860effd61402a30f0c4842"
 dependencies = [
  "bytes",
  "hep-rs",
@@ -3999,7 +4070,7 @@ dependencies = [
 [[package]]
 name = "sip-identity"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.25#74bf30e58c256726d365e3885d19d4b5f1162ebf"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.09.03#0bed4fd3d9a3c99da4860effd61402a30f0c4842"
 dependencies = [
  "base64 0.22.1",
  "ring",
@@ -4012,7 +4083,7 @@ dependencies = [
 [[package]]
 name = "sip-observe"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.25#74bf30e58c256726d365e3885d19d4b5f1162ebf"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.09.03#0bed4fd3d9a3c99da4860effd61402a30f0c4842"
 dependencies = [
  "once_cell",
  "tracing",
@@ -4021,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "sip-parse"
 version = "0.3.4"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.25#74bf30e58c256726d365e3885d19d4b5f1162ebf"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.09.03#0bed4fd3d9a3c99da4860effd61402a30f0c4842"
 dependencies = [
  "bytes",
  "httpdate",
@@ -4035,7 +4106,7 @@ dependencies = [
 [[package]]
 name = "sip-ratelimit"
 version = "0.3.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.25#74bf30e58c256726d365e3885d19d4b5f1162ebf"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.09.03#0bed4fd3d9a3c99da4860effd61402a30f0c4842"
 dependencies = [
  "dashmap 5.5.3",
  "parking_lot",
@@ -4046,7 +4117,7 @@ dependencies = [
 [[package]]
 name = "sip-registrar"
 version = "0.3.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.25#74bf30e58c256726d365e3885d19d4b5f1162ebf"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.09.03#0bed4fd3d9a3c99da4860effd61402a30f0c4842"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4074,9 +4145,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sip-sdp"
+version = "0.3.1"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.09.03#0bed4fd3d9a3c99da4860effd61402a30f0c4842"
+dependencies = [
+ "nom 7.1.3",
+ "smol_str",
+]
+
+[[package]]
 name = "sip-transaction"
-version = "0.6.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.25#74bf30e58c256726d365e3885d19d4b5f1162ebf"
+version = "0.7.0"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.09.03#0bed4fd3d9a3c99da4860effd61402a30f0c4842"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4094,8 +4174,8 @@ dependencies = [
 
 [[package]]
 name = "sip-transport"
-version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.25#74bf30e58c256726d365e3885d19d4b5f1162ebf"
+version = "0.6.0"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.09.03#0bed4fd3d9a3c99da4860effd61402a30f0c4842"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4105,6 +4185,7 @@ dependencies = [
  "memchr",
  "rustls",
  "rustls-pki-types",
+ "sha2 0.10.9",
  "sip-hep",
  "sip-observe",
  "sip-ratelimit",
@@ -4113,12 +4194,13 @@ dependencies = [
  "tokio-rustls",
  "tokio-tungstenite 0.21.0",
  "tracing",
+ "x509-parser",
 ]
 
 [[package]]
 name = "sip-uac"
 version = "0.7.1"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.25#74bf30e58c256726d365e3885d19d4b5f1162ebf"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.09.03#0bed4fd3d9a3c99da4860effd61402a30f0c4842"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4131,7 +4213,7 @@ dependencies = [
  "sip-dialog",
  "sip-dns",
  "sip-parse",
- "sip-sdp",
+ "sip-sdp 0.3.1 (git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.09.03)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -4143,7 +4225,7 @@ dependencies = [
 [[package]]
 name = "sip-uas"
 version = "0.5.0"
-source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.08.25#74bf30e58c256726d365e3885d19d4b5f1162ebf"
+source = "git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.09.03#0bed4fd3d9a3c99da4860effd61402a30f0c4842"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4153,7 +4235,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp",
+ "sip-sdp 0.3.1 (git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.09.03)",
  "sip-transaction",
  "sip-transport",
  "smol_str",
@@ -4290,6 +4372,7 @@ dependencies = [
  "siphon-ai-routes",
  "siphon-ai-security",
  "siphon-ai-telemetry",
+ "tempfile",
  "thiserror 1.0.69",
  "toml",
  "tracing",
@@ -4318,7 +4401,7 @@ dependencies = [
  "sip-core",
  "sip-dialog",
  "sip-parse",
- "sip-sdp",
+ "sip-sdp 0.3.1 (git+https://github.com/thevoiceguy/siphon-rs?tag=v2026.09.03)",
  "sip-transaction",
  "sip-uac",
  "sip-uas",
@@ -5053,10 +5136,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -5064,6 +5149,16 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinystr"
@@ -6320,6 +6415,23 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "xattr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,22 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 # impossible type mismatches.
 
 # siphon-rs — RFC 3261 SIP stack.
+# Bumped 2026-09-03 **v2026.08.25** → **v2026.09.03** = siphon-rs #130 (issue
+# #129, filed for FCP's cascaded conferencing and consumed here as the SIP
+# mutual-TLS surface): the TLS listener can request and verify a client
+# certificate (`load_rustls_server_config_with_client_auth`), an outbound
+# `ClientConfig` can present one (`ClientIdentity` +
+# `build_rustls_client_config`), and every packet from a connection whose
+# certificate verified carries a `PeerIdentity` (subject, CN, DNS/URI/IP
+# SANs, SHA-256 fingerprint) that `TransportContext::peer_identity()`
+# exposes to the UAS layer. Additive — sip-transport 0.5.0 → 0.6.0,
+# sip-transaction 0.6.0 → 0.7.0, siphond 0.7.0; no signature changed, and a
+# listener that never asks for a certificate behaves exactly as before.
+# What this project does with it: `[sip.tls].client_ca` + `client_auth`,
+# `[sip.tls_client].client_cert` + `client_key`, and the `peer_cert_san`
+# route match key.
+# (Prior: 2026-08-25 **v2026.08.24.1** → **v2026.08.25** — sip-uas 0.5.0,
+# `on_register` receives the TransportContext.)
 # Bumped 2026-08-21 **v2026.08.20.1** → **v2026.08.21** = siphon-rs #121
 # (opened from this project against its own #549, found while verifying the
 # 0.49.8 deploy): a UAC dialog's local URI now comes from the dialog-forming
@@ -321,32 +337,32 @@ chrono      = { version = "0.4", default-features = false, features = ["clock", 
 #  `6fd432270bb8` = #67 dialog_manager share, siphon-ai #324;
 #  `fcaff011f9c6` = #65 invite_with_from, siphon-ai #316;
 #  `3a4fc312ade3` = #64 TLS-SNI-is-hostname, siphon-ai #312.)
-sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.25" }
-sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.25" }
-sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.25", features = ["tls", "ws"] }
-sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.25" }
-sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.25" }
-sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.25" }
-sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.25" }
-sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.25" }
-sip-registrar   = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.25" }
-sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.25" }
+sip-core        = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.09.03" }
+sip-parse       = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.09.03" }
+sip-transport   = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.09.03", features = ["tls", "ws"] }
+sip-transaction = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.09.03" }
+sip-dialog      = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.09.03" }
+sip-uas         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.09.03" }
+sip-uac         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.09.03" }
+sip-auth        = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.09.03" }
+sip-registrar   = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.09.03" }
+sip-dns         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.09.03" }
 # sip-sdp — the SAME sip-sdp sip-uac's SdpAnswerGenerator trait speaks
 # (distinct from forge-media's pinned sip-sdp). Used by the outbound
 # delayed-offer answer generator to hand the UAC a SessionDescription it
 # accepts. Must stay on the same siphon-rs rev as the rest below.
-sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.25" }
-sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.25" }
+sip-sdp         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.09.03" }
+sip-hep         = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.09.03" }
 # sip-observe — the transport-layer observability seam. We implement its
 # `TransportMetrics` trait in siphon-ai-telemetry and install it with
 # `set_transport_metrics`, which is the only way to see ingress
 # rate-limit drops: the hook is defaulted to a no-op upstream, so an
 # embedder that installs nothing (as we did until 0.48.11) silently gets
 # the `NoopTransportMetrics` fallback (siphon-ai #459).
-sip-observe     = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.25" }
+sip-observe     = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.09.03" }
 # sip-identity — STIR/SHAKEN Identity-header parsing + PASSporT verification
 # (ES256 + X.509 chain validation). Consumed by the stir-shaken verifier crate.
-sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.08.25" }
+sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v2026.09.03" }
 
 # forge-media — RTP / codecs / SDP / DTMF / engine.
 #
@@ -376,7 +392,7 @@ sip-identity    = { git = "https://github.com/thevoiceguy/siphon-rs", tag = "v20
 #    became `pub`. First consumer is FCP, not this daemon; we have no
 #    B2BUA leg whose PTs arrive late.
 #  * **forge-sdp** `Cargo.toml`: `sip-sdp` moves from a submodule-relative
-#    path to `git … tag = "v2026.08.25"`. That is the *same* tag this
+#    path to `git … tag = "v2026.09.03"`. That is the *same* tag this
 #    workspace pins every other `sip-*` crate to, so cargo unifies them and
 #    the lock still holds exactly one `sip-sdp`. Had the tags differed we
 #    would have linked two copies of the SDP negotiator — worth re-checking

--- a/bins/sightglass/src/keys.rs
+++ b/bins/sightglass/src/keys.rs
@@ -428,6 +428,7 @@ mod tests {
             sip_call_id: format!("{id}@host"),
             direction: "inbound".to_string(),
             webrtc_state: None,
+            peer_identity: None,
         }
     }
 

--- a/bins/sightglass/src/model.rs
+++ b/bins/sightglass/src/model.rs
@@ -1010,6 +1010,7 @@ mod tests {
             sip_call_id: format!("{id}@host"),
             direction: "inbound".to_string(),
             webrtc_state: None,
+            peer_identity: None,
         }
     }
 

--- a/bins/sightglass/src/ui/mod.rs
+++ b/bins/sightglass/src/ui/mod.rs
@@ -53,12 +53,14 @@ mod tests {
                         sip_call_id: "aa11@pbx".into(),
                         direction: "inbound".into(),
                         webrtc_state: None,
+                        peer_identity: None,
                     },
                     AdminCallRow {
                         call_id: "siphon-bb22".into(),
                         sip_call_id: "bb22@pbx".into(),
                         direction: "outbound".into(),
                         webrtc_state: None,
+                        peer_identity: None,
                     },
                 ],
                 registrations: vec![RegistrationRow {

--- a/bins/siphon-ai/src/inspect.rs
+++ b/bins/siphon-ai/src/inspect.rs
@@ -27,6 +27,10 @@ pub struct RouteTestInput {
     pub from_user: String,
     pub from_host: String,
     pub register_source: String,
+    /// Names asserted by a verified client certificate (mutual TLS),
+    /// matched against `[route.match].peer_cert_san`. Empty = the call
+    /// presented no certificate.
+    pub peer_cert_names: Vec<String>,
     /// `("X-Header", "value")` pairs.
     pub headers: Vec<(String, String)>,
 }
@@ -576,6 +580,14 @@ pub fn render_config_json(config: &Config, show_secrets: bool) -> String {
             "listen": config.sip.listen_addr.to_string(),
             "transports": config.sip.transports.iter().map(transport_str).collect::<Vec<_>>(),
             "tls": config.sip.tls.is_some(),
+            "tls_client_auth": config.sip.tls.as_ref().and_then(|t| t.client_auth.as_ref()).map(|a| json!({
+                "client_ca": a.ca_path.display().to_string(),
+                "mode": a.mode.as_str(),
+            })),
+            "tls_client_identity": config.sip.tls_client_identity.as_ref().map(|i| json!({
+                "client_cert": i.cert_path.display().to_string(),
+                "client_key": i.key_path.display().to_string(),
+            })),
             "allow_delayed_offer": config.sip.allow_delayed_offer,
         },
         "media": {
@@ -702,6 +714,7 @@ pub fn route_test(config: &Config, input: &RouteTestInput) -> String {
         from_user: &input.from_user,
         from_host: &input.from_host,
         register_source: &input.register_source,
+        peer_cert_names: &input.peer_cert_names,
         headers: &headers,
     };
 
@@ -712,6 +725,9 @@ pub fn route_test(config: &Config, input: &RouteTestInput) -> String {
     let _ = writeln!(s, "  to          = {}@{}", input.to_user, input.to_host);
     let _ = writeln!(s, "  from        = {}@{}", input.from_user, input.from_host);
     let _ = writeln!(s, "  register_source = {}", input.register_source);
+    if !input.peer_cert_names.is_empty() {
+        let _ = writeln!(s, "  peer_cert_san   = {:?}", input.peer_cert_names);
+    }
     if !input.headers.is_empty() {
         let _ = writeln!(s, "  headers     = {:?}", input.headers);
     }

--- a/bins/siphon-ai/src/main.rs
+++ b/bins/siphon-ai/src/main.rs
@@ -98,6 +98,12 @@ enum Command {
         /// `[[register]]` block name.
         #[arg(long = "register-source", default_value = "trunk")]
         register_source: String,
+        /// Repeatable: a name the caller's verified TLS client
+        /// certificate asserts (a `sip:` URI / DNS SAN or the CN),
+        /// matched against `[route.match].peer_cert_san`. Omit to
+        /// model a call that presented no certificate.
+        #[arg(long = "peer-cert-san")]
+        peer_cert_san: Vec<String>,
         /// Repeatable SIP header, `Name: Value`, matched against
         /// `[route.match].header.*`.
         #[arg(long = "header", short = 'H')]
@@ -242,6 +248,7 @@ async fn main() -> Result<()> {
                 from,
                 from_host,
                 register_source,
+                peer_cert_san,
                 headers,
             } => run_route_test(
                 &path,
@@ -259,6 +266,7 @@ async fn main() -> Result<()> {
                     from_user: from.clone(),
                     from_host: from_host.clone(),
                     register_source: register_source.clone(),
+                    peer_cert_names: peer_cert_san.clone(),
                     headers: parse_headers(headers)?,
                 },
             ),

--- a/bins/siphon-ai/src/runtime.rs
+++ b/bins/siphon-ai/src/runtime.rs
@@ -886,8 +886,11 @@ impl Runtime {
         // per-connection writer the listener attached.
         let tcp_client_pool = Arc::new(ConnectionPool::new());
         let tls_client_pool = Arc::new(TlsPool::new());
-        let tls_client_config = build_tls_client_config(sip.tls_client_extra_ca.as_deref())
-            .with_context(|| "build client TLS verification roots")?;
+        let tls_client_config = build_tls_client_config(
+            sip.tls_client_extra_ca.as_deref(),
+            sip.tls_client_identity.as_ref(),
+        )
+        .with_context(|| "build client TLS verification roots")?;
         let dispatcher: Arc<dyn TransportDispatcher> = Arc::new(MultiTransportDispatcher::new(
             Arc::clone(&udp_socket),
             Arc::clone(&tcp_client_pool),
@@ -1854,6 +1857,9 @@ impl CallRegistryHandle for RuntimeCallRegistry {
                 .to_string(),
                 // Present only for a browser leg (§4.6).
                 webrtc_state: c.webrtc_state.map(str::to_string),
+                // Present only when the connection proved itself with a
+                // client certificate (mutual TLS).
+                peer_identity: c.peer_identity,
             })
             .collect()
     }
@@ -2123,7 +2129,15 @@ impl siphon_ai_sip_glue::TrunkAllowlist for ConfigTrunkAllowlist {
 /// Twilio — plus the operator's `[sip.tls_client].extra_ca` PEM
 /// bundle for private-CA deployments and self-signed test rigs.
 /// Failure is fatal at startup, same contract as the server side.
-fn build_tls_client_config(extra_ca: Option<&std::path::Path>) -> Result<Arc<TlsClientConfig>> {
+///
+/// `identity` (`[sip.tls_client].client_cert` + `client_key`) is
+/// presented to a peer that requests a client certificate — mutual TLS
+/// toward a trunk (siphon-rs #129). Without it the config is the
+/// classic roots-only client.
+fn build_tls_client_config(
+    extra_ca: Option<&std::path::Path>,
+    identity: Option<&siphon_ai_config::TlsClientIdentity>,
+) -> Result<Arc<TlsClientConfig>> {
     let mut roots = tokio_rustls::rustls::RootCertStore::empty();
     roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
     if let Some(path) = extra_ca {
@@ -2145,11 +2159,32 @@ fn build_tls_client_config(extra_ca: Option<&std::path::Path>) -> Result<Arc<Tls
         }
         info!(path = %path.display(), added, "client TLS extra CA roots loaded");
     }
-    Ok(Arc::new(
-        tokio_rustls::rustls::ClientConfig::builder()
-            .with_root_certificates(roots)
-            .with_no_client_auth(),
-    ))
+    let identity =
+        match identity {
+            None => None,
+            Some(id) => {
+                let cert = id.cert_path.to_str().ok_or_else(|| {
+                    anyhow!("[sip.tls_client].client_cert path is not valid UTF-8")
+                })?;
+                let key = id.key_path.to_str().ok_or_else(|| {
+                    anyhow!("[sip.tls_client].client_key path is not valid UTF-8")
+                })?;
+                let loaded = sip_transport::ClientIdentity::load(cert, key).with_context(|| {
+                    format!(
+                        "load [sip.tls_client] client_cert={} client_key={}",
+                        id.cert_path.display(),
+                        id.key_path.display()
+                    )
+                })?;
+                info!(
+                    cert = %id.cert_path.display(),
+                    "outbound TLS client certificate loaded (presented to peers that request one)"
+                );
+                Some(loaded)
+            }
+        };
+    sip_transport::build_rustls_client_config(roots, identity)
+        .with_context(|| "assemble outbound TLS client config")
 }
 
 /// Resolve `[webrtc]` against what this binary was actually built
@@ -2284,7 +2319,34 @@ pub(crate) fn load_sip_tls_server_config(
         .key_path
         .to_str()
         .ok_or_else(|| anyhow!("[sip.tls].key path is not valid UTF-8"))?;
-    let cfg = load_rustls_server_config(cert, key).with_context(|| {
+    let cfg = match tls.client_auth.as_ref() {
+        // Mutual TLS: request a client certificate and verify it against
+        // the CA bundle. A bad bundle is fatal here, at startup (or on
+        // SIGHUP, where the previous config is kept) — there is no
+        // cleartext fallback for "verify the peer".
+        Some(auth) => {
+            let ca = auth
+                .ca_path
+                .to_str()
+                .ok_or_else(|| anyhow!("[sip.tls].client_ca path is not valid UTF-8"))?;
+            let mode = match auth.mode {
+                siphon_ai_config::TlsClientAuthMode::Optional => {
+                    sip_transport::ClientAuthMode::Optional
+                }
+                siphon_ai_config::TlsClientAuthMode::Required => {
+                    sip_transport::ClientAuthMode::Required
+                }
+            };
+            info!(
+                client_ca = %auth.ca_path.display(),
+                mode = auth.mode.as_str(),
+                "SIP TLS listener requires client certificates (mutual TLS)"
+            );
+            sip_transport::load_rustls_server_config_with_client_auth(cert, key, ca, mode)
+        }
+        None => load_rustls_server_config(cert, key),
+    }
+    .with_context(|| {
         format!(
             "load TLS cert={} key={}",
             tls.cert_path.display(),
@@ -3295,6 +3357,10 @@ async fn handle_packet(
     // request on :5061 advertises `:5061;transport=tls`, not the
     // UDP listener's port).
     let local = packet.local();
+    // Mutual TLS (siphon-rs #129): the verified client certificate on
+    // this connection, if the listener asked for one. Copied onto the
+    // context so the routing handler can authorize by it.
+    let peer_identity = packet.peer_identity().cloned();
     let (transport, peer, payload, stream) = packet.into_parts();
 
     let Some(request) = parse_request(&payload) else {
@@ -3313,7 +3379,9 @@ async fn handle_packet(
     };
 
     let tx_kind = map_transport_kind(transport);
-    let ctx = TransportContext::new(tx_kind, peer, stream).with_local_addr(local);
+    let ctx = TransportContext::new(tx_kind, peer, stream)
+        .with_local_addr(local)
+        .with_peer_identity(peer_identity);
 
     if request.method().as_str() == "ACK" {
         // ACK opens no server transaction of its own; hand it to the
@@ -3810,6 +3878,7 @@ mod tls_reload_tests {
             listen_addr: "127.0.0.1:0".parse::<SocketAddr>().unwrap(),
             cert_path: cert,
             key_path: key,
+            client_auth: None,
         }
     }
 

--- a/crates/admin-api-types/src/lib.rs
+++ b/crates/admin-api-types/src/lib.rs
@@ -48,6 +48,15 @@ pub struct AdminCallRow {
     /// an older daemon sees `None` everywhere.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub webrtc_state: Option<String>,
+    /// The verified TLS client certificate the call's connection
+    /// presented (mutual TLS, siphon-rs #129): subject DN followed by
+    /// the SANs, e.g. `CN=node-1,O=Example san=[sip:node-1@example.com]`.
+    ///
+    /// Absent when the connection presented none — a UDP/TCP call, or a
+    /// TLS listener without `[sip.tls].client_auth`. Additive optional
+    /// field, same contract as `webrtc_state`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub peer_identity: Option<String>,
 }
 
 /// `GET /admin/v1/calls` response envelope.
@@ -411,6 +420,7 @@ mod tests {
                 sip_call_id: "abc@host".into(),
                 direction: "inbound".into(),
                 webrtc_state: None,
+                peer_identity: None,
             }],
         };
         assert_eq!(
@@ -437,6 +447,7 @@ mod tests {
             sip_call_id: "web@host".into(),
             direction: "inbound".into(),
             webrtc_state: Some("ice_connected".into()),
+            peer_identity: None,
         };
         assert_eq!(
             serde_json::to_value(&row).unwrap(),
@@ -455,6 +466,29 @@ mod tests {
         }))
         .expect("a pre-0.51.0 daemon's row still parses");
         assert_eq!(legacy.webrtc_state, None);
+        assert_eq!(legacy.peer_identity, None);
+    }
+
+    /// A call whose connection presented a verified client certificate
+    /// (mutual TLS) carries the identity; every other row omits the key.
+    #[test]
+    fn an_mtls_call_row_carries_its_peer_identity() {
+        let row = AdminCallRow {
+            call_id: "siphon-mtls".into(),
+            sip_call_id: "mtls@host".into(),
+            direction: "inbound".into(),
+            webrtc_state: None,
+            peer_identity: Some("CN=node-1 san=[sip:node-1@example.com]".into()),
+        };
+        assert_eq!(
+            serde_json::to_value(&row).unwrap(),
+            json!({
+                "call_id": "siphon-mtls",
+                "sip_call_id": "mtls@host",
+                "direction": "inbound",
+                "peer_identity": "CN=node-1 san=[sip:node-1@example.com]",
+            })
+        );
     }
 
     #[test]

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -29,3 +29,7 @@ siphon-ai-security.workspace   = true
 # `[admin]` compiles into telemetry's auth types (Role / AdminToken /
 # AdminAuth). telemetry sits below core, so this dep is acyclic.
 siphon-ai-telemetry.workspace  = true
+
+[dev-dependencies]
+# Real files on disk for the [sip.tls] / [sip.tls_client] path-existence tests.
+tempfile = "3"

--- a/crates/config/src/compile.rs
+++ b/crates/config/src/compile.rs
@@ -655,6 +655,10 @@ pub struct SipConfig {
     /// transports list. `None` when TLS isn't enabled. Daemon
     /// loads cert/key from these paths at startup.
     pub tls: Option<SipTlsConfig>,
+    /// `[sip.tls_client].client_cert` / `client_key` — certificate this
+    /// daemon presents on outgoing TLS connections to a peer that asks
+    /// for one (mutual TLS toward a trunk). `None` = present nothing.
+    pub tls_client_identity: Option<TlsClientIdentity>,
     /// `[sip.tls_client].extra_ca` — optional PEM bundle appended to
     /// the webpki roots when verifying OUTGOING TLS connections
     /// (gateways / registrations with `transport = "tls"`).
@@ -776,6 +780,48 @@ impl std::fmt::Debug for SipAuthUser {
 #[derive(Debug, Clone)]
 pub struct SipTlsConfig {
     pub listen_addr: SocketAddr,
+    pub cert_path: PathBuf,
+    pub key_path: PathBuf,
+    /// `[sip.tls].client_ca` + `client_auth` — mutual TLS on the SIP
+    /// TLS listener (siphon-rs #129). `None` = never ask for a client
+    /// certificate, the pre-0.51 behaviour.
+    pub client_auth: Option<SipTlsClientAuth>,
+}
+
+/// Mutual-TLS policy for the SIP TLS listener.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SipTlsClientAuth {
+    /// PEM bundle the peer's certificate chain must terminate in.
+    pub ca_path: PathBuf,
+    pub mode: TlsClientAuthMode,
+}
+
+/// Whether the TLS listener insists on a client certificate. Both
+/// modes verify a presented certificate against `ca_path`; they
+/// differ only when the peer presents none.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TlsClientAuthMode {
+    /// Request a certificate; admit a peer with none (its INVITEs then
+    /// carry no identity and can never match a `peer_cert_san` route).
+    Optional,
+    /// Request a certificate; fail the handshake without one.
+    Required,
+}
+
+impl TlsClientAuthMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TlsClientAuthMode::Optional => "optional",
+            TlsClientAuthMode::Required => "required",
+        }
+    }
+}
+
+/// `[sip.tls_client].client_cert` + `client_key` — the identity this
+/// daemon presents on **outgoing** TLS connections to a peer that
+/// requests one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TlsClientIdentity {
     pub cert_path: PathBuf,
     pub key_path: PathBuf,
 }
@@ -1219,6 +1265,37 @@ pub enum CompileError {
     TlsClientExtraCaMissing(String),
 
     #[error(
+        "[sip.tls_client].client_cert and client_key must be set together \
+         (an outbound client certificate needs its private key, and vice versa)"
+    )]
+    TlsClientIdentityIncomplete,
+
+    #[error("[sip.tls_client].client_cert {0:?} does not exist or is not a file")]
+    TlsClientCertMissing(String),
+
+    #[error("[sip.tls_client].client_key {0:?} does not exist or is not a file")]
+    TlsClientKeyMissing(String),
+
+    #[error(
+        "[sip.tls].client_ca and client_auth must be set together \
+         (mutual TLS needs both the trust bundle and the optional|required mode)"
+    )]
+    SipTlsClientAuthIncomplete,
+
+    #[error("[sip.tls].client_auth {0:?} is not one of \"optional\", \"required\"")]
+    SipTlsUnknownClientAuth(String),
+
+    #[error("[sip.tls].client_ca {0:?} does not exist or is not a file")]
+    SipTlsClientCaMissing(String),
+
+    #[error(
+        "route {route:?} matches on peer_cert_san, but [sip.tls].client_auth is not set — \
+         the TLS listener never asks for a client certificate, so that route could never match. \
+         Set [sip.tls].client_ca + client_auth (and \"tls\" in [sip].transports), or drop the key."
+    )]
+    RoutePeerCertSanWithoutClientAuth { route: String },
+
+    #[error(
         "[[gateway]] {name:?} sets both `register` and `transport`; \
          the transport is inherited from the register block"
     )]
@@ -1444,6 +1521,22 @@ pub fn compile(raw: RawConfig) -> Result<Config, CompileError> {
     let media = compile_media(&raw.media)?;
     let bridge_defaults = compile_bridge(raw.bridge, &raw.media)?;
     let routes = compile_dialplan(raw.routes)?;
+    // A `peer_cert_san` route can only ever match an INVITE whose
+    // connection presented a verified client certificate, which only
+    // a listener with `[sip.tls].client_auth` asks for. Refuse the
+    // combination at load (CLAUDE.md §4.6) rather than ship a route
+    // that silently never fires.
+    let asks_for_client_cert = sip
+        .tls
+        .as_ref()
+        .is_some_and(|tls| tls.client_auth.is_some());
+    if !asks_for_client_cert {
+        if let Some(route) = routes.iter().find(|r| r.uses_peer_cert_san()) {
+            return Err(CompileError::RoutePeerCertSanWithoutClientAuth {
+                route: route.name.clone(),
+            });
+        }
+    }
     let registrations = compile_registrations(raw.registrations)?;
     let registrar = compile_registrar(raw.registrar, sip.auth.is_some())?;
     let webrtc = compile_webrtc(raw.webrtc)?;
@@ -1771,6 +1864,29 @@ fn compile_sip(raw: RawSip) -> Result<SipConfig, CompileError> {
     // Client-side roots are independent of the TLS *listener* — a
     // UDP-only daemon can still dial a TLS trunk. Validate the path
     // at load per CLAUDE.md §4.6 (fail loud at startup).
+    // Outbound client identity: both halves or neither, and both must
+    // exist now — a trunk that demands a certificate would otherwise
+    // fail on the first dial-out with a rustls error instead of here.
+    let tls_client_identity = match (raw.tls_client.client_cert, raw.tls_client.client_key) {
+        (None, None) => None,
+        (Some(_), None) | (None, Some(_)) => {
+            return Err(CompileError::TlsClientIdentityIncomplete);
+        }
+        (Some(cert), Some(key)) => {
+            let cert_path = PathBuf::from(&cert);
+            if !cert_path.is_file() {
+                return Err(CompileError::TlsClientCertMissing(cert));
+            }
+            let key_path = PathBuf::from(&key);
+            if !key_path.is_file() {
+                return Err(CompileError::TlsClientKeyMissing(key));
+            }
+            Some(TlsClientIdentity {
+                cert_path,
+                key_path,
+            })
+        }
+    };
     let tls_client_extra_ca = match raw.tls_client.extra_ca {
         None => None,
         Some(p) => {
@@ -1819,6 +1935,7 @@ fn compile_sip(raw: RawSip) -> Result<SipConfig, CompileError> {
         contact: raw.contact,
         tls,
         tls_client_extra_ca,
+        tls_client_identity,
         ws,
         wss,
         call_progress,
@@ -1989,7 +2106,11 @@ fn compile_sip_tls(
     tls_enabled: bool,
     sip_listen: &SocketAddr,
 ) -> Result<Option<SipTlsConfig>, CompileError> {
-    let has_any_tls_field = raw.cert.is_some() || raw.key.is_some() || raw.listen.is_some();
+    let has_any_tls_field = raw.cert.is_some()
+        || raw.key.is_some()
+        || raw.listen.is_some()
+        || raw.client_ca.is_some()
+        || raw.client_auth.is_some();
 
     if !tls_enabled {
         if has_any_tls_field {
@@ -2018,10 +2139,34 @@ fn compile_sip_tls(
         None => SocketAddr::new(sip_listen.ip(), 5061),
     };
 
+    // Mutual TLS: both halves or neither. The CA bundle is checked
+    // for existence here (CLAUDE.md §4.6 — fail at load, not on the
+    // first handshake); its contents are parsed when the listener's
+    // ServerConfig is built at startup, which is also fatal.
+    let client_auth = match (raw.client_ca, raw.client_auth) {
+        (None, None) => None,
+        (Some(_), None) | (None, Some(_)) => {
+            return Err(CompileError::SipTlsClientAuthIncomplete);
+        }
+        (Some(ca), Some(mode)) => {
+            let mode = match mode.as_str() {
+                "optional" => TlsClientAuthMode::Optional,
+                "required" => TlsClientAuthMode::Required,
+                other => return Err(CompileError::SipTlsUnknownClientAuth(other.to_string())),
+            };
+            let ca_path = PathBuf::from(&ca);
+            if !ca_path.is_file() {
+                return Err(CompileError::SipTlsClientCaMissing(ca));
+            }
+            Some(SipTlsClientAuth { ca_path, mode })
+        }
+    };
+
     Ok(Some(SipTlsConfig {
         listen_addr,
         cert_path: PathBuf::from(cert_path),
         key_path: PathBuf::from(key_path),
+        client_auth,
     }))
 }
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -39,9 +39,9 @@ pub use compile::{
     Config, Gateway, GatewayCredentials, HepConfig, MediaConfig, NodeConfig, ObservabilityConfig,
     OtlpConfig, OtlpLogsConfig, OutboundConfig, ParkConfig, ParkTimeoutAction, QualityConfig,
     QualityFileConfig, QualityWebhookConfig, RegisterConfig, RegistrarConfig, SecurityConfig,
-    ShutdownConfig, SipAdmissionConfig, SipAuthConfig, SipAuthUser, SipConfig, SipTlsConfig,
-    SipTransport, SipWsConfig, SipWssConfig, TrunkCidr, TrunkCidrParseError, TrunkConfig,
-    TurnServerConfig, WebRtcConfig, WebhooksConfig,
+    ShutdownConfig, SipAdmissionConfig, SipAuthConfig, SipAuthUser, SipConfig, SipTlsClientAuth,
+    SipTlsConfig, SipTransport, SipWsConfig, SipWssConfig, TlsClientAuthMode, TlsClientIdentity,
+    TrunkCidr, TrunkCidrParseError, TrunkConfig, TurnServerConfig, WebRtcConfig, WebhooksConfig,
 };
 pub use env::{expand, expand_cow, EnvError, EnvSource, ProcessEnv};
 pub use raw::{

--- a/crates/config/src/raw.rs
+++ b/crates/config/src/raw.rs
@@ -434,6 +434,16 @@ pub struct RawSipTls {
     /// PEM-encoded private key (path on disk). Required.
     #[serde(default)]
     pub key: Option<String>,
+    /// Mutual TLS: PEM bundle of CAs a connecting peer's client
+    /// certificate must chain to. Set together with `client_auth`.
+    #[serde(default)]
+    pub client_ca: Option<String>,
+    /// Mutual TLS mode: `"optional"` (a peer without a certificate may
+    /// still connect; one that presents a certificate that does not
+    /// chain is refused) or `"required"` (no certificate, no
+    /// connection). Set together with `client_ca`.
+    #[serde(default)]
+    pub client_auth: Option<String>,
 }
 
 /// `[webrtc]` — the browser media leg (DEV_PLAN_WebRTC.md Phase 2
@@ -559,6 +569,14 @@ pub struct RawSipTlsClient {
     /// self-signed certs.
     #[serde(default)]
     pub extra_ca: Option<String>,
+    /// Client certificate chain (PEM) presented on outgoing TLS
+    /// connections to peers that ask for one. Set together with
+    /// `client_key`.
+    #[serde(default)]
+    pub client_cert: Option<String>,
+    /// Private key (PEM, owner-only readable) for `client_cert`.
+    #[serde(default)]
+    pub client_key: Option<String>,
 }
 
 fn default_transports() -> Vec<String> {

--- a/crates/config/tests/load.rs
+++ b/crates/config/tests/load.rs
@@ -3700,3 +3700,245 @@ password = "${TURN_PASS}""#,
     let w = cfg.webrtc.expect("webrtc present");
     assert_eq!(w.turn_servers[0].password, "s3cret-relay");
 }
+
+/// Mutual TLS config surface (siphon-rs #129): `[sip.tls].client_ca` +
+/// `client_auth`, `[sip.tls_client].client_cert` + `client_key`, and the
+/// `peer_cert_san` route key's dependency on the former.
+mod mtls {
+    use super::*;
+    use std::io::Write as _;
+
+    /// Real files on disk: the compile step checks existence, and the
+    /// TLS listener's own cert/key are required whenever `tls` is on.
+    struct Fixture {
+        _dir: tempfile::TempDir,
+        cert: String,
+        key: String,
+        ca: String,
+    }
+
+    fn fixture() -> Fixture {
+        let dir = tempfile::tempdir().unwrap();
+        let mk = |name: &str| {
+            let path = dir.path().join(name);
+            std::fs::File::create(&path)
+                .unwrap()
+                .write_all(b"-----BEGIN CERTIFICATE-----\nMA==\n-----END CERTIFICATE-----\n")
+                .unwrap();
+            path.to_string_lossy().into_owned()
+        };
+        let cert = mk("cert.pem");
+        let key = mk("key.pem");
+        let ca = mk("ca.pem");
+        Fixture {
+            _dir: dir,
+            cert,
+            key,
+            ca,
+        }
+    }
+
+    fn tls_base(f: &Fixture, extra: &str) -> String {
+        format!(
+            r#"
+[sip]
+listen = "127.0.0.1:5060"
+transports = ["udp", "tls"]
+
+[sip.tls]
+cert = "{cert}"
+key = "{key}"
+{extra}
+
+[bridge]
+ws_url = "wss://x/y"
+"#,
+            cert = f.cert,
+            key = f.key,
+        )
+    }
+
+    #[test]
+    fn client_auth_unset_by_default() {
+        let f = fixture();
+        let cfg = load_from_str_with_env(&tls_base(&f, ""), &MapEnv::new([])).expect("compiles");
+        assert!(cfg.sip.tls.unwrap().client_auth.is_none());
+        assert!(cfg.sip.tls_client_identity.is_none());
+    }
+
+    #[test]
+    fn client_auth_required_and_optional_compile() {
+        let f = fixture();
+        for (mode, want) in [
+            ("required", siphon_ai_config::TlsClientAuthMode::Required),
+            ("optional", siphon_ai_config::TlsClientAuthMode::Optional),
+        ] {
+            let toml = tls_base(
+                &f,
+                &format!("client_ca = \"{}\"\nclient_auth = \"{mode}\"", f.ca),
+            );
+            let cfg = load_from_str_with_env(&toml, &MapEnv::new([])).expect("compiles");
+            let auth = cfg.sip.tls.unwrap().client_auth.expect("client auth set");
+            assert_eq!(auth.mode, want);
+            assert_eq!(auth.ca_path.to_string_lossy(), f.ca);
+        }
+    }
+
+    #[test]
+    fn client_auth_halves_must_come_together() {
+        let f = fixture();
+        for extra in [
+            format!("client_ca = \"{}\"", f.ca),
+            "client_auth = \"required\"".to_string(),
+        ] {
+            let err = load_from_str_with_env(&tls_base(&f, &extra), &MapEnv::new([]))
+                .expect_err("half a client-auth block must fail at load");
+            assert!(
+                err.to_string().contains("client_ca and client_auth"),
+                "{err}"
+            );
+        }
+    }
+
+    #[test]
+    fn client_auth_rejects_unknown_mode_and_missing_bundle() {
+        let f = fixture();
+        let err = load_from_str_with_env(
+            &tls_base(
+                &f,
+                &format!("client_ca = \"{}\"\nclient_auth = \"on\"", f.ca),
+            ),
+            &MapEnv::new([]),
+        )
+        .expect_err("unknown mode");
+        assert!(err.to_string().contains("\"on\""), "{err}");
+
+        let err = load_from_str_with_env(
+            &tls_base(
+                &f,
+                "client_ca = \"/nonexistent/ca.pem\"\nclient_auth = \"required\"",
+            ),
+            &MapEnv::new([]),
+        )
+        .expect_err("missing bundle");
+        assert!(err.to_string().contains("client_ca"), "{err}");
+    }
+
+    #[test]
+    fn client_auth_without_tls_transport_is_the_usual_misconfig_error() {
+        let f = fixture();
+        let toml = format!(
+            r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[sip.tls]
+client_ca = "{}"
+client_auth = "required"
+
+[bridge]
+ws_url = "wss://x/y"
+"#,
+            f.ca
+        );
+        let err = load_from_str_with_env(&toml, &MapEnv::new([]))
+            .expect_err("[sip.tls] fields without \"tls\" in transports fail");
+        assert!(err.to_string().to_lowercase().contains("tls"), "{err}");
+    }
+
+    #[test]
+    fn outbound_client_identity_compiles_and_needs_both_halves() {
+        let f = fixture();
+        let toml = format!(
+            r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[sip.tls_client]
+client_cert = "{cert}"
+client_key = "{key}"
+
+[bridge]
+ws_url = "wss://x/y"
+"#,
+            cert = f.cert,
+            key = f.key,
+        );
+        let cfg = load_from_str_with_env(&toml, &MapEnv::new([])).expect("compiles");
+        let id = cfg.sip.tls_client_identity.expect("identity set");
+        assert_eq!(id.cert_path.to_string_lossy(), f.cert);
+        assert_eq!(id.key_path.to_string_lossy(), f.key);
+
+        let half = format!(
+            r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[sip.tls_client]
+client_cert = "{}"
+
+[bridge]
+ws_url = "wss://x/y"
+"#,
+            f.cert
+        );
+        let err = load_from_str_with_env(&half, &MapEnv::new([])).expect_err("half fails");
+        assert!(
+            err.to_string().contains("client_cert and client_key"),
+            "{err}"
+        );
+
+        let missing = format!(
+            r#"
+[sip]
+listen = "127.0.0.1:5060"
+
+[sip.tls_client]
+client_cert = "{}"
+client_key = "/nonexistent/key.pem"
+
+[bridge]
+ws_url = "wss://x/y"
+"#,
+            f.cert
+        );
+        let err = load_from_str_with_env(&missing, &MapEnv::new([])).expect_err("missing key");
+        assert!(err.to_string().contains("client_key"), "{err}");
+    }
+
+    #[test]
+    fn peer_cert_san_route_requires_client_auth_on_the_listener() {
+        let f = fixture();
+        let route = r#"
+[[route]]
+name = "cascade"
+[route.match]
+peer_cert_san = "sip:node-1@example.com"
+[route.bridge]
+ws_url = "wss://cascade/sip"
+
+[[route]]
+name = "default"
+[route.match]
+any = true
+"#;
+        // Listener never asks for a certificate → the route could never
+        // match → refused at load.
+        let without = format!("{}\n{route}", tls_base(&f, ""));
+        let err = load_from_str_with_env(&without, &MapEnv::new([]))
+            .expect_err("peer_cert_san without client_auth must fail");
+        assert!(err.to_string().contains("cascade"), "{err}");
+        assert!(err.to_string().contains("client_auth"), "{err}");
+
+        // Same dialplan with mutual TLS on → fine.
+        let with = format!(
+            "{}\n{route}",
+            tls_base(
+                &f,
+                &format!("client_ca = \"{}\"\nclient_auth = \"optional\"", f.ca)
+            )
+        );
+        let cfg = load_from_str_with_env(&with, &MapEnv::new([])).expect("compiles");
+        assert!(cfg.routes.iter().any(|r| r.uses_peer_cert_san()));
+    }
+}

--- a/crates/core/src/acceptor.rs
+++ b/crates/core/src/acceptor.rs
@@ -2297,6 +2297,13 @@ pub struct DialogFlow {
     pub local: Option<std::net::SocketAddr>,
 }
 
+/// The verified TLS client certificate on the INVITE's connection,
+/// rendered for the admin listing (subject DN plus SANs), or `None`
+/// when the peer presented none (mutual TLS, siphon-rs #129).
+fn peer_identity_display(ctx: &TransportContext) -> Option<String> {
+    ctx.peer_identity().map(|id| id.to_string())
+}
+
 impl DialogFlow {
     /// Capture the flow from the transport context the INVITE
     /// arrived on. `None` for datagram transports or when the
@@ -3614,7 +3621,11 @@ impl CallAcceptor for BridgingAcceptor {
             )
             .await
         {
-            Ok(prepared) => {
+            Ok(mut prepared) => {
+                // Mutual TLS: carry the connection's verified identity to
+                // the admin listing. `prepare_call` only sees the transport
+                // kind, so it is stamped here where the context is.
+                prepared.peer_identity = peer_identity_display(call.transport);
                 let uas = self
                     .uas
                     .get()
@@ -3966,13 +3977,15 @@ impl BridgingAcceptor {
         // accepted call is reachable by the id operators see. Carries the
         // SIP Call-ID + direction so `GET /admin/v1/calls` can report both
         // id namespaces (issue #311).
-        self.control_registry.insert_with_leg_phase(
+        self.control_registry.insert_with_details(
             cleanup_handle.clone(),
             prepared.sip_call_id.clone(),
             Direction::Inbound,
             // A browser call reports where it is in ICE/DTLS for as
             // long as it is listed; a classic one has no such phase.
             prepared.controller.leg_phase_probe(),
+            // Who the connection proved itself to be (mutual TLS).
+            prepared.peer_identity.clone(),
         );
 
         // Per-route counter is owned-by-route — bounded cardinality
@@ -4185,6 +4198,12 @@ pub struct PreparedCall {
     /// `None` only for a transport with no CDR name — see
     /// [`cdr_leg_transport`].
     pub leg_transport: Option<CdrLegTransport>,
+    /// The verified TLS client certificate the INVITE's connection
+    /// presented (mutual TLS, siphon-rs #129), in `PeerIdentity`'s
+    /// display form, for the admin call listing. Set by the accept
+    /// paths from the `TransportContext` after `prepare_call`, which
+    /// only sees the transport *kind*. `None` when none was presented.
+    pub peer_identity: Option<String>,
 }
 
 impl std::fmt::Debug for PreparedCall {
@@ -4400,6 +4419,7 @@ impl BridgingAcceptor {
             handle,
             is_webrtc: true,
             leg_transport,
+            peer_identity: None,
         })
     }
 
@@ -4766,6 +4786,7 @@ impl BridgingAcceptor {
             handle,
             is_webrtc: false,
             leg_transport: cdr_leg_transport(transport),
+            peer_identity: None,
         })
     }
 }
@@ -4813,6 +4834,8 @@ struct PendingDelayedOffer {
     /// with the other CDR facts because the transport context is long
     /// gone by the time the ACK answer arrives.
     cdr_leg_transport: Option<CdrLegTransport>,
+    /// See [`PreparedCall::peer_identity`].
+    peer_identity: Option<String>,
     /// Resolved barge-in policy announcement for `start.barge_in_mode`
     /// (0.32.0) — captured here because the route isn't in scope when
     /// the ACK answer finally arrives.
@@ -5082,6 +5105,7 @@ impl BridgingAcceptor {
                 cdr_to,
                 cdr_ws_url,
                 cdr_leg_transport: cdr_leg_transport(call.transport.transport()),
+                peer_identity: peer_identity_display(call.transport),
                 barge_in_mode: barge_in_mode_info(&resolve_barge_in(&self.defaults, route)),
                 ws_failure_prompt: resolve_ws_failure_prompt(&self.defaults, route),
             },
@@ -5209,6 +5233,7 @@ impl BridgingAcceptor {
             cdr_to,
             cdr_ws_url,
             cdr_leg_transport,
+            peer_identity,
             barge_in_mode,
             ws_failure_prompt,
         } = pending;
@@ -5404,6 +5429,7 @@ impl BridgingAcceptor {
             handle,
             is_webrtc: false,
             leg_transport: cdr_leg_transport,
+            peer_identity,
         };
         metrics::counter!(DELAYED_OFFER_TOTAL, "result" => "answered").increment(1);
         self.run_call(
@@ -7248,6 +7274,7 @@ a=sendrecv\r\n";
             from_user: "caller",
             from_host: "example.net",
             register_source: "trunk",
+            peer_cert_names: &[],
             headers: leak_empty_headers(),
         }
     }
@@ -7858,6 +7885,7 @@ a=sendrecv\r\n",
                 verstat: None,
                 bridge_config: BridgeConfig::default(),
                 cdr_leg_transport: Some(CdrLegTransport::Udp),
+                peer_identity: None,
                 tap_options: TapOptions {
                     barge_in_action: siphon_ai_media_glue::BargeInAction::Notify,
                     barge_in_debounce: None,

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -284,6 +284,11 @@ struct ControlEntry {
     /// (`DEV_PLAN_WebRTC.md` §4.6). `None` for a classic leg — which
     /// has no such phase, rather than an unknown one.
     leg_phase: Option<crate::media_leg::LegPhaseProbe>,
+    /// The verified TLS client certificate the call's connection
+    /// presented (mutual TLS, siphon-rs #129), rendered as
+    /// `PeerIdentity`'s display form: subject DN plus SANs. `None`
+    /// when the connection presented none.
+    peer_identity: Option<String>,
 }
 
 /// One active call in the admin `GET /admin/v1/calls` snapshot. `call_id`
@@ -298,6 +303,9 @@ pub struct CallSnapshot {
     /// `ice_connected`, `connected`, `failed`, `closed` (§4.6).
     /// `None` for a classic call: it has no such phase.
     pub webrtc_state: Option<&'static str>,
+    /// Subject + SANs of the verified client certificate on the call's
+    /// connection, when there was one (mutual TLS).
+    pub peer_identity: Option<String>,
 }
 
 impl std::fmt::Debug for CallControlRegistry {
@@ -341,6 +349,20 @@ impl CallControlRegistry {
         direction: Direction,
         leg_phase: Option<crate::media_leg::LegPhaseProbe>,
     ) {
+        self.insert_with_details(handle, sip_call_id, direction, leg_phase, None)
+    }
+
+    /// [`insert_with_leg_phase`](Self::insert_with_leg_phase) plus the
+    /// verified client-certificate identity the call's connection
+    /// presented, for the admin listing (mutual TLS, siphon-rs #129).
+    pub fn insert_with_details(
+        &self,
+        handle: CallHandle,
+        sip_call_id: impl Into<String>,
+        direction: Direction,
+        leg_phase: Option<crate::media_leg::LegPhaseProbe>,
+        peer_identity: Option<String>,
+    ) {
         let key = handle.call_id().as_str().to_string();
         let sip_call_id = sip_call_id.into();
         let entry = ControlEntry {
@@ -348,6 +370,7 @@ impl CallControlRegistry {
             sip_call_id: sip_call_id.clone(),
             direction,
             leg_phase,
+            peer_identity,
         };
         // Promote this dialog's SIP-ladder trace to the live
         // population (DESIGN_SIP_LADDER.md). This is the moment the
@@ -382,6 +405,7 @@ impl CallControlRegistry {
                 sip_call_id: e.sip_call_id.clone(),
                 direction: e.direction,
                 webrtc_state: e.leg_phase.as_ref().map(|probe| probe()),
+                peer_identity: e.peer_identity.clone(),
             })
             .collect()
     }

--- a/crates/routes/src/call_info.rs
+++ b/crates/routes/src/call_info.rs
@@ -89,6 +89,14 @@ pub struct CallInfo<'a> {
     /// `[[register]]` block's `name`.
     pub register_source: &'a str,
 
+    /// Every name the peer's **verified** TLS client certificate
+    /// asserts — URI / DNS / IP / e-mail SANs plus the Common Name
+    /// (`sip_transport::PeerIdentity::names()` order). Empty when the
+    /// call did not arrive on a connection that presented a
+    /// certificate the listener verified, which is what makes the
+    /// `peer_cert_san` key unmatchable for such a call.
+    pub peer_cert_names: &'a [String],
+
     pub headers: &'a Headers,
 }
 

--- a/crates/routes/src/compile.rs
+++ b/crates/routes/src/compile.rs
@@ -169,6 +169,7 @@ fn compile_match(
         from_user,
         from_host,
         register_source,
+        peer_cert_san,
         header,
     } = raw;
 
@@ -179,6 +180,7 @@ fn compile_match(
         || from_user.is_some()
         || from_host.is_some()
         || register_source.is_some()
+        || peer_cert_san.is_some()
         || !header.is_empty();
 
     if any && has_other_keys {
@@ -234,6 +236,7 @@ fn compile_match(
         from_user: pred("from_user", from_user)?,
         from_host: pred("from_host", from_host)?,
         register_source: pred("register_source", register_source)?,
+        peer_cert_san: pred("peer_cert_san", peer_cert_san)?,
         headers,
     })
 }

--- a/crates/routes/src/compiled.rs
+++ b/crates/routes/src/compiled.rs
@@ -74,6 +74,10 @@ pub(crate) struct CompiledMatch {
 
     pub(crate) register_source: Option<Matcher>,
 
+    /// Predicate over the peer certificate's names; see
+    /// `RawRouteMatch::peer_cert_san`.
+    pub(crate) peer_cert_san: Option<Matcher>,
+
     /// `(lowercased_header_name, predicate)` pairs.
     pub(crate) headers: Vec<(String, Matcher)>,
 }
@@ -97,6 +101,14 @@ pub struct CompiledRoute {
 }
 
 impl CompiledRoute {
+    /// `true` when this route's `[match]` block predicates on
+    /// `peer_cert_san`. The config crate uses it to refuse a dialplan
+    /// that names a client-certificate key on a daemon whose TLS
+    /// listener never asks for one — such a route could never match.
+    pub fn uses_peer_cert_san(&self) -> bool {
+        self.match_.peer_cert_san.is_some()
+    }
+
     /// True iff this route's `[match]` block predicates all hold
     /// against `info`. `any = true` short-circuits to `true`.
     pub fn matches(&self, info: &crate::CallInfo<'_>) -> bool {
@@ -136,6 +148,16 @@ impl CompiledRoute {
         }
         if let Some(p) = &m.register_source {
             if !p.matches(info.register_source) {
+                return false;
+            }
+        }
+        if let Some(p) = &m.peer_cert_san {
+            // Any one asserted name satisfies the key. An empty list
+            // (no verified certificate) can never match — the
+            // predicate is never even consulted, so `^$` under
+            // `regex = true` does not sneak an unauthenticated call
+            // through.
+            if !info.peer_cert_names.iter().any(|n| p.matches(n)) {
                 return false;
             }
         }

--- a/crates/routes/src/raw.rs
+++ b/crates/routes/src/raw.rs
@@ -88,6 +88,16 @@ pub struct RawRouteMatch {
     /// `"trunk"` for unregistered inbound (UAS-mode) calls.
     pub register_source: Option<String>,
 
+    /// A name the peer's **verified TLS client certificate** asserts —
+    /// any subjectAltName (`sip:` URI, DNS, IP, e-mail) or, as the RFC
+    /// 5922 §7.1 fallback, its Common Name. Matches when *any one* of
+    /// those names satisfies the predicate. A call whose connection
+    /// presented no verified certificate (UDP/TCP, or TLS without
+    /// `[sip.tls].client_auth`) has no names and never matches this
+    /// key — unlike an absent header, there is no empty-string
+    /// candidate for a regex to hit.
+    pub peer_cert_san: Option<String>,
+
     /// `header.<NAME> = "<value>"` — name is case-insensitive,
     /// matched against the inbound INVITE's headers.
     #[serde(default)]

--- a/crates/routes/tests/match_grammar.rs
+++ b/crates/routes/tests/match_grammar.rs
@@ -20,6 +20,7 @@ fn info<'a>(request_uri_user: &'a str, headers: &'a Headers) -> CallInfo<'a> {
         from_user: "+13125551234",
         from_host: "carrier.example.net",
         register_source: "trunk",
+        peer_cert_names: &[],
         headers,
     }
 }
@@ -232,4 +233,94 @@ fn any_combined_with_other_keys_fails_to_load() {
         request_uri_user = "5000"
     "#;
     assert!(load_from_toml(toml).is_err());
+}
+
+/// `peer_cert_san` (siphon-rs #129 / mutual TLS): matches when any
+/// name the verified client certificate asserts satisfies the
+/// predicate, and never for a call that presented no certificate.
+#[test]
+fn peer_cert_san_matches_any_asserted_name() {
+    let toml = r#"
+        [[route]]
+        name = "node-1"
+        [route.match]
+        peer_cert_san = "sip:node-1@example.com"
+
+        [[route]]
+        name = "fallback"
+        [route.match]
+        any = true
+    "#;
+    let set = load_from_toml(toml).unwrap();
+    let h = empty_headers();
+
+    // URI SAN first, DNS SAN second, CN last — order the transport uses.
+    let names = vec![
+        "sip:node-1@example.com".to_string(),
+        "node-1.example.com".to_string(),
+        "node-1".to_string(),
+    ];
+    let mut i = info("any", &h);
+    i.peer_cert_names = &names;
+    assert_eq!(matched_name(&set, &i), Some("node-1"));
+
+    // Literal matching is case-insensitive like every other key.
+    let upper = vec!["SIP:NODE-1@EXAMPLE.COM".to_string()];
+    let mut i = info("any", &h);
+    i.peer_cert_names = &upper;
+    assert_eq!(matched_name(&set, &i), Some("node-1"));
+
+    // A different node falls through to the default.
+    let other = vec!["sip:node-2@example.com".to_string()];
+    let mut i = info("any", &h);
+    i.peer_cert_names = &other;
+    assert_eq!(matched_name(&set, &i), Some("fallback"));
+}
+
+#[test]
+fn peer_cert_san_never_matches_a_call_without_a_verified_certificate() {
+    let toml = r#"
+        [[route]]
+        name = "authenticated-trunk"
+        [route.match]
+        regex = true
+        peer_cert_san = ".*"
+    "#;
+    let set = load_from_toml(toml).unwrap();
+    let h = empty_headers();
+    // Even a match-everything regex cannot admit a call with no
+    // names: there is no candidate string to run it against.
+    let i = info("any", &h);
+    assert_eq!(matched_name(&set, &i), None);
+    assert!(set.iter().next().unwrap().uses_peer_cert_san());
+}
+
+#[test]
+fn peer_cert_san_regex_and_ands_with_other_keys() {
+    let toml = r#"
+        [[route]]
+        name = "cascade"
+        [route.match]
+        regex = true
+        peer_cert_san = "^sip:node-[0-9]+@example\\.com$"
+        request_uri_user = "^conf-"
+    "#;
+    let set = load_from_toml(toml).unwrap();
+    let h = empty_headers();
+    let names = vec!["sip:node-7@example.com".to_string()];
+
+    let mut i = info("conf-1234", &h);
+    i.peer_cert_names = &names;
+    assert_eq!(matched_name(&set, &i), Some("cascade"));
+
+    // Right certificate, wrong target → no match.
+    let mut i = info("5000", &h);
+    i.peer_cert_names = &names;
+    assert_eq!(matched_name(&set, &i), None);
+
+    // Right target, certificate from outside the pattern → no match.
+    let rogue = vec!["sip:attacker@example.org".to_string()];
+    let mut i = info("conf-1234", &h);
+    i.peer_cert_names = &rogue;
+    assert_eq!(matched_name(&set, &i), None);
 }

--- a/crates/sip-glue/src/handler.rs
+++ b/crates/sip-glue/src/handler.rs
@@ -44,13 +44,15 @@ use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use sip_core::{Request, Response};
 use sip_dialog::Dialog;
-use sip_transaction::{ServerTransactionHandle, TransportContext};
+use sip_transaction::{ServerTransactionHandle, TransportContext, TransportKind};
 use sip_uas::integrated::{IntegratedUAS, UasRequestHandler};
 use sip_uas::UserAgentServer;
 use siphon_ai_routes::{CompiledRoute, RouteSet};
 // Metric names from the crate that declares them — see the note in
 // media-glue's tap.rs (#474).
-use siphon_ai_telemetry::metrics::{INVITES_TOTAL, INVITE_ADMISSION_SOURCES, NOTIFY_TOTAL};
+use siphon_ai_telemetry::metrics::{
+    INVITES_TOTAL, INVITE_ADMISSION_SOURCES, NOTIFY_TOTAL, TLS_PEER_IDENTITY_TOTAL,
+};
 use tracing::{debug, info, instrument, warn};
 
 use crate::dialog::{
@@ -131,18 +133,24 @@ fn drain_reject_response(
 ///
 /// Pure / synchronous. The async trait wrapper [`RoutingHandler`]
 /// adapts this to the upstream [`UasRequestHandler`] surface.
+///
+/// `peer_cert_names` is every name the connection's verified TLS
+/// client certificate asserts (empty when none) — the candidate set
+/// for the `peer_cert_san` route key.
 pub fn dispatch_invite<'a>(
     routes: &'a RouteSet,
     register_source: &str,
+    peer_cert_names: &[String],
     request: &Request,
 ) -> RouteAction<'a> {
-    match route_invite(request, register_source, routes) {
+    match route_invite(request, register_source, peer_cert_names, routes) {
         RouteDecision::Matched { facts, route } => {
             info!(
                 route = route.name.as_str(),
                 from_user = facts.from_user.as_str(),
                 request_uri_user = facts.request_uri_user.as_str(),
                 register_source,
+                peer_cert_names = ?peer_cert_names,
                 "INVITE routed"
             );
             RouteAction::Accept { facts, route }
@@ -152,6 +160,7 @@ pub fn dispatch_invite<'a>(
                 from_user = facts.from_user.as_str(),
                 request_uri_user = facts.request_uri_user.as_str(),
                 register_source,
+                peer_cert_names = ?peer_cert_names,
                 "INVITE rejected: no route matched"
             );
             RouteAction::SendFinal(UserAgentServer::create_response(request, 404, "Not Found"))
@@ -773,8 +782,33 @@ impl<A: CallAcceptor + 'static> UasRequestHandler for RoutingHandler<A> {
             }
         }
 
+        // Mutual TLS (siphon-rs #129): the identity the connection
+        // proved before this INVITE was read, if the listener asked for
+        // a client certificate and the peer presented one that chained.
+        // Counted per INVITE on a TLS-family transport so an operator
+        // rolling `client_auth = "optional"` out can watch the share of
+        // peers that have certificates before flipping to `required`.
+        let peer_cert_names: Vec<String> = match ctx.peer_identity() {
+            Some(identity) => {
+                info!(
+                    peer = %ctx.peer(),
+                    peer_identity = %identity,
+                    fingerprint = %identity.fingerprint_hex(),
+                    "INVITE arrived on a connection with a verified client certificate"
+                );
+                metrics::counter!(TLS_PEER_IDENTITY_TOTAL, "result" => "verified").increment(1);
+                identity.names()
+            }
+            None => {
+                if matches!(ctx.transport(), TransportKind::Tls | TransportKind::Wss) {
+                    metrics::counter!(TLS_PEER_IDENTITY_TOTAL, "result" => "none").increment(1);
+                }
+                Vec::new()
+            }
+        };
+
         let routes = self.routes.load();
-        match dispatch_invite(&routes, &register_source, request) {
+        match dispatch_invite(&routes, &register_source, &peer_cert_names, request) {
             RouteAction::SendFinal(mut response) => {
                 self.fill_response(&mut response, ctx).await;
                 handle.send_final(response).await;

--- a/crates/sip-glue/src/invite.rs
+++ b/crates/sip-glue/src/invite.rs
@@ -85,7 +85,16 @@ impl InviteFacts {
     /// the call arrived through, or `"trunk"` for unregistered
     /// inbound. The caller (sip-glue's UAS handler, ultimately)
     /// knows which it was.
-    pub fn as_call_info<'a>(&'a self, register_source: &'a str) -> CallInfo<'a> {
+    ///
+    /// `peer_cert_names` is every name the connection's **verified**
+    /// TLS client certificate asserts (`PeerIdentity::names()`), or
+    /// empty when there was none — the candidate set for the
+    /// `peer_cert_san` route key.
+    pub fn as_call_info<'a>(
+        &'a self,
+        register_source: &'a str,
+        peer_cert_names: &'a [String],
+    ) -> CallInfo<'a> {
         CallInfo {
             request_uri_user: &self.request_uri_user,
             request_uri_host: &self.request_uri_host,
@@ -94,6 +103,7 @@ impl InviteFacts {
             from_user: &self.from_user,
             from_host: &self.from_host,
             register_source,
+            peer_cert_names,
             headers: &self.headers,
         }
     }

--- a/crates/sip-glue/src/route.rs
+++ b/crates/sip-glue/src/route.rs
@@ -36,19 +36,24 @@ pub enum RouteDecision<'a> {
 /// `register_source` is the name of the `[[register]]` block the
 /// call arrived on, or `"trunk"` for unregistered inbound.
 ///
+/// `peer_cert_names` is what the connection's verified TLS client
+/// certificate asserts (see `InviteFacts::as_call_info`); pass an
+/// empty slice for a call that presented none.
+///
 /// The returned `&CompiledRoute` lifetime is tied to `routes`
-/// alone, *not* `register_source`. The matcher needs both at
-/// call-evaluation time but the result only references the route
-/// table — callers can pass a short-lived register_source string
-/// (e.g., synthesized per-request) and still hand the matched
-/// route off to a longer-lived consumer.
+/// alone, *not* `register_source` or `peer_cert_names`. The matcher
+/// needs all of them at call-evaluation time but the result only
+/// references the route table — callers can pass short-lived
+/// per-request strings and still hand the matched route off to a
+/// longer-lived consumer.
 pub fn route_invite<'r>(
     request: &Request,
     register_source: &str,
+    peer_cert_names: &[String],
     routes: &'r RouteSet,
 ) -> RouteDecision<'r> {
     let facts = InviteFacts::extract(request);
-    let info = facts.as_call_info(register_source);
+    let info = facts.as_call_info(register_source, peer_cert_names);
     match routes.find_match(&info) {
         Some(route) => RouteDecision::Matched { facts, route },
         None => RouteDecision::NoMatch { facts },

--- a/crates/sip-glue/tests/handler_dispatch.rs
+++ b/crates/sip-glue/tests/handler_dispatch.rs
@@ -52,7 +52,7 @@ fn matched_invite_yields_accept_with_route_and_facts() {
         "<sip:5000@siphon.example.com>",
     );
 
-    match dispatch_invite(&routes, "trunk", &req) {
+    match dispatch_invite(&routes, "trunk", &[], &req) {
         RouteAction::Accept { facts, route } => {
             assert_eq!(route.name, "reception");
             assert_eq!(
@@ -86,7 +86,7 @@ fn unmatched_invite_yields_404_with_request_correlation_headers() {
         "<sip:9999@siphon.example.com>",
     );
 
-    match dispatch_invite(&routes, "trunk", &req) {
+    match dispatch_invite(&routes, "trunk", &[], &req) {
         RouteAction::SendFinal(response) => {
             assert_eq!(response.code(), 404);
             assert_eq!(response.reason(), "Not Found");
@@ -124,7 +124,7 @@ fn matched_route_with_default_fallback_picks_specific_first() {
         "<sip:caller@example.net>",
         "<sip:5000@siphon.example.com>",
     );
-    match dispatch_invite(&routes, "trunk", &req) {
+    match dispatch_invite(&routes, "trunk", &[], &req) {
         RouteAction::Accept { route, .. } => assert_eq!(route.name, "reception"),
         _ => panic!("expected Accept reception"),
     }
@@ -135,7 +135,7 @@ fn matched_route_with_default_fallback_picks_specific_first() {
         "<sip:caller@example.net>",
         "<sip:1234@siphon.example.com>",
     );
-    match dispatch_invite(&routes, "trunk", &req) {
+    match dispatch_invite(&routes, "trunk", &[], &req) {
         RouteAction::Accept { route, .. } => assert_eq!(route.name, "default"),
         _ => panic!("expected Accept default"),
     }
@@ -164,11 +164,11 @@ fn register_source_distinguishes_routes() {
         "<sip:5000@siphon.example.com>",
     );
 
-    match dispatch_invite(&routes, "cucm-main", &req) {
+    match dispatch_invite(&routes, "cucm-main", &[], &req) {
         RouteAction::Accept { route, .. } => assert_eq!(route.name, "from-cucm"),
         _ => panic!("expected Accept from-cucm"),
     }
-    match dispatch_invite(&routes, "trunk", &req) {
+    match dispatch_invite(&routes, "trunk", &[], &req) {
         RouteAction::Accept { route, .. } => assert_eq!(route.name, "from-trunk"),
         _ => panic!("expected Accept from-trunk"),
     }
@@ -198,12 +198,55 @@ fn dispatch_returned_route_outlives_register_source_string() {
 
     let action = {
         let rs = String::from("trunk");
-        dispatch_invite(&routes, &rs, &req)
+        dispatch_invite(&routes, &rs, &[], &req)
         // rs dropped here
     };
 
     match action {
         RouteAction::Accept { route, .. } => assert_eq!(route.name, "any-call"),
         _ => panic!("expected Accept"),
+    }
+}
+
+/// Mutual TLS (siphon-rs #129): the names off the connection's verified
+/// client certificate reach the matcher, and a call that presented none
+/// cannot take a `peer_cert_san` route.
+#[test]
+fn peer_cert_names_select_the_route() {
+    let routes = load_from_toml(
+        r#"
+        [[route]]
+        name = "cascade-trunk"
+        [route.match]
+        peer_cert_san = "sip:node-1@example.com"
+        [route.bridge]
+        ws_url = "wss://cascade.example.com/sip"
+
+        [[route]]
+        name = "default"
+        [route.match]
+        any = true
+        [route.bridge]
+        ws_url = "wss://bot.example.com/sip"
+        "#,
+    )
+    .unwrap();
+    let req = invite(
+        "sip:5000@siphon.example.com",
+        "sip:node-1@example.com",
+        "sip:5000@siphon.example.com",
+    );
+
+    let names = vec![
+        "sip:node-1@example.com".to_string(),
+        "node-1.example.com".to_string(),
+    ];
+    match dispatch_invite(&routes, "trunk", &names, &req) {
+        RouteAction::Accept { route, .. } => assert_eq!(route.name, "cascade-trunk"),
+        other => panic!("expected the certificate-scoped route, got {other:?}"),
+    }
+    match dispatch_invite(&routes, "trunk", &[], &req) {
+        RouteAction::Accept { route, .. } => assert_eq!(route.name, "default"),
+        other => panic!("expected the default route, got {other:?}"),
     }
 }

--- a/crates/sip-glue/tests/invite_routing.rs
+++ b/crates/sip-glue/tests/invite_routing.rs
@@ -132,7 +132,7 @@ fn matches_route_by_request_uri_user() {
     )
     .build();
 
-    match route_invite(&req, "trunk", &routes) {
+    match route_invite(&req, "trunk", &[], &routes) {
         RouteDecision::Matched { route, .. } => assert_eq!(route.name, "reception"),
         RouteDecision::NoMatch { .. } => panic!("expected reception match"),
     }
@@ -162,7 +162,7 @@ fn falls_through_to_default() {
     )
     .build();
 
-    match route_invite(&req, "trunk", &routes) {
+    match route_invite(&req, "trunk", &[], &routes) {
         RouteDecision::Matched { route, .. } => assert_eq!(route.name, "default"),
         RouteDecision::NoMatch { .. } => panic!("expected default match"),
     }
@@ -188,7 +188,7 @@ fn no_match_returns_nomatch_when_no_default() {
     .build();
 
     assert!(matches!(
-        route_invite(&req, "trunk", &routes),
+        route_invite(&req, "trunk", &[], &routes),
         RouteDecision::NoMatch { .. }
     ));
 }
@@ -217,11 +217,11 @@ fn register_source_distinguishes_routes() {
     )
     .build();
 
-    match route_invite(&req, "cucm-main", &routes) {
+    match route_invite(&req, "cucm-main", &[], &routes) {
         RouteDecision::Matched { route, .. } => assert_eq!(route.name, "from-cucm"),
         _ => panic!("expected from-cucm match"),
     }
-    match route_invite(&req, "trunk", &routes) {
+    match route_invite(&req, "trunk", &[], &routes) {
         RouteDecision::Matched { route, .. } => assert_eq!(route.name, "from-trunk"),
         _ => panic!("expected from-trunk match"),
     }
@@ -254,7 +254,7 @@ fn header_match_with_regex() {
     .header("X-Tenant-Id", "acme")
     .build();
 
-    match route_invite(&req, "trunk", &routes) {
+    match route_invite(&req, "trunk", &[], &routes) {
         RouteDecision::Matched { route, .. } => assert_eq!(route.name, "tenant-acme"),
         _ => panic!("expected tenant-acme match"),
     }
@@ -267,7 +267,7 @@ fn header_match_with_regex() {
     .header("X-Tenant-Id", "globex")
     .build();
 
-    match route_invite(&req_other, "trunk", &routes) {
+    match route_invite(&req_other, "trunk", &[], &routes) {
         RouteDecision::Matched { route, .. } => assert_eq!(route.name, "default"),
         _ => panic!("expected default match"),
     }
@@ -297,7 +297,7 @@ fn from_user_match_with_regex_anchors() {
     )
     .build();
 
-    match route_invite(&req, "trunk", &routes) {
+    match route_invite(&req, "trunk", &[], &routes) {
         RouteDecision::Matched { route, .. } => assert_eq!(route.name, "vip"),
         _ => panic!("expected vip match"),
     }

--- a/crates/telemetry/src/admin.rs
+++ b/crates/telemetry/src/admin.rs
@@ -1282,6 +1282,7 @@ mod tests {
                     sip_call_id: sip.clone(),
                     direction: "inbound".into(),
                     webrtc_state: None,
+                    peer_identity: None,
                 })
                 .collect()
         }

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -72,6 +72,16 @@ pub const CALLS_TOTAL: &str = "siphon_ai_calls_total";
 /// `[[route]].name`). Useful for "which route is hot" dashboards.
 pub const ROUTE_MATCH_TOTAL: &str = "siphon_ai_route_match_total";
 
+/// Inbound INVITEs on a TLS-family transport (TLS, WSS) by whether the
+/// connection presented a client certificate the listener verified
+/// (mutual TLS, siphon-rs #129). Labeled by `result`: `verified` (the
+/// request carries a `PeerIdentity`; `peer_cert_san` routes can match
+/// it) or `none` (the peer presented nothing — only reachable with
+/// `[sip.tls].client_auth = "optional"` or no client auth at all).
+/// UDP/TCP INVITEs are not counted. Bounded cardinality (two values);
+/// the identity itself is in the log line and the admin call listing.
+pub const TLS_PEER_IDENTITY_TOTAL: &str = "siphon_ai_tls_peer_identity_total";
+
 /// STIR/SHAKEN verification outcomes on inbound INVITEs, counted only
 /// when `[security.stir_shaken].enabled = true`. Labeled by `result`:
 /// `passed` (every check held — attestation is trustworthy),
@@ -937,6 +947,10 @@ pub fn register_descriptions() {
     );
     describe_counter!(ROUTE_MATCH_TOTAL, "Calls accepted by matched route name.");
     describe_counter!(
+        TLS_PEER_IDENTITY_TOTAL,
+        "Inbound INVITEs over TLS/WSS by whether the connection presented a verified client certificate (mutual TLS)."
+    );
+    describe_counter!(
         VERSTAT_TOTAL,
         "STIR/SHAKEN verification outcomes by result (passed, failed, unsigned)."
     );
@@ -1400,6 +1414,7 @@ pub const ALL_COUNTERS: &[&str] = &[
     CALLS_TOTAL,
     CALLS_DRAIN_FORCED_TOTAL,
     ROUTE_MATCH_TOTAL,
+    TLS_PEER_IDENTITY_TOTAL,
     VERSTAT_TOTAL,
     RECORDINGS_TOTAL,
     RECORDING_UPLOADS_TOTAL,

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -224,6 +224,8 @@ credentials. Resolved secret values are never logged.
 | `listen` | `host:port` | same IP + port `5061` | Where the TLS listener binds. |
 | `cert`   | path        | required when TLS on | PEM cert chain on disk. |
 | `key`    | path        | required when TLS on | PEM private key on disk. |
+| `client_ca` | path     | unset                | **Mutual TLS** (0.51.0, siphon-rs #129). PEM bundle of CAs a connecting peer's client certificate must chain to. Set together with `client_auth`; checked for existence at load, parsed at startup. |
+| `client_auth` | `"optional"` \| `"required"` | unset | With `client_ca`: `required` fails the handshake for a peer that presents no certificate — it never gets to send a SIP message; `optional` admits such a peer (its INVITEs carry no identity) while still refusing a certificate that does not chain. Use `optional` to roll certificates out across a fleet, then flip to `required`. Either way, every INVITE arriving on a connection whose certificate verified carries the certificate's identity — subject, CN, `sip:`/DNS/IP SANs — which the `peer_cert_san` route key matches on (see `docs/DIALPLAN.md` §4.6), the log line and the admin call listing show, and `siphon_ai_tls_peer_identity_total` counts. Applies to the SIP TLS listener only, not `[sip.wss]` (browsers do not present client certificates). Changing it takes a restart; the cert/key SIGHUP reload keeps the mode. |
 
 > **Server side only.** `[sip.tls]` is the inbound listener's
 > cert/key. *Outgoing* TLS connections — `[[gateway]]` and
@@ -254,6 +256,8 @@ browsers register to us, not the reverse.
 | Field      | Type | Default | Notes |
 |------------|------|---------|-------|
 | `extra_ca` | path | unset   | PEM bundle appended to the built-in webpki (Mozilla CA) roots when verifying outgoing TLS. For trunks fronted by a private CA and for test rigs with self-signed certs. Public trunks (e.g. Twilio) verify against the built-in roots without this. |
+| `client_cert` | path | unset | **Mutual TLS toward a trunk** (0.51.0). PEM certificate chain this daemon presents on every outgoing TLS connection — `[[gateway]]` / `[[register]]` with `transport = "tls"` — to a peer that requests a client certificate. Set together with `client_key`. A peer that never asks sees no difference. |
+| `client_key` | path | unset | Private key for `client_cert`. Must be owner-only readable (`0600`), the same rule as `[sip.tls].key`; a group- or world-readable key is refused at startup. |
 
 The path is checked at config load; an unreadable or empty bundle
 fails at startup, not at first dial-out.
@@ -417,7 +421,9 @@ min_attestation = "A"            # strict override of [security].min_attestation
 
 Match keys (any combination, all AND together): `request_uri_user`,
 `request_uri_host`, `to_user`, `to_host`, `from_user`, `from_host`,
-`register_source`, `header.<NAME> = "<value>"`, `any = true`.
+`register_source`, `peer_cert_san` (mutual TLS — needs
+`[sip.tls].client_auth`, refused at load otherwise),
+`header.<NAME> = "<value>"`, `any = true`.
 
 ## `[registrar]` — serve REGISTER (Phase 1 of the WebRTC plan)
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -248,6 +248,41 @@ to UDP.
 > return a clear error rather than silently downgrading. Inbound
 > `INVITE sips:…` from the carrier works.
 
+#### Mutual TLS (0.51.0)
+
+To authenticate the *peer* rather than only encrypt to it — a
+cascade of conference nodes, a partner trunk that must not be
+reachable by anyone who found the port — have the listener ask for a
+client certificate and verify it against your CA:
+
+```toml
+[sip.tls]
+listen      = "0.0.0.0:5061"
+cert        = "/etc/siphon-ai/tls/fullchain.pem"
+key         = "/etc/siphon-ai/tls/privkey.pem"
+client_ca   = "/etc/siphon-ai/tls/trunk-ca.pem"   # what peers' certs must chain to
+client_auth = "required"                          # or "optional" while rolling out
+```
+
+`required` refuses the handshake — the peer never sends a SIP
+message. `optional` admits a peer with no certificate but still
+refuses one whose certificate does not chain; its INVITEs then carry
+no identity. Either way an INVITE that arrives on a verified
+connection carries the certificate's subject and SANs, which the
+`peer_cert_san` route key matches on (`docs/DIALPLAN.md` §4.6), the
+`INVITE arrived on a connection with a verified client certificate`
+log line prints with the SHA-256 fingerprint, and
+`GET /admin/v1/calls` shows as `peer_identity`. Roll out with
+`optional` and watch `siphon_ai_tls_peer_identity_total{result="none"}`
+drop to zero before switching to `required`.
+
+For the reverse direction — a trunk that demands a certificate from
+*us* — set `[sip.tls_client].client_cert` + `client_key`; every
+outgoing TLS connection presents it to a peer that asks. The key must
+be `0600` like the listener key. `siphon-ai check` validates both
+blocks (paths exist, halves come in pairs, mode is
+`optional|required`) before a restart.
+
 ### 3. WSS to the WebSocket server
 
 Just set `wss://` in `[bridge].ws_url` (or `[route.bridge].ws_url`):
@@ -1395,6 +1430,7 @@ applied (and test-enforced) in our `prometheus_builder()` (issue #437).
 | `siphon_ai_calls_total`                 | counter   | `cause=caller_hangup\|server_hangup\|local_shutdown\|drain_forced\|bridge_ended\|ws_disconnect\|tap_ended\|transfer` | Ended calls by termination cause. `caller_hangup` (0.40.0) = the far end sent BYE, split out of `local_shutdown`, which now means admin force-hangup / CANCEL / session expiry only. `drain_forced` (0.17.0) = force-ended at the graceful-shutdown drain deadline. `transfer` (0.41.x) = the call was handed off via REFER. `ws_disconnect` (0.45.0) = the WS dropped unexpectedly mid-call (or reconnect never recovered), split out of `bridge_ended` — alert on this one; it's the WS server crashing or the network failing, not a call ending. Counts inbound **and** outbound legs (#373 — outbound legs were previously invisible here, so `ws_disconnect` alerting missed outbound WS crashes). |
 | `siphon_ai_calls_active`                | gauge     | —                                     | Currently-running bridged calls, inbound and outbound (#373 — previously inbound-only). An outbound leg joins at answer; before that it counts only on `siphon_ai_outbound_calls_active`. |
 | `siphon_ai_route_match_total`           | counter   | `route`                               | Calls per matched route. |
+| `siphon_ai_tls_peer_identity_total`     | counter   | `result=verified\|none`               | Inbound INVITEs over TLS/WSS by whether the connection presented a client certificate the listener verified (mutual TLS, 0.51.0). `verified` = the INVITE carries a `PeerIdentity` and can match a `peer_cert_san` route; `none` = the peer presented nothing, which only `[sip.tls].client_auth = "optional"` (or no client auth) lets through. UDP/TCP INVITEs are not counted. Rolling mTLS out: run `optional`, drive `none` to zero, then switch to `required` — at which point `none` can only rise if the mode was reverted. Handshakes refused under `required` never reach this counter (the peer sends no INVITE); they are in sip-transport's handshake-error transport metrics. |
 | `siphon_ai_verstat_total`               | counter   | `result=passed\|failed\|unsigned`     | STIR/SHAKEN verification outcomes per inbound INVITE. Emitted only when `[security.stir_shaken].enabled = true`. `passed` = every check held; `failed` = `Identity` header present but verification didn't fully pass; `unsigned` = no `Identity` header. |
 | `siphon_ai_sip_auth_total`              | counter   | `result=ok\|challenged\|failed\|stale` | Inbound digest-auth outcomes per challenged INVITE (0.19.0). Emitted only for sources that require `[sip.auth]`. `ok` = a valid `Authorization` verified; `challenged` = no credentials presented → `401` issued; `failed` = credentials presented but wrong (bad password / unknown user) → `401`; `stale` = a nonce-freshness rejection → `401 stale=true` — the nonce was TTL-expired **or** past its reuse window (`[sip.auth].nonce_reuse_window_secs`, #430); the credential is not implicated either way. A rising `failed` is a brute-force / misconfiguration signal — pair with the fail2ban recipe. A rising `stale` usually just means peers re-authenticate less often than the reuse window — raise the window if the extra 401 round-trips bother you. |
 | `siphon_ai_invite_admission_total`      | counter   | `result=accepted\|rate_limited\|dropped` | Inbound INVITE admission decisions (0.19.0). Emitted only when `[sip.admission]` is on. `accepted` = admitted; `rate_limited` = per-source rate trip or global `max_concurrent` cap → `503`; `dropped` = source flooding past `drop_after` → silently dropped (no response). A rising `dropped` means a sustained flood; `rate_limited` spikes with bursty peers or an undersized cap. |

--- a/docs/DIALPLAN.md
+++ b/docs/DIALPLAN.md
@@ -106,6 +106,7 @@ All match keys are optional. Use as many as you need; they AND.
 | `from_user`          | User-part of the `From` header URI.                                                   |
 | `from_host`          | Host-part of the `From` header URI.                                                   |
 | `register_source`    | Name of the `[[register]]` block the call arrived on, or `"trunk"` for unregistered. |
+| `peer_cert_san`      | A name the peer's **verified TLS client certificate** asserts — any SAN or the CN. Mutual TLS only; see §4.6. |
 | `header.<NAME>`      | Value of header `<NAME>` (case-insensitive on the name).                              |
 | `any`                | Boolean. `true` matches everything; mutually exclusive with all the above.            |
 
@@ -192,6 +193,61 @@ Unconditional match. Place it at the end of the file as the
 catch-all. `any = true` together with any other match key is a
 config-load error — silent precedence between "match anything" and
 "match this specific thing" would be a footgun.
+
+### 4.6 `peer_cert_san` (mutual TLS, 0.51.0)
+
+`peer_cert_san` matches against the identity of the TLS **client
+certificate** the caller's connection presented — and only when the
+daemon's TLS listener verified it, which requires
+`[sip.tls].client_ca` + `client_auth` (siphon-rs #129). The candidate
+set is every name the certificate asserts, in this order: URI SANs
+(RFC 5922 §7.1 puts a SIP identity in a `sip:` URI SAN), DNS SANs,
+IP SANs, e-mail SANs, and finally the subject Common Name. The key
+matches when **any one** of them satisfies the predicate.
+
+```toml
+[sip.tls]
+cert        = "/etc/siphon-ai/tls/fullchain.pem"
+key         = "/etc/siphon-ai/tls/privkey.pem"
+client_ca   = "/etc/siphon-ai/tls/cascade-ca.pem"
+client_auth = "required"
+
+# Conference nodes dial each other with certificates our CA issued
+# (SAN sip:node-N@conf.example.com). Only they reach the cascade
+# bridge; everything else — including a caller who reached the TLS
+# listener with no certificate under `client_auth = "optional"` —
+# falls to the default route.
+[[route]]
+name = "cascade-trunk"
+[route.match]
+regex = true
+peer_cert_san = "^sip:node-[0-9]+@conf\\.example\\.com$"
+[route.bridge]
+ws_url = "wss://cascade.example.com/sip-bridge"
+
+[[route]]
+name = "default"
+[route.match]
+any = true
+```
+
+Two things distinguish this key from the others:
+
+- **A call with no verified certificate never matches it.** There is
+  no empty-string candidate, so `regex = true` with `peer_cert_san =
+  ".*"` (or `^$`) cannot admit an unauthenticated caller the way an
+  absent header can. The identity is what the *TLS layer* proved
+  before any SIP was read — no header in the INVITE can forge it.
+- **It is refused at config load unless the listener asks for
+  certificates.** Without `[sip.tls].client_auth` no INVITE could ever
+  carry an identity, so a route naming this key could never fire; the
+  daemon (and `siphon-ai check`) fails with a message naming the route
+  rather than shipping a dead entry.
+
+Literal values compare case-insensitively like every other key, which
+is right for DNS names and harmless for URIs; use `regex = true` with
+anchors when the exact URI matters. `siphon-ai route-test
+--peer-cert-san sip:node-3@conf.example.com` exercises it offline.
 
 ---
 


### PR DESCRIPTION
Consumes siphon-rs [v2026.09.03](https://github.com/thevoiceguy/siphon-rs/releases/tag/v2026.09.03) (siphon-rs #129 / #130): the SIP TLS trunk can now *authenticate* the peer, not just encrypt to it, and the dialplan can route on who the connection proved itself to be.

## Config

- **`[sip.tls].client_ca` + `client_auth = "optional" | "required"`** — the TLS listener requests a client certificate and verifies it against a PEM CA bundle. `required` fails the handshake for a peer with no certificate (it never sends a SIP message); `optional` admits such a peer with no identity while still refusing a certificate that does not chain, so a fleet can roll certificates out before the switch is thrown. Halves must come together, the bundle must exist, the mode is validated — all at load, so `siphon-ai check` catches every one. The SIGHUP cert reload keeps the mode. SIP TLS listener only; `[sip.wss]` is untouched (browsers do not present client certificates).
- **`[sip.tls_client].client_cert` + `client_key`** — presented on every outgoing TLS connection to a peer that asks (mutual TLS *toward* a trunk). Key must be `0600`, same rule as the listener key.

## Dialplan

- **`peer_cert_san`** match key (`docs/DIALPLAN.md` §4.6): matches when any name the verified certificate asserts — URI SANs (RFC 5922 puts a SIP identity there), DNS, IP, e-mail SANs, then the CN — satisfies the predicate. A call with no verified certificate has no candidate names and **can never match it**, so `regex = true` + `.*` cannot admit an unauthenticated caller the way it can for an absent header. A dialplan naming the key on a daemon whose listener never asks for a certificate is **refused at load**, naming the route. `siphon-ai route-test --peer-cert-san <name>` (repeatable) models it offline.

## Plumbing + observability

- The packet pump copies `InboundPacket::peer_identity()` onto the `TransportContext` (the one-liner the siphon-rs PR promised); the routing handler turns it into the matcher's candidate names.
- Per INVITE on a verified connection: an `info` line with the identity (subject + SANs) and SHA-256 fingerprint; `peer_cert_names` on the routed / no-match lines.
- New counter `siphon_ai_tls_peer_identity_total{result="verified"|"none"}` per INVITE over TLS/WSS, documented in DEPLOY.md with the rollout recipe (run `optional`, drive `none` to zero, switch to `required`).
- `GET /admin/v1/calls` rows gain an additive optional `peer_identity`; rows for calls that presented none are byte-identical to before (wire test). `print-config` shows both new blocks.

## Not in this PR

The identity is not on the CDR (that would be v10), and `[sip.admission]` / `[[trunk]]` do not consult it — routing is the authorization point for now; an unrecognized certificate lands on the default route, or 404 without one.

## Verification

- `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, the metrics / doc-link / version scripts — all clean.
- New tests: routes grammar (any-name match, case-insensitivity, no-cert never matches, regex + AND), sip-glue dispatch, config load (pairs, mode, missing paths, the route/listener cross-check), admin wire shape.
- `siphon-ai check` / `route-test` / the cross-check error all exercised against an openssl-generated CA on this box; a live daemon probe (no cert → refused, rogue CA → refused, CA-issued → OPTIONS 200 and the INVITE routed to the `peer_cert_san` route) is recorded in the PR comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UnFM3nqi5BqM66YgoLWAy7
