### PR TITLE
chore(release): 0.51.0 — browser calls, mutual TLS, OTLP log export, collector outages made visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.51.0] - 2026-09-03
+
 ### Added
 
 - **A dead collector is now visible on `/metrics`, for both exporters**
@@ -654,6 +656,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   which siphon-ai compiles today (forge-webrtc is not yet a dependency;
   the version bumps are manifest-only for the crates we use), so no
   behaviour change.
+
+### Fixed
+
+- **`examples/browser-sip/gen-cert.sh` works on a fresh clone** (#587) — it
+  assumed state a previous run left behind; the lab's first-time path now
+  generates the browser-trusted cert without it.
 
 ## [0.50.1] - 2026-08-24
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4245,7 +4245,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai"
-version = "0.50.1"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4297,7 +4297,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-admin-api-types"
-version = "0.50.1"
+version = "0.51.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -4305,7 +4305,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-audit"
-version = "0.50.1"
+version = "0.51.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4321,7 +4321,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-bridge"
-version = "0.50.1"
+version = "0.51.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4343,7 +4343,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-cdr"
-version = "0.50.1"
+version = "0.51.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4360,7 +4360,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-config"
-version = "0.50.1"
+version = "0.51.0"
 dependencies = [
  "regex",
  "serde",
@@ -4380,7 +4380,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-core"
-version = "0.50.1"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4428,7 +4428,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-http"
-version = "0.50.1"
+version = "0.51.0"
 dependencies = [
  "base64 0.22.1",
  "hmac 0.12.1",
@@ -4451,7 +4451,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-media-glue"
-version = "0.50.1"
+version = "0.51.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4477,7 +4477,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-protocol-testkit"
-version = "0.50.1"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4495,7 +4495,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-quality"
-version = "0.50.1"
+version = "0.51.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4513,7 +4513,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-recording"
-version = "0.50.1"
+version = "0.51.0"
 dependencies = [
  "aes-gcm 0.10.3",
  "audiopus",
@@ -4527,7 +4527,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-routes"
-version = "0.50.1"
+version = "0.51.0"
 dependencies = [
  "regex",
  "serde",
@@ -4539,7 +4539,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-security"
-version = "0.50.1"
+version = "0.51.0"
 dependencies = [
  "schemars",
  "serde",
@@ -4549,7 +4549,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sightglass"
-version = "0.50.1"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4564,7 +4564,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-sip-glue"
-version = "0.50.1"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4593,7 +4593,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-stir-shaken"
-version = "0.50.1"
+version = "0.51.0"
 dependencies = [
  "base64 0.22.1",
  "rcgen",
@@ -4611,7 +4611,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-telemetry"
-version = "0.50.1"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "forge-engine",
@@ -4643,7 +4643,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webhooks"
-version = "0.50.1"
+version = "0.51.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4658,7 +4658,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-ai-webrtc-glue"
-version = "0.50.1"
+version = "0.51.0"
 dependencies = [
  "bytes",
  "forge-codecs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.50.1"
+version = "0.51.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ handling, jitter, barge-in, DTMF, hold, transfer. See
 
 ## Status
 
-**Current release: v0.50.1.** Production-deployed against real carriers
+**Current release: v0.51.0.** Production-deployed against real carriers
 (Twilio Elastic SIP Trunking, FreeSWITCH, CUCM). The WS protocol is still
 `version: "1"` — every release has been additive, so a WS server built
 against 0.1.0 keeps working unchanged. Daemon upgrades are near-drop-in


### PR DESCRIPTION
Release-prep for **0.51.0** per RELEASING.md: workspace version `0.50.1 → 0.51.0` (lock refreshed), `## [Unreleased]` dated `## [0.51.0] - 2026-09-03` with a fresh empty Unreleased above it, README marker updated. One added changelog line for #587 (`gen-cert.sh` on a fresh clone), which had none.

Everything since v0.50.1 (2026-08-24), all already documented under the section:

- **WebRTC Phase 2** — a browser can place a call that carries audio (#580), port-pool accounting (#581), ICE/DTLS timing + observability and CDR **v9** (#582–#584), end-to-end browser CI and the nightly three-browser matrix (#585, #586)
- **JSON log output** `--log-format json` (#590) and **OTLP log export** with trace correlation (#591/#592), soaked at 200 concurrent with the collector killed (#594)
- **Mutual TLS on the SIP trunk** — `[sip.tls].client_ca` + `client_auth`, `[sip.tls_client].client_cert`/`client_key`, `peer_cert_san` route key (#600, siphon-rs v2026.09.03)
- **Collector outages are visible** — `siphon_ai_otlp_collector_up`, `siphon_ai_hep_collector_up`, `reason="collector_down"` (#601, closes #596); **the `warn` log floor is enforced** with `--log-no-floor` (closes #597)
- Pins: siphon-rs `v2026.09.03`, forge-media `v2026.09.02` (#593), hep-rs main `f503378` (send_failures, hep-rs #3 — hep-rs main has nothing newer)

Checks run locally: `check-version-consistency.py` (plain and `--tag v0.51.0`), `extract-changelog.py 0.51.0` (653 lines of notes).

After merge: `git tag -a v0.51.0 -m "v0.51.0 — …"` on the merge commit and push; the release workflow does the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UnFM3nqi5BqM66YgoLWAy7
